### PR TITLE
[Batch File] Fix escape sequences, word boundaries and redirections

### DIFF
--- a/Batch File/Batch File (Compound).sublime-syntax
+++ b/Batch File/Batch File (Compound).sublime-syntax
@@ -21,4 +21,4 @@ hidden: true
 extends: Packages/Batch File/Batch File.sublime-syntax
 
 variables:
-  command_terminator_chars: '[|&<>)]'
+  eoc_char: '[\n|&)]'

--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -25,7 +25,7 @@ variables:
   # A character that, when unquoted, separates words. A metacharacter is a
   # space, tab, newline, or one of the following characters:
   # ‘|’, ‘&’, ‘,’, ‘;’, ‘<’, or ‘>’.
-  metachar: '[\s=,;{{redirection_or_eoc}}]'
+  metachar: '[\s=,;{{redir_or_eoc_char}}]'
 
   # Keywords
   keyword_break: (?![^{{metachar}}(.:\\/])
@@ -43,7 +43,8 @@ variables:
   arg_char: '[^{{metachar}}:]'
 
   # Command statement terminators and redirections
-  redirection_or_eoc: '[<>{{eoc_char}}]'
+  redir_or_eoc: (?=\s*{{redir_or_eoc_char}})
+  redir_or_eoc_char: '[<>{{eoc_char}}]'
   eoc: (?=\s*{{eoc_char}})
   eoc_char: '[\n|&]'
 
@@ -52,21 +53,21 @@ variables:
   label_start: '[^{{metachar}}:%!+]'
   label_char: '[^{{metachar}}(%!]'
 
-  path_terminator_chars: '[\s,;"{{redirection_or_eoc}}]'
+  path_terminator_chars: '[\s,;"{{redir_or_eoc_char}}]'
   path_terminators: (?={{path_terminator_chars}})
 
   set_arithmetic_operators_unquoted: (?:\+|-|\*|/|%%|~)
   set_arithmetic_operators_quoted: (?:\||<<|>>|&|\^)
-  set_quoted_end: \"(?![^"{{redirection_or_eoc}}]*\")
+  set_quoted_end: \"(?![^"{{redir_or_eoc_char}}]*\")
 
   expansion_begin: |-
     (?x:
       %
       (?=
         # anything but no colon, percentage or command terminator char
-        ( [^:%{{redirection_or_eoc}}]
+        ( [^:%{{redir_or_eoc_char}}]
         # otherwise must not look like followed by a command
-        | [{{redirection_or_eoc}}](?!\s*\w+[\s{{redirection_or_eoc}}])
+        | [{{redir_or_eoc_char}}](?!\s*\w+[\s{{redir_or_eoc_char}}])
         )+
         # don't check substrings and substitutions
         (:~?[^%]*)? %
@@ -78,9 +79,9 @@ variables:
       !
       (?=
         # anything but no colon, exclamation mark or command terminator char
-        ( [^:!{{redirection_or_eoc}}]
+        ( [^:!{{redir_or_eoc_char}}]
         # otherwise must not look like followed by a command
-        | [{{redirection_or_eoc}}](?!\s*\w+[\s{{redirection_or_eoc}}])
+        | [{{redir_or_eoc_char}}](?!\s*\w+[\s{{redir_or_eoc_char}}])
         )+
         # don't check substrings and substitutions
         (:~?[^!]*)? !
@@ -94,7 +95,7 @@ variables:
   var_break: (?![^%{{metachar}}])
   var_char:  (?:{{var_literal}}|{{var_escape}})
   var_escape: \^[^=\s]
-  var_literal: '[^=\s"^{{redirection_or_eoc}}]'
+  var_literal: '[^=\s"^{{redir_or_eoc_char}}]'
 
   # An unquoted word, which may contain escapes or interpolation,
   # but no redirections. It is terminated by meta-chars or quoted words
@@ -201,14 +202,14 @@ contexts:
       scope: meta.embedded.dosbatch punctuation.section.embedded.begin.dosbatch
       embed: commands
       embed_scope: meta.embedded.dosbatch source.dosbatch.embedded
-      escape: \'(?=\s*['{{redirection_or_eoc}}])
+      escape: \'(?=\s*['{{redir_or_eoc_char}}])
       escape_captures:
         0: meta.embedded.dosbatch punctuation.section.embedded.end.dosbatch
     - match: \`
       scope: meta.embedded.dosbatch punctuation.section.embedded.begin.dosbatch
       embed: commands
       embed_scope: meta.embedded.dosbatch source.dosbatch.embedded
-      escape: \`(?=\s*[`{{redirection_or_eoc}}])
+      escape: \`(?=\s*[`{{redir_or_eoc_char}}])
       escape_captures:
         0: meta.embedded.dosbatch punctuation.section.embedded.end.dosbatch
 
@@ -1486,7 +1487,7 @@ contexts:
       scope: punctuation.separator.semicolon.dosbatch
 
   invalid-operators:
-    - match: '{{redirection_or_eoc}}'
+    - match: '{{redir_or_eoc_char}}'
       scope: invalid.illegal.operator.dosbatch
 
 ###[ CONSTANTS ]##############################################################
@@ -1873,7 +1874,7 @@ contexts:
         1: keyword.operator.arithmetic.dosbatch
         2: constant.numeric.value.dosbatch
     # Note: This makes the whole expansion being handled as plain text.
-    - match: ':[^%!{{redirection_or_eoc}}]*'
+    - match: ':[^%!{{redir_or_eoc_char}}]*'
       scope: invalid.illegal.unexpected.dosbatch
 
 ###[ ILLEGALS ]###############################################################
@@ -1932,6 +1933,6 @@ contexts:
     - include: line-continuations
 
   unquoted-var-pop:
-    - match: (?=\s*{{redirection_or_eoc}})
+    - match: '{{redir_or_eoc}}'
       pop: 1
     - include: line-continuations

--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -277,6 +277,7 @@ contexts:
 
   ctl-if-condition:
     - include: eoc-pop
+    - include: cmd-arg-help
     - match: (?i:(/)i){{arg_break}}
       scope: variable.parameter.option.dosbatch
       captures:
@@ -378,6 +379,7 @@ contexts:
     - include: immediately-pop
 
   ctl-for-switches:
+    - include: cmd-arg-help
     # https://ss64.com/nt/for_d.html
     - match: (?i:(/)d){{arg_break}}
       scope: variable.parameter.option.dir.dosbatch
@@ -408,6 +410,7 @@ contexts:
   ctl-for-maybe-r-args:
     - match: (?={{var_parameter}})
       pop: 1
+    - include: cmd-arg-help
     - include: path-pattern
 
   ctl-for-maybe-f-args:
@@ -482,12 +485,15 @@ contexts:
     - match: ':'
       scope: punctuation.definition.variable.dosbatch
       set: ctl-call-label
+    - include: cmd-arg-help
     - include: else-pop
 
   ctl-call-label:
     - meta_scope: meta.function-call.identifier.dosbatch variable.label.dosbatch
     - match: '{{word_break}}'
-      set: cmd-args-body
+      set:
+        - cmd-args-meta
+        - cmd-args-body
     - include: line-continuations
     - include: escaped-characters
     - include: variables
@@ -498,14 +504,21 @@ contexts:
     # https://ss64.com/nt/exit.html
     - match: (?i:exit){{keyword_break}}
       scope: keyword.control.flow.exit.dosbatch
-      push: ctl-exit-args
+      push:
+        - ctl-exit-meta
+        - ctl-exit-args
+
+  ctl-exit-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.command.exit.dosbatch
+    - include: immediately-pop
 
   ctl-exit-args:
-    - meta_scope: meta.command.exit.dosbatch
     - match: (?i:(/)b){{arg_break}}
       scope: variable.parameter.option.dosbatch
       captures:
         1: punctuation.definition.variable.dosbatch
+    - include: cmd-arg-help
     - include: numbers
     - include: variables
     - include: expect-eoc
@@ -527,6 +540,7 @@ contexts:
 
   ctl-goto-args:
     - include: redirections
+    - include: cmd-arg-help
     - include: eoc-pop
     - match: (:)(?i:(eof)){{word_break}}
       scope: variable.label.dosbatch
@@ -550,10 +564,17 @@ contexts:
     # https://ss64.com/nt/pause.html
     - match: (?i:pause){{keyword_break}}
       scope: keyword.control.flow.pause.dosbatch
-      push: ctl-pause-args
+      push:
+        - ctl-pause-meta
+        - ctl-pause-args
+
+  ctl-pause-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.command.pause.dosbatch
+    - include: immediately-pop
 
   ctl-pause-args:
-    - meta_scope: meta.command.pause.dosbatch
+    - include: cmd-arg-help
     - include: expect-eoc
 
 ###[ CONTEXT SETLOCAL ]#######################################################
@@ -562,16 +583,23 @@ contexts:
     # https://ss64.com/nt/setlocal.html
     - match: (?i:setlocal){{keyword_break}}
       scope: keyword.context.setlocal.dosbatch
-      push: ctl-setlocal-args
+      push:
+        - ctl-setlocal-meta
+        - ctl-setlocal-args
+
+  ctl-setlocal-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.command.setlocal.dosbatch
+    - include: immediately-pop
 
   ctl-setlocal-args:
-    - meta_scope: meta.command.setlocal.dosbatch
     - match: |-
         \b(?xi:
           EnableDelayedExpansion | DisableDelayedExpansion |
           EnableExtensions | DisableExtensions
         ){{arg_break}}
       scope: constant.language.dosbatch
+    - include: cmd-arg-help
     - include: expect-eoc
 
 ###[ CONTEXT ENDLOCAL ]#######################################################
@@ -580,10 +608,17 @@ contexts:
     # https://ss64.com/nt/endlocal.html
     - match: (?i:endlocal){{keyword_break}}
       scope: keyword.context.endlocal.dosbatch
-      push: ctl-endlocal-args
+      push:
+        - ctl-endlocal-meta
+        - ctl-endlocal-args
+
+  ctl-endlocal-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.command.endlocal.dosbatch
+    - include: immediately-pop
 
   ctl-endlocal-args:
-    - meta_scope: meta.command.endlocal.dosbatch
+    - include: cmd-arg-help
     - include: expect-eoc
 
 ###[ COMMANDS ]###############################################################
@@ -593,7 +628,9 @@ contexts:
       scope:
         meta.function-call.identifier.dosbatch
         support.function.builtin.dosbatch
-      push: cmd-args-body
+      push:
+        - cmd-args-meta
+        - cmd-args-body
 
   cmd-other:
     - match: '{{cmd_begin}}'
@@ -606,7 +643,9 @@ contexts:
         meta.function-call.identifier.dosbatch
         variable.function.dosbatch
     - match: '{{cmd_break}}'
-      set: cmd-args-body
+      set:
+        - cmd-args-meta
+        - cmd-args-body
     - match: \"
       scope: punctuation.definition.string.begin.dosbatch
       push:
@@ -621,12 +660,24 @@ contexts:
     - meta_scope: meta.string.dosbatch variable.function.dosbatch
     - include: path-pattern-quoted-body
 
-  cmd-args-body:
+  cmd-args-meta:
+    - meta_include_prototype: false
     - meta_content_scope: meta.function-call.arguments.dosbatch
+    - include: immediately-pop
+
+  cmd-args-body:
     - include: redirections
     - include: eoc-pop
+    - include: cmd-arg-help
     - include: cmd-args-options
     - include: cmd-args-values
+
+  cmd-arg-help:
+    - match: (/)\?{{arg_break}}
+      scope: variable.parameter.option.help.dosbatch
+      captures:
+        1: punctuation.definition.variable.dosbatch
+      set: ignored-tail-outer
 
   cmd-args-options:
     # The shell basically just passes words to a called command.
@@ -642,11 +693,6 @@ contexts:
     #
     # This context applies various heuristics to try to highlight
     # different kinds of command line arguments and their values.
-    - match: (/)\?{{arg_break}}
-      scope: variable.parameter.option.help.dosbatch
-      captures:
-        1: punctuation.definition.variable.dosbatch
-      push: ignored-tail-outer
     - match: '{{opt_punctuation}}'
       scope:
         meta.parameter.option.dosbatch
@@ -737,11 +783,17 @@ contexts:
       scope:
         meta.function-call.identifier.dosbatch
         support.function.external.dosbatch
-      push: cmd-mode-args
+      push:
+        - cmd-mode-meta
+        - cmd-mode-args
 
-  cmd-mode-args:
+  cmd-mode-meta:
+    - meta_include_prototype: false
     - meta_scope: meta.command.mode.dosbatch
     - meta_content_scope: meta.function-call.arguments.dosbatch
+    - include: immediately-pop
+
+  cmd-mode-args:
     - include: redirections
     - include: eoc-pop
     - match: (?i:COM\d+|CON|LPT\d+):?{{arg_break}}
@@ -757,6 +809,7 @@ contexts:
       scope: variable.parameter.option.dosbatch
     - match: =
       scope: keyword.operator.assignment.dosbatch
+    - include: cmd-arg-help
     - include: cmd-args-options
     - include: cmd-args-values
 
@@ -766,17 +819,24 @@ contexts:
     # https://ss64.com/nt/rem.html
     - match: (?i:rem){{keyword_break}}
       scope: keyword.declaration.rem.dosbatch
-      push: cmd-rem-body
+      push:
+        - cmd-rem-meta
+        - cmd-rem-body
+
+  cmd-rem-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.command.rem.dosbatch
+    - include: immediately-pop
 
   cmd-rem-body:
     - meta_include_prototype: false
+    - include: cmd-arg-help
     - include: unquoted-eol-pop
     - match: (?=\S)
       set: cmd-rem-comment-body
 
   cmd-rem-comment-body:
     - meta_include_prototype: false
-    - meta_scope: meta.command.rem.dosbatch
     # meta_content_scope is used since rem should not be
     # highlighted as a comment, but a command
     - meta_content_scope: comment.line.rem.dosbatch
@@ -804,6 +864,7 @@ contexts:
     - include: eoc-pop
     - include: cmd-set-arithmetic
     - include: cmd-set-prompt
+    - include: cmd-arg-help
     - include: cmd-arg-illegal-options
     - include: cmd-set-quoted
     - include: cmd-set-unquoted
@@ -1011,6 +1072,7 @@ contexts:
     - include: immediately-pop
 
   cmd-set-arithmetic-start:
+    - include: cmd-arg-help
     - match: \"
       scope: meta.string.dosbatch punctuation.definition.string.begin.dosbatch
       set:
@@ -1132,6 +1194,7 @@ contexts:
     - include: immediately-pop
 
   cmd-set-prompt-start:
+    - include: cmd-arg-help
     - include: cmd-set-quoted-prompt
     - include: cmd-set-unquoted-prompt
 

--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -687,9 +687,7 @@ contexts:
       fail: cmd-args-values
     - include: quoted-words
     - include: unquoted-escapes-and-interpolations
-    - include: line-continuations
-    - match: '{{arg_break}}'
-      pop: 1
+    - include: unquoted-word-end
 
   cmd-arg-illegal-options:
     - match: /{{arg_char}}+

--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -49,9 +49,7 @@ variables:
   eoc_char: '[\n|&]'
 
   label_comment: ':[^{{label_start}}]'
-  label_name: '{{label_start}}{{label_char}}*'
-  label_start: '[^{{metachar}}:%!+]'
-  label_char: '[^{{metachar}}(%!]'
+  label_start: '[^{{metachar}}:+]'
 
   path_terminator_chars: '[\s,;"{{redir_or_eoc_char}}]'
   path_terminators: (?={{path_terminator_chars}})
@@ -102,6 +100,11 @@ variables:
   unquoted_word_begin: (?={{unquoted_word_char}})
   unquoted_word_break: (?!{{unquoted_word_char}})
   unquoted_word_char: '[^"{{metachar}}]'
+
+  # Words are separated by meta-chars, only.
+  # They may contain quoted regions, escaped chars or interpolations.
+  word_break: (?!{{word_char}})
+  word_char: '[^{{metachar}}]'
 
   builtin_commands: |-
     \b(?xi:
@@ -182,20 +185,23 @@ contexts:
 
 ###[ LABELS ]#################################################################
 
-  labels:
-    - match: ^\s*((:){{label_name}})
-      captures:
-        1: entity.name.label.dosbatch
-        2: punctuation.definition.label.dosbatch
-      push: ignored-tail-outer
-
   maybe-label:
-    - match: ((:){{label_name}})
-      captures:
-        1: entity.name.label.dosbatch
-        2: punctuation.definition.label.dosbatch
-      set: ignored-tail-outer
+    - match: \:(?={{label_start}})
+      scope: entity.name.label.dosbatch punctuation.definition.label.dosbatch
+      set: label-name
     - include: else-pop
+
+  labels:
+    - match: ^\s*(:)(?={{label_start}})
+      captures:
+        1: entity.name.label.dosbatch punctuation.definition.label.dosbatch
+      push: label-name
+
+  label-name:
+    - meta_content_scope: entity.name.label.dosbatch
+    - match: '{{word_break}}'
+      set: ignored-tail-outer
+    - include: escaped-characters
 
 ###[ BLOCKS ]#################################################################
 
@@ -479,14 +485,14 @@ contexts:
     - include: else-pop
 
   ctl-call-label:
-    - meta_scope:
-        meta.function-call.identifier.dosbatch
-        variable.label.dosbatch
-    - match: '{{cmd_break}}'
+    - meta_scope: meta.function-call.identifier.dosbatch variable.label.dosbatch
+    - match: '{{word_break}}'
       set:
         - cmd-args-meta
         - cmd-args-common
-    - include: unquoted-escapes-and-interpolations
+    - include: line-continuations
+    - include: escaped-characters
+    - include: variables
 
 ###[ CONTROL EXIT ]###########################################################
 
@@ -522,22 +528,22 @@ contexts:
     - include: immediately-pop
 
   ctl-goto-args:
+    - include: redirections
     - include: eoc-pop
-    - match: (:)(?i:(eof)){{cmd_break}}
+    - match: (:)(?i:(eof)){{word_break}}
       scope: variable.label.dosbatch
       captures:
         1: punctuation.definition.variable.dosbatch
         2: keyword.control.flow.return.dosbatch
       pop: 1
-    - match: (:)?(?=\S)
-      scope: punctuation.definition.variable.dosbatch
+    - match: (:)?(?={{label_start}})
+      scope: punctuation.definition.label.dosbatch
       set: clt-goto-label
 
   clt-goto-label:
     - meta_scope: variable.label.dosbatch
-    - match: '{{cmd_break}}'
-      set: ignored-tail-outer
-    - include: escaped-characters
+    - include: line-continuations
+    - include: label-name
     - include: variables
 
 ###[ CONTROL PAUSE ]##########################################################

--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -712,7 +712,7 @@ contexts:
         1: variable.parameter.option.help.dosbatch
         2: punctuation.definition.variable.dosbatch
       push: ignored-tail-outer
-    - match: \s*((?i:on|off)){{eoc}}
+    - match: \s*((?i:on|off)){{redir_or_eoc}}
       captures:
         1: constant.language.dosbatch
       push: ignored-tail-outer

--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -96,6 +96,12 @@ variables:
   var_escape: \^[^=\s]
   var_literal: '[^=\s"^{{redirection_or_eoc}}]'
 
+  # An unquoted word, which may contain escapes or interpolation,
+  # but no redirections. It is terminated by meta-chars or quoted words
+  unquoted_word_begin: (?={{unquoted_word_char}})
+  unquoted_word_break: (?!{{unquoted_word_char}})
+  unquoted_word_char: '[^"{{metachar}}]'
+
   builtin_commands: |-
     \b(?xi:
       assoc | break | cd | chdir | cls | color | copy | date | del | dir
@@ -162,14 +168,14 @@ contexts:
 
   ignored-tail-outer:
     - include: redirections
-    - include: unquoted-eoc-pop
+    - include: eoc-pop
     - match: (?=\S)
       set: ignored-tail-body
 
   ignored-tail-body:
     - meta_scope: comment.line.ignored.dosbatch
     - include: redirection-interpolations
-    - include: unquoted-eoc-pop
+    - include: eoc-pop
 
 ###[ LABELS ]#################################################################
 
@@ -210,7 +216,7 @@ contexts:
     - match: \(
       scope: punctuation.section.block.begin.dosbatch
       set: Packages/Batch File/Batch File (Compound).sublime-syntax#block-common
-    - include: unquoted-eoc-pop
+    - include: eoc-pop
     - include: statements
 
   blocks:
@@ -261,7 +267,7 @@ contexts:
     - include: immediately-pop
 
   ctl-if-condition:
-    - include: unquoted-eoc-pop
+    - include: eoc-pop
     - match: (?i:(/)i){{arg_break}}
       scope: variable.parameter.option.dosbatch
       captures:
@@ -281,7 +287,7 @@ contexts:
         - maybe-operator-not
 
   ctl-if-checks:
-    - include: unquoted-eoc-pop
+    - include: eoc-pop
     - match: (?i:errorlevel|cmdextversion){{keyword_break}}
       scope: variable.language.dosbatch
       set:
@@ -513,7 +519,7 @@ contexts:
     - include: immediately-pop
 
   ctl-goto-args:
-    - include: unquoted-eoc-pop
+    - include: eoc-pop
     - match: (:)(?i:(eof)){{cmd_break}}
       scope: variable.label.dosbatch
       captures:
@@ -619,7 +625,7 @@ contexts:
 
   cmd-args-common:
     - include: redirections
-    - include: unquoted-eoc-pop
+    - include: eoc-pop
     - include: cmd-args-options
     - include: cmd-args-values
 
@@ -677,26 +683,11 @@ contexts:
     - meta_scope: meta.string.dosbatch string.unquoted.dosbatch
     - match: (?=(\.\.?|\:)[\\%{{metachar}}]|[?*]|\\(?!"))
       fail: cmd-args-values
+    - include: quoted-words
     - include: unquoted-escapes-and-interpolations
     - include: line-continuations
-    - include: cmd-args-quoted
     - match: '{{arg_break}}'
       pop: 1
-
-  cmd-args-quoted:
-    - match: \"
-      push: cmd-args-quoted-body
-
-  cmd-args-quoted-body:
-    # echo "text" outputs quotation marks no matter where they are located.
-    # Hence no `punctuation` nor `string.quoted` scopes are applied.
-    # This context is needed as a limited set of escaped chars and no line
-    # continuation operators are supported within quotes.
-    - match: \"
-      pop: 1
-    - match: $
-      pop: 2
-    - include: quoted-escapes-and-interpolations
 
   cmd-arg-illegal-options:
     - match: /{{arg_char}}+
@@ -715,7 +706,7 @@ contexts:
 
   cmd-echo-args:
     - meta_content_scope: meta.command.echo.dosbatch meta.function-call.arguments.dosbatch
-    - include: unquoted-eoc-pop
+    - include: eoc-pop
     - match: \s*((/)\?){{arg_break}}
       captures:
         1: variable.parameter.option.help.dosbatch
@@ -734,9 +725,10 @@ contexts:
   cmd-echo-output:
     - meta_scope: meta.command.echo.dosbatch meta.function-call.arguments.dosbatch
     - meta_content_scope: meta.string.dosbatch string.unquoted.dosbatch
-    - include: cmd-args-quoted
-    - include: unquoted-escapes-and-interpolations
-    - include: unquoted-eoc-pop
+    - include: quoted-words
+    - include: redirection-interpolations
+    - include: unquoted-words
+    - include: eoc-pop
 
 ###[ COMMAND MODE ]###########################################################
 
@@ -751,7 +743,7 @@ contexts:
     - meta_scope: meta.command.mode.dosbatch
     - meta_content_scope: meta.function-call.arguments.dosbatch
     - include: redirections
-    - include: unquoted-eoc-pop
+    - include: eoc-pop
     - match: (?i:COM\d+|CON|LPT\d+):?{{arg_break}}
       scope: variable.language.device.dosbatch
     # known option values
@@ -811,17 +803,34 @@ contexts:
 
   cmd-set-type:
     - include: redirections
-    - include: unquoted-eoc-pop
+    - include: eoc-pop
     - include: cmd-set-arithmetic
     - include: cmd-set-prompt
     - include: cmd-arg-illegal-options
     - include: cmd-set-quoted
     - include: cmd-set-unquoted
 
+  cmd-set-variable-inner-common:
+    - include: cmd-set-variable-common
+    - include: quoted-eol-pop
+
+  cmd-set-variable-outer-common:
+    - include: cmd-set-variable-common
+    - include: unquoted-var-pop
+
   cmd-set-variable-common:
     - match: \^=
       scope: invalid.illegal.parameter.dosbatch
     - match: \^\S
+
+  cmd-set-value-inner-common:
+    - include: quoted-escapes-and-interpolations
+    - include: quoted-eol-pop
+
+  cmd-set-value-outer-common:
+    - include: redirection-interpolations
+    - include: unquoted-words
+    - include: eoc-pop
 
 ###[ COMMAND SET "VARIABLE=VALUE" ]############################################
 
@@ -864,8 +873,7 @@ contexts:
     - match: \"
       scope: meta.string.dosbatch variable.other.readwrite.dosbatch
       set: cmd-set-quoted-variable-outer
-    - include: cmd-set-variable-common
-    - include: quoted-eoc-pop
+    - include: cmd-set-variable-inner-common
 
   cmd-set-quoted-variable-outer:
     - meta_include_prototype: false
@@ -876,8 +884,7 @@ contexts:
     - match: \"
       scope: meta.string.dosbatch variable.other.readwrite.dosbatch
       set: cmd-set-quoted-variable-inner
-    - include: cmd-set-variable-common
-    - include: unquoted-eoc-pop
+    - include: cmd-set-variable-outer-common
 
   cmd-set-quoted-value-inner:
     - meta_include_prototype: false
@@ -891,8 +898,7 @@ contexts:
     - match: \"
       scope: meta.string.dosbatch string.unquoted.dosbatch
       set: cmd-set-quoted-value-outer
-    - include: quoted-escapes-and-interpolations
-    - include: quoted-eol-pop
+    - include: cmd-set-value-inner-common
 
   cmd-set-quoted-value-inner-continue:
     - meta_include_prototype: false
@@ -927,8 +933,7 @@ contexts:
     - match: \"
       scope: meta.string.dosbatch string.unquoted.dosbatch
       set: cmd-set-quoted-value-inner
-    - include: unquoted-escapes-and-interpolations
-    - include: unquoted-eoc-pop
+    - include: cmd-set-value-outer-common
 
 ###[ COMMAND SET VARIABLE=VALUE ]##############################################
 
@@ -948,8 +953,7 @@ contexts:
     - match: \"
       scope: variable.other.readwrite.dosbatch
       set: cmd-set-unquoted-variable-outer
-    - include: cmd-set-variable-common
-    - include: quoted-eoc-pop
+    - include: cmd-set-variable-inner-common
 
   cmd-set-unquoted-variable-outer:
     - meta_include_prototype: false
@@ -960,8 +964,7 @@ contexts:
     - match: \"
       scope: variable.other.readwrite.dosbatch
       set: cmd-set-unquoted-variable-inner
-    - include: cmd-set-variable-common
-    - include: unquoted-eoc-pop
+    - include: cmd-set-variable-outer-common
 
   cmd-set-unquoted-value-inner:
     - meta_include_prototype: false
@@ -969,8 +972,7 @@ contexts:
     - match: \"
       scope: meta.string.dosbatch string.unquoted.dosbatch
       set: cmd-set-unquoted-value-outer
-    - include: quoted-escapes-and-interpolations
-    - include: quoted-eol-pop
+    - include: cmd-set-value-inner-common
 
   cmd-set-unquoted-value-outer:
     - meta_include_prototype: false
@@ -978,8 +980,7 @@ contexts:
     - match: \"
       scope: meta.string.dosbatch string.unquoted.dosbatch
       set: cmd-set-unquoted-value-inner
-    - include: unquoted-escapes-and-interpolations
-    - include: unquoted-eoc-pop
+    - include: cmd-set-value-outer-common
 
 ###[ COMMAND SET /A ]#########################################################
 
@@ -1077,12 +1078,12 @@ contexts:
       scope: meta.group.dosbatch punctuation.section.group.begin.dosbatch
       push: cmd-set-arithmetic-unquoted-group
     - include: cmd-set-arithmetic-unquoted-common
-    - include: unquoted-eoc-pop
+    - include: eoc-pop
 
   cmd-set-arithmetic-unquoted-group:
     - meta_content_scope: meta.group.dosbatch
     # Note: must be included before \) pattern to support compound termination
-    - include: unquoted-eoc-pop
+    - include: eoc-pop
     - match: \"
       scope: meta.group.dosbatch punctuation.definition.string.begin.dosbatch
       set: cmd-set-arithmetic-quoted-first-group
@@ -1136,14 +1137,6 @@ contexts:
     - include: cmd-set-quoted-prompt
     - include: cmd-set-unquoted-prompt
 
-  cmd-set-prompt-value-inner-common:
-    - include: quoted-escapes-and-interpolations
-    - include: quoted-eol-pop
-
-  cmd-set-prompt-value-outer-common:
-    - include: unquoted-escapes-and-interpolations
-    - include: unquoted-eoc-pop
-
 ###[ COMMAND SET /P "VARIABLE=PROMPT" ]#######################################
 
   cmd-set-quoted-prompt:
@@ -1175,8 +1168,7 @@ contexts:
     - match: \"
       scope: variable.other.readwrite.dosbatch
       set: cmd-set-quoted-prompt-variable-outer
-    - include: cmd-set-variable-common
-    - include: quoted-eoc-pop
+    - include: cmd-set-variable-inner-common
 
   cmd-set-quoted-prompt-variable-outer:
     - meta_include_prototype: false
@@ -1187,8 +1179,7 @@ contexts:
     - match: \"
       scope: variable.other.readwrite.dosbatch
       set: cmd-set-quoted-prompt-variable-inner
-    - include: cmd-set-variable-common
-    - include: unquoted-eoc-pop
+    - include: cmd-set-variable-outer-common
 
 
   cmd-set-quoted-prompt-value-inner-start:
@@ -1232,7 +1223,7 @@ contexts:
     - match: \"
       scope: meta.string.dosbatch string.quoted.double.dosbatch
       set: cmd-set-quoted-prompt-quoted-value-outer
-    - include: cmd-set-prompt-value-inner-common
+    - include: cmd-set-value-inner-common
 
   cmd-set-quoted-prompt-quoted-value-inner-continue:
     - meta_include_prototype: false
@@ -1270,7 +1261,7 @@ contexts:
     - match: \"
       scope: meta.string.dosbatch string.quoted.double.dosbatch
       set: cmd-set-quoted-prompt-quoted-value-inner
-    - include: cmd-set-prompt-value-outer-common
+    - include: cmd-set-value-outer-common
 
 
   cmd-set-quoted-prompt-unquoted-value-inner:
@@ -1285,7 +1276,7 @@ contexts:
     - match: \"
       scope: meta.string.dosbatch string.unquoted.dosbatch
       set: cmd-set-quoted-prompt-unquoted-value-outer
-    - include: cmd-set-prompt-value-inner-common
+    - include: cmd-set-value-inner-common
 
   cmd-set-quoted-prompt-unquoted-value-inner-continue:
     - meta_include_prototype: false
@@ -1319,7 +1310,7 @@ contexts:
     - match: \"
       scope: meta.string.dosbatch string.unquoted.dosbatch
       set: cmd-set-quoted-prompt-unquoted-value-inner
-    - include: cmd-set-prompt-value-outer-common
+    - include: cmd-set-value-outer-common
 
 ###[ COMMAND SET /P VARIABLE=PROMPT ]#########################################
 
@@ -1341,8 +1332,7 @@ contexts:
     - match: \"
       scope: variable.other.readwrite.dosbatch
       set: cmd-set-unquoted-prompt-variable-outer
-    - include: cmd-set-variable-common
-    - include: quoted-eoc-pop
+    - include: cmd-set-variable-inner-common
 
   cmd-set-unquoted-prompt-variable-outer:
     - meta_include_prototype: false
@@ -1353,8 +1343,7 @@ contexts:
     - match: \"
       scope: variable.other.readwrite.dosbatch
       set: cmd-set-unquoted-prompt-variable-inner
-    - include: cmd-set-variable-common
-    - include: unquoted-eoc-pop
+    - include: cmd-set-variable-outer-common
 
 
   cmd-set-unquoted-prompt-value-inner-start:
@@ -1390,7 +1379,7 @@ contexts:
     - match: \"
       scope: meta.string.dosbatch string.quoted.double.dosbatch
       set: cmd-set-unquoted-prompt-quoted-value-outer
-    - include: cmd-set-prompt-value-inner-common
+    - include: cmd-set-value-inner-common
 
   cmd-set-unquoted-prompt-quoted-value-inner-continue:
     - meta_include_prototype: false
@@ -1427,7 +1416,7 @@ contexts:
     - match: \"
       scope: meta.string.dosbatch string.quoted.double.dosbatch
       set: cmd-set-unquoted-prompt-quoted-value-inner
-    - include: cmd-set-prompt-value-outer-common
+    - include: cmd-set-value-outer-common
 
 
   cmd-set-unquoted-prompt-unquoted-value-inner:
@@ -1436,7 +1425,7 @@ contexts:
     - match: \"
       scope: meta.string.dosbatch string.unquoted.dosbatch
       set: cmd-set-unquoted-prompt-unquoted-value-outer
-    - include: cmd-set-prompt-value-inner-common
+    - include: cmd-set-value-inner-common
 
   cmd-set-unquoted-prompt-unquoted-value-outer:
     - meta_include_prototype: false
@@ -1444,7 +1433,7 @@ contexts:
     - match: \"
       scope: meta.string.dosbatch string.unquoted.dosbatch
       set: cmd-set-unquoted-prompt-unquoted-value-inner
-    - include: cmd-set-prompt-value-outer-common
+    - include: cmd-set-value-outer-common
 
 ###[ COMMAND TITLE ]##########################################################
 
@@ -1458,7 +1447,7 @@ contexts:
   cmd-title-args:
     - meta_scope: meta.command.title.dosbatch
     - meta_content_scope: meta.function-call.arguments.dosbatch
-    - include: unquoted-eoc-pop
+    - include: eoc-pop
     - match: \s*((/)\?){{arg_break}}
       captures:
         1: variable.parameter.option.help.dosbatch
@@ -1472,7 +1461,9 @@ contexts:
         meta.command.title.dosbatch
         meta.function-call.arguments.dosbatch
         meta.string.dosbatch string.unquoted.dosbatch
-    - include: unquoted-eoc-pop
+    - include: redirection-interpolations
+    - include: unquoted-words
+    - include: eoc-pop
 
 ###[ OPERATORS ]##############################################################
 
@@ -1544,7 +1535,7 @@ contexts:
 ###[ PATH PATTERNS ]##########################################################
 
   redirection-interpolations:
-    - match: (\b\d)?(<&?|>[&>]?)
+    - match: (\d)?(<&?|>[&>]?)
       captures:
         1: meta.number.integer.decimal.dosbatch
            constant.numeric.value.dosbatch
@@ -1560,7 +1551,7 @@ contexts:
     - include: immediately-pop
 
   redirections:
-    - match: (\b\d)?(<&?|>[&>]?)
+    - match: (\d)?(<&?|>[&>]?)
       captures:
         1: meta.number.integer.decimal.dosbatch
            constant.numeric.value.dosbatch
@@ -1665,11 +1656,37 @@ contexts:
     - match: '%%'
       scope: constant.character.escape.dosbatch
 
+###[ WORDS ]##################################################################
+
+  quoted-words:
+    - match: \"
+      push: quoted-word-body
+
+  quoted-word-body:
+    # echo "text" outputs quotation marks no matter where they are located.
+    # Hence no `punctuation` nor `string.quoted` scopes are applied.
+    # This context is needed as a limited set of escaped chars and no line
+    # continuation operators are supported within quotes.
+    - match: \"
+      pop: 1
+    - match: $
+      pop: 2
+    - include: quoted-escapes-and-interpolations
+
+  unquoted-words:
+    - match: '{{unquoted_word_begin}}'
+      push: unquoted-word-body
+
+  unquoted-word-body:
+    - match: '{{unquoted_word_break}}'
+      pop: 1
+    - include: line-continuations
+    - include: unquoted-escapes-and-interpolations
+
 ###[ INTERPOLATIONS ]#########################################################
 
   unquoted-escapes-and-interpolations:
     - include: escaped-characters
-    - include: redirection-interpolations
     - include: quoted-escapes-and-interpolations
 
   quoted-escapes-and-interpolations:
@@ -1862,7 +1879,7 @@ contexts:
 ###[ ILLEGALS ]###############################################################
 
   expect-eoc:
-    - include: unquoted-eoc-pop
+    - include: eoc-pop
     - match: \S
       scope: invalid.illegal.expect-end-of-command.dosbatch
 
@@ -1873,10 +1890,10 @@ contexts:
     - include: else-pop
 
   illegal-token-pop:
+    - include: unquoted-eol-pop
     - match: \S+
       scope: invalid.illegal.unexpected.dosbatch
       set: else-pop
-    - include: unquoted-eol-pop
 
 ###[ PROTOTYPES ]#############################################################
 
@@ -1899,18 +1916,22 @@ contexts:
       scope: punctuation.separator.continuation.line.dosbatch
       push: bol-pop
 
-  quoted-eoc-pop:
+  eoc-pop:
+    # Note: An end of command appears in unquoted regions only!
+    #       `&` or `|` are literals in quoted words.
     - match: '{{eoc}}'
       pop: 1
+    - include: line-continuations
 
   quoted-eol-pop:
     - match: $
       pop: 1
 
-  unquoted-eoc-pop:
-    - include: quoted-eoc-pop
-    - include: line-continuations
-
   unquoted-eol-pop:
     - include: quoted-eol-pop
+    - include: line-continuations
+
+  unquoted-var-pop:
+    - match: (?=\s*{{redirection_or_eoc}})
+      pop: 1
     - include: line-continuations

--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -770,10 +770,8 @@ contexts:
       push: cmd-rem-body
 
   cmd-rem-body:
+    - meta_include_prototype: false
     - include: unquoted-eol-pop
-    - match: \^\n
-      scope: punctuation.separator.continuation.line.dosbatch
-      set: cmd-rem-comment-body
     - match: (?=\S)
       set: cmd-rem-comment-body
 

--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -25,7 +25,7 @@ variables:
   # A character that, when unquoted, separates words. A metacharacter is a
   # space, tab, newline, or one of the following characters:
   # ‘|’, ‘&’, ‘,’, ‘;’, ‘<’, or ‘>’.
-  metachar: '[\s=,;{{command_terminator_chars}}]'
+  metachar: '[\s=,;{{redirection_or_eoc}}]'
 
   # Keywords
   keyword_break: (?![^{{metachar}}(.:\\/])
@@ -42,29 +42,31 @@ variables:
   arg_break: (?!{{arg_char}})
   arg_char: '[^{{metachar}}:]'
 
-  command_terminator_chars: '[|&<>]'
-  command_terminators: (?:$|(?=\s*[{{command_terminator_chars}}]))
+  # Command statement terminators and redirections
+  redirection_or_eoc: '[<>{{eoc_char}}]'
+  eoc: (?=\s*{{eoc_char}})
+  eoc_char: '[\n|&]'
 
   label_comment: ':[^{{label_start}}]'
   label_name: '{{label_start}}{{label_char}}*'
-  label_start: '[^\s+=,;:%!{{command_terminator_chars}}]'
+  label_start: '[^{{metachar}}:%!+]'
   label_char: '[^{{metachar}}(%!]'
 
-  path_terminator_chars: '[\s,;"{{command_terminator_chars}}]'
+  path_terminator_chars: '[\s,;"{{redirection_or_eoc}}]'
   path_terminators: (?={{path_terminator_chars}})
 
   set_arithmetic_operators_unquoted: (?:\+|-|\*|/|%%|~)
   set_arithmetic_operators_quoted: (?:\||<<|>>|&|\^)
-  set_quoted_end: \"(?![^"{{command_terminator_chars}}]*\")
+  set_quoted_end: \"(?![^"{{redirection_or_eoc}}]*\")
 
   expansion_begin: |-
     (?x:
       %
       (?=
         # anything but no colon, percentage or command terminator char
-        ( [^:%{{command_terminator_chars}}]
+        ( [^:%{{redirection_or_eoc}}]
         # otherwise must not look like followed by a command
-        | [{{command_terminator_chars}}](?!\s*\w+[\s{{command_terminator_chars}}])
+        | [{{redirection_or_eoc}}](?!\s*\w+[\s{{redirection_or_eoc}}])
         )+
         # don't check substrings and substitutions
         (:~?[^%]*)? %
@@ -76,9 +78,9 @@ variables:
       !
       (?=
         # anything but no colon, exclamation mark or command terminator char
-        ( [^:!{{command_terminator_chars}}]
+        ( [^:!{{redirection_or_eoc}}]
         # otherwise must not look like followed by a command
-        | [{{command_terminator_chars}}](?!\s*\w+[\s{{command_terminator_chars}}])
+        | [{{redirection_or_eoc}}](?!\s*\w+[\s{{redirection_or_eoc}}])
         )+
         # don't check substrings and substitutions
         (:~?[^!]*)? !
@@ -92,7 +94,7 @@ variables:
   var_break: (?![^%{{metachar}}])
   var_char:  (?:{{var_literal}}|{{var_escape}})
   var_escape: \^[^=\s]
-  var_literal: '[^="\^\s{{command_terminator_chars}}]'
+  var_literal: '[^=\s"^{{redirection_or_eoc}}]'
 
   builtin_commands: |-
     \b(?xi:
@@ -159,12 +161,14 @@ contexts:
       pop: 1
 
   ignored-tail-outer:
+    - include: redirections
     - include: unquoted-eoc-pop
     - match: (?=\S)
       set: ignored-tail-body
 
   ignored-tail-body:
     - meta_scope: comment.line.ignored.dosbatch
+    - include: redirection-interpolations
     - include: unquoted-eoc-pop
 
 ###[ LABELS ]#################################################################
@@ -191,14 +195,14 @@ contexts:
       scope: meta.embedded.dosbatch punctuation.section.embedded.begin.dosbatch
       embed: commands
       embed_scope: meta.embedded.dosbatch source.dosbatch.embedded
-      escape: \'(?=\s*($|['{{command_terminator_chars}}]))
+      escape: \'(?=\s*['{{redirection_or_eoc}}])
       escape_captures:
         0: meta.embedded.dosbatch punctuation.section.embedded.end.dosbatch
     - match: \`
       scope: meta.embedded.dosbatch punctuation.section.embedded.begin.dosbatch
       embed: commands
       embed_scope: meta.embedded.dosbatch source.dosbatch.embedded
-      escape: \`(?=\s*($|[`{{command_terminator_chars}}]))
+      escape: \`(?=\s*[`{{redirection_or_eoc}}])
       escape_captures:
         0: meta.embedded.dosbatch punctuation.section.embedded.end.dosbatch
 
@@ -473,7 +477,7 @@ contexts:
       set:
         - cmd-args-meta
         - cmd-args-common
-    - include: variable-interpolations
+    - include: unquoted-escapes-and-interpolations
 
 ###[ CONTROL EXIT ]###########################################################
 
@@ -599,8 +603,8 @@ contexts:
       push:
         - cmd-other-identifier-quoted-common
         - path-pattern-relative
+    - include: path-pattern-unquoted-content
     - include: line-continuations
-    - include: path-pattern-common
 
   cmd-other-identifier-quoted-common:
     - clear_scopes: 1
@@ -615,9 +619,9 @@ contexts:
 
   cmd-args-common:
     - include: redirections
+    - include: unquoted-eoc-pop
     - include: cmd-args-options
     - include: cmd-args-values
-    - include: unquoted-eoc-pop
 
   cmd-args-options:
     - match: (?:^|\s*)((/)\?){{arg_break}}
@@ -644,8 +648,8 @@ contexts:
     - match: \"
       scope: punctuation.definition.string.begin.dosbatch
       push: cmd-args-option-identifier-quoted-common
+    - include: unquoted-escapes-and-interpolations
     - include: line-continuations
-    - include: variable-interpolations
     - match: '{{arg_break}}'
       pop: 1
 
@@ -673,9 +677,9 @@ contexts:
     - meta_scope: meta.string.dosbatch string.unquoted.dosbatch
     - match: (?=(\.\.?|\:)[\\%{{metachar}}]|[?*]|\\(?!"))
       fail: cmd-args-values
-    - include: cmd-args-quoted
-    - include: escapes-and-interpolations
+    - include: unquoted-escapes-and-interpolations
     - include: line-continuations
+    - include: cmd-args-quoted
     - match: '{{arg_break}}'
       pop: 1
 
@@ -692,9 +696,7 @@ contexts:
       pop: 1
     - match: $
       pop: 2
-    - match: '%%'
-      scope: constant.character.escape.dosbatch
-    - include: variable-interpolations
+    - include: quoted-escapes-and-interpolations
 
   cmd-arg-illegal-options:
     - match: /{{arg_char}}+
@@ -719,7 +721,7 @@ contexts:
         1: variable.parameter.option.help.dosbatch
         2: punctuation.definition.variable.dosbatch
       push: ignored-tail-outer
-    - match: \s*((?i:on|off)){{command_terminators}}
+    - match: \s*((?i:on|off)){{eoc}}
       captures:
         1: constant.language.dosbatch
       push: ignored-tail-outer
@@ -733,7 +735,7 @@ contexts:
     - meta_scope: meta.command.echo.dosbatch meta.function-call.arguments.dosbatch
     - meta_content_scope: meta.string.dosbatch string.unquoted.dosbatch
     - include: cmd-args-quoted
-    - include: escapes-and-interpolations
+    - include: unquoted-escapes-and-interpolations
     - include: unquoted-eoc-pop
 
 ###[ COMMAND MODE ]###########################################################
@@ -748,6 +750,8 @@ contexts:
   cmd-mode-args:
     - meta_scope: meta.command.mode.dosbatch
     - meta_content_scope: meta.function-call.arguments.dosbatch
+    - include: redirections
+    - include: unquoted-eoc-pop
     - match: (?i:COM\d+|CON|LPT\d+):?{{arg_break}}
       scope: variable.language.device.dosbatch
     # known option values
@@ -763,7 +767,6 @@ contexts:
       scope: keyword.operator.assignment.dosbatch
     - include: cmd-args-options
     - include: cmd-args-values
-    - include: unquoted-eoc-pop
 
 ###[ COMMAND REM ]############################################################
 
@@ -782,6 +785,7 @@ contexts:
       set: cmd-rem-comment-body
 
   cmd-rem-comment-body:
+    - meta_include_prototype: false
     - meta_scope: meta.command.rem.dosbatch
     # meta_content_scope is used since rem should not be
     # highlighted as a comment, but a command
@@ -806,6 +810,7 @@ contexts:
     - include: immediately-pop
 
   cmd-set-type:
+    - include: redirections
     - include: unquoted-eoc-pop
     - include: cmd-set-arithmetic
     - include: cmd-set-prompt
@@ -886,7 +891,7 @@ contexts:
     - match: \"
       scope: meta.string.dosbatch string.unquoted.dosbatch
       set: cmd-set-quoted-value-outer
-    - include: escapes-and-interpolations
+    - include: quoted-escapes-and-interpolations
     - include: quoted-eol-pop
 
   cmd-set-quoted-value-inner-continue:
@@ -898,9 +903,9 @@ contexts:
     - meta_include_prototype: false
     - match: '{{set_quoted_end}}'
       pop: 1
-    - match: '{{command_terminators}}'
+    - match: '{{eoc}}'
       fail: cmd-set-quoted-value-inner
-    - include: escapes-and-interpolations
+    - include: quoted-escapes-and-interpolations
     - include: line-continuations
 
   cmd-set-quoted-value-inner-end:
@@ -922,7 +927,7 @@ contexts:
     - match: \"
       scope: meta.string.dosbatch string.unquoted.dosbatch
       set: cmd-set-quoted-value-inner
-    - include: escapes-and-interpolations
+    - include: unquoted-escapes-and-interpolations
     - include: unquoted-eoc-pop
 
 ###[ COMMAND SET VARIABLE=VALUE ]##############################################
@@ -964,7 +969,7 @@ contexts:
     - match: \"
       scope: meta.string.dosbatch string.unquoted.dosbatch
       set: cmd-set-unquoted-value-outer
-    - include: escapes-and-interpolations
+    - include: quoted-escapes-and-interpolations
     - include: quoted-eol-pop
 
   cmd-set-unquoted-value-outer:
@@ -973,7 +978,7 @@ contexts:
     - match: \"
       scope: meta.string.dosbatch string.unquoted.dosbatch
       set: cmd-set-unquoted-value-inner
-    - include: escapes-and-interpolations
+    - include: unquoted-escapes-and-interpolations
     - include: unquoted-eoc-pop
 
 ###[ COMMAND SET /A ]#########################################################
@@ -1132,12 +1137,11 @@ contexts:
     - include: cmd-set-unquoted-prompt
 
   cmd-set-prompt-value-inner-common:
-    - include: escapes-and-interpolations
+    - include: quoted-escapes-and-interpolations
     - include: quoted-eol-pop
 
   cmd-set-prompt-value-outer-common:
-    - include: redirection-interpolations
-    - include: escapes-and-interpolations
+    - include: unquoted-escapes-and-interpolations
     - include: unquoted-eoc-pop
 
 ###[ COMMAND SET /P "VARIABLE=PROMPT" ]#######################################
@@ -1239,9 +1243,9 @@ contexts:
     - meta_include_prototype: false
     - match: '{{set_quoted_end}}'
       pop: 1
-    - match: '{{command_terminators}}'
+    - match: '{{eoc}}'
       fail: cmd-set-quoted-prompt-quoted-value-inner
-    - include: escapes-and-interpolations
+    - include: quoted-escapes-and-interpolations
     - include: line-continuations
 
   cmd-set-quoted-prompt-quoted-value-inner-end:
@@ -1292,9 +1296,9 @@ contexts:
     - meta_include_prototype: false
     - match: '{{set_quoted_end}}'
       pop: 1
-    - match: '{{command_terminators}}'
+    - match: '{{eoc}}'
       fail: cmd-set-quoted-prompt-unquoted-value-inner
-    - include: escapes-and-interpolations
+    - include: quoted-escapes-and-interpolations
     - include: line-continuations
 
   cmd-set-quoted-prompt-unquoted-value-inner-end:
@@ -1399,9 +1403,9 @@ contexts:
       scope: punctuation.definition.string.end.dosbatch
       pop: 2
       set: ignored-tail-inner
-    - match: '{{command_terminators}}'
+    - match: '{{eoc}}'
       fail: cmd-set-unquoted-prompt-inner
-    - include: escapes-and-interpolations
+    - include: quoted-escapes-and-interpolations
     - include: line-continuations
 
   cmd-set-unquoted-prompt-quoted-value-inner-end:
@@ -1491,7 +1495,7 @@ contexts:
       scope: punctuation.separator.semicolon.dosbatch
 
   invalid-operators:
-    - match: '[{{command_terminator_chars}}]'
+    - match: '{{redirection_or_eoc}}'
       scope: invalid.illegal.operator.dosbatch
 
 ###[ CONSTANTS ]##############################################################
@@ -1540,38 +1544,28 @@ contexts:
 ###[ PATH PATTERNS ]##########################################################
 
   redirection-interpolations:
-    - match: \s*(?=\d?(?:<&?|>[&>]?))
-      push: redirection-interpolations-body
-
-  redirection-interpolations-body:
-    - meta_include_prototype: false
-    - match: (\d)?(<&?|>[&>]?)
+    - match: (\b\d)?(<&?|>[&>]?)
       captures:
         1: meta.number.integer.decimal.dosbatch
            constant.numeric.value.dosbatch
         2: keyword.operator.assignment.redirection.dosbatch
-      set:
-        - redirection-interpolations-meta
+      push:
+        - redirection-interpolation-meta
         - redirection-path
 
-  redirection-interpolations-meta:
+  redirection-interpolation-meta:
     - clear_scopes: 1
     - meta_include_prototype: false
-    - meta_scope: meta.interpolation.dosbatch meta.redirection.dosbatch
+    - meta_scope: meta.redirection.dosbatch
     - include: immediately-pop
 
   redirections:
-    - match: (?=\d?(?:<&?|>[&>]?))
-      push: redirection-body
-
-  redirection-body:
-    - meta_include_prototype: false
-    - match: (\d)?(<&?|>[&>]?)
+    - match: (\b\d)?(<&?|>[&>]?)
       captures:
         1: meta.number.integer.decimal.dosbatch
            constant.numeric.value.dosbatch
         2: keyword.operator.assignment.redirection.dosbatch
-      set:
+      push:
         - redirection-meta
         - redirection-path
 
@@ -1600,16 +1594,23 @@ contexts:
       set:
         - path-pattern-unquoted-body
         - path-pattern-relative
-    - include: any-pop
 
   path-pattern-quoted-body:
     - meta_scope: meta.path.dosbatch meta.string.dosbatch string.quoted.double.dosbatch
     - include: string-end
+    - include: path-pattern-quoted-content
+
+  path-pattern-quoted-content:
+    - include: quoted-escapes-and-interpolations
     - include: path-pattern-common
 
   path-pattern-unquoted-body:
     - meta_scope: meta.path.dosbatch meta.string.dosbatch string.unquoted.dosbatch
     - include: path-pattern-unquoted-end
+    - include: path-pattern-unquoted-content
+
+  path-pattern-unquoted-content:
+    - include: unquoted-escapes-and-interpolations
     - include: path-pattern-common
 
   path-pattern-unquoted-end:
@@ -1618,7 +1619,6 @@ contexts:
     - include: line-continuations
 
   path-pattern-common:
-    - include: escapes-and-interpolations
     - match: '[:\\/]'
       scope: punctuation.separator.path.dosbatch
       push: path-pattern-relative
@@ -1649,7 +1649,7 @@ contexts:
     - meta_include_prototype: false
     - meta_scope: meta.string.dosbatch string.quoted.double.dosbatch
     - include: string-end
-    - include: escapes-and-interpolations
+    - include: quoted-escapes-and-interpolations
 
   string-end:
     - match: \"
@@ -1658,17 +1658,22 @@ contexts:
     - include: quoted-eol-pop
 
   escaped-characters:
-    - match: '%%|\^.'
+    - match: \^.
+      scope: constant.character.escape.dosbatch
+
+  escaped-variables:
+    - match: '%%'
       scope: constant.character.escape.dosbatch
 
 ###[ INTERPOLATIONS ]#########################################################
 
-  escapes-and-interpolations:
+  unquoted-escapes-and-interpolations:
     - include: escaped-characters
-    - include: variable-interpolations
+    - include: redirection-interpolations
+    - include: quoted-escapes-and-interpolations
 
-  # NOTE: To be used in strings to remove `string` scope.
-  variable-interpolations:
+  quoted-escapes-and-interpolations:
+    - include: escaped-variables
     - include: parameter-interpolations
     - include: expansion-interpolations
     - include: delayed-interpolations
@@ -1708,6 +1713,7 @@ contexts:
 ###[ VARIABLES ]##############################################################
 
   variables:
+    - include: escaped-variables
     - include: variable-parameters
     - include: variable-expansions
     - include: variable-delayed
@@ -1850,7 +1856,7 @@ contexts:
         1: keyword.operator.arithmetic.dosbatch
         2: constant.numeric.value.dosbatch
     # Note: This makes the whole expansion being handled as plain text.
-    - match: ':[^%!{{command_terminator_chars}}]*'
+    - match: ':[^%!{{redirection_or_eoc}}]*'
       scope: invalid.illegal.unexpected.dosbatch
 
 ###[ ILLEGALS ]###############################################################
@@ -1874,10 +1880,6 @@ contexts:
 
 ###[ PROTOTYPES ]#############################################################
 
-  any-pop:
-    - match: (?=\S)
-      pop: 1
-
   bol-pop:
     # Note: empty lines are ignored
     - match: ^(?!$)
@@ -1885,7 +1887,8 @@ contexts:
 
   else-pop:
     - include: unquoted-eol-pop
-    - include: any-pop
+    - match: (?=\S)
+      pop: 1
 
   immediately-pop:
     - match: ''
@@ -1897,7 +1900,7 @@ contexts:
       push: bol-pop
 
   quoted-eoc-pop:
-    - match: '{{command_terminators}}'
+    - match: '{{eoc}}'
       pop: 1
 
   quoted-eol-pop:

--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -37,7 +37,7 @@ variables:
   cmd_char: '[^{{metachar}}(]'
 
   # Command arguments are identifiers, which may start with interpolation.
-  opt_punctuation: (--?|//?){{arg_begin}}
+  opt_punctuation: (?:--?|//?){{arg_begin}}
   arg_begin: (?={{arg_char}})
   arg_break: (?!{{arg_char}})
   arg_char: '[^{{metachar}}:]'
@@ -400,7 +400,7 @@ contexts:
       captures:
         1: punctuation.definition.variable.dosbatch
       push: ctl-for-maybe-r-args
-    - match: (?i:/\S+){{arg_break}}
+    - match: /{{arg_char}}+
       scope: invalid.illegal.parameter.dosbatch
       pop: 1
     - include: else-pop
@@ -648,10 +648,10 @@ contexts:
         1: punctuation.definition.variable.dosbatch
       push: ignored-tail-outer
     - match: '{{opt_punctuation}}'
-      captures:
-        1: meta.parameter.option.dosbatch
-           variable.parameter.option.dosbatch
-           punctuation.definition.variable.dosbatch
+      scope:
+        meta.parameter.option.dosbatch
+        variable.parameter.option.dosbatch
+        punctuation.definition.variable.dosbatch
       push: cmd-args-option-identifier
 
   cmd-args-option-identifier:

--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -177,6 +177,8 @@ contexts:
     - meta_scope: comment.line.ignored.dosbatch
     - include: redirection-interpolations
     - include: eoc-pop
+    - match: '{{unquoted_word_begin}}'
+      push: unquoted-word-end
 
 ###[ LABELS ]#################################################################
 
@@ -1677,10 +1679,13 @@ contexts:
       push: unquoted-word-body
 
   unquoted-word-body:
+    - include: unquoted-word-end
+    - include: unquoted-escapes-and-interpolations
+
+  unquoted-word-end:
     - match: '{{unquoted_word_break}}'
       pop: 1
     - include: line-continuations
-    - include: unquoted-escapes-and-interpolations
 
 ###[ INTERPOLATIONS ]#########################################################
 

--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -1679,7 +1679,7 @@ contexts:
     - match: \.
       scope: punctuation.separator.path.dosbatch
     - match: '[*?]'
-      scope: constant.other.placeholder.dosbatch
+      scope: keyword.operator.wildcard.dosbatch
 
   path-pattern-relative:
     - match: \.\.(?=[\\/])

--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -487,9 +487,7 @@ contexts:
   ctl-call-label:
     - meta_scope: meta.function-call.identifier.dosbatch variable.label.dosbatch
     - match: '{{word_break}}'
-      set:
-        - cmd-args-meta
-        - cmd-args-common
+      set: cmd-args-body
     - include: line-continuations
     - include: escaped-characters
     - include: variables
@@ -595,9 +593,7 @@ contexts:
       scope:
         meta.function-call.identifier.dosbatch
         support.function.builtin.dosbatch
-      push:
-        - cmd-args-meta
-        - cmd-args-common
+      push: cmd-args-body
 
   cmd-other:
     - match: '{{cmd_begin}}'
@@ -610,9 +606,7 @@ contexts:
         meta.function-call.identifier.dosbatch
         variable.function.dosbatch
     - match: '{{cmd_break}}'
-      set:
-        - cmd-args-meta
-        - cmd-args-common
+      set: cmd-args-body
     - match: \"
       scope: punctuation.definition.string.begin.dosbatch
       push:
@@ -627,12 +621,8 @@ contexts:
     - meta_scope: meta.string.dosbatch variable.function.dosbatch
     - include: path-pattern-quoted-body
 
-  cmd-args-meta:
-    - meta_include_prototype: false
+  cmd-args-body:
     - meta_content_scope: meta.function-call.arguments.dosbatch
-    - include: immediately-pop
-
-  cmd-args-common:
     - include: redirections
     - include: eoc-pop
     - include: cmd-args-options

--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -37,7 +37,7 @@ variables:
   cmd_char: '[^{{metachar}}(]'
 
   # Command arguments are identifiers, which may start with interpolation.
-  opt_punctuation: (?:\s+|^)(--?|//?){{arg_begin}}
+  opt_punctuation: (--?|//?){{arg_begin}}
   arg_begin: (?={{arg_char}})
   arg_break: (?!{{arg_char}})
   arg_char: '[^{{metachar}}:]'
@@ -629,10 +629,23 @@ contexts:
     - include: cmd-args-values
 
   cmd-args-options:
-    - match: (?:^|\s*)((/)\?){{arg_break}}
+    # The shell basically just passes words to a called command.
+    # The command is responsible to parse and interpret each word.
+    #
+    # A word may be
+    # - an option `/b` or `-b`
+    # - a value `foo`
+    # - a key-value pair `/key:value` or `--key=value`
+    #
+    # Interpretation includes whether quotation marks
+    # are treated literal or whether they are removed.
+    #
+    # This context applies various heuristics to try to highlight
+    # different kinds of command line arguments and their values.
+    - match: (/)\?{{arg_break}}
+      scope: variable.parameter.option.help.dosbatch
       captures:
-        1: variable.parameter.option.help.dosbatch
-        2: punctuation.definition.variable.dosbatch
+        1: punctuation.definition.variable.dosbatch
       push: ignored-tail-outer
     - match: '{{opt_punctuation}}'
       captures:
@@ -650,19 +663,9 @@ contexts:
         meta.parameter.dosbatch
         keyword.operator.assignment.dosbatch
       set: cmd-args-option-value
-    - match: \"
-      scope: punctuation.definition.string.begin.dosbatch
-      push: cmd-args-option-identifier-quoted-common
+    - include: quoted-words
     - include: unquoted-escapes-and-interpolations
-    - include: line-continuations
-    - match: '{{arg_break}}'
-      pop: 1
-
-  cmd-args-option-identifier-quoted-common:
-    - clear_scopes: 1
-    - meta_include_prototype: false
-    - meta_scope: meta.string.dosbatch variable.parameter.option.dosbatch
-    - include: string-common
+    - include: unquoted-word-end
 
   cmd-args-option-value:
     - meta_content_scope: meta.parameter.value.dosbatch

--- a/Batch File/Indexed Reference List.tmPreferences
+++ b/Batch File/Indexed Reference List.tmPreferences
@@ -2,12 +2,10 @@
 <plist version="1.0">
 <dict>
 	<key>scope</key>
-	<string>source.dosbatch entity.name.label - source.dosbatch entity.name.label punctuation.definition.label</string>
+	<string>source.dosbatch variable.label - source.dosbatch variable.label punctuation.definition.label</string>
 	<key>settings</key>
 	<dict>
-		<key>showInSymbolList</key>
-		<integer>1</integer>
-		<key>showInIndexedSymbolList</key>
+		<key>showInIndexedReferenceList</key>
 		<integer>1</integer>
 		<key>symbolTransformation</key>
 		<string>s/\^//;</string>

--- a/Batch File/tests/syntax_test_batch_file.bat
+++ b/Batch File/tests/syntax_test_batch_file.bat
@@ -471,14 +471,16 @@ ECHO : Not a comment ^
 :::: [ Conditionals ] :::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
    IF foo EQU bar echo "equal"
-:: ^^  keyword.control.conditional.if.dosbatch
+:: ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.dosbatch
+:: ^^ keyword.control.conditional.if.dosbatch
 ::    ^^^ string.unquoted.dosbatch
 ::        ^^^ keyword.operator.comparison.dosbatch
 ::            ^^^ string.unquoted.dosbatch
 ::                ^^^^ support.function.builtin.dosbatch
 
    IF NOT foo EQU bar echo "equal"
-:: ^^  keyword.control.conditional.if.dosbatch
+:: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.dosbatch
+:: ^^ keyword.control.conditional.if.dosbatch
 ::    ^^^ keyword.operator.logical.dosbatch
 ::        ^^^ string.unquoted.dosbatch
 ::            ^^^ keyword.operator.comparison.dosbatch
@@ -486,6 +488,7 @@ ECHO : Not a comment ^
 ::                    ^^^^ support.function.builtin.dosbatch
 
    IF NEQ == NEQ echo "equal"
+:: ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.dosbatch
 :: ^^ keyword.control.conditional.if.dosbatch
 ::    ^^^ string.unquoted.dosbatch
 ::        ^^ keyword.operator.comparison.dosbatch
@@ -493,6 +496,7 @@ ECHO : Not a comment ^
 ::               ^^^^ support.function.builtin.dosbatch
 
    IF NEQ NEQ NEQ echo "equal"
+:: ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.dosbatch
 :: ^^ keyword.control.conditional.if.dosbatch
 ::    ^^^ string.unquoted.dosbatch
 ::        ^^^ keyword.operator.comparison.dosbatch
@@ -500,6 +504,7 @@ ECHO : Not a comment ^
 ::                ^^^^ support.function.builtin.dosbatch
 
    IF foo == bar echo "equal"
+:: ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.dosbatch
 :: ^^ keyword.control.conditional.if.dosbatch
 ::    ^^^ string.unquoted.dosbatch
 ::        ^^ keyword.operator.comparison.dosbatch
@@ -507,6 +512,7 @@ ECHO : Not a comment ^
 ::               ^^^^ support.function.builtin.dosbatch
 
    IF foo==bar echo "equal"
+:: ^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.dosbatch
 :: ^^ keyword.control.conditional.if.dosbatch
 ::    ^^^ string.unquoted.dosbatch
 ::       ^^ keyword.operator.comparison.dosbatch
@@ -514,6 +520,7 @@ ECHO : Not a comment ^
 ::             ^^^^ support.function.builtin.dosbatch
 
    IF %foo%=="bar" echo "equal"
+:: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.dosbatch
 :: ^^ keyword.control.conditional.if.dosbatch
 ::    ^^^^^ meta.interpolation.dosbatch
 ::         ^^ keyword.operator.comparison.dosbatch
@@ -523,6 +530,7 @@ ECHO : Not a comment ^
 ::                 ^^^^ support.function.builtin.dosbatch
 
    IF (2) GEQ (15) echo "bigger"
+:: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.dosbatch
 :: ^^ keyword.control.conditional.if.dosbatch
 ::    ^^^ meta.group.dosbatch
 ::    ^ punctuation.section.group.begin.dosbatch
@@ -537,6 +545,7 @@ ECHO : Not a comment ^
 ::                      ^^^^^^^^ string.unquoted.dosbatch
 
    IF "2" GEQ "15" echo "bigger"
+:: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.dosbatch
 :: ^^ keyword.control.conditional.if.dosbatch
 ::    ^^^ string.unquoted.dosbatch
 ::        ^^^ keyword.operator.comparison.dosbatch
@@ -544,7 +553,41 @@ ECHO : Not a comment ^
 ::                 ^^^^ support.function.builtin.dosbatch
 ::                      ^^^^^^^^ string.unquoted.dosbatch
 
+   IF ^
+   "2" GEQ "15" echo "bigger"
+:: ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.dosbatch
+:: ^^^ meta.string.dosbatch string.unquoted.dosbatch
+::     ^^^ keyword.operator.comparison.dosbatch
+::         ^^^^ meta.string.dosbatch string.unquoted.dosbatch
+::              ^^^^^^^^^^^^^ meta.command.echo.dosbatch
+
+   IF ^
+   "2" ^
+   GEQ "15" echo "bigger"
+:: ^^^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.dosbatch
+:: ^^^ keyword.operator.comparison.dosbatch
+::     ^^^^ meta.string.dosbatch string.unquoted.dosbatch
+::          ^^^^^^^^^^^^^ meta.command.echo.dosbatch
+
+   IF ^
+   "2" ^
+   GEQ ^
+   "15" echo "bigger"
+:: ^^^^^^^^^^^^^^^^^^ meta.statement.conditional.dosbatch
+:: ^^^^ meta.string.dosbatch string.unquoted.dosbatch
+::      ^^^^^^^^^^^^^ meta.command.echo.dosbatch
+
+   IF ^
+   "2" ^
+   GEQ ^
+   "15" ^
+   echo "bigger"
+:: ^^^^^^^^^^^^^ meta.statement.conditional.dosbatch meta.command.echo.dosbatch
+:: ^^^^ support.function.builtin.dosbatch
+::      ^^^^^^^^ meta.string.dosbatch string.unquoted.dosbatch
+
    IF errorlevel 0 echo "ok"
+:: ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.dosbatch
 :: ^^ keyword.control.conditional.if.dosbatch
 ::    ^^^^^^^^^^ variable.language.dosbatch
 ::               ^ meta.number.integer.decimal.dosbatch constant.numeric.value.dosbatch
@@ -552,6 +595,7 @@ ECHO : Not a comment ^
 ::                      ^^^^ string.unquoted.dosbatch
 
    IF errorlevel==0 echo "ok"
+:: ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.dosbatch
 :: ^^ keyword.control.conditional.if.dosbatch
 ::    ^^^^^^^^^^ variable.language.dosbatch
 ::              ^^ keyword.operator.comparison.dosbatch
@@ -560,6 +604,7 @@ ECHO : Not a comment ^
 ::                       ^^^^ string.unquoted.dosbatch
 
    IF not errorlevel == 0 echo "error"
+:: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.dosbatch
 :: ^^ keyword.control.conditional.if.dosbatch
 ::    ^^^ keyword.operator.logical.dosbatch
 ::        ^^^^^^^^^^ variable.language.dosbatch
@@ -569,6 +614,7 @@ ECHO : Not a comment ^
 ::                             ^^^^^^^ string.unquoted.dosbatch
 
    IF errorlevel NEQ 0 echo "ok"
+:: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.dosbatch
 :: ^^ keyword.control.conditional.if.dosbatch
 ::    ^^^^^^^^^^ variable.language.dosbatch
 ::               ^^^ invalid.illegal.unexpected.dosbatch
@@ -577,6 +623,7 @@ ECHO : Not a comment ^
 ::                          ^^^^ string.unquoted.dosbatch
 
    IF %ERRORLEVEL% NEQ 0 EXIT /B 1
+:: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.dosbatch
 :: ^^ keyword.control.conditional.if.dosbatch
 ::    ^^^^^^^^^^^^ meta.interpolation.dosbatch
 ::    ^ punctuation.section.interpolation.begin.dosbatch - variable
@@ -584,15 +631,17 @@ ECHO : Not a comment ^
 ::               ^ punctuation.section.interpolation.end.dosbatch - variable
 
    IF EXIST "C:\file.log"
+:: ^^^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.dosbatch
 :: ^^ keyword.control.conditional.if.dosbatch
 ::    ^^^^^ support.function.builtin.dosbatch
 ::          ^^^^^^^^^^^^^ string.quoted.double.dosbatch
 
    IF NOT EXIST "C:\file.log"
+:: ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.dosbatch
 :: ^^ keyword.control.conditional.if.dosbatch
 ::    ^^^ keyword.operator.logical.dosbatch
 ::        ^^^^^ support.function.builtin.dosbatch
-::              ^^^^^^^^^^^^^ string.quoted.double.dosbatch
+::              ^^^^^^^^^^^^^ meta.path.dosbatch meta.string.dosbatch string.quoted.double.dosbatch
 
    IF^
 :: ^^ - keyword.control.conditional
@@ -600,30 +649,34 @@ ECHO : Not a comment ^
 
    IF ^
    NOT EXIST "C:\file.log"
+:: ^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.dosbatch
 :: ^^^ keyword.operator.logical.dosbatch
 ::     ^^^^^ support.function.builtin.dosbatch
-::           ^^^^^^^^^^^^^ string.quoted.double.dosbatch
+::           ^^^^^^^^^^^^^ meta.path.dosbatch meta.string.dosbatch string.quoted.double.dosbatch
 
    IF ^
    NOT ^
    EXIST "C:\file.log"
+:: ^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.dosbatch
 :: ^^^^^ support.function.builtin.dosbatch
-::       ^^^^^^^^^^^^^ string.quoted.double.dosbatch
+::       ^^^^^^^^^^^^^ meta.path.dosbatch meta.string.dosbatch string.quoted.double.dosbatch
 
    IF ^
    NOT ^
    EXIST ^
    "C:\file.log"
-:: ^^^^^^^^^^^^^ string.quoted.double.dosbatch
+:: ^^^^^^^^^^^^^ meta.statement.conditional.dosbatch meta.path.dosbatch meta.string.dosbatch string.quoted.double.dosbatch
 
 :: See http://ss64.com/nt/syntax-brackets.html
    IF EXIST file.txt ECHO Some(more)Potatoes
+:: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.dosbatch
 :: ^^ keyword.control.conditional.if
 ::    ^^^^^ support.function.builtin.dosbatch
 ::                   ^^^^ support.function.builtin.dosbatch
 ::                        ^^^^^^^^^^^^^^^^^^ string.unquoted.dosbatch - meta.block - meta.group
 
    IF EXIST file.txt (ECHO Some(more)Potatoes)
+:: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.dosbatch
 :: ^^ keyword.control.conditional.if
 ::    ^^^^^ support.function.builtin.dosbatch
 ::                   ^^^^^^^^^^^^^^^^ meta.block.dosbatch
@@ -634,6 +687,7 @@ ECHO : Not a comment ^
 ::                                   ^^^^^^^^^ invalid.illegal.expect-end-of-command.dosbatch
 
    IF EXIST file.txt (ECHO Some[more]Potatoes)
+:: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.dosbatch
 :: ^^ keyword.control.conditional.if
 ::    ^^^^^ support.function.builtin.dosbatch
 ::                   ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.dosbatch
@@ -644,6 +698,7 @@ ECHO : Not a comment ^
 ::                                           ^ punctuation.section.block.end.dosbatch
 
    IF EXIST file.txt (ECHO Some^(more^)Potatoes)
+:: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.dosbatch
 :: ^^ keyword.control.conditional.if
 ::    ^^^^^ support.function.builtin.dosbatch
 ::                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.dosbatch
@@ -656,6 +711,7 @@ ECHO : Not a comment ^
 ::                                             ^ punctuation.section.block.end.dosbatch
 
    IF foo GTR (2) (ECHO bar) ELSE (ECHO baz)
+:: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.dosbatch
 :: ^^ keyword.control.conditional.if.dosbatch
 ::    ^^^ string.unquoted.dosbatch
 ::        ^^^ keyword.operator.comparison.dosbatch
@@ -674,6 +730,7 @@ ECHO : Not a comment ^
 ::                                         ^ punctuation.section.block.end.dosbatch
 
    IF foo GTR (2) (
+:: ^^^^^^^^^^^^^^^^^ meta.statement.conditional.dosbatch
 :: ^^ keyword.control.conditional.if.dosbatch
 ::    ^^^ string.unquoted.dosbatch
 ::        ^^^ keyword.operator.comparison.dosbatch
@@ -694,6 +751,7 @@ ECHO : Not a comment ^
 ::                        ^^^ string.unquoted.dosbatch
 ::                            ^ punctuation.section.block.end.dosbatch
    ) ELSE (
+::^^^^^^^^^^ meta.statement.conditional.dosbatch
 ::^^ meta.block.dosbatch
 ::  ^^^^^^ - meta.block
 ::        ^^ meta.block.dosbatch
@@ -713,11 +771,12 @@ ECHO : Not a comment ^
 ::                         ^^^ string.unquoted.dosbatch
 ::                             ^ punctuation.section.block.end.dosbatch
    )
-::^^ meta.block.dosbatch
-::  ^ - meta.block
+::^^ meta.statement.conditional.dosbatch meta.block.dosbatch
+::  ^ - meta.statement - meta.block
 :: ^ punctuation.section.block.end.dosbatch
 
    ) ELSE echo baz
+:: ^^^^^^^^^^^^^^^ - meta.statement.conditional
 :: ^ invalid.illegal.stray.dosbatch
 ::  ^ - invalid
 ::   ^^^^ invalid.illegal.stray.dosbatch
@@ -725,12 +784,14 @@ ECHO : Not a comment ^
 ::             ^^^ string.unquoted.dosbatch
 
    IF "%FOO%" == "BAR" ( SET BAZ=42 )
+:: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.dosbatch
 ::                     ^ punctuation.section.block.begin.dosbatch
 ::                     ^^^^^^^^^^^^^^ meta.block.dosbatch
 ::                                  ^ punctuation.section.block.end.dosbatch
 ::                               ^^ string.unquoted
 
    if foo == (<file.txt) ( foo >nul )
+:: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.dosbatch
 ::           ^ meta.group.dosbatch - meta.redirection
 ::            ^^^^^^^^^ meta.group.dosbatch meta.redirection.dosbatch
 ::                     ^ meta.group.dosbatch - meta.redirection
@@ -742,6 +803,7 @@ ECHO : Not a comment ^
 
    IF ^
    DEFINED foo (ECHO bar)
+:: ^^^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.dosbatch
 :: ^^^^^^^ support.function.builtin.dosbatch
 ::         ^^^ variable.other.readwrite.dosbatch
 ::             ^^^^^^^^^^ meta.block.dosbatch
@@ -750,6 +812,7 @@ ECHO : Not a comment ^
    IF ^
    DEFINED ^
    foo (ECHO bar)
+:: ^^^^^^^^^^^^^^ meta.statement.conditional.dosbatch
 :: ^^^ variable.other.readwrite.dosbatch
 ::     ^^^^^^^^^^ meta.block.dosbatch
 ::      ^^^^ support.function.builtin.dosbatch
@@ -758,13 +821,13 @@ ECHO : Not a comment ^
    DEFINED ^
    foo ^
    (ECHO bar)
-:: ^^^^^^^^^^ meta.block.dosbatch
+:: ^^^^^^^^^^ meta.statement.conditional.dosbatch meta.block.dosbatch
 ::  ^^^^ support.function.builtin.dosbatch
 
    IF ^
    /i
+:: ^^ meta.statement.conditional.dosbatch variable.parameter.option.dosbatch
 :: ^ punctuation.definition.variable.dosbatch
-:: ^^ variable.parameter.option.dosbatch
 
    IF DEFINED ^& ECHO EXISTS
 ::            ^^ variable.other.readwrite.dosbatch

--- a/Batch File/tests/syntax_test_batch_file.bat
+++ b/Batch File/tests/syntax_test_batch_file.bat
@@ -161,17 +161,25 @@ ECHO : Not a comment ^
 ::                   ^^^^^^^^^^^^^^^^^ meta.block.dosbatch
 
    E@CHO john.doe@email.com
-::  ^ - keyword-operator
-::               ^ - keyword-operator
+::  ^ - keyword.operator
+::               ^ - keyword.operator
+
+   E^@CHO john.doe^@email.com
+::  ^^ constant.character.escape.dosbatch
+::                ^^ constant.character.escape.dosbatch
+
+   "E^@CHO" "john.doe^@email.com"
+::   ^^ - constant.character - keyword.operator
+::                   ^^ - constant.character - keyword.operator
 
    dir @logs
-::     ^ - keyword-operator
+::     ^ - keyword.operator
 
    dir C:\@logs
-::        ^ - keyword-operator
+::        ^ - keyword.operator
 
    my @
-::    ^ - keyword-operator
+::    ^ - keyword.operator
 
 :::: [ Labels ] :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
@@ -187,16 +195,18 @@ ECHO : Not a comment ^
 
 :::: [ Control Flow ] :::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-   CALL:This is a #@$虎 strange label
+   CALL:This is a #@$虎 ^strange %%label
 ::^ - meta.function-call
 :: ^^^^  meta.function-call.dosbatch
 ::     ^^^^^ meta.function-call.identifier.dosbatch
-::          ^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.dosbatch
-::                                  ^ - meta.function-call
+::          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.dosbatch
+::                                     ^ - meta.function-call
 :: ^^^^ keyword.control.flow.call.dosbatch
 ::     ^ punctuation.definition.variable.dosbatch
 ::     ^^^^^ variable.label.dosbatch - keyword
-::          ^^^^^^^^^^^^^^^^^^^^^^^^ - variable
+::          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ - variable
+::                     ^^ constant.character.escape.dosbatch
+::                              ^^ constant.character.escape.dosbatch
 
    CALL:EOF
 ::^ - meta.function-call
@@ -451,6 +461,12 @@ ECHO : Not a comment ^
 ::     ^ meta.command.goto.dosbatch - keyword - meta.interpolation
 ::      ^^^^^ meta.command.goto.dosbatch meta.interpolation.dosbatch
 
+   GOTO <target.txt
+:: ^^^^^ meta.command.goto.dosbatch - meta.redirection
+::      ^^^^^^^^^^^ meta.command.goto.dosbatch meta.redirection.dosbatch
+:: ^^^^ keyword.control.flow.goto.dosbatch
+::      ^ keyword.operator.assignment.redirection.dosbatch
+::       ^^^^^^^^^^ meta.path.dosbatch meta.string.dosbatch string.unquoted.dosbatch
 
 :::: [ Conditionals ] :::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
@@ -713,6 +729,16 @@ ECHO : Not a comment ^
 ::                     ^^^^^^^^^^^^^^ meta.block.dosbatch
 ::                                  ^ punctuation.section.block.end.dosbatch
 ::                               ^^ string.unquoted
+
+   if foo == (<file.txt) ( foo >nul )
+::           ^ meta.group.dosbatch - meta.redirection
+::            ^^^^^^^^^ meta.group.dosbatch meta.redirection.dosbatch
+::                     ^ meta.group.dosbatch - meta.redirection
+::                       ^^^^^^^^^^^^ meta.block.dosbatch
+::                             ^^^^ meta.redirection.dosbatch
+
+   IF <file.txt==""
+::    ^^^^^^^^^^^^^ invalid.illegal.unexpected.dosbatch
 
    IF ^
    DEFINED foo (ECHO bar)
@@ -1408,36 +1434,49 @@ put arg1 arg2
 ::                   ^ keyword.operator.assignment.redirection.dosbatch
 
    ECHO >> NUL
+:: ^^^^^^^^^^^ meta.command.echo.dosbatch
 ::     ^ - meta.redirection
 ::      ^^^^^^ meta.redirection.dosbatch
 ::            ^ - meta.redirection
 ::      ^^ keyword.operator.assignment.redirection.dosbatch
 ::         ^^^ constant.language.null.dosbatch
 
-   dir > f.txt 2>&1
+   ECHO <contet.txt and others
+:: ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.command.echo.dosbatch
+::      ^^^^^^^^^^^ meta.string.dosbatch meta.redirection.dosbatch - string string
+
+   ECHO "<contet.txt and others"
+:: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.command.echo.dosbatch
+::      ^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.dosbatch string.unquoted.dosbatch - meta.interpolation - meta.redirection
+
+   dir > f.txt 2>&1 /b
+:: ^^^^^^^^^^^^^^^^^^^ meta.function-call
 ::    ^ - meta.redirection
 ::     ^^^^^^^ meta.redirection.dosbatch
 ::            ^ - meta.redirection
 ::             ^^^^ meta.redirection.dosbatch
-::                 ^ - meta.redirection
+::                 ^^^ - meta.redirection
 ::     ^ keyword.operator.assignment.redirection.dosbatch
 ::       ^^^^^ string.unquoted.dosbatch
 ::             ^ meta.number.integer.decimal.dosbatch constant.numeric.value.dosbatch
 ::              ^^ keyword.operator.assignment.redirection.dosbatch
 ::                ^ meta.number.integer.decimal.dosbatch  constant.numeric.value.dosbatch
+::                  ^^ variable.parameter.option.dosbatch
 
-   dir foo 1>nul 2>nul
+   dir foo 1>nul /b 2>nul
+:: ^^^^^^^^^^^^^^^^^^^^^^ meta.function-call
 ::        ^ - meta.redirection
 ::         ^^^^^ meta.redirection.dosbatch
-::              ^ - meta.redirection
-::               ^^^^^ meta.redirection.dosbatch
-::                    ^ - meta.redirection
+::              ^^^^ - meta.redirection
+::                  ^^^^^ meta.redirection.dosbatch
+::                       ^ - meta.redirection
 ::         ^ meta.number.integer.decimal.dosbatch  constant.numeric.value.dosbatch
 ::          ^ keyword.operator.assignment.redirection.dosbatch
 ::           ^^^ constant.language.null.dosbatch
-::               ^ meta.number.integer.decimal.dosbatch  constant.numeric.value.dosbatch
-::                ^ keyword.operator.assignment.redirection.dosbatch
-::                 ^^^ constant.language.null.dosbatch
+::               ^^ variable.parameter.option.dosbatch
+::                  ^ meta.number.integer.decimal.dosbatch  constant.numeric.value.dosbatch
+::                   ^ keyword.operator.assignment.redirection.dosbatch
+::                    ^^^ constant.language.null.dosbatch
 
 :: Redirect any error message into a file
    command 2> filename
@@ -1523,20 +1562,31 @@ put arg1 arg2
 
 :: Redirect all output to stdout using variables
    command >%STDOUT% %STDERR%>&%STDOUT%
-:: ^^^^^^^^ - meta.redirection
-::         ^^^^^^^^^ meta.redirection.dosbatch
-::                  ^^^^^^^^^ - meta.redirection
-::                           ^^^^^^^^^^ meta.redirection.dosbatch
-:: ^^^^^^^^^ - meta.interpolation
-::          ^^^^^^^^ meta.interpolation.dosbatch
-::                  ^ - meta.interpolation
-::                   ^^^^^^^^ meta.interpolation.dosbatch
-::                           ^^ - meta.interpolation
-::                             ^^^^^^^^ meta.interpolation.dosbatch
-::                                     ^ - meta.interpolation
+:: ^^^^^^^^ - meta.redirection - meta.interpolation
+::         ^ meta.redirection.dosbatch keyword.operator.assignment.redirection.dosbatch - meta.interpolation
+::          ^^^^^^^^ meta.redirection.dosbatch meta.path.dosbatch meta.string.dosbatch meta.interpolation.dosbatch
+::                  ^ - meta.string - meta.redirection - meta.interpolation
+::                   ^^^^^^^^ meta.string.dosbatch meta.interpolation.dosbatch - meta.redirection
+::                           ^^ meta.string.dosbatch meta.redirection.dosbatch - meta.interpolation
+::                             ^^^^^^^^ meta.string.dosbatch meta.redirection.dosbatch meta.path.dosbatch meta.string.dosbatch meta.interpolation.dosbatch
 :: ^^^^^^^ variable.function.dosbatch
 ::         ^ keyword.operator.assignment.redirection.dosbatch
 ::                           ^^ keyword.operator.assignment.redirection.dosbatch
+
+   (command >nul 2>&1)
+::  ^^^^^^^ variable.function.dosbatch
+::          ^ keyword.operator.assignment.redirection.dosbatch
+::           ^^^ constant.language.null.dosbatch
+::               ^ constant.numeric.value.dosbatch
+::                ^^ keyword.operator.assignment.redirection.dosbatch
+::                  ^ constant.numeric.value.dosbatch
+
+   (>nul 2>&1)
+::  ^ keyword.operator.assignment.redirection.dosbatch
+::   ^^^ constant.language.null.dosbatch
+::       ^ constant.numeric.value.dosbatch
+::        ^^ keyword.operator.assignment.redirection.dosbatch
+::          ^ constant.numeric.value.dosbatch
 
 
 :::: [ ECHO Command ] :::::::::::::::::::::::::::::::::::::::::::::::::::::::::
@@ -2235,7 +2285,7 @@ put arg1 arg2
 
    ECHO if /i "%%PROCESSOR%%"=="AMD64" goto x64>custom\SetAria2EnvVars.cmd
 ::      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.command.echo.dosbatch meta.string.dosbatch string.unquoted.dosbatch - meta.redirection
-::                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.redirection.dosbatch - meta.command
+::                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.command meta.redirection.dosbatch
 ::                                             ^ keyword.operator.assignment.redirection.dosbatch
 ::             ^^ constant.character.escape.dosbatch
 ::                        ^^ constant.character.escape.dosbatch
@@ -2747,6 +2797,49 @@ put arg1 arg2
 ::                           ^ punctuation.definition.string.end.dosbatch - string
 ::                             ^^^^^^^ comment.line.ignored.dosbatch
 
+   set "foo"=ba"r & echo !foo" ignored >nul ignored
+:: ^^^^ meta.command.set.dosbatch - meta.string
+::     ^^^^^^^^^^^^^^^^^^^^^^^ meta.command.set.dosbatch meta.string.dosbatch - meta.interpolation
+::                            ^^^^^^^^^ meta.command.set.dosbatch - meta.redirection - meta.string
+::                                     ^^^^ meta.redirection.dosbatch
+::                                         ^^^^^^^^ meta.command.set.dosbatch - meta.redirection - meta.string
+:: ^^^ support.function.builtin.dosbatch
+::     ^ - variable.other.readwrite
+::      ^^^^ variable.other.readwrite.dosbatch
+::         ^ - punctuation
+::          ^ keyword.operator.assignment.dosbatch
+::           ^^^^^^^^^^^^^^^^ string.unquoted.dosbatch
+::              ^ - punctuation
+::                ^ - keyword
+::                  ^^^^ - support
+::                           ^ punctuation.definition.string.end.dosbatch - string
+::                             ^^^^^^^ comment.line.ignored.dosbatch
+::                                     ^ keyword.operator.assignment.redirection.dosbatch
+::                                      ^^^ constant.language.null.dosbatch
+
+   set "foo"=ba"r & echo !foo" ignored 2>nul ignored
+:: ^^^^ meta.command.set.dosbatch - meta.string
+::     ^^^^^^^^^^^^^^^^^^^^^^^ meta.command.set.dosbatch meta.string.dosbatch - meta.interpolation
+::                            ^^^^^^^^^ meta.command.set.dosbatch - meta.redirection - meta.string
+::                                     ^^^^^ meta.command.set.dosbatch meta.redirection.dosbatch
+::                                          ^^^^^^^^ meta.command.set.dosbatch - meta.redirection - meta.string
+::                                                  ^ - meta.command
+:: ^^^ support.function.builtin.dosbatch
+::     ^ - variable.other.readwrite
+::      ^^^^ variable.other.readwrite.dosbatch
+::         ^ - punctuation
+::          ^ keyword.operator.assignment.dosbatch
+::           ^^^^^^^^^^^^^^^^ string.unquoted.dosbatch
+::              ^ - punctuation
+::                ^ - keyword
+::                  ^^^^ - support
+::                           ^ punctuation.definition.string.end.dosbatch - string
+::                             ^^^^^^^ comment.line.ignored.dosbatch
+::                                    ^^^^^^ meta.command.set.dosbatch
+::                                     ^ constant.numeric.value.dosbatch
+::                                      ^ keyword.operator.assignment.redirection.dosbatch
+::                                       ^^^ constant.language.null.dosbatch
+
    set "foo"=b"ar ba"z & echo !foo"!
 :: ^^^^ meta.command.set.dosbatch - meta.string
 ::     ^^^^^^^^^^^^^^ meta.command.set.dosbatch meta.string.dosbatch - meta.interpolation
@@ -2795,6 +2888,12 @@ put arg1 arg2
 :: ^^^^^^^^^^^^^^^^^^^ meta.command.set.dosbatch meta.string.dosbatch
 :: ^^^^^^^^^^^^^^^^^^ string.unquoted.dosbatch
 ::                   ^ punctuation.definition.string.end.dosbatch
+
+   set "foo"=<file.txt>nul
+::           ^^^^^^^^^^^^^ meta.command.set.dosbatch meta.string.dosbatch meta.redirection.dosbatch
+
+   set "foo"="<file.txt>nul"
+::           ^^^^^^^^^^^^^^^ meta.command.set.dosbatch meta.string.dosbatch - meta.interpolation - meta.redirection
 
    set "foo=b"ar^
    b)a"z & echo !foo"
@@ -3721,7 +3820,7 @@ put arg1 arg2
 ::               ^^^^^^ string.unquoted.dosbatch
 ::                     ^^^^^^ - string
 ::                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.dosbatch
-::                             ^^ constant.character.escape.dosbatch
+::                             ^^ - constant.character.escape
 ::                                            ^ - keyword
 ::                                                       ^ - string
 
@@ -3986,7 +4085,7 @@ put arg1 arg2
 :: ^^^^^^^ meta.command.set.dosbatch - meta.string
 ::        ^^^^^^ meta.command.set.dosbatch meta.prompt.dosbatch - meta.string
 ::              ^^^^^^ meta.command.set.dosbatch meta.prompt.dosbatch meta.string.dosbatch - meta.interpolation
-::                    ^^^^^^^^^^ meta.command.set.dosbatch meta.prompt.dosbatch meta.interpolation.dosbatch meta.redirection.dosbatch
+::                    ^^^^^^^^^^ meta.command.set.dosbatch meta.prompt.dosbatch meta.redirection.dosbatch
 ::                              ^^^^^^^ meta.command.set.dosbatch meta.prompt.dosbatch meta.string.dosbatch - meta.interpolation
 :: ^^^ support.function.builtin.dosbatch
 ::    ^ - keyword - variable
@@ -4000,8 +4099,8 @@ put arg1 arg2
 :: ^^^^^^^ meta.command.set.dosbatch - meta.string
 ::        ^^^^^^ meta.command.set.dosbatch meta.prompt.dosbatch - meta.string
 ::              ^^^^^^ meta.command.set.dosbatch meta.prompt.dosbatch meta.string.dosbatch
-::                    ^^ meta.command.set.dosbatch meta.prompt.dosbatch meta.interpolation.dosbatch meta.redirection.dosbatch
-::                      ^^^^^^^^^^^^^^^ meta.command.set.dosbatch meta.prompt.dosbatch meta.string.dosbatch meta.interpolation.dosbatch meta.redirection.dosbatch meta.path.dosbatch meta.string.dosbatch
+::                    ^^ meta.command.set.dosbatch meta.prompt.dosbatch meta.redirection.dosbatch
+::                      ^^^^^^^^^^^^^^^ meta.command.set.dosbatch meta.prompt.dosbatch meta.string.dosbatch meta.redirection.dosbatch meta.path.dosbatch meta.string.dosbatch
 ::                                     ^^^^^^^ meta.command.set.dosbatch meta.prompt.dosbatch meta.string.dosbatch
 :: ^^^ support.function.builtin.dosbatch
 ::    ^ - keyword - variable
@@ -4031,7 +4130,8 @@ put arg1 arg2
    set /p "today="<today.txt
 :: ^^^^^^^ meta.command.set.dosbatch - meta.string
 ::        ^^^^^^^^ meta.command.set.dosbatch meta.prompt.dosbatch - meta.string
-::                ^^^^^^^^^^^ - meta.command
+::                ^^^^^^^^^^ meta.command.set.dosbatch meta.prompt.dosbatch meta.redirection.dosbatch
+::                          ^ - meta.command
 :: ^^^ support.function.builtin.dosbatch
 ::    ^ - keyword - variable
 ::     ^ punctuation.definition.variable.dosbatch
@@ -4042,11 +4142,12 @@ put arg1 arg2
 ::               ^ punctuation.definition.prompt.end.dosbatch
 ::                ^ keyword.operator.assignment.redirection.dosbatch
 
-   set /p "today=" this is ignored <today.txt
+   set /p "today=" this is ignored <today.txt also ignored
 :: ^^^^^^^ meta.command.set.dosbatch - meta.string
 ::        ^^^^^^^^ meta.command.set.dosbatch meta.prompt.dosbatch - meta.string
-::                ^^^^^^^^^^^^^^^^ meta.command.set.dosbatch
-::                                ^^^^^^^^^^^^ - meta.command
+::                ^^^^^^^^^^^^^^^^^ meta.command.set.dosbatch - meta.redirection
+::                                 ^^^^^^^^^^ meta.command.set.dosbatch meta.redirection.dosbatch - comment
+::                                           ^^^^^^^^^^^^^ meta.command.set.dosbatch - meta.redirection
 :: ^^^ support.function.builtin.dosbatch
 ::    ^ - keyword - variable
 ::     ^ punctuation.definition.variable.dosbatch
@@ -4056,14 +4157,14 @@ put arg1 arg2
 ::              ^ keyword.operator.assignment.dosbatch
 ::               ^ punctuation.definition.prompt.end.dosbatch
 ::                ^ - comment - string
-::                 ^^^^^^^^^^^^^^^ comment.line.ignored.dosbatch
-::                                ^ - comment - keyword
+::                 ^^^^^^^^^^^^^^^^ comment.line.ignored.dosbatch
 ::                                 ^ keyword.operator.assignment.redirection.dosbatch
+::                                  ^^^^^^^^^ meta.path.dosbatch meta.string.dosbatch string.unquoted.dosbatch
 
    set /p "today="<"c:\this week\to day.txt"
 :: ^^^^^^^ meta.command.set.dosbatch - meta.string
 ::        ^^^^^^^^ meta.command.set.dosbatch meta.prompt.dosbatch - meta.string
-::                ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.redirection.dosbatch - meta.command
+::                ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.command.set.dosbatch meta.prompt.dosbatch meta.redirection.dosbatch
 :: ^^^ support.function.builtin.dosbatch
 ::    ^ - keyword - variable
 ::     ^ punctuation.definition.variable.dosbatch

--- a/Batch File/tests/syntax_test_batch_file.bat
+++ b/Batch File/tests/syntax_test_batch_file.bat
@@ -1567,8 +1567,8 @@ put arg1 arg2
 ::          ^^^^^^^^ meta.redirection.dosbatch meta.path.dosbatch meta.string.dosbatch meta.interpolation.dosbatch
 ::                  ^ - meta.string - meta.redirection - meta.interpolation
 ::                   ^^^^^^^^ meta.string.dosbatch meta.interpolation.dosbatch - meta.redirection
-::                           ^^ meta.string.dosbatch meta.redirection.dosbatch - meta.interpolation
-::                             ^^^^^^^^ meta.string.dosbatch meta.redirection.dosbatch meta.path.dosbatch meta.string.dosbatch meta.interpolation.dosbatch
+::                           ^^ meta.redirection.dosbatch - meta.string - meta.interpolation
+::                             ^^^^^^^^ meta.redirection.dosbatch meta.path.dosbatch meta.string.dosbatch meta.interpolation.dosbatch
 :: ^^^^^^^ variable.function.dosbatch
 ::         ^ keyword.operator.assignment.redirection.dosbatch
 ::                           ^^ keyword.operator.assignment.redirection.dosbatch
@@ -2439,12 +2439,25 @@ put arg1 arg2
 ::     ^^ invalid.illegal.parameter.dosbatch
 
    set 12>nul
-::     ^^ variable.other.readwrite.dosbatch
 ::     ^^ - meta.redirection
 ::       ^^^^ meta.redirection.dosbatch
 ::           ^ - meta.redirection
+::     ^^ variable.other.readwrite.dosbatch
 ::       ^ keyword.operator.assignment.redirection.dosbatch
 ::        ^^^ constant.language.null.dosbatch
+
+   set var=12>nul 3
+::     ^^^^ - meta.string - meta.redirection
+::         ^^ meta.string.dosbatch - meta.redirection
+::           ^^^^ meta.string.dosbatch meta.redirection.dosbatch
+::               ^^ meta.string.dosbatch - meta.redirection
+::                 ^ - meta.string - meta.redirection
+::     ^^^ variable.other.readwrite.dosbatch
+::        ^ keyword.operator.assignment.dosbatch
+::         ^^ string.unquoted.dosbatch
+::           ^ keyword.operator.assignment.redirection.dosbatch
+::            ^^^ constant.language.null.dosbatch
+::               ^^ string.unquoted.dosbatch
 
    set foo_bar & echo %foo_bar%
 :: ^^^^^^^^^^^ meta.command.set.dosbatch
@@ -2695,6 +2708,13 @@ put arg1 arg2
 ::      ^^^ variable.other.readwrite.dosbatch
 ::         ^ keyword.operator.assignment.dosbatch
 ::          ^ punctuation.definition.string.end.dosbatch
+
+   set "foo & echo on
+:: ^^^^^^^^^^^^^^^^^^ meta.command.set.dosbatch
+:: ^^^ support.function.builtin.dosbatch
+::     ^^^^^^^^^^^^^^ meta.string.dosbatch
+::     ^ punctuation.definition.string.begin.dosbatch
+::      ^^^^^^^^^^^^^ variable.other.readwrite.dosbatch - keyword - punctuation
 
 :: "bar is output as no quote follows.
    set "foo="bar" & echo !foo!

--- a/Batch File/tests/syntax_test_batch_file.bat
+++ b/Batch File/tests/syntax_test_batch_file.bat
@@ -1990,6 +1990,15 @@ put arg1 arg2
 ::                     ^ punctuation.section.interpolation.end.dosbatch
 ::                      ^ - punctuation
 
+   command /param:va^l:u%var%e
+::         ^^^^^^ meta.parameter.option.dosbatch variable.parameter.option.dosbatch
+::               ^ meta.parameter.dosbatch keyword.operator.assignment.dosbatch
+::                ^^^^^^ meta.parameter.value.dosbatch meta.string.dosbatch string.unquoted.dosbatch
+::                  ^^ constant.character.escape.dosbatch
+::                      ^^^^^ meta.parameter.value.dosbatch meta.string.dosbatch meta.interpolation.dosbatch - string
+::                           ^ meta.parameter.value.dosbatch meta.string.dosbatch string.unquoted.dosbatch
+::                            ^ - meta.parameter
+
    command ..\folder2\ /type:*.txt
 :: ^^^^^^^ meta.function-call.identifier.dosbatch variable.function.dosbatch
 ::        ^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.dosbatch

--- a/Batch File/tests/syntax_test_batch_file.bat
+++ b/Batch File/tests/syntax_test_batch_file.bat
@@ -73,17 +73,21 @@ continuation
    Me too!
 :: ^^^^^^^ comment.line.colon.dosbatch
 
+   :> ignored content ( & | )
+:: ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.colon.dosbatch
+:: ^^ punctuation.definition.comment.dosbatch
+
+   :< ignored content ( & | )
+:: ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.colon.dosbatch
+:: ^^ punctuation.definition.comment.dosbatch
+
    :& ignored content ( & | )
 :: ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.colon.dosbatch
+:: ^^ punctuation.definition.comment.dosbatch
 
    :| ignored content ( & | )
 :: ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.colon.dosbatch
-
-   :%var% ignored content ( & | )
-:: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.colon.dosbatch
-
-   :!var! ignored content ( & | )
-:: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.colon.dosbatch
+:: ^^ punctuation.definition.comment.dosbatch
 
 ECHO &&:: A comment
 ::   ^^ keyword.operator.logical.dosbatch
@@ -192,21 +196,168 @@ ECHO : Not a comment ^
 
 :::: [ Labels ] :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-  :This is a #@$虎 strange label
-::^ punctuation.definition.label.dosbatch
-::^^^^^ entity.name.label.dosbatch
-::      ^^^^^^^^^^^^^^^^^^^^^^^ comment.line.ignored.dosbatch
+   :l
+::^ - entity
+:: ^ entity.name.label.dosbatch punctuation.definition.label.dosbatch
+::  ^ entity.name.label.dosbatch - punctuation
+::   ^ - entity
 
-  :End
-::^ punctuation.definition.label.dosbatch
-::^^^^ entity.name.label.dosbatch
+   :(
+::^ - entity
+:: ^ entity.name.label.dosbatch punctuation.definition.label.dosbatch
+::  ^ entity.name.label.dosbatch - punctuation
+::   ^ - entity
 
+   :)
+::^ - entity
+:: ^ entity.name.label.dosbatch punctuation.definition.label.dosbatch
+::  ^ entity.name.label.dosbatch - punctuation
+::   ^ - entity
+
+   :[
+::^ - entity
+:: ^ entity.name.label.dosbatch punctuation.definition.label.dosbatch
+::  ^ entity.name.label.dosbatch - punctuation
+::   ^ - entity
+
+   :]
+::^ - entity
+:: ^ entity.name.label.dosbatch punctuation.definition.label.dosbatch
+::  ^ entity.name.label.dosbatch - punctuation
+::   ^ - entity
+
+   :{
+::^ - entity
+:: ^ entity.name.label.dosbatch punctuation.definition.label.dosbatch
+::  ^ entity.name.label.dosbatch - punctuation
+::   ^ - entity
+
+   :}
+::^ - entity
+:: ^ entity.name.label.dosbatch punctuation.definition.label.dosbatch
+::  ^ entity.name.label.dosbatch - punctuation
+::   ^ - entity
+
+   :^(
+::^ - entity
+:: ^ entity.name.label.dosbatch punctuation.definition.label.dosbatch
+::  ^^ entity.name.label.dosbatch constant.character.escape.dosbatch - punctuation
+::    ^ - entity
+
+   :^)
+::^ - entity
+:: ^ entity.name.label.dosbatch punctuation.definition.label.dosbatch
+::  ^^ entity.name.label.dosbatch constant.character.escape.dosbatch - punctuation
+::    ^ - entity
+
+   :^[
+::^ - entity
+:: ^ entity.name.label.dosbatch punctuation.definition.label.dosbatch
+::  ^^ entity.name.label.dosbatch constant.character.escape.dosbatch - punctuation
+::    ^ - entity
+
+   :^]
+::^ - entity
+:: ^ entity.name.label.dosbatch punctuation.definition.label.dosbatch
+::  ^^ entity.name.label.dosbatch constant.character.escape.dosbatch - punctuation
+::    ^ - entity
+
+   :^{
+::^ - entity
+:: ^ entity.name.label.dosbatch punctuation.definition.label.dosbatch
+::  ^^ entity.name.label.dosbatch constant.character.escape.dosbatch - punctuation
+::    ^ - entity
+
+   :^}
+::^ - entity
+:: ^ entity.name.label.dosbatch punctuation.definition.label.dosbatch
+::  ^^ entity.name.label.dosbatch constant.character.escape.dosbatch - punctuation
+::    ^ - entity
+
+   :^>
+::^ - entity
+:: ^ entity.name.label.dosbatch punctuation.definition.label.dosbatch
+::  ^^ entity.name.label.dosbatch constant.character.escape.dosbatch - punctuation
+::    ^ - entity
+
+   :^<
+::^ - entity
+:: ^ entity.name.label.dosbatch punctuation.definition.label.dosbatch
+::  ^^ entity.name.label.dosbatch constant.character.escape.dosbatch - punctuation
+::    ^ - entity
+
+   :^&
+::^ - entity
+:: ^ entity.name.label.dosbatch punctuation.definition.label.dosbatch
+::  ^^ entity.name.label.dosbatch constant.character.escape.dosbatch - punctuation
+::    ^ - entity
+
+   :^|
+::^ - entity
+:: ^ entity.name.label.dosbatch punctuation.definition.label.dosbatch
+::  ^^ entity.name.label.dosbatch constant.character.escape.dosbatch - punctuation
+::    ^ - entity
+
+   :%%
+::^ - entity
+:: ^ entity.name.label.dosbatch punctuation.definition.label.dosbatch
+::  ^^ entity.name.label.dosbatch - constant.character.escape - punctuation
+::    ^ - entity
+
+   :%
+::^ - entity
+:: ^ entity.name.label.dosbatch punctuation.definition.label.dosbatch
+::  ^ entity.name.label.dosbatch - constant.character.escape - punctuation
+::   ^ - entity
+
+   :%var% ignored content ( & echo foo
+::^ - entity
+:: ^^^^^^ entity.name.label.dosbatch
+:: ^ punctuation.definition.label.dosbatch
+::       ^ - entity - comment
+::        ^^^^^^^^^^^^^^^^^ comment.line.ignored.dosbatch
+::                          ^ keyword.operator.logical.dosbatch
+::                            ^^^^^^^^ meta.command.echo.dosbatch
+
+   :!
+::^ - entity
+:: ^ entity.name.label.dosbatch punctuation.definition.label.dosbatch
+::  ^ entity.name.label.dosbatch - constant.character.escape - punctuation
+::   ^ - entity
+
+   :!var! ignored content ( | echo foo
+::^ - entity
+:: ^^^^^^ entity.name.label.dosbatch
+:: ^ punctuation.definition.label.dosbatch
+::       ^ - entity - comment
+::        ^^^^^^^^^^^^^^^^^ comment.line.ignored.dosbatch
+::                          ^ keyword.operator.assignment.pipe.dosbatch
+::                            ^^^^^^^^ meta.command.echo.dosbatch
+
+   :This is a #@$虎 strange label
+::^ - entity
+:: ^ punctuation.definition.label.dosbatch
+:: ^^^^^ entity.name.label.dosbatch
+::      ^ - entity - comment
+::       ^^^^^^^^^^^^^^^^^^^^^^^ comment.line.ignored.dosbatch
+
+   :This" is a #@$虎" strange label
+::^ - entity
+:: ^^^^^^ entity.name.label.dosbatch
+::       ^ - entity - comment
+::        ^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.ignored.dosbatch
+
+   :"This is a #@$虎" strange label
+::^ - entity
+:: ^^^^^^ entity.name.label.dosbatch
+::       ^ - entity - comment
+::        ^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.ignored.dosbatch
 
 :::: [ Control Flow ] :::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
    CALL:This is a #@$虎 ^strange %%label
 ::^ - meta.function-call
-:: ^^^^  meta.function-call.dosbatch
+:: ^^^^ meta.function-call.dosbatch
 ::     ^^^^^ meta.function-call.identifier.dosbatch
 ::          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.dosbatch
 ::                                     ^ - meta.function-call
@@ -219,7 +370,7 @@ ECHO : Not a comment ^
 
    CALL:EOF
 ::^ - meta.function-call
-:: ^^^^  meta.function-call.dosbatch
+:: ^^^^ meta.function-call.dosbatch
 ::     ^^^^ meta.function-call.identifier.dosbatch
 ::         ^ - meta.function-call
 :: ^^^^ keyword.control.flow.call.dosbatch
@@ -235,7 +386,7 @@ ECHO : Not a comment ^
 
    CALL :foo 10 %1
 ::^ - meta.function-call
-:: ^^^^^  meta.function-call.dosbatch
+:: ^^^^^ meta.function-call.dosbatch
 ::      ^^^^ meta.function-call.identifier.dosbatch
 ::          ^^^^^^ meta.function-call.arguments.dosbatch
 ::                ^ - meta.function-call
@@ -247,7 +398,7 @@ ECHO : Not a comment ^
 
    CALL :foo%bar% 10
 ::^ - meta.function-call
-:: ^^^^^  meta.function-call.dosbatch
+:: ^^^^^ meta.function-call.dosbatch
 ::      ^^^^^^^^^ meta.function-call.identifier.dosbatch
 ::                ^^ meta.function-call.arguments.dosbatch
 ::                  ^ - meta.function-call
@@ -258,7 +409,7 @@ ECHO : Not a comment ^
 
    CALL :foo %bar% 10
 ::^ - meta.function-call
-:: ^^^^^  meta.function-call.dosbatch
+:: ^^^^^ meta.function-call.dosbatch
 ::      ^^^^ meta.function-call.identifier.dosbatch
 ::           ^^^^^^^^ meta.function-call.arguments.dosbatch
 ::                   ^ - meta.function-call
@@ -268,9 +419,162 @@ ECHO : Not a comment ^
 ::           ^^^^^ meta.interpolation.dosbatch - variable.label - keyword
 ::                 ^^ meta.number.integer.decimal.dosbatch constant.numeric.value.dosbatch
 
+   CALL :( 10
+::^ - meta.function-call
+:: ^^^^^ meta.function-call.dosbatch
+::      ^^ meta.function-call.identifier.dosbatch
+::        ^^^ meta.function-call.arguments.dosbatch
+::           ^ - meta.function-call
+:: ^^^^ keyword.control.flow.call.dosbatch
+::      ^ punctuation.definition.variable.dosbatch
+::      ^^ variable.label.dosbatch - keyword
+::         ^^ meta.number.integer.decimal.dosbatch constant.numeric.value.dosbatch
+
+   CALL :^( 10
+::^ - meta.function-call
+:: ^^^^^ meta.function-call.dosbatch
+::      ^^^ meta.function-call.identifier.dosbatch
+::         ^^^ meta.function-call.arguments.dosbatch
+::            ^ - meta.function-call
+:: ^^^^ keyword.control.flow.call.dosbatch
+::      ^ punctuation.definition.variable.dosbatch
+::      ^^^ variable.label.dosbatch - keyword
+::       ^^ constant.character.escape.dosbatch
+::          ^^ meta.number.integer.decimal.dosbatch constant.numeric.value.dosbatch
+
+   CALL :) 10
+::^ - meta.function-call
+:: ^^^^^ meta.function-call.dosbatch
+::      ^^ meta.function-call.identifier.dosbatch
+::        ^^^ meta.function-call.arguments.dosbatch
+::           ^ - meta.function-call
+:: ^^^^ keyword.control.flow.call.dosbatch
+::      ^ punctuation.definition.variable.dosbatch
+::      ^^ variable.label.dosbatch - keyword
+::         ^^ meta.number.integer.decimal.dosbatch constant.numeric.value.dosbatch
+
+   CALL :^) 10
+::^ - meta.function-call
+:: ^^^^^ meta.function-call.dosbatch
+::      ^^^ meta.function-call.identifier.dosbatch
+::         ^^^ meta.function-call.arguments.dosbatch
+::            ^ - meta.function-call
+:: ^^^^ keyword.control.flow.call.dosbatch
+::      ^ punctuation.definition.variable.dosbatch
+::      ^^^ variable.label.dosbatch - keyword
+::       ^^ constant.character.escape.dosbatch
+::          ^^ meta.number.integer.decimal.dosbatch constant.numeric.value.dosbatch
+
+   CALL :^> 10
+::^ - meta.function-call
+:: ^^^^^ meta.function-call.dosbatch
+::      ^^^ meta.function-call.identifier.dosbatch
+::         ^^^ meta.function-call.arguments.dosbatch
+::            ^ - meta.function-call
+:: ^^^^ keyword.control.flow.call.dosbatch
+::      ^ punctuation.definition.variable.dosbatch
+::      ^^^ variable.label.dosbatch - keyword
+::       ^^ constant.character.escape.dosbatch
+::          ^^ meta.number.integer.decimal.dosbatch constant.numeric.value.dosbatch
+
+   CALL :^< 10
+::^ - meta.function-call
+:: ^^^^^ meta.function-call.dosbatch
+::      ^^^ meta.function-call.identifier.dosbatch
+::         ^^^ meta.function-call.arguments.dosbatch
+::            ^ - meta.function-call
+:: ^^^^ keyword.control.flow.call.dosbatch
+::      ^ punctuation.definition.variable.dosbatch
+::      ^^^ variable.label.dosbatch - keyword
+::       ^^ constant.character.escape.dosbatch
+::          ^^ meta.number.integer.decimal.dosbatch constant.numeric.value.dosbatch
+
+   CALL :^& 10
+::^ - meta.function-call
+:: ^^^^^ meta.function-call.dosbatch
+::      ^^^ meta.function-call.identifier.dosbatch
+::         ^^^ meta.function-call.arguments.dosbatch
+::            ^ - meta.function-call
+:: ^^^^ keyword.control.flow.call.dosbatch
+::      ^ punctuation.definition.variable.dosbatch
+::      ^^^ variable.label.dosbatch - keyword
+::       ^^ constant.character.escape.dosbatch
+::          ^^ meta.number.integer.decimal.dosbatch constant.numeric.value.dosbatch
+
+   CALL :^| 10
+::^ - meta.function-call
+:: ^^^^^ meta.function-call.dosbatch
+::      ^^^ meta.function-call.identifier.dosbatch
+::         ^^^ meta.function-call.arguments.dosbatch
+::            ^ - meta.function-call
+:: ^^^^ keyword.control.flow.call.dosbatch
+::      ^ punctuation.definition.variable.dosbatch
+::      ^^^ variable.label.dosbatch - keyword
+::       ^^ constant.character.escape.dosbatch
+::          ^^ meta.number.integer.decimal.dosbatch constant.numeric.value.dosbatch
+
+   CALL :%% 10
+::^ - meta.function-call
+:: ^^^^^ meta.function-call.dosbatch
+::      ^^^ meta.function-call.identifier.dosbatch
+::         ^^^ meta.function-call.arguments.dosbatch
+::            ^ - meta.function-call
+:: ^^^^ keyword.control.flow.call.dosbatch
+::      ^ punctuation.definition.variable.dosbatch
+::      ^^^ variable.label.dosbatch - keyword
+::       ^^ constant.character.escape.dosbatch
+::          ^^ meta.number.integer.decimal.dosbatch constant.numeric.value.dosbatch
+
+   CALL :%label% 10
+::^ - meta.function-call
+:: ^^^^^ meta.function-call.dosbatch
+::      ^^^^^^^^ meta.function-call.identifier.dosbatch
+::              ^^^ meta.function-call.arguments.dosbatch
+::                 ^ - meta.function-call
+:: ^^^^ keyword.control.flow.call.dosbatch
+::      ^ variable.label.dosbatch punctuation.definition.variable.dosbatch
+::       ^^^^^^^ variable.label.dosbatch meta.interpolation.dosbatch
+::       ^ punctuation.section.interpolation.begin.dosbatch
+::        ^^^^^ variable.other.readwrite.dosbatch
+::             ^ punctuation.section.interpolation.end.dosbatch
+::               ^^ meta.number.integer.decimal.dosbatch constant.numeric.value.dosbatch
+
+   CALL :^! 10
+::^ - meta.function-call
+:: ^^^^^ meta.function-call.dosbatch
+::      ^^^ meta.function-call.identifier.dosbatch
+::         ^^^ meta.function-call.arguments.dosbatch
+::            ^ - meta.function-call
+:: ^^^^ keyword.control.flow.call.dosbatch
+::      ^ punctuation.definition.variable.dosbatch
+::      ^^^ variable.label.dosbatch - keyword
+::       ^^ constant.character.escape.dosbatch
+::          ^^ meta.number.integer.decimal.dosbatch constant.numeric.value.dosbatch
+
+   CALL :!label! 10
+::^ - meta.function-call
+:: ^^^^^ meta.function-call.dosbatch
+::      ^^^^^^^^ meta.function-call.identifier.dosbatch
+::              ^^^ meta.function-call.arguments.dosbatch
+::                 ^ - meta.function-call
+:: ^^^^ keyword.control.flow.call.dosbatch
+::      ^ variable.label.dosbatch punctuation.definition.variable.dosbatch
+::       ^^^^^^^ variable.label.dosbatch meta.interpolation.dosbatch
+::       ^ punctuation.section.interpolation.begin.dosbatch
+::        ^^^^^ variable.other.readwrite.dosbatch
+::             ^ punctuation.section.interpolation.end.dosbatch
+::               ^^ meta.number.integer.decimal.dosbatch constant.numeric.value.dosbatch
+
+   CALL :foo^
+bar baz
+:: <- meta.function-call.identifier.dosbatch variable.label.dosbatch
+::^ meta.function-call.identifier.dosbatch variable.label.dosbatch
+:: ^^^^ meta.function-call.arguments.dosbatch
+::  ^^^ meta.string.dosbatch string.unquoted.dosbatch
+
    CALL foo %bar%
 ::^ - meta.function-call
-:: ^^^^^  meta.function-call.dosbatch
+:: ^^^^^ meta.function-call.dosbatch
 ::      ^^^ meta.function-call.identifier.dosbatch
 ::         ^^^^^^ meta.function-call.arguments.dosbatch
 ::               ^ - meta.function-call
@@ -280,8 +584,13 @@ ECHO : Not a comment ^
 ::          ^^^^^ meta.interpolation.dosbatch
 
    CALL ^
-   foo
+   foo %bar%
 :: ^^^ meta.function-call.identifier.dosbatch variable.function.dosbatch
+::    ^^^^^^ meta.function-call.arguments.dosbatch
+::     ^^^^^ meta.string.dosbatch meta.interpolation.dosbatch
+::     ^ punctuation.section.interpolation.begin.dosbatch
+::      ^^^ variable.other.readwrite.dosbatch
+::         ^ punctuation.section.interpolation.end.dosbatch
 
    CALL SET _str=%%_var:~%_start%,%_length%%%
 :: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -301,7 +610,7 @@ ECHO : Not a comment ^
 
    CALL ..\foo\bar.exe /param:10
 ::^ - meta.function-call
-:: ^^^^^  meta.function-call.dosbatch
+:: ^^^^^ meta.function-call.dosbatch
 ::      ^^^^^^^^^^^^^^ meta.function-call.identifier.dosbatch
 ::                    ^^^^^^^^^^ meta.function-call.arguments.dosbatch
 ::                              ^ - meta.function-call
@@ -317,7 +626,7 @@ ECHO : Not a comment ^
 
    CALL ..\%foo%\bar.exe /param:str
 ::^ - meta.function-call
-:: ^^^^^  meta.function-call.dosbatch
+:: ^^^^^ meta.function-call.dosbatch
 ::      ^^^ meta.function-call.identifier.dosbatch variable.function.dosbatch - meta.interpolation
 ::         ^^^^^ meta.function-call.identifier.dosbatch meta.interpolation.dosbatch
 ::              ^^^^^^^^ meta.function-call.identifier.dosbatch variable.function.dosbatch - meta.interpolation
@@ -337,7 +646,7 @@ ECHO : Not a comment ^
 
    CALL foo\bar.exe /pa_am:%var%
 ::^ - meta.function-call
-:: ^^^^^  meta.function-call.dosbatch
+:: ^^^^^ meta.function-call.dosbatch
 ::      ^^^^^^^^^^^ meta.function-call.identifier.dosbatch variable.function.dosbatch
 ::                 ^^^^^^^^ meta.function-call.arguments.dosbatch - meta.interpolation
 ::                         ^^^^^ meta.function-call.arguments.dosbatch meta.interpolation.dosbatch
@@ -351,7 +660,7 @@ ECHO : Not a comment ^
 
    CALL %foo%\bar.exe /pa-am:-10
 ::^ - meta.function-call
-:: ^^^^^  meta.function-call.dosbatch
+:: ^^^^^ meta.function-call.dosbatch
 ::      ^^^^^ meta.function-call.identifier.dosbatch meta.interpolation.dosbatch
 ::           ^^^^^^^^ meta.function-call.identifier.dosbatch variable.function.dosbatch - meta.interpolation
 ::                   ^^^^^^^^^^^ meta.function-call.arguments.dosbatch
@@ -369,7 +678,7 @@ ECHO : Not a comment ^
 
    CALL "d:\foo %bar%\baz.exe" /par-am=10 /D
 ::^ - meta.function-call
-:: ^^^^^  meta.function-call.dosbatch
+:: ^^^^^ meta.function-call.dosbatch
 ::      ^^^^^^^^ meta.function-call.identifier.dosbatch meta.string.dosbatch - meta.interpolation
 ::              ^^^^^ meta.function-call.identifier.dosbatch meta.string.dosbatch meta.interpolation.dosbatch
 ::                   ^^^^^^^^^ meta.function-call.identifier.dosbatch meta.string.dosbatch - meta.interpolation
@@ -433,19 +742,225 @@ ECHO : Not a comment ^
    GOTO :End
 :: ^^^^^^^^^ meta.command.goto.dosbatch
 :: ^^^^ keyword.control.flow.goto.dosbatch
-::      ^ punctuation.definition.variable.dosbatch
+::      ^ punctuation.definition.label.dosbatch
 ::      ^^^^ variable.label.dosbatch - keyword
 
    GOTO:End
 :: ^^^^^^^^ meta.command.goto.dosbatch
 :: ^^^^ keyword.control.flow.goto.dosbatch
-::     ^ punctuation.definition.variable.dosbatch
+::     ^ punctuation.definition.label.dosbatch
 ::     ^^^^ variable.label.dosbatch - keyword
+
+   GOTO l
+:: ^^^^^^ meta.command.goto.dosbatch
+::       ^ - meta.command
+:: ^^^^ keyword.control.flow.goto.dosbatch
+::     ^ - keyword - variable
+::      ^ variable.label.dosbatch
+::       ^ - variable
+
+   GOTO (
+:: ^^^^^^ meta.command.goto.dosbatch
+::       ^ - meta.command
+:: ^^^^ keyword.control.flow.goto.dosbatch
+::     ^ - keyword - variable
+::      ^ variable.label.dosbatch
+::       ^ - variable
+
+   GOTO )
+:: ^^^^^^ meta.command.goto.dosbatch
+::       ^ - meta.command
+:: ^^^^ keyword.control.flow.goto.dosbatch
+::     ^ - keyword - variable
+::      ^ variable.label.dosbatch
+::       ^ - variable
+
+   GOTO [
+:: ^^^^^^ meta.command.goto.dosbatch
+::       ^ - meta.command
+:: ^^^^ keyword.control.flow.goto.dosbatch
+::     ^ - keyword - variable
+::      ^ variable.label.dosbatch
+::       ^ - variable
+
+   GOTO ]
+:: ^^^^^^ meta.command.goto.dosbatch
+::       ^ - meta.command
+:: ^^^^ keyword.control.flow.goto.dosbatch
+::     ^ - keyword - variable
+::      ^ variable.label.dosbatch
+::       ^ - variable
+
+   GOTO {
+:: ^^^^^^ meta.command.goto.dosbatch
+::       ^ - meta.command
+:: ^^^^ keyword.control.flow.goto.dosbatch
+::     ^ - keyword - variable
+::      ^ variable.label.dosbatch
+::       ^ - variable
+
+   GOTO }
+:: ^^^^^^ meta.command.goto.dosbatch
+::       ^ - meta.command
+:: ^^^^ keyword.control.flow.goto.dosbatch
+::     ^ - keyword - variable
+::      ^ variable.label.dosbatch
+::       ^ - variable
+
+   GOTO ^(
+:: ^^^^^^^ meta.command.goto.dosbatch
+::        ^ - meta.command
+:: ^^^^ keyword.control.flow.goto.dosbatch
+::     ^ - keyword - variable
+::      ^^ variable.label.dosbatch constant.character.escape.dosbatch
+::        ^ - variable
+
+   GOTO ^)
+:: ^^^^^^^ meta.command.goto.dosbatch
+::        ^ - meta.command
+:: ^^^^ keyword.control.flow.goto.dosbatch
+::     ^ - keyword - variable
+::      ^^ variable.label.dosbatch constant.character.escape.dosbatch
+::        ^ - variable
+
+   GOTO ^[
+:: ^^^^^^^ meta.command.goto.dosbatch
+::        ^ - meta.command
+:: ^^^^ keyword.control.flow.goto.dosbatch
+::     ^ - keyword - variable
+::      ^^ variable.label.dosbatch constant.character.escape.dosbatch
+::        ^ - variable
+
+   GOTO ^]
+:: ^^^^^^^ meta.command.goto.dosbatch
+::        ^ - meta.command
+:: ^^^^ keyword.control.flow.goto.dosbatch
+::     ^ - keyword - variable
+::      ^^ variable.label.dosbatch constant.character.escape.dosbatch
+::        ^ - variable
+
+   GOTO ^{
+:: ^^^^^^^ meta.command.goto.dosbatch
+::        ^ - meta.command
+:: ^^^^ keyword.control.flow.goto.dosbatch
+::     ^ - keyword - variable
+::      ^^ variable.label.dosbatch constant.character.escape.dosbatch
+::        ^ - variable
+
+   GOTO ^}
+:: ^^^^^^^ meta.command.goto.dosbatch
+::        ^ - meta.command
+:: ^^^^ keyword.control.flow.goto.dosbatch
+::     ^ - keyword - variable
+::      ^^ variable.label.dosbatch constant.character.escape.dosbatch
+::        ^ - variable
+
+   GOTO ^>
+:: ^^^^^^^ meta.command.goto.dosbatch
+::        ^ - meta.command
+:: ^^^^ keyword.control.flow.goto.dosbatch
+::     ^ - keyword - variable
+::      ^^ variable.label.dosbatch constant.character.escape.dosbatch
+::        ^ - variable
+
+   GOTO ^<
+:: ^^^^^^^ meta.command.goto.dosbatch
+::        ^ - meta.command
+:: ^^^^ keyword.control.flow.goto.dosbatch
+::     ^ - keyword - variable
+::      ^^ variable.label.dosbatch constant.character.escape.dosbatch
+::        ^ - variable
+
+   GOTO ^&
+:: ^^^^^^^ meta.command.goto.dosbatch
+::        ^ - meta.command
+:: ^^^^ keyword.control.flow.goto.dosbatch
+::     ^ - keyword - variable
+::      ^^ variable.label.dosbatch constant.character.escape.dosbatch
+::        ^ - variable
+
+   GOTO ^|
+:: ^^^^^^^ meta.command.goto.dosbatch
+::        ^ - meta.command
+:: ^^^^ keyword.control.flow.goto.dosbatch
+::     ^ - keyword - variable
+::      ^^ variable.label.dosbatch constant.character.escape.dosbatch
+::        ^ - variable
+
+   GOTO %%
+:: ^^^^^^^ meta.command.goto.dosbatch
+::        ^ - meta.command
+:: ^^^^ keyword.control.flow.goto.dosbatch
+::     ^ - keyword - variable
+::      ^^ variable.label.dosbatch constant.character.escape.dosbatch
+::        ^ - variable
+
+   GOTO %
+:: ^^^^^^ meta.command.goto.dosbatch
+::       ^ - meta.command
+:: ^^^^ keyword.control.flow.goto.dosbatch
+::     ^ - keyword - variable
+::      ^ variable.label.dosbatch
+::       ^ - variable
+
+   GOTO %var% ignored content ( & echo foo
+:: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.command.goto.dosbatch
+::                             ^^^ - meta.command
+::                                ^^^^^^^^ meta.command.echo.dosbatch
+:: ^^^^ keyword.control.flow.goto.dosbatch
+::      ^^^^^ variable.label.dosbatch meta.interpolation.dosbatch
+::      ^ punctuation.section.interpolation.begin.dosbatch
+::       ^^^ variable.other.readwrite.dosbatch
+::          ^ punctuation.section.interpolation.end.dosbatch
+::            ^^^^^^^^^^^^^^^^^ comment.line.ignored.dosbatch
+::                              ^ keyword.operator.logical.dosbatch
+
+   GOTO %%var%% ignored content ( & echo foo
+:: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.command.goto.dosbatch
+::                               ^^^ - meta.command
+::                                  ^^^^^^^^ meta.command.echo.dosbatch
+:: ^^^^ keyword.control.flow.goto.dosbatch
+::      ^^^^^^^ variable.label.dosbatch
+::      ^^ constant.character.escape.dosbatch
+::           ^^ constant.character.escape.dosbatch
+::              ^^^^^^^^^^^^^^^^^ comment.line.ignored.dosbatch
+::                                ^ keyword.operator.logical.dosbatch
+
+   GOTO !
+:: ^^^^^^ meta.command.goto.dosbatch
+::       ^ - meta.command
+:: ^^^^ keyword.control.flow.goto.dosbatch
+::     ^ - keyword - variable
+::      ^ variable.label.dosbatch
+::       ^ - variable
+
+   GOTO !var! ignored content ( | echo foo
+:: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.command.goto.dosbatch
+::                             ^^^ - meta.command
+::                                ^^^^^^^^ meta.command.echo.dosbatch
+:: ^^^^ keyword.control.flow.goto.dosbatch
+::      ^^^^^ variable.label.dosbatch meta.interpolation.dosbatch
+::      ^ punctuation.section.interpolation.begin.dosbatch
+::       ^^^ variable.other.readwrite.dosbatch
+::          ^ punctuation.section.interpolation.end.dosbatch
+::            ^^^^^^^^^^^^^^^^^ comment.line.ignored.dosbatch
+::                              ^ keyword.operator.assignment.pipe.dosbatch
+
+   GOTO ^!var^! ignored content ( | echo foo
+:: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.command.goto.dosbatch
+::                               ^^^ - meta.command
+::                                  ^^^^^^^^ meta.command.echo.dosbatch
+:: ^^^^ keyword.control.flow.goto.dosbatch
+::      ^^^^^^^ variable.label.dosbatch
+::      ^^ constant.character.escape.dosbatch
+::           ^^ constant.character.escape.dosbatch
+::              ^^^^^^^^^^^^^^^^^ comment.line.ignored.dosbatch
+::                                ^ keyword.operator.assignment.pipe.dosbatch
 
    GOTO:This is a #@$虎 strange label
 :: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.command.goto.dosbatch
 :: ^^^^ keyword.control.flow.goto.dosbatch
-::     ^ punctuation.definition.variable.dosbatch
+::     ^ punctuation.definition.label.dosbatch
 ::     ^^^^^ variable.label.dosbatch - keyword
 ::           ^^^^^^^^^^^^^^^^^^^^^^^ comment.line.ignored.dosbatch
 
@@ -455,9 +970,33 @@ ECHO : Not a comment ^
 ::      ^^^^ variable.label.dosbatch - keyword
 ::           ^^^^^^^^^^^^^^^^^^^^^^^ comment.line.ignored.dosbatch
 
+   GOTO This^
+is a #@$虎" strange label
+:: <- meta.command.goto.dosbatch variable.label.dosbatch
+:: ^^^^^^^^^^^^^^^^^^^^^ comment.line.ignored.dosbatch
+
+   GOTO This^
+   is a #@$虎" strange label
+:: <- meta.command.goto.dosbatch - variable.label.dosbatch
+:: ^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.ignored.dosbatch
+
    GOTO This is^
    a #%@$虎 strange label
 :: ^^^^^^^^^^^^^^^^^^^^^ comment.line.ignored.dosbatch
+
+   GOTO This" is a #@$虎" strange label
+:: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.command.goto.dosbatch
+:: ^^^^ keyword.control.flow.goto.dosbatch
+::      ^^^^^ variable.label.dosbatch - keyword
+::           ^ - variable - comment
+::            ^^^^^^^^^^^^^^^^^^^^^^^ comment.line.ignored.dosbatch
+
+   GOTO "This is a #@$虎" strange label
+:: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.command.goto.dosbatch
+:: ^^^^ keyword.control.flow.goto.dosbatch
+::      ^^^^^ variable.label.dosbatch - keyword
+::           ^ - variable - comment
+::            ^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.ignored.dosbatch
 
    GOTO %%i
 :: ^^^^ meta.command.goto.dosbatch keyword.control.flow.goto.dosbatch - meta.interpolation

--- a/Batch File/tests/syntax_test_batch_file.bat
+++ b/Batch File/tests/syntax_test_batch_file.bat
@@ -3,12 +3,30 @@
 
 :::: [ Comments ] :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
+   REM/? ignored
+:: ^^^^^^^^^^^^^ meta.command.rem.dosbatch
+:: ^^^ keyword.declaration.rem.dosbatch
+::    ^^ variable.parameter.option.help.dosbatch
+::       ^^^^^^^ comment.line.ignored.dosbatch
+   REM ^
+   /? ignored
+:: ^^^^^^^^^^ meta.command.rem.dosbatch
+:: ^^ variable.parameter.option.help.dosbatch
+::    ^^^^^^^ comment.line.ignored.dosbatch
+
+   REM/?/a
+:: ^^^^^^^^ meta.command.rem.dosbatch
+:: ^^^ keyword.declaration.rem.dosbatch
+::    ^^^^^ comment.line.rem.dosbatch
+
    REM I'm a (com|ment)
+:: ^^^^^^^^^^^^^^^^^^^^^ meta.command.rem.dosbatch
 :: ^^^ keyword.declaration.rem.dosbatch - comment
 ::     ^^^^^^^^^^^^^^^^^ comment.line.rem.dosbatch
 
    ( rem comment )
-:: ^^^^^^^^^^^^^^^^ meta.block.dosbatch
+:: ^^ meta.block.dosbatch - meta.command
+::   ^^^^^^^^^^^^^^ meta.block.dosbatch meta.command.rem.dosbatch
 :: ^ punctuation.section.block.begin.dosbatch
 ::   ^^^ keyword.declaration.rem.dosbatch
 ::       ^^^^^^^^^^ comment.line.rem.dosbatch
@@ -354,6 +372,14 @@ ECHO : Not a comment ^
 ::        ^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.ignored.dosbatch
 
 :::: [ Control Flow ] :::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+   CALL/?
+:: ^^^^ meta.function-call.dosbatch keyword.control.flow.call.dosbatch
+::     ^^ variable.parameter.option.help.dosbatch
+
+   CALL /?
+:: ^^^^ meta.function-call.dosbatch keyword.control.flow.call.dosbatch
+::      ^^ variable.parameter.option.help.dosbatch
 
    CALL:This is a #@$虎 ^strange %%label
 ::^ - meta.function-call
@@ -709,6 +735,28 @@ bar baz
    EXIT
 :: ^^^^ meta.command.exit.dosbatch keyword.control.flow.exit.dosbatch
 
+   EXIT /?
+:: ^^^^^^^ meta.command.exit.dosbatch
+:: ^^^^ keyword.control.flow.exit.dosbatch
+::      ^^ variable.parameter.option.help.dosbatch
+
+   :: all arguments are ignored, if /? is present
+   EXIT /? /b > help.txt
+:: ^^^^^^^^^^^^^^^^^^^^^ meta.command.exit.dosbatch
+:: ^^^^ keyword.control.flow.exit.dosbatch
+::      ^^ variable.parameter.option.help.dosbatch
+::         ^^ meta.command.exit.dosbatch comment.line.ignored.dosbatch
+::            ^^^^^^^^^^ meta.redirection.dosbatch
+::            ^ keyword.operator.assignment.redirection.dosbatch
+::              ^^^^^^^^ meta.path.dosbatch meta.string.dosbatch string.unquoted.dosbatch
+
+   :: /b is ignored, but it's not handled
+   EXIT /b /?
+:: ^^^^^^^^^^ meta.command.exit.dosbatch
+:: ^^^^ keyword.control.flow.exit.dosbatch
+::      ^^ variable.parameter.option.dosbatch
+::         ^^ variable.parameter.option.help.dosbatch
+
    EXIT /b 12 illegal
 :: ^^^^^^^^^^^^^^^^^^ meta.command.exit.dosbatch
 :: ^^^^ keyword.control.flow.exit.dosbatch
@@ -724,6 +772,17 @@ bar baz
 ::      ^^ variable.parameter.option.dosbatch
 ::         ^^^^^ meta.interpolation.dosbatch
 ::               ^^^^^^^ invalid.illegal.expect-end-of-command.dosbatch
+
+   GOTO/?
+:: ^^^^^^ meta.command.goto.dosbatch
+:: ^^^^ keyword.control.flow.goto.dosbatch
+::     ^^ variable.parameter.option.help.dosbatch
+
+   GOTO /? ignored
+:: ^^^^^^^^^^^^^^^ meta.command.goto.dosbatch
+:: ^^^^ keyword.control.flow.goto.dosbatch
+::      ^^ variable.parameter.option.help.dosbatch
+::         ^^^^^^^ comment.line.ignored.dosbatch
 
    GOTO:EOF
 :: ^^^^^^^^ meta.command.goto.dosbatch
@@ -1017,6 +1076,17 @@ is a #@$虎" strange label
 ::       ^^^^^^^^^^ meta.path.dosbatch meta.string.dosbatch string.unquoted.dosbatch
 
 :::: [ Conditionals ] :::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+   IF/?
+:: ^^^^ meta.statement.conditional.dosbatch
+:: ^^ keyword.control.conditional.if.dosbatch
+::   ^^ variable.parameter.option.help.dosbatch
+
+   IF /? /i
+:: ^^^^^^^^ meta.statement.conditional.dosbatch
+:: ^^ keyword.control.conditional.if.dosbatch
+::    ^^ variable.parameter.option.help.dosbatch
+::       ^^ comment.line.ignored.dosbatch
 
    IF foo EQU bar echo "equal"
 :: ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.dosbatch
@@ -1389,6 +1459,11 @@ is a #@$虎" strange label
 
 :::: [ Loops ] ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
+   FOR /?
+:: ^^^^^^ meta.statement.loop.for.dosbatch
+:: ^^^ keyword.control.loop.for.dosbatch
+::     ^^ variable.parameter.option.help.dosbatch
+
    FOR %%# IN (0,1) DO md %%#
 ::     ^^^ variable.other.readwrite.dosbatch
 ::                        ^^^ string.unquoted.dosbatch
@@ -1676,6 +1751,16 @@ is a #@$虎" strange label
 :: ^^^^^^^^ meta.command.setlocal.dosbatch keyword.context.setlocal.dosbatch
    ENDLOCAL
 :: ^^^^^^^^ meta.command.endlocal.dosbatch keyword.context.endlocal.dosbatch
+
+   SETLOCAL /? >nul
+:: ^^^^^^^^^^^^ meta.command.setlocal.dosbatch
+::             ^^^^ meta.command.setlocal.dosbatch meta.redirection.dosbatch
+::          ^^ variable.parameter.option.help.dosbatch
+
+   ENDLOCAL /? >nul
+:: ^^^^^^^^^^^^ meta.command.endlocal.dosbatch
+::             ^^^^ meta.command.endlocal.dosbatch meta.redirection.dosbatch
+::          ^^ variable.parameter.option.help.dosbatch
 
    setlocal endlocal & echo hello & endlocal illegal
 :: ^^^^^^^^^^^^^^^^^ meta.command.setlocal.dosbatch
@@ -3035,6 +3120,12 @@ put arg1 arg2
 
 :::: [ SET variable=string ] ::::::::::::::::::::::::::::::::::::::::::::::::::
 
+   set /? ignored
+:: ^^^^^^^^^^^^^^ meta.command.set.dosbatch
+:: ^^^ support.function.builtin.dosbatch
+::     ^^ variable.parameter.option.help.dosbatch
+::        ^^^^^^^ comment.line.ignored.dosbatch
+
    set # & echo %#%
 ::     ^ variable.other.readwrite.dosbatch
 ::       ^ keyword.operator.logical.dosbatch
@@ -3628,6 +3719,19 @@ put arg1 arg2
 ::                 ^ keyword.operator.assignment.redirection.dosbatch
 ::                  ^^^ constant.language.null.dosbatch
 
+   set /? /a ignored
+:: ^^^^^^^^^^^^^^^^^ meta.command.set.dosbatch
+:: ^^^ support.function.builtin.dosbatch
+::     ^^ variable.parameter.option.help.dosbatch
+::        ^^^^^^^^^^ comment.line.ignored.dosbatch
+
+   set /A /? ignored
+:: ^^^^^^^^^^^^^^^^^ meta.command.set.dosbatch
+:: ^^^ support.function.builtin.dosbatch
+::     ^^ variable.parameter.option.expression.dosbatch
+::        ^^ variable.parameter.option.help.dosbatch
+::           ^^^^^^^ comment.line.ignored.dosbatch
+
    set /A hello_world
 :: ^^^ support.function.builtin.dosbatch
 ::        ^^^^^^^^^^^ meta.expression.dosbatch
@@ -4007,6 +4111,19 @@ put arg1 arg2
 ::                      ^ punctuation.section.block.end.dosbatch
 
 :::: [ SET /P variable=promptString ]::::::::::::::::::::::::::::::::::::::::::
+
+   set /? /p ignored
+:: ^^^^^^^^^^^^^^^^^ meta.command.set.dosbatch
+:: ^^^ support.function.builtin.dosbatch
+::     ^^ variable.parameter.option.help.dosbatch
+::        ^^^^^^^^^^ comment.line.ignored.dosbatch
+
+   set /p /? ignored
+:: ^^^^^^^^^^^^^^^^^ meta.command.set.dosbatch
+:: ^^^ support.function.builtin.dosbatch
+::     ^^ variable.parameter.option.prompt.dosbatch
+::        ^^ variable.parameter.option.help.dosbatch
+::           ^^^^^^^ comment.line.ignored.dosbatch
 
    set /p today=
 :: ^^^^^^^ meta.command.set.dosbatch - meta.prompt

--- a/Batch File/tests/syntax_test_batch_file.bat
+++ b/Batch File/tests/syntax_test_batch_file.bat
@@ -2246,6 +2246,19 @@ put arg1 arg2
 ::  ^^^^ support.function.builtin.dosbatch
 ::       ^^^ constant.language.dosbatch
 
+   @ECHO OFF > nul
+:: ^ - meta.command
+::  ^^^^^^^^ meta.command.echo.dosbatch
+::  ^^^^ meta.function-call.identifier.dosbatch
+::      ^^^^^ meta.function-call.arguments.dosbatch
+::           ^^^^^ meta.function-call.arguments.dosbatch meta.redirection.dosbatch
+::                ^ - meta.command
+:: ^ keyword.operator.at.dosbatch
+::  ^^^^ support.function.builtin.dosbatch
+::       ^^^ constant.language.dosbatch
+::           ^ keyword.operator.assignment.redirection.dosbatch
+::             ^^^ constant.language.null.dosbatch
+
    @ECHO OFF :: no (comment) & :: comment
 :: ^ - meta.command
 ::  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.command.echo.dosbatch

--- a/Batch File/tests/syntax_test_batch_file.bat
+++ b/Batch File/tests/syntax_test_batch_file.bat
@@ -4234,12 +4234,16 @@ put arg1 arg2
 ::               ^ punctuation.definition.prompt.end.dosbatch
 ::                ^ keyword.operator.assignment.redirection.dosbatch
 
-   set /p "today=" this is ignored <today.txt also ignored
+   set /p "today=" this is ignored <today.txt not 2>nul, but 12>1 is ignored
 :: ^^^^^^^ meta.command.set.dosbatch - meta.string
 ::        ^^^^^^^^ meta.command.set.dosbatch meta.prompt.dosbatch - meta.string
 ::                ^^^^^^^^^^^^^^^^^ meta.command.set.dosbatch - meta.redirection
 ::                                 ^^^^^^^^^^ meta.command.set.dosbatch meta.redirection.dosbatch - comment
-::                                           ^^^^^^^^^^^^^ meta.command.set.dosbatch - meta.redirection
+::                                           ^^^^^ meta.command.set.dosbatch - meta.redirection
+::                                                ^^^^^ meta.command.set.dosbatch meta.redirection.dosbatch - comment
+::                                                     ^^^^^^^^ comment.line.ignored.dosbatch - meta.redirection
+::                                                             ^^ meta.command.set.dosbatch meta.redirection.dosbatch
+::                                                               ^^^^^^^^^^^ comment.line.ignored.dosbatch - meta.redirection
 :: ^^^ support.function.builtin.dosbatch
 ::    ^ - keyword - variable
 ::     ^ punctuation.definition.variable.dosbatch

--- a/Batch File/tests/syntax_test_batch_file.bat
+++ b/Batch File/tests/syntax_test_batch_file.bat
@@ -2610,7 +2610,7 @@ put arg1 arg2
 ::                                           ^^^^^^ - constant
 ::                                                 ^^ constant.character.escape.dosbatch
 ::                                                   ^^^ - constant
-::                                                      ^ constant.other.placeholder.dosbatch
+::                                                      ^ keyword.operator.wildcard.dosbatch
 ::                                                       ^^ constant.character.escape.dosbatch
 ::                                                         ^ - constant
 ::                                                          ^^ constant.character.escape.dosbatch

--- a/Batch File/tests/syntax_test_batch_file.bat
+++ b/Batch File/tests/syntax_test_batch_file.bat
@@ -32,6 +32,15 @@ REM This follows a REM command
 :: <- keyword.declaration.rem.dosbatch - comment
 ::  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.rem.dosbatch
 
+REM This & and | echo "is commented out" ^
+:: <- keyword.declaration.rem.dosbatch
+::  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.command.rem.dosbatch comment.line.rem.dosbatch
+
+REM No line ^
+continuation
+:: <- - comment
+:: ^^^^^^^^^ - comment
+
    :: Me too!
 :: ^^ punctuation.definition.comment.dosbatch
 :: ^^^^^^^^^^ comment.line.colon.dosbatch

--- a/Batch File/tests/syntax_test_batch_file.bat
+++ b/Batch File/tests/syntax_test_batch_file.bat
@@ -1980,17 +1980,15 @@ put arg1 arg2
 :: ^^^^^^^ meta.function-call.identifier.dosbatch variable.function.dosbatch
 ::        ^^^^^^^^^^^^^^^ meta.function-call.arguments.dosbatch
 ::         ^ meta.parameter.option.dosbatch - meta.string - meta.interpolation
-::          ^^^^^^^^ meta.parameter.option.dosbatch meta.string.dosbatch - meta.interpolation
-::                  ^^^^ meta.parameter.option.dosbatch meta.string.dosbatch meta.interpolation.dosbatch
-::                      ^ meta.parameter.option.dosbatch meta.string.dosbatch - meta.interpolation
-::         ^^^^^^^^^ variable.parameter.option.dosbatch
-::                  ^^^^ - variable.parameter
+::          ^^^^^^^^ meta.parameter.option.dosbatch - meta.interpolation
+::                  ^^^^ meta.parameter.option.dosbatch meta.interpolation.dosbatch
+::                      ^ meta.parameter.option.dosbatch - meta.interpolation
 ::         ^ punctuation.definition.variable.dosbatch
-::          ^ punctuation.definition.string.begin.dosbatch
+::          ^ - punctuation
 ::                  ^ punctuation.section.interpolation.begin.dosbatch
 ::                   ^^ variable.other.readwrite.dosbatch
 ::                     ^ punctuation.section.interpolation.end.dosbatch
-::                      ^ variable.parameter.option.dosbatch punctuation.definition.string.end.dosbatch
+::                      ^ - punctuation
 
    command ..\folder2\ /type:*.txt
 :: ^^^^^^^ meta.function-call.identifier.dosbatch variable.function.dosbatch
@@ -2022,7 +2020,8 @@ put arg1 arg2
 ::                         ^^^^^^^ meta.interpolation.dosbatch
 ::                               ^ punctuation.section.interpolation.end.dosbatch
 
-   powershell get-date -uformat "%%Y%%m%%d" > today.txt
+   powershell get-date -uformat "%%Y%%m%%d">today.txt
+::           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.dosbatch
 ::            ^^^^^^^^ - variable.parameter
 ::                     ^^^^^^^^ meta.parameter.option.dosbatch variable.parameter.option.dosbatch
 ::                     ^ punctuation.definition.variable.dosbatch
@@ -2033,7 +2032,25 @@ put arg1 arg2
 ::                                    ^ - constant.character.escape.dosbatch
 ::                                     ^^ constant.character.escape.dosbatch
 ::                                       ^ - constant.character.escape.dosbatch
+::                                         ^^^^^^^^^^ meta.redirection.dosbatch
+::                                         ^ keyword.operator.assignment.redirection.dosbatch
+::                                          ^^^^^^^^^ meta.path.dosbatch meta.string.dosbatch string.unquoted.dosbatch
 
+   powershell get-date>today.txt -uformat "%%Y%%m%%d"
+::           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.dosbatch
+::            ^^^^^^^^ - variable.parameter
+::                    ^^^^^^^^^^ meta.redirection.dosbatch
+::                    ^ keyword.operator.assignment.redirection.dosbatch
+::                     ^^^^^^^^^ meta.path.dosbatch meta.string.dosbatch string.unquoted.dosbatch
+::                               ^^^^^^^^ meta.parameter.option.dosbatch variable.parameter.option.dosbatch
+::                               ^ punctuation.definition.variable.dosbatch
+::                                        ^^^^^^^^^^^ string.unquoted.dosbatch
+::                                         ^^ constant.character.escape.dosbatch
+::                                           ^ - constant.character.escape.dosbatch
+::                                            ^^ constant.character.escape.dosbatch
+::                                              ^ - constant.character.escape.dosbatch
+::                                               ^^ constant.character.escape.dosbatch
+::                                                 ^ - constant.character.escape.dosbatch
 
 :::: [ Redirections ] :::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 


### PR DESCRIPTION
This PR modifies behavior of Batch File.sublime-syntax to treat redirections as normal command arguments. That's what Bash also does.

Up to this commit, redirections have been expected, with some exceptions, to appear at the end of a command only. Thus they terminated statements.

This commit therefore applies following changes:

1. `<` and `>` are removed from command terminator patterns

2. a new `redirection_or_eoc` variable is introduced to terminate tokens, which are known not to contain redirections.

3. the `metachar` variable and some of its children are tweaked, mostly to reduce duplicated characters and to clarify dependencies.

4. `redirections` context is included into all relevant contexts

5. various remaining issues related to unquoted vs. quoted escape sequences and interpolations are fixed by including clearly named contexts:

   - quoted-escapes-and-interpolations
   - unquoted-escapes-and-interpolations
   
   into related quoted and unquoted token contexts.

   That's a follow-up of #3743.

6. word boundaries and line continuation treatment is improved in various commands and contexts

#### Benchmarks

Parsing performance is not changed by this PR.