### PR TITLE
[Rails] Toggle ERB instead of HTML comments

### DIFF
--- a/Rails/HTML (Rails) - Comments.tmPreferences
+++ b/Rails/HTML (Rails) - Comments.tmPreferences
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>scope</key>
+	<string>
+		source.css.rails,
+		source.js.rails,
+		source.json.rails,
+		text.html.rails,
+		text.html.rails source.css.embedded,
+		text.html.rails source.js.embedded,
+		text.html.rails source.json.embedded
+	</string>
+	<key>settings</key>
+	<dict>
+		<key>shellVariables</key>
+		<array>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START</string>
+				<key>value</key>
+				<string><![CDATA[<%# ]]></string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_END</string>
+				<key>value</key>
+				<string><![CDATA[ %>]]></string>
+			</dict>
+		</array>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
Fixes #3756

This PR adds definition for ERB comments to be added/removed when toggling comments in ERB templates.