### PR TITLE
[Go] Add Template Snippets

### DIFF
--- a/Go/Snippets/Template/block-end.sublime-snippet
+++ b/Go/Snippets/Template/block-end.sublime-snippet
@@ -1,0 +1,8 @@
+<snippet>
+<content><![CDATA[${TM_TEMPLATE_START}block "${1:name}"${TM_TEMPLATE_END}
+$0
+${TM_TEMPLATE_START}end${TM_TEMPLATE_END}]]></content>
+<tabTrigger>tblockend</tabTrigger>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.go string) - source.go.template</scope>
+<description>{{block "name"}} ... {{end}}</description>
+</snippet>

--- a/Go/Snippets/Template/block.sublime-snippet
+++ b/Go/Snippets/Template/block.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+<content><![CDATA[${TM_TEMPLATE_START}block "${1:name}"${TM_TEMPLATE_END}]]></content>
+<tabTrigger>tblock</tabTrigger>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.go string) - source.go.template</scope>
+<description>{{block "name"}}</description>
+</snippet>

--- a/Go/Snippets/Template/break.sublime-snippet
+++ b/Go/Snippets/Template/break.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+<content><![CDATA[${TM_TEMPLATE_START}break${TM_TEMPLATE_END}]]></content>
+<tabTrigger>tbreak</tabTrigger>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.go string) - source.go.template</scope>
+<description>{{break}}</description>
+</snippet>

--- a/Go/Snippets/Template/continue.sublime-snippet
+++ b/Go/Snippets/Template/continue.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+<content><![CDATA[${TM_TEMPLATE_START}continue${TM_TEMPLATE_END}]]></content>
+<tabTrigger>tcontinue</tabTrigger>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.go string) - source.go.template</scope>
+<description>{{continue}}</description>
+</snippet>

--- a/Go/Snippets/Template/define.sublime-snippet
+++ b/Go/Snippets/Template/define.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+<content><![CDATA[${TM_TEMPLATE_START}define "${1:name}"${TM_TEMPLATE_END}]]></content>
+<tabTrigger>tdefine</tabTrigger>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.go string) - source.go.template</scope>
+<description>{{define "name"}}</description>
+</snippet>

--- a/Go/Snippets/Template/else if.sublime-snippet
+++ b/Go/Snippets/Template/else if.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+<content><![CDATA[${TM_TEMPLATE_START}else if ${1:pipeline}${TM_TEMPLATE_END}]]></content>
+<tabTrigger>telseif</tabTrigger>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.go string) - source.go.template</scope>
+<description>{{else if ...}}</description>
+</snippet>

--- a/Go/Snippets/Template/else.sublime-snippet
+++ b/Go/Snippets/Template/else.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+<content><![CDATA[${TM_TEMPLATE_START}else${TM_TEMPLATE_END}]]></content>
+<tabTrigger>telse</tabTrigger>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.go string) - source.go.template</scope>
+<description>{{else}}</description>
+</snippet>

--- a/Go/Snippets/Template/end.sublime-snippet
+++ b/Go/Snippets/Template/end.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+<content><![CDATA[${TM_TEMPLATE_START}end${TM_TEMPLATE_END}]]></content>
+<tabTrigger>tend</tabTrigger>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.go string) - source.go.template</scope>
+<description>{{end}}</description>
+</snippet>

--- a/Go/Snippets/Template/if-end.sublime-snippet
+++ b/Go/Snippets/Template/if-end.sublime-snippet
@@ -1,0 +1,8 @@
+<snippet>
+<content><![CDATA[${TM_TEMPLATE_START}if ${1:pipeline}${TM_TEMPLATE_END}
+$0
+${TM_TEMPLATE_START}end${TM_TEMPLATE_END}]]></content>
+<tabTrigger>tifend</tabTrigger>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.go string) - source.go.template</scope>
+<description>{{if ...}} ... {{end}}</description>
+</snippet>

--- a/Go/Snippets/Template/if.sublime-snippet
+++ b/Go/Snippets/Template/if.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+<content><![CDATA[${TM_TEMPLATE_START}if ${1:pipeline}${TM_TEMPLATE_END}]]></content>
+<tabTrigger>tif</tabTrigger>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.go string) - source.go.template</scope>
+<description>{{if ...}}</description>
+</snippet>

--- a/Go/Snippets/Template/partial.sublime-snippet
+++ b/Go/Snippets/Template/partial.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+<content><![CDATA[${TM_TEMPLATE_START}partial "${1:name}"${TM_TEMPLATE_END}]]></content>
+<tabTrigger>tpartial</tabTrigger>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.go string) - source.go.template</scope>
+<description>{{partial "name"}}</description>
+</snippet>

--- a/Go/Snippets/Template/range-end.sublime-snippet
+++ b/Go/Snippets/Template/range-end.sublime-snippet
@@ -1,0 +1,8 @@
+<snippet>
+<content><![CDATA[${TM_TEMPLATE_START}range ${1:pipeline}${TM_TEMPLATE_END}
+$0
+${TM_TEMPLATE_START}end${TM_TEMPLATE_END}]]></content>
+<tabTrigger>trangeend</tabTrigger>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.go string) - source.go.template</scope>
+<description>{{range ...}}...{{end}}</description>
+</snippet>

--- a/Go/Snippets/Template/range.sublime-snippet
+++ b/Go/Snippets/Template/range.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+<content><![CDATA[${TM_TEMPLATE_START}range ${1:pipeline}${TM_TEMPLATE_END}]]></content>
+<tabTrigger>trange</tabTrigger>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.go string) - source.go.template</scope>
+<description>{{range ...}}</description>
+</snippet>

--- a/Go/Snippets/Template/template.sublime-snippet
+++ b/Go/Snippets/Template/template.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+<content><![CDATA[${TM_TEMPLATE_START}template "${1:header}" ${0:.}${TM_TEMPLATE_END}]]></content>
+<tabTrigger>ttemplate</tabTrigger>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.go string) - source.go.template</scope>
+<description>{{template "name" .}}</description>
+</snippet>

--- a/Go/Snippets/Template/var.sublime-snippet
+++ b/Go/Snippets/Template/var.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+<content><![CDATA[${TM_TEMPLATE_START}.${0:Var}${TM_TEMPLATE_END}]]></content>
+<tabTrigger>tvar</tabTrigger>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.go string) - source.go.template</scope>
+<description>{{.Var}}</description>
+</snippet>

--- a/Go/Snippets/Template/with-end.sublime-snippet
+++ b/Go/Snippets/Template/with-end.sublime-snippet
@@ -1,0 +1,8 @@
+<snippet>
+<content><![CDATA[${TM_TEMPLATE_START}with ${1:pipeline}${TM_TEMPLATE_END}
+$0
+${TM_TEMPLATE_START}end${TM_TEMPLATE_END}]]></content>
+<tabTrigger>twithend</tabTrigger>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.go string) - source.go.template</scope>
+<description>{{with ...}}...{{end}}</description>
+</snippet>

--- a/Go/Snippets/Template/with.sublime-snippet
+++ b/Go/Snippets/Template/with.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+<content><![CDATA[${TM_TEMPLATE_START}with ${1:pipeline}${TM_TEMPLATE_END}]]></content>
+<tabTrigger>twith</tabTrigger>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.go string) - source.go.template</scope>
+<description>{{with ...}}</description>
+</snippet>

--- a/Go/Template.tmPreferences
+++ b/Go/Template.tmPreferences
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<!--
+	Template begin and end punctuation to wrap snippets into,
+	when expanding within plain HTML, Markdown, CSS, JavaScript or Go strings.
+
+	These variables are used to share snippets accross
+	plain text and template source code and to be able to adjust
+	whether templates are wrapped with whitespace.
+	 -->
+	<key>scope</key>
+	<string>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.go string) - source.go.template</string>
+	<key>settings</key>
+	<dict>
+		<key>shellVariables</key>
+		<array>
+			<dict>
+				<key>name</key>
+				<string>TM_TEMPLATE_START</string>
+				<key>value</key>
+				<string><![CDATA[{{ ]]></string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>TM_TEMPLATE_END</string>
+				<key>value</key>
+				<string><![CDATA[ }}]]></string>
+			</dict>
+		</array>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
This PR proposes to add basic snippets for Go templates.

#### Examples:

    tif      => {{ if | }}
    tifend   => {{ if | }} ... {{ end }}
    telse    => {{ else }}

Triggers follow the scheme to prefix each valid template keyword with `t`.

#### Note:

We basically don't want to add new snippets, so an alternative would be to publish them as separate package, but I always found some helpers to add template tags very helpful.

Thoughts?