### PR TITLE
[TypeScript] Add missing sub-scopes to operator keywords

### DIFF
--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -397,7 +397,7 @@ contexts:
             scope: variable.other.readwrite.js
             push:
               - match: in{{identifier_break}}
-                scope: keyword.operator.type.js
+                scope: keyword.operator.type.in.js
                 set:
                   - ts-type-expression-end
                   - ts-type-expression-end-no-line-terminator
@@ -726,7 +726,7 @@ contexts:
       scope: keyword.operator.type.js
 
     - match: as{{identifier_break}}
-      scope: keyword.operator.type.js
+      scope: keyword.operator.type.as.js
       push:
         - match: const{{identifier_break}}
           scope: storage.modifier.const.js
@@ -739,7 +739,7 @@ contexts:
             - ts-type-expression-begin
 
     - match: satisfies{{identifier_break}}
-      scope: keyword.operator.type.js
+      scope: keyword.operator.type.satisfies.js
       push:
         - ts-type-meta
         - ts-type-expression-end
@@ -786,7 +786,7 @@ contexts:
       scope: keyword.operator.word.js
       push: [ts-type-expression-end-no-line-terminator, ts-type-expression-begin]
     - match: as{{identifier_break}}
-      scope: keyword.operator.type.js
+      scope: keyword.operator.type.as.js
       push:
         - ts-type-expression-end
         - ts-type-expression-end-no-line-terminator
@@ -869,11 +869,11 @@ contexts:
 
   ts-type-expression-begin:
     - match: keyof{{identifier_break}}
-      scope: keyword.operator.type.js
+      scope: keyword.operator.type.keyof.js
     - match: typeof{{identifier_break}}
-      scope: keyword.operator.type.js
+      scope: keyword.operator.type.typeof.js
     - match: infer{{identifier_break}}
-      scope: keyword.operator.type.js
+      scope: keyword.operator.type.infer.js
     - match: new{{identifier_break}}
       scope: keyword.operator.new.js
 
@@ -887,7 +887,7 @@ contexts:
       scope: storage.modifier.abstract.js
 
     - match: import{{identifier_break}}
-      scope: keyword.operator.type.js
+      scope: keyword.operator.type.import.js
       set:
         - match: \(
           scope: punctuation.section.group.begin.js

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -723,15 +723,15 @@ function f(this : any) {}
 /* Assertions */
 
 x as boolean;
-//^^ keyword.operator.type
+//^^ keyword.operator.type.as
 //   ^^^^^^^ meta.type support.type.primitive.boolean
 
 x satisfies boolean;
-//^^^^^^^^^ keyword.operator.type
+//^^^^^^^^^ keyword.operator.type.satisfies
 //          ^^^^^^^ meta.type support.type.primitive.boolean
 
 x as const;
-//^^ keyword.operator.type
+//^^ keyword.operator.type.as
 //   ^^^^^ storage.modifier.const
 
     foo!.bar;
@@ -900,11 +900,11 @@ let x: 0xabc;
 
 let x: typeof Foo;
 //     ^^^^^^^^^^ meta.type
-//     ^^^^^ keyword.operator.type
+//     ^^^^^ keyword.operator.type.typeof
 //            ^^^ support.class
 let x: keyof Foo;
 //     ^^^^^^^^^ meta.type
-//     ^^^^^ keyword.operator.type
+//     ^^^^^ keyword.operator.type.keyof
 //           ^^^ support.class
 
 let x: Foo.bar;
@@ -1038,8 +1038,8 @@ let x: {
 //  ^^^^^^^^^^^^^^^^ meta.brackets
 //  ^ punctuation.section.brackets.begin
 //    ^ variable.other.readwrite
-//      ^^ keyword.operator.type
-//         ^^^^^ keyword.operator.type
+//      ^^ keyword.operator.type.in
+//         ^^^^^ keyword.operator.type.keyof
 //               ^ meta.brackets support.class
 //                 ^ punctuation.section.brackets.end
 //                   ^ punctuation.separator.type
@@ -1054,10 +1054,10 @@ let x: {
 //  ^^^^^^^^^^^^^^^^^^^^^ meta.brackets
 //  ^ punctuation.section.brackets.begin
 //    ^ variable.other.readwrite
-//      ^^ keyword.operator.type
-//         ^^^^^ keyword.operator.type
+//      ^^ keyword.operator.type.in
+//         ^^^^^ keyword.operator.type.keyof
 //               ^ meta.brackets support.class
-//                 ^^ keyword.operator.type
+//                 ^^ keyword.operator.type.as
 //                    ^ meta.brackets support.class
 //                      ^ punctuation.section.brackets.end
 
@@ -1067,8 +1067,8 @@ let x: {
 //             ^^^^^^^^^^^^^^^^ meta.brackets
 //             ^ punctuation.section.brackets.begin
 //               ^ variable.other.readwrite
-//                 ^^ keyword.operator.type
-//                    ^^^^^ keyword.operator.type
+//                 ^^ keyword.operator.type.in
+//                    ^^^^^ keyword.operator.type.keyof
 //                          ^ meta.brackets support.class
 //                            ^ punctuation.section.brackets.end
 //                              ^ storage.modifier
@@ -1186,7 +1186,7 @@ let x: T extends infer U ? V : W;
 //     ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type
 //     ^ support.class
 //       ^^^^^^^ keyword.operator.type.extends
-//               ^^^^^ keyword.operator.type
+//               ^^^^^ keyword.operator.type.infer
 //                     ^ support.class
 //                       ^ keyword.operator.type
 //                         ^ support.class
@@ -1195,7 +1195,7 @@ let x: T extends infer U ? V : W;
 
 let x: import ( "foo" ) . Bar ;
 //     ^^^^^^^^^^^^^^^^^^^^^^^ meta.type
-//     ^^^^^^ keyword.operator.type
+//     ^^^^^^ keyword.operator.type.import
 //            ^^^^^^^^^ meta.group
 //            ^ punctuation.section.group.begin
 //              ^^^^^ meta.string string.quoted.double


### PR DESCRIPTION
Some operator keywords in the TypeScript syntax use quite specific sub-scopes, for example
https://github.com/sublimehq/Packages/blob/17188f5973c6762ce60793dc0f7711243853ca94/JavaScript/TypeScript.sublime-syntax#L779-L784
and
https://github.com/sublimehq/Packages/blob/17188f5973c6762ce60793dc0f7711243853ca94/JavaScript/TypeScript.sublime-syntax#L801-L802
while some others do not.

This PR adds the corresponding sub-scopes to the operator keywords where they were missing, so that color schemes are able to target them one-by-one (as a workaround for #3694).

I didn't add it to the operator symbols where the sub-scopes are missing, because I'm not a TypeScript user and don't know what they mean:
https://github.com/sublimehq/Packages/blob/17188f5973c6762ce60793dc0f7711243853ca94/JavaScript/TypeScript.sublime-syntax#L725-L726
https://github.com/sublimehq/Packages/blob/17188f5973c6762ce60793dc0f7711243853ca94/JavaScript/TypeScript.sublime-syntax#L804-L808

But I could add them as well, if so desired, and someone tells me the appropriate scope names.