### PR TITLE
[Git Formats] Change wildcard and path separator scopes

### DIFF
--- a/Git Formats/Git Common.sublime-syntax
+++ b/Git Formats/Git Common.sublime-syntax
@@ -162,7 +162,7 @@ contexts:
     # windows drive letter and separator
     - match: '[A-Za-z](:)(?=/)'
       captures:
-        1: punctuation.separator.drive.fnmatch.git
+        1: punctuation.separator.path.fnmatch.git
       pop: 1
     # homedir tilde operator
     - match: ~(?=/)
@@ -184,15 +184,15 @@ contexts:
       scope: punctuation.separator.path.fnmatch.git
       push: fnmatch-dir-pattern
     - match: \.(?!.*[./]) # the last dot not followed by path sep
-      scope: punctuation.separator.path.extension.fnmatch.git
+      scope: punctuation.separator.path.fnmatch.git
     - match: '[*?]'       # unescapable operators
-      scope: keyword.operator.path.asterisk.fnmatch.git
+      scope: keyword.operator.wildcard.fnmatch.git
     - match: '\\[^$*?]'   # backslash escapes nearly everything
       scope: constant.character.escape.path.fnmatch.git
     - match: \$\w+
       scope: variable.language.environment.other.fnmatch.git
     - match: ':'          # drive separators
-      scope: invalid.illegal.separator.drive.fnmatch.git
+      scope: invalid.illegal.separator.path.fnmatch.git
     - match: '\\(?=\s)'   # single backslash is invalid
       scope: invalid.illegal.escape.path.fnmatch.git
 

--- a/Git Formats/Git Link.sublime-syntax
+++ b/Git Formats/Git Link.sublime-syntax
@@ -64,7 +64,7 @@ contexts:
     # windows drive letter and separator
     - match: '[A-Za-z](:)(?=[\\/])'
       captures:
-        1: punctuation.separator.drive.git
+        1: punctuation.separator.path.git
       pop: 1
     # homedir tilde operator
     - match: ~(?=/)

--- a/Git Formats/tests/syntax_test_git_attributes
+++ b/Git Formats/tests/syntax_test_git_attributes
@@ -84,7 +84,7 @@
 # <- string.quoted.double.git.attributes punctuation.definition.string.begin.git.attributes - entity.name.pattern.git
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.git.attributes
 #^^^^^^^^^^^^^^^^^^^^^^^^^^ entity.name.pattern.git
-#  ^ keyword.operator.path.asterisk.fnmatch.git
+#  ^ keyword.operator.wildcard.fnmatch.git
 #    ^^ constant.character.escape.path.fnmatch.git
 #       ^^^^ meta.char-class.fnmatch.git
 #       ^ keyword.control.char-class.begin.fnmatch.git
@@ -108,9 +108,9 @@
 #              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attributes-list.git.attributes - meta.pattern
 #^^^^^^^^^^^^^^ string.unquoted.git.attributes
 #    ^ punctuation.separator.path.fnmatch.git
-#     ^ keyword.operator.path.asterisk.fnmatch.git
-#      ^ punctuation.separator.path.extension.fnmatch.git
-#         ^ keyword.operator.path.asterisk.fnmatch.git
+#     ^ keyword.operator.wildcard.fnmatch.git
+#      ^ punctuation.separator.path.fnmatch.git
+#         ^ keyword.operator.wildcard.fnmatch.git
 #              ^ - variable.language.attribute - keyword.operator.logical
 #               ^^^^^^ variable.language.attribute.git.attributes
 #                     ^ - variable.language.attribute - keyword.operator.logical

--- a/Git Formats/tests/syntax_test_git_codeowners
+++ b/Git Formats/tests/syntax_test_git_codeowners
@@ -6,7 +6,7 @@
 # These owners will be the default owners for everything in
 # the repo, unless a later match takes precedence.
 *       @global-owner1 @global-owner2
-# <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners keyword.operator.path.asterisk.fnmatch.git
+# <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners keyword.operator.wildcard.fnmatch.git
 #^^^^^^^ - meta.path - meta.owners
 #       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.owners.git.codeowners
 #       ^^^^^^^^^^^^^^ meta.reference.username.git entity.name.reference.username.git
@@ -19,7 +19,7 @@
 # modifies JS files, only @js-owner and not the global
 # owner(s) will be requested for a review.
 *.js    @js-owner
-# <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners keyword.operator.path.asterisk.fnmatch.git
+# <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners keyword.operator.wildcard.fnmatch.git
 #^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
 #   ^^^^ - meta.path - meta.owners
 #       ^^^^^^^^^ meta.owners.git.codeowners meta.reference.username.git entity.name.reference.username.git
@@ -29,7 +29,7 @@
 # used to look up users just like we do for commit author
 # emails.
 *.go docs@example.com
-# <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners keyword.operator.path.asterisk.fnmatch.git
+# <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners keyword.operator.wildcard.fnmatch.git
 #^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
 #   ^ - meta.path - meta.owners
 #    ^^^^^^^^^^^^^^^^ meta.owners.git.codeowners meta.reference.email.git entity.name.reference.email.git
@@ -53,7 +53,7 @@ docs/*  docs@example.com
 # <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
 #^^^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
 #   ^ punctuation.separator.path.fnmatch.git
-#    ^ keyword.operator.path.asterisk.fnmatch.git
+#    ^ keyword.operator.wildcard.fnmatch.git
 #     ^^ - meta.path - meta.owners
 #       ^^^^^^^^^^^^^^^^ meta.owners.git.codeowners meta.reference.email.git entity.name.reference.email.git
 

--- a/Git Formats/tests/syntax_test_git_ignore
+++ b/Git Formats/tests/syntax_test_git_ignore
@@ -8,10 +8,10 @@
 #  ^ variable.language.environment.home.fnmatch.git
 #   ^ punctuation.separator.path.fnmatch.git
 #    ^ - constant
-#       ^ keyword.operator.path.asterisk.fnmatch.git
+#       ^ keyword.operator.wildcard.fnmatch.git
 #               ^ punctuation.separator.path.fnmatch.git
-#                ^ keyword.operator.path.asterisk.fnmatch.git
-#                 ^ punctuation.separator.path.extension.fnmatch.git
+#                ^ keyword.operator.wildcard.fnmatch.git
+#                 ^ punctuation.separator.path.fnmatch.git
 
   ~/../f..o\'ld\"er/fo\*l\?der/fol../der
 #^ - entity.name.pattern
@@ -22,9 +22,9 @@
 #          ^^ constant.character.escape.path.fnmatch.git
 #              ^^ constant.character.escape.path.fnmatch.git
 #                     ^ - constant.character.escape.path.fnmatch.git - punctuation.separator.path.fnmatch.git
-#                      ^ keyword.operator.path.asterisk.fnmatch.git
+#                      ^ keyword.operator.wildcard.fnmatch.git
 #                        ^ - constant.character.escape.path.fnmatch.git - punctuation.separator.path.fnmatch.git
-#                         ^ keyword.operator.path.asterisk.fnmatch.git
+#                         ^ keyword.operator.wildcard.fnmatch.git
 #                                 ^^ - constant.language.path.parent.fnmatch.git
 #                                       ^ - entity.name.pattern
 
@@ -33,9 +33,9 @@
 # ^^^^^^^^^^^^ string.unquoted.git.ignore entity.name.pattern.git.ignore
 # ^ - variable.language.environment.home.fnmatch.git
 #       ^ - variable.language.environment.home.fnmatch.git
-#         ^ punctuation.separator.path.extension.fnmatch.git
+#         ^ punctuation.separator.path.fnmatch.git
 #          ^ - variable.language.environment.home.fnmatch.git
-#            ^ keyword.operator.path.asterisk.fnmatch.git
+#            ^ keyword.operator.wildcard.fnmatch.git
   ~..fname
 # ^^^^^^^^ string.unquoted.git.ignore entity.name.pattern.git.ignore
 # ^ - variable.language.environment.home.fnmatch.git
@@ -64,18 +64,18 @@
 # DRIVE SEPARATOR TESTS
   c:/fo:lder:/
 # ^^^^^^^^^^^^ string.unquoted.git.ignore entity.name.pattern.git.ignore
-#  ^ punctuation.separator.drive.fnmatch.git
+#  ^ punctuation.separator.path.fnmatch.git
 #   ^ punctuation.separator.path.fnmatch.git
-#      ^ invalid.illegal.separator.drive.fnmatch.git
-#           ^ invalid.illegal.separator.drive.fnmatch.git
+#      ^ invalid.illegal.separator.path.fnmatch.git
+#           ^ invalid.illegal.separator.path.fnmatch.git
 #            ^ punctuation.separator.path.fnmatch.git
   cd:/folder
 # ^^^^^^^^^^ string.unquoted.git.ignore entity.name.pattern.git.ignore
-#   ^ invalid.illegal.separator.drive.fnmatch.git
+#   ^ invalid.illegal.separator.path.fnmatch.git
 #    ^ punctuation.separator.path.fnmatch.git
   :/folder
 # ^^^^^^^^ string.unquoted.git.ignore entity.name.pattern.git.ignore
-# ^ invalid.illegal.separator.drive.fnmatch.git
+# ^ invalid.illegal.separator.path.fnmatch.git
 #  ^ punctuation.separator.path.fnmatch.git
 
 

--- a/Git Formats/tests/syntax_test_git_link
+++ b/Git Formats/tests/syntax_test_git_link
@@ -6,7 +6,7 @@ gitdir: c:/data/sublime/packages/.git
 #      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.value.git.link - meta.mapping.key.git.link
 #      ^ - string.unquoted.git
 #       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.git
-#        ^ punctuation.separator.drive.git
+#        ^ punctuation.separator.path.git
 #         ^ punctuation.separator.path.git
 #              ^ punctuation.separator.path.git
 #                               ^ punctuation.separator.path.git
@@ -17,7 +17,7 @@ gitdir: c:\data\sublime\packages\.git
 #      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.value.git.link - meta.mapping.key.git.link
 #      ^ - string.unquoted.git
 #       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.git
-#        ^ punctuation.separator.drive.git
+#        ^ punctuation.separator.path.git
 #         ^ punctuation.separator.path.git
 #              ^ punctuation.separator.path.git
 #                                    ^ - string.unquoted.git


### PR DESCRIPTION
1. Wildcards are scoped `keyword.operator.wildcard`
2. All path separators are scoped `punctuation.separator.path`. All other sub scopes are removed.