### PR TITLE
[ShellScript] Improve FOR LOOP highlighting

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -398,17 +398,19 @@ contexts:
   cmd-arithmetic:
     - match: \(\((?=.+\)\))
       scope: punctuation.section.arithmetic.begin.shell
-      push:
-        - meta_scope: meta.arithmetic.shell
-        - match: \)\)
-          scope: punctuation.section.arithmetic.end.shell
-          pop: 1
-        - include: expressions
+      push: cmd-arithmetic-body
     - match: let{{cmd_break}}
       scope:
         meta.function-call.identifier.shell
         support.function.let.shell
       push: cmd-arithmetic-args
+
+  cmd-arithmetic-body:
+    - meta_scope: meta.arithmetic.shell
+    - match: \)\)
+      scope: punctuation.section.arithmetic.end.shell
+      pop: 1
+    - include: expressions
 
   cmd-arithmetic-args:
     - meta_content_scope: meta.function-call.arguments.shell
@@ -1165,13 +1167,36 @@ contexts:
     - include: cmd-args-boilerplate
 
   for-args:
-    - match: (?=(do|done){{cmd_break}})
-      pop: 1
-    - include: cmd-args-boilerplate
-    - include: cmd-arithmetic
+    - include: for-end
+    - match: \(\(
+      scope: punctuation.section.arithmetic.begin.shell
+      set: cmd-arithmetic-body
+    - match: (?=\S)
+      set: for-var
+
+  for-var:
     - match: in{{cmd_break}}
       scope: keyword.control.in.shell
+      set: for-iterator
+    - include: for-end
     - include: variables
+
+  for-iterator:
+    - include: for-end
+    - include: number-range
+    - match: (?=\S)
+      set: for-wordlist
+
+  for-wordlist:
+    - include: for-end
+    - include: booleans
+    - include: strings-unquoted
+
+  for-end:
+    - match: (?=(?:do|done){{cmd_break}})
+      pop: 1
+    - include: redirections
+    - include: eoc-pop
 
   select-args:
     - include: cmd-args-boilerplate
@@ -1533,6 +1558,22 @@ contexts:
       captures:
         1: keyword.operator.arithmetic.shell
         2: meta.number.integer.decimal.shell constant.numeric.value.shell
+      pop: 1
+
+  number-range:
+    - match: ({)(([-+]?)\d+)(..)(([-+]?)\d+)(?:(..)(([-+]?)\d+))?(})
+      scope: meta.sequence.range.shell
+      captures:
+        1: punctuation.section.sequence.begin.shell
+        2: meta.number.integer.decimal.shell constant.numeric.value.shell
+        3: keyword.operator.arithmetic.shell
+        4: keyword.operator.range.shell
+        5: meta.number.integer.decimal.shell constant.numeric.value.shell
+        6: keyword.operator.arithmetic.shell
+        7: keyword.operator.range.shell
+        8: meta.number.integer.decimal.shell constant.numeric.value.shell
+        9: keyword.operator.arithmetic.shell
+        10: punctuation.section.sequence.end.shell
       pop: 1
 
 ###[ OPERATORS ]###############################################################
@@ -1972,6 +2013,10 @@ contexts:
       scope: meta.interpolation.tilde.shell variable.language.tilde.shell
 
 ###[ STRINGS ]#################################################################
+
+  strings-unquoted:
+    - match: (?=[^{{metachar}}])
+      push: string-unquoted-body
 
   string-unquoted:
     - match: (?=[^{{metachar}}])

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -1082,7 +1082,7 @@ contexts:
       push: for-args
     - match: select{{cmd_break}}
       scope: keyword.control.loop.select.shell
-      push: select-args
+      push: loop-iterator-var
     - match: until{{cmd_break}}
       scope: keyword.control.loop.until.shell
     - match: while{{cmd_break}}
@@ -1167,42 +1167,36 @@ contexts:
     - include: cmd-args-boilerplate
 
   for-args:
-    - include: for-end
+    - include: loop-end
     - match: \(\(
       scope: punctuation.section.arithmetic.begin.shell
       set: cmd-arithmetic-body
     - match: (?=\S)
-      set: for-var
+      set: loop-iterator-var
 
-  for-var:
+  loop-iterator-var:
     - match: in{{cmd_break}}
       scope: keyword.control.in.shell
-      set: for-iterator
-    - include: for-end
+      set: loop-iterator-range
+    - include: loop-end
     - include: variables
 
-  for-iterator:
-    - include: for-end
+  loop-iterator-range:
+    - include: loop-end
     - include: number-range
     - match: (?=\S)
-      set: for-wordlist
+      set: loop-iterator-wordlist
 
-  for-wordlist:
-    - include: for-end
+  loop-iterator-wordlist:
+    - include: loop-end
     - include: booleans
     - include: strings-unquoted
 
-  for-end:
+  loop-end:
     - match: (?=(?:do|done){{cmd_break}})
       pop: 1
     - include: redirections
     - include: eoc-pop
-
-  select-args:
-    - include: cmd-args-boilerplate
-    - match: in{{cmd_break}}
-      scope: keyword.control.in.shell
-    - include: variables
 
 ###[ REDIRECTIONS AND HEREDOCS ]###############################################
 

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -5521,6 +5521,106 @@ do
 done
 # <- keyword.control.loop.end.shell
 
+for i in str1 $str2 "str3" 'str4' st$r5; do echo $i; done;
+# <- keyword.control.loop.for.shell
+#   ^ variable.other.readwrite.shell
+#     ^^ keyword.control.in.shell
+#        ^^^^ meta.string.shell string.unquoted.shell
+#             ^^^^^ meta.interpolation.parameter.shell variable.other.readwrite.shell
+#                   ^^^^^^ meta.string.shell string.quoted.double.shell
+#                          ^^^^^^ meta.string.shell string.quoted.single.shell
+#                                 ^^ meta.string.shell string.unquoted.shell
+#                                   ^^^ meta.string.shell meta.interpolation.parameter.shell variable.other.readwrite.shell
+#                                      ^ punctuation.terminator.statement.shell
+#                                        ^^ keyword.control.loop.do.shell
+#                                           ^^^^ meta.function-call.identifier.shell support.function.echo.shell
+#                                                ^^ meta.function-call.arguments.shell meta.interpolation.parameter.shell variable.other.readwrite.shell
+#                                                  ^ punctuation.terminator.statement.shell
+#                                                    ^^^^ keyword.control.loop.end.shell
+#                                                        ^ punctuation.terminator.statement.shell
+
+for i in <files.txt; do echo $i; done;
+# <- keyword.control.loop.for.shell
+#   ^ variable.other.readwrite.shell
+#     ^^ keyword.control.in.shell
+#        ^ keyword.operator.assignment.redirection.shell
+#                  ^ punctuation.terminator.statement.shell
+#                    ^^ keyword.control.loop.do.shell
+#                       ^^^^ meta.function-call.identifier.shell support.function.echo.shell
+#                           ^^^ meta.function-call.arguments.shell
+#                            ^^ variable.other.readwrite.shell
+#                              ^ punctuation.terminator.statement.shell
+#                                ^^^^ keyword.control.loop.end.shell
+#                                    ^ punctuation.terminator.statement.shell
+#
+
+for i in {1..10}; do echo $i; done;
+# <- keyword.control.loop.for.shell
+#   ^ meta.variable.shell variable.other.readwrite.shell
+#     ^^ keyword.control.in.shell
+#        ^^^^^^^ meta.sequence.range.shell
+#        ^ punctuation.section.sequence.begin.shell
+#         ^ meta.number.integer.decimal.shell constant.numeric.value.shell
+#          ^^ keyword.operator.range.shell
+#            ^^ meta.number.integer.decimal.shell constant.numeric.value.shell
+#              ^ punctuation.section.sequence.end.shell
+#               ^ punctuation.terminator.statement.shell
+#                 ^^ keyword.control.loop.do.shell
+#                    ^^^^ meta.function-call.identifier.shell support.function.echo.shell
+#                         ^ meta.function-call.arguments.shell meta.interpolation.parameter.shell variable.other.readwrite.shell punctuation.definition.variable.shell
+#                          ^ meta.function-call.arguments.shell meta.interpolation.parameter.shell variable.other.readwrite.shell
+#                           ^ punctuation.terminator.statement.shell
+#                             ^^^^ keyword.control.loop.end.shell
+#                                 ^ punctuation.terminator.statement.shell
+
+for i in {-10..+20}; do echo $i; done;
+# <- keyword.control.loop.for.shell
+#   ^ meta.variable.shell variable.other.readwrite.shell
+#     ^^ keyword.control.in.shell
+#        ^^^^^^^^^^ meta.sequence.range.shell
+#        ^ punctuation.section.sequence.begin.shell
+#         ^ meta.number.integer.decimal.shell constant.numeric.value.shell keyword.operator.arithmetic.shell
+#          ^^ meta.number.integer.decimal.shell constant.numeric.value.shell
+#            ^^ keyword.operator.range.shell
+#              ^ meta.number.integer.decimal.shell constant.numeric.value.shell keyword.operator.arithmetic.shell
+#               ^^ meta.number.integer.decimal.shell constant.numeric.value.shell
+#                 ^ punctuation.section.sequence.end.shell
+#                  ^ punctuation.terminator.statement.shell
+#                    ^^ keyword.control.loop.do.shell
+#                       ^^^^ meta.function-call.identifier.shell support.function.echo.shell
+#                            ^ meta.function-call.arguments.shell meta.interpolation.parameter.shell variable.other.readwrite.shell punctuation.definition.variable.shell
+#                             ^ meta.function-call.arguments.shell meta.interpolation.parameter.shell variable.other.readwrite.shell
+#                              ^ punctuation.terminator.statement.shell
+#                                ^^^^ keyword.control.loop.end.shell
+#                                    ^ punctuation.terminator.statement.shell
+
+for i in {-10..+20..-4}; do echo $i; done;
+# <- keyword.control.loop.for.shell
+#   ^ meta.variable.shell variable.other.readwrite.shell
+#     ^^ keyword.control.in.shell
+#        ^^^^^^^^^^ meta.sequence.range.shell
+#        ^ punctuation.section.sequence.begin.shell
+#         ^ meta.number.integer.decimal.shell constant.numeric.value.shell keyword.operator.arithmetic.shell
+#          ^^ meta.number.integer.decimal.shell constant.numeric.value.shell
+#            ^^ keyword.operator.range.shell
+#              ^ meta.number.integer.decimal.shell constant.numeric.value.shell keyword.operator.arithmetic.shell
+#               ^^ meta.number.integer.decimal.shell constant.numeric.value.shell
+#                 ^^ keyword.operator.range.shell
+#                   ^ meta.number.integer.decimal.shell constant.numeric.value.shell keyword.operator.arithmetic.shell
+#                    ^ meta.number.integer.decimal.shell constant.numeric.value.shell
+#                     ^ punctuation.section.sequence.end.shell
+#                      ^ punctuation.terminator.statement.shell
+#                        ^^ keyword.control.loop.do.shell
+#                           ^^^^ meta.function-call.identifier.shell support.function.echo.shell
+#                                ^ meta.function-call.arguments.shell meta.interpolation.parameter.shell variable.other.readwrite.shell punctuation.definition.variable.shell
+#                                 ^ meta.function-call.arguments.shell meta.interpolation.parameter.shell variable.other.readwrite.shell
+#                                  ^ punctuation.terminator.statement.shell
+#                                    ^^^^ keyword.control.loop.end.shell
+#                                        ^ punctuation.terminator.statement.shell
+
+for i in $*; do echo $i; done;
+#        ^^ meta.interpolation.parameter.shell variable.language.shell
+
 for i in $(seq 100); do
 # <- keyword.control.loop.for.shell
 #^^ keyword.control.loop.for.shell

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -5254,11 +5254,33 @@ esac
 # select loops                                                     #
 ####################################################################
 
+select var in 1 2 3 4 5; do echo $i; done;
+# <- keyword.control.loop.select.shell
+#      ^^^ variable.other.readwrite.shell
+#          ^^ keyword.control.in.shell
+#            ^ - string
+#             ^ meta.string.shell string.unquoted.shell
+#              ^ - string
+#               ^ meta.string.shell string.unquoted.shell
+#                ^ - string
+#                 ^ meta.string.shell string.unquoted.shell
+#                  ^ - string
+#                   ^ meta.string.shell string.unquoted.shell
+#                    ^ - string
+#                     ^ meta.string.shell string.unquoted.shell
+#                      ^ punctuation.terminator.statement.shell
+#                        ^^ keyword.control.loop.do.shell
+#                           ^^^^ support.function.echo.shell
+#                                ^^ variable.other.readwrite.shell
+#                                  ^ punctuation.terminator.statement.shell
+#                                    ^^^^ keyword.control.loop.end.shell
+#                                        ^ punctuation.terminator.statement.shell
+
 select fname in *;
 # <- keyword.control.loop.select.shell
 #^^^^^ keyword.control.loop.select.shell
 #            ^^ keyword.control.in.shell
-#               ^ keyword.operator.quantifier.regexp.shell
+#               ^ meta.string.shell string.unquoted.shell
 #                ^ punctuation.terminator.statement.shell
 do
 # <- keyword.control.loop.do.shell


### PR DESCRIPTION
Fixes #3761

This commit adds more detailed implementation of for statement arguments to correctly scope word lists and number ranges after `in` keyword.