### PR TITLE
[TypeScript] Simplify function parameter list implementation to support this parameter in function types

### DIFF
--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -1052,19 +1052,7 @@ contexts:
     - match: \)
       scope: punctuation.section.group.end.js
       pop: 1
-    - match: \.\.\.
-      scope: keyword.operator.spread.js
-      push:
-        - ts-type-annotation
-        - ts-type-annotation-optional
-    - match: (?={{identifier_start}}|\[|\{)
-      push:
-        - ts-type-annotation
-        - ts-type-annotation-optional
-        - function-parameter-binding-pattern
-
-    - include: comma-separator
-    - include: else-pop
+    - include: function-parameter-binding-list
 
   ts-type-function-body:
     - include: ts-type-function-arrow

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -604,14 +604,8 @@ contexts:
 
   function-parameter-binding-list:
     - meta_prepend: true
-
     - include: decorator
-
     - include: function-parameter-modifiers
-
-    - match: this{{identifier_break}}
-      scope: variable.language.this.js
-      push: ts-type-annotation
 
   function-parameter-modifiers:
     - match: (?={{modifier}})
@@ -628,6 +622,12 @@ contexts:
           pop: 1
         - match: (?=\S)
           fail: function-parameter-modifier
+
+  function-parameter-binding-pattern:
+    - meta_prepend: true
+    - match: this{{identifier_break}}
+      scope: variable.language.this.js
+      pop: 1
 
   class-field:
     - meta_include_prototype: false

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -1120,6 +1120,16 @@ let x: ({ foo }: any) => any;
 //                       ^^^ support.type.any
 //                          ^ punctuation.terminator.statement
 
+let x: (this: any) => any;
+//    ^^^^^^^^^^^^^^^^^^^ meta.type
+//     ^^^^^^^^^^^ meta.group
+//      ^^^^ variable.language.this
+//          ^ punctuation.separator.type
+//            ^^^ support.type.any
+//                 ^^ keyword.declaration.function
+//                    ^^^ support.type.any
+//                       ^ punctuation.terminator.statement
+
 let x: < T > ( ... foo : any ) => any;
 //     ^^^^^ meta.generic
 //       ^ variable.parameter.generic


### PR DESCRIPTION
Fix #3772.

Simplify some of the function parameter list code to make it work more consistently between different contexts that use it.