### PR TITLE
[Git Formats] Fix file extension separator highlighting

### DIFF
--- a/Git Formats/Git Attributes.sublime-syntax
+++ b/Git Formats/Git Attributes.sublime-syntax
@@ -57,14 +57,14 @@ contexts:
     - meta_scope: string.quoted.double.git.attributes
     - meta_content_scope: entity.name.pattern.git.attributes
     - include: string-end
-    - include: Git Common.sublime-syntax#fnmatch-body
+    - include: Git Common.sublime-syntax#fnmatch-quoted-body
 
   pattern-content-unquoted:
     - meta_scope: string.unquoted.git.attributes
     - meta_content_scope: entity.name.pattern.git.attributes
     - match: (?=\s)
       pop: 1
-    - include: Git Common.sublime-syntax#fnmatch-body
+    - include: Git Common.sublime-syntax#fnmatch-unquoted-body
 
   pattern-attributes:
     - meta_include_prototype: false

--- a/Git Formats/Git Code Owners.sublime-syntax
+++ b/Git Formats/Git Code Owners.sublime-syntax
@@ -26,10 +26,11 @@ contexts:
         - Git Common.sublime-syntax#fnmatch-start
 
   pattern-content:
+    # note: character classes are not supported
     - meta_content_scope: meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
     - match: \s+(?=([^\@\s]+)?\@)
       set: owners
-    # note: character classes are not supported
+    - include: Git Common.sublime-syntax#fnmatch-unquoted-file-extensions
     - include: Git Common.sublime-syntax#fnmatch-common
     - include: eol-pop
 

--- a/Git Formats/Git Common.sublime-syntax
+++ b/Git Formats/Git Common.sublime-syntax
@@ -175,16 +175,20 @@ contexts:
   # fnmatch-body as include in a scope, which defines the desired meta
   # and the required bail-out scopes as they might be different and
   # therefore are not part of the following section.
-  fnmatch-body:
+  fnmatch-quoted-body:
     - include: fnmatch-char-classes
+    - include: fnmatch-quoted-file-extensions
+    - include: fnmatch-common
+
+  fnmatch-unquoted-body:
+    - include: fnmatch-char-classes
+    - include: fnmatch-unquoted-file-extensions
     - include: fnmatch-common
 
   fnmatch-common:
     - match: '/'          # path separators
       scope: punctuation.separator.path.fnmatch.git
       push: fnmatch-dir-pattern
-    - match: \.(?!.*[./]) # the last dot not followed by path sep
-      scope: punctuation.separator.path.extension.fnmatch.git
     - match: '[*?]'       # unescapable operators
       scope: keyword.operator.path.asterisk.fnmatch.git
     - match: '\\[^$*?]'   # backslash escapes nearly everything
@@ -238,6 +242,14 @@ contexts:
       scope: invalid.illegal.unexpected.char-class.fnmatch.git
     - match: \S
       scope: constant.character.char-class.fnmatch.git
+
+  fnmatch-quoted-file-extensions:
+    - match: \.(?![^./"]*[./]) # the last dot not followed by path sep
+      scope: punctuation.separator.path.fnmatch.git
+
+  fnmatch-unquoted-file-extensions:
+    - match: \.(?!(?:\\\s|\S)*[./]) # the last dot not followed by path sep
+      scope: punctuation.separator.path.fnmatch.git
 
 ###[ PRETTY FORMATS ]##########################################################
 

--- a/Git Formats/Git Ignore.sublime-syntax
+++ b/Git Formats/Git Ignore.sublime-syntax
@@ -29,5 +29,5 @@ contexts:
     - meta_scope: string.unquoted.git.ignore entity.name.pattern.git.ignore
     - match: $
       pop: 1
-    - include: Git Common.sublime-syntax#fnmatch-body
+    - include: Git Common.sublime-syntax#fnmatch-unquoted-body
 

--- a/Git Formats/tests/syntax_test_git_codeowners
+++ b/Git Formats/tests/syntax_test_git_codeowners
@@ -21,6 +21,7 @@
 *.js    @js-owner
 # <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners keyword.operator.path.asterisk.fnmatch.git
 #^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
+#^ punctuation.separator.path.fnmatch.git
 #   ^^^^ - meta.path - meta.owners
 #       ^^^^^^^^^ meta.owners.git.codeowners meta.reference.username.git entity.name.reference.username.git
 #       ^ punctuation.definition.reference.username.git
@@ -31,6 +32,7 @@
 *.go docs@example.com
 # <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners keyword.operator.path.asterisk.fnmatch.git
 #^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
+#^ punctuation.separator.path.fnmatch.git
 #   ^ - meta.path - meta.owners
 #    ^^^^^^^^^^^^^^^^ meta.owners.git.codeowners meta.reference.email.git entity.name.reference.email.git
 


### PR DESCRIPTION
Fixes #3767

This commit distinguishes between quoted and unquoted file patterns to determine last period in file names or patterns.