### PR TITLE
[CSS] Change wildcard operator scopes

### DIFF
--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -1118,7 +1118,7 @@ contexts:
 
   selector-variables:
     - match: \*
-      scope: variable.language.wildcard.asterisk.css
+      scope: keyword.operator.wildcard.css
 
   vendor-prefixes:
     - match: '{{vendor_prefix}}'
@@ -2768,7 +2768,7 @@ contexts:
         - attr-name-identifier-content
         - attr-name-namespace-content
     - match: \*(?!=)
-      scope: variable.language.wildcard.asterisk.css
+      scope: keyword.operator.wildcard.css
     - match: \|(?!=)
       scope: punctuation.separator.namespace.css
     - include: immediately-pop
@@ -3053,7 +3053,7 @@ contexts:
     - meta_scope: meta.string.css string.unquoted.css
     - include: string-content
     - match: \*
-      scope: variable.language.wildcard.asterisk.css
+      scope: keyword.operator.wildcard.css
     - match: '{{break}}'
       pop: 1
 

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -85,9 +85,9 @@
 
     *.* {}
 /*  ^^^ meta.selector.css */
-/*  ^ variable.language.wildcard.asterisk.css - punctuation */
+/*  ^ keyword.operator.wildcard.css - punctuation */
 /*   ^ entity.other.attribute-name.class.css punctuation.definition.entity.css */
-/*    ^ variable.language.wildcard.asterisk.css - punctuation */
+/*    ^ keyword.operator.wildcard.css - punctuation */
 
     # {}
 /*^^ - meta.selector.css */
@@ -100,7 +100,7 @@
 /*  ^^^ meta.selector.css */
 /*     ^^ - meta.selector.css */
 /*  ^ entity.other.attribute-name.id.css punctuation.definition.entity.css */
-/*   ^ variable.language.wildcard.asterisk.css - punctuation */
+/*   ^ keyword.operator.wildcard.css - punctuation */
 
     #01 {}
 /*^^ - meta.selector.css */
@@ -2138,11 +2138,11 @@
 /*                                               ^^ - meta.string - string */
 /*                                                 ^^^^^^^^^^ meta.string.css string.quoted.double.css */
 /*                                                           ^^^^ - meta.string - string */
-/*                              ^ variable.language.wildcard.asterisk.css */
+/*                              ^ keyword.operator.wildcard.css */
 /*                                ^^ constant.character.escape.css */
 /*                                  ^ punctuation.separator.sequence.css */
 /*                                         ^ punctuation.separator.sequence.css */
-/*                                           ^ variable.language.wildcard.asterisk.css */
+/*                                           ^ keyword.operator.wildcard.css */
 /*                                               ^ punctuation.separator.sequence.css */
 /*                                                     ^ - variable.language.wildcard */
 /*                                                        ^^ constant.character.escape.css */
@@ -2150,17 +2150,17 @@
 .test-pseudo-class-tag:not(*) {}
 /*                    ^ punctuation.definition.pseudo-class.css - entity */
 /*                     ^^^ entity.other.pseudo-class.css */
-/*                         ^ variable.language.wildcard.asterisk.css */
+/*                         ^ keyword.operator.wildcard.css */
 
 .test-pseudo-class-tag:is(*) {}
 /*                    ^ punctuation.definition.pseudo-class.css - entity */
 /*                     ^^ entity.other.pseudo-class.css */
-/*                        ^ variable.language.wildcard.asterisk.css */
+/*                        ^ keyword.operator.wildcard.css */
 
 .test-pseudo-class-tag:where(*) {}
 /*                    ^ punctuation.definition.pseudo-class.css - entity */
 /*                     ^^^^^ entity.other.pseudo-class.css */
-/*                           ^ variable.language.wildcard.asterisk.css */
+/*                           ^ keyword.operator.wildcard.css */
 
 .test-pseudo-elements::before {}
 /*                   ^^ punctuation.definition.pseudo-element.css - entity */
@@ -2286,12 +2286,12 @@
 .test-attribute-selectors-namespaces[n|a=""][*|a=""][|att][*|*] {}
 /*                                   ^ entity.other.namespace-prefix.css */
 /*                                    ^ punctuation.separator.namespace.css */
-/*                                           ^ variable.language.wildcard.asterisk.css */
+/*                                           ^ keyword.operator.wildcard.css */
 /*                                            ^ punctuation.separator.namespace.css */
 /*                                                   ^ punctuation.separator.namespace.css */
-/*                                                         ^ variable.language.wildcard.asterisk.css */
+/*                                                         ^ keyword.operator.wildcard.css */
 /*                                                          ^ punctuation.separator.namespace.css */
-/*                                                           ^ variable.language.wildcard.asterisk.css */
+/*                                                           ^ keyword.operator.wildcard.css */
 
 .test-attribute-selectors-operators[a=""][a~=""][a|=""][a^=""][a$=""][a*=""] {}
 /*                                   ^ keyword.operator.logical.css */
@@ -2332,7 +2332,7 @@
 /*                                                   ^ meta.selector.css - meta.group */
 
    *.test-universal-selector {}
-/* ^ variable.language.wildcard.asterisk.css */
+/* ^ keyword.operator.wildcard.css */
 
 .test-combinators >>> a >> a > a + b ~ a || td {}
 /*                ^^^ keyword.operator.combinator.css */
@@ -3175,7 +3175,7 @@
 .test-attr-function {
     top: attr(*|c);
 /*       ^^^^ support.function.attr.css */
-/*            ^ variable.language.wildcard.asterisk.css */
+/*            ^ keyword.operator.wildcard.css */
 /*             ^ punctuation.separator.namespace.css */
 /*              ^ entity.other.attribute-name.css */
 


### PR DESCRIPTION
This commit follows the suggestion of #3766 and scopes wildcards `?` and `*` `keyword.operator.wildcard`.