### PR TITLE
[Python] Fix target lists in generators

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1136,7 +1136,7 @@ contexts:
       set: except-statement-as
     - include: illegal-assignment-expressions
     - include: line-continuation-or-pop
-    - include: target-lists
+    - include: expression-in-a-statement
 
   except-statement-as:
     - meta_content_scope: meta.statement.exception.catch.python
@@ -1165,7 +1165,7 @@ contexts:
       scope: keyword.control.loop.for.in.python
       set: for-statement-in
     - include: line-continuation-or-pop
-    - include: target-lists
+    - include: expression-in-a-statement
 
   for-statement-in:
     - meta_content_scope: meta.statement.loop.for.python
@@ -1398,24 +1398,7 @@ contexts:
       pop: 1
     - match: (?=[)\]}])
       pop: 1
-    - include: comments
-    - include: illegal-name
-    - include: target-lists
-
-  target-lists:
-    - match: \(
-      scope: punctuation.section.tuple.begin.python
-      push: target-list-body
-    - include: sequence-separators
-    - include: name
-
-  target-list-body:
-    - meta_scope: meta.sequence.tuple.python
-    - match: \)
-      scope: punctuation.section.tuple.end.python
-      pop: 1
-    - include: comments
-    - include: target-lists
+    - include: expression-in-a-group
 
 ###[ FLOW EXPRESSIONS ]#######################################################
 

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -2383,9 +2383,9 @@ generator = ((k1, k2, v) for ((k1, k2), v) in xs)
 #            ^^^^^^^^^^^ meta.sequence.tuple.python
 #           ^^ punctuation.section.sequence.begin.python
 #                      ^ punctuation.section.sequence.end.python
-#                            ^^ punctuation.section.tuple.begin.python
-#                                    ^ punctuation.section.tuple.end.python
-#                                        ^ punctuation.section.tuple.end.python
+#                            ^^ punctuation.section.sequence.begin.python
+#                                    ^ punctuation.section.sequence.end.python
+#                                        ^ punctuation.section.sequence.end.python
 #                                               ^ punctuation.section.sequence.end.python
 
 list_ = [(k1, k2, v) for ((k1, k2), v) in xs]
@@ -2395,9 +2395,9 @@ list_ = [(k1, k2, v) for ((k1, k2), v) in xs]
 #       ^ punctuation.section.sequence.begin.python
 #        ^ punctuation.section.sequence.begin.python
 #                  ^ punctuation.section.sequence.end.python
-#                        ^^ punctuation.section.tuple.begin.python
-#                                ^ punctuation.section.tuple.end.python
-#                                    ^ punctuation.section.tuple.end.python
+#                        ^^ punctuation.section.sequence.begin.python
+#                                ^ punctuation.section.sequence.end.python
+#                                    ^ punctuation.section.sequence.end.python
 #                                           ^ punctuation.section.sequence.end.python
 
 dict_ = {k1: (k2, v) for ((k1, k2), v) in xs}
@@ -2406,10 +2406,53 @@ dict_ = {k1: (k2, v) for ((k1, k2), v) in xs}
 #            ^^^^^^^ meta.sequence.tuple.python
 #            ^ punctuation.section.sequence.begin.python
 #                  ^ punctuation.section.sequence.end.python
-#                        ^^ punctuation.section.tuple.begin.python
-#                                ^ punctuation.section.tuple.end.python
-#                                    ^ punctuation.section.tuple.end.python
+#                        ^^ punctuation.section.sequence.begin.python
+#                                ^ punctuation.section.sequence.end.python
+#                                    ^ punctuation.section.sequence.end.python
 #                                           ^ punctuation.section.mapping.end.python
+
+unpack_ = [*(_ for [[][:], *_] in [((1, 2), "woops")])]
+#         ^^ meta.sequence.list.python - meta.sequence.generator
+#           ^^^^^^^ meta.sequence.list.python meta.sequence.generator.python
+#                  ^^^^^^^^^^^ meta.sequence.list.python meta.sequence.generator.python meta.sequence.list.python
+#                             ^^^ meta.sequence.list.python meta.sequence.generator.python
+#                                 ^ meta.sequence.list.python meta.sequence.generator.python meta.sequence.list.python
+#                                  ^ meta.sequence.list.python meta.sequence.generator.python meta.sequence.list.python meta.sequence.tuple.python
+#                                   ^^^^^^ meta.sequence.list.python meta.sequence.generator.python meta.sequence.list.python meta.sequence.tuple.python meta.sequence.tuple.python
+#                                         ^^^^^^^^^^ meta.sequence.list.python meta.sequence.generator.python meta.sequence.list.python meta.sequence.tuple.python
+#                                                   ^ meta.sequence.list.python meta.sequence.generator.python meta.sequence.list.python
+#                                                    ^ meta.sequence.list.python meta.sequence.generator.python
+#                                                     ^ meta.sequence.list.python - meta.sequence.generator
+#                                                      ^ - meta.sequence
+#         ^ punctuation.section.sequence.begin.python
+#          ^ keyword.operator.unpacking.sequence.python
+#           ^ punctuation.section.sequence.begin.python
+#            ^ meta.path.python variable.language.anonymous.python
+#              ^^^ keyword.control.loop.for.generator.python
+#                  ^ punctuation.section.sequence.begin.python
+#                   ^ punctuation.section.sequence.begin.python
+#                    ^ punctuation.section.sequence.end.python
+#                     ^ punctuation.section.brackets.begin.python
+#                      ^ punctuation.separator.slice.python
+#                       ^ punctuation.section.brackets.end.python
+#                        ^ punctuation.separator.sequence.python
+#                          ^ keyword.operator.unpacking.sequence.python
+#                           ^ meta.path.python variable.language.anonymous.python
+#                            ^ punctuation.section.sequence.end.python
+#                              ^^ keyword.control.loop.for.in.python
+#                                 ^ punctuation.section.sequence.begin.python
+#                                  ^ punctuation.section.sequence.begin.python
+#                                   ^ punctuation.section.sequence.begin.python
+#                                    ^ meta.number.integer.decimal.python constant.numeric.value.python
+#                                     ^ punctuation.separator.sequence.python
+#                                       ^ meta.number.integer.decimal.python constant.numeric.value.python
+#                                        ^ punctuation.section.sequence.end.python
+#                                         ^ punctuation.separator.sequence.python
+#                                           ^^^^^^^ meta.string.python string.quoted.double.python
+#                                                  ^ punctuation.section.sequence.end.python
+#                                                   ^ punctuation.section.sequence.end.python
+#                                                    ^ punctuation.section.sequence.end.python
+#                                                     ^ punctuation.section.sequence.end.python
 
 list_ = [lambda: 1 for i in range(10)]
 #       ^ meta.sequence.list.python - meta.function


### PR DESCRIPTION
This commit fixes unpacking operations in generator target lists and maybe other expressions by replacing limited `target-lists` by normal expressions.