### PR TITLE
[C#] Fix pathological regexps

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -1916,7 +1916,7 @@ contexts:
         - include: string_escaped
         - match: '(?=\})'
           pop: true
-        - match: '([^}"\\]+(\\.)*)+(?=")'
+        - match: '(?:[^}"\\](?:\\.)*)+(?=")'
           scope: invalid.illegal.unclosed-string-placeholder.cs
           pop: true
         - match: '\{'
@@ -1937,7 +1937,7 @@ contexts:
           pop: true
         - match: \\(?:""|[^"])
           scope: constant.character.escape.cs
-        - match: (?:[^}"]+|"")+(?="(?!"))
+        - match: (?:[^}"]|"")+(?="(?!"))
           scope: invalid.illegal.unclosed-string-placeholder.cs
           pop: true
         - match: \{


### PR DESCRIPTION
The two regexps exhibit pathological behavior under Oniguruma, though Sublime's engine handles them fine. Removing the redundant `+` quantifier fixes the problem. Performance in Sublime should be unaffected.