### PR TITLE
[ShellScript] Fix array item index scope

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -1439,13 +1439,27 @@ contexts:
     - match: \[
       scope: punctuation.section.item-access.begin.shell
       push:
-        - meta_scope: meta.item-access.shell
-        - match: \]
-          scope: punctuation.section.item-access.end.shell
-          pop: 1
-        - match: '[*@]'
-          scope: variable.language.array.shell
-        - include: expressions
+        - array-item-access-end
+        - array-item-access-begin
+
+  array-item-access-end:
+    - meta_scope: meta.item-access.shell
+    - match: \]
+      scope: punctuation.section.item-access.end.shell
+      pop: 1
+
+  array-item-access-begin:
+    - match: '[*@]'
+      scope: variable.language.array.shell
+      pop: 1
+    - match: ''
+      set: array-key-body
+
+  array-key-body:
+    - meta_scope: meta.string.shell string.unquoted.shell
+    - match: (?=\])
+      pop: 1
+    - include: string-unquoted-body
 
   expressions:
     - match: \(

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -2806,7 +2806,7 @@ array[500]=value
 #^^^^ meta.variable.shell variable.other.readwrite.shell
 #    ^^^^^ meta.variable.shell meta.item-access.shell - variable
 #    ^ punctuation.section.item-access.begin.shell
-#     ^^^ meta.number.integer.decimal.shell constant.numeric.value.shell
+#     ^^^ meta.string.shell string.unquoted.shell
 #        ^ punctuation.section.item-access.end.shell
 #         ^ keyword.operator.assignment
 #          ^^^^^ meta.string.shell string.unquoted.shell
@@ -2826,11 +2826,12 @@ array["foo"]=bar
 #          ^ punctuation.section.item-access.end.shell
 #           ^ keyword.operator.assignment.shell
 #            ^^^ meta.string.shell string.unquoted.shell
+
 array[foo]=bar
 #^^^^ meta.variable.shell variable.other.readwrite.shell
 #    ^^^^^ meta.variable.shell meta.item-access.shell
 #    ^ punctuation.section.item-access.begin.shell - variable
-#     ^^^ variable.other.readwrite.shell
+#     ^^^ meta.string.shell string.unquoted.shell
 #        ^ punctuation.section.item-access.end.shell - variable
 #         ^ keyword.operator.assignment.shell
 #          ^^^ meta.string.shell string.unquoted.shell
@@ -2841,12 +2842,12 @@ foo[${j}+10]="`foo`"
 #  ^^^^^^^^^ meta.variable.shell meta.item-access.shell
 #^^ variable.other.readwrite.shell
 #  ^ punctuation.section.item-access.begin.shell
+#   ^^^^ meta.string.shell meta.interpolation.parameter.shell
 #   ^ punctuation.definition.variable.shell
 #    ^ punctuation.section.interpolation.begin.shell
 #     ^ variable.other.readwrite.shell
 #      ^ punctuation.section.interpolation.end.shell
-#       ^ keyword.operator.arithmetic.shell
-#        ^^ meta.number.integer.decimal.shell constant.numeric.value.shell
+#       ^^^ meta.string.shell string.unquoted.shell
 #          ^ punctuation.section.item-access.end.shell
 #           ^ keyword.operator.assignment.shell
 
@@ -4449,7 +4450,7 @@ let var[10]=5*(20+$idx)
 #  ^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell
 #      ^^^^ meta.item-access.shell
 #      ^ punctuation.section.item-access.begin.shell
-#       ^^ meta.number.integer.decimal.shell constant.numeric.value.shell
+#       ^^ meta.string.shell string.unquoted.shell
 #         ^ punctuation.section.item-access.end.shell
 #          ^ keyword.operator.assignment.shell
 #           ^ meta.number.integer.decimal.shell constant.numeric.value.shell


### PR DESCRIPTION
Fixes #3801

This commit changes array item index scope to `string.unquoted`.