### PR TITLE
[Common] Adjust wildcard scopes

### DIFF
--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -1623,7 +1623,7 @@ contexts:
       scope: punctuation.separator.path.dosbatch
       push: path-pattern-relative
     - match: \.\.?(?=[\\/])
-      scope: variable.language.parent.path.dosbatch
+      scope: constant.other.path.parent.dosbatch
     - match: \.
       scope: punctuation.separator.path.dosbatch
     - match: \*
@@ -1633,10 +1633,10 @@ contexts:
 
   path-pattern-relative:
     - match: \.\.(?=[\\/])
-      scope: variable.language.parent.path.dosbatch
+      scope: constant.other.path.parent.dosbatch
       pop: 1
     - match: \.(?=[\\/])
-      scope: variable.language.self.path.dosbatch
+      scope: constant.other.path.self.dosbatch
       pop: 1
     - include: immediately-pop
 

--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -1627,9 +1627,9 @@ contexts:
     - match: \.
       scope: punctuation.separator.path.dosbatch
     - match: \*
-      scope: variable.language.wildcard.asterisk.dosbatch
+      scope: constant.other.wildcard.asterisk.dosbatch
     - match: \?
-      scope: variable.language.wildcard.questionmark.dosbatch
+      scope: constant.other.wildcard.questionmark.dosbatch
 
   path-pattern-relative:
     - match: \.\.(?=[\\/])

--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -1626,8 +1626,10 @@ contexts:
       scope: constant.language.path.parent.dosbatch
     - match: \.
       scope: punctuation.separator.path.dosbatch
-    - match: '[*?]'
-      scope: constant.other.placeholder.dosbatch
+    - match: \*
+      scope: variable.language.wildcard.asterisk.dosbatch
+    - match: \?
+      scope: variable.language.wildcard.questionmark.dosbatch
 
   path-pattern-relative:
     - match: \.\.(?=[\\/])

--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -1623,7 +1623,7 @@ contexts:
       scope: punctuation.separator.path.dosbatch
       push: path-pattern-relative
     - match: \.\.?(?=[\\/])
-      scope: constant.language.path.parent.dosbatch
+      scope: variable.language.parent.path.dosbatch
     - match: \.
       scope: punctuation.separator.path.dosbatch
     - match: \*
@@ -1633,10 +1633,10 @@ contexts:
 
   path-pattern-relative:
     - match: \.\.(?=[\\/])
-      scope: constant.language.path.parent.dosbatch
+      scope: variable.language.parent.path.dosbatch
       pop: 1
     - match: \.(?=[\\/])
-      scope: constant.language.path.self.dosbatch
+      scope: variable.language.self.path.dosbatch
       pop: 1
     - include: immediately-pop
 

--- a/Batch File/tests/syntax_test_batch_file.bat
+++ b/Batch File/tests/syntax_test_batch_file.bat
@@ -1825,7 +1825,7 @@ put arg1 arg2
 ::                                           ^^^^^^ - constant
 ::                                                 ^^ constant.character.escape.dosbatch
 ::                                                   ^^^ - constant
-::                                                      ^ variable.language.wildcard.asterisk.dosbatch
+::                                                      ^ constant.other.wildcard.asterisk.dosbatch
 ::                                                       ^^ constant.character.escape.dosbatch
 ::                                                         ^ - constant
 ::                                                          ^^ constant.character.escape.dosbatch

--- a/Batch File/tests/syntax_test_batch_file.bat
+++ b/Batch File/tests/syntax_test_batch_file.bat
@@ -287,7 +287,7 @@ ECHO : Not a comment ^
 ::                    ^^^^^^^^^^ meta.function-call.arguments.dosbatch
 ::                              ^ - meta.function-call
 :: ^^^^ keyword.control.flow.call.dosbatch
-::      ^^ variable.language.parent.path.dosbatch
+::      ^^ constant.other.path.parent.dosbatch
 ::        ^ punctuation.separator.path.dosbatch
 ::            ^ punctuation.separator.path.dosbatch
 ::                ^ punctuation.separator.path.dosbatch
@@ -305,7 +305,7 @@ ECHO : Not a comment ^
 ::                      ^^^^^^^^^^^ meta.function-call.arguments.dosbatch
 ::                                 ^ - meta.function-call
 :: ^^^^ keyword.control.flow.call.dosbatch
-::      ^^ variable.language.parent.path.dosbatch
+::      ^^ constant.other.path.parent.dosbatch
 ::        ^ punctuation.separator.path.dosbatch
 ::         ^ punctuation.section.interpolation.begin.dosbatch
 ::          ^^^ variable.other.readwrite.dosbatch
@@ -835,7 +835,7 @@ ECHO : Not a comment ^
 ::                  ^ punctuation.section.set.begin.dosbatch
 ::                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.set.dosbatch
 ::                          ^ punctuation.separator.comma.dosbatch
-::                            ^^ variable.language.parent.path.dosbatch
+::                            ^^ constant.other.path.parent.dosbatch
 ::                                      ^ punctuation.separator.comma.dosbatch
 ::                                                 ^ punctuation.section.set.end.dosbatch
 ::                                                   ^^ keyword.control.loop.do.dosbatch
@@ -855,7 +855,7 @@ ECHO : Not a comment ^
 ::              ^ punctuation.section.set.begin.dosbatch
 ::              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.set.dosbatch
 ::                      ^ punctuation.separator.comma.dosbatch
-::                        ^^ variable.language.parent.path.dosbatch
+::                        ^^ constant.other.path.parent.dosbatch
 ::                                  ^ punctuation.separator.comma.dosbatch
 ::                                             ^ punctuation.section.set.end.dosbatch
 ::                                               ^^ keyword.control.loop.do.dosbatch
@@ -869,7 +869,7 @@ ECHO : Not a comment ^
 ::        ^ punctuation.section.set.begin.dosbatch
 ::        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.set.dosbatch
 ::                ^ punctuation.separator.comma.dosbatch
-::                  ^^ variable.language.parent.path.dosbatch
+::                  ^^ constant.other.path.parent.dosbatch
 ::                            ^ punctuation.separator.comma.dosbatch
 ::                                       ^ punctuation.section.set.end.dosbatch
 ::                                         ^^ keyword.control.loop.do.dosbatch
@@ -882,7 +882,7 @@ ECHO : Not a comment ^
 ::    ^ punctuation.section.set.begin.dosbatch
 ::    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.set.dosbatch
 ::            ^ punctuation.separator.comma.dosbatch
-::              ^^ variable.language.parent.path.dosbatch
+::              ^^ constant.other.path.parent.dosbatch
 ::                        ^ punctuation.separator.comma.dosbatch
 ::                                   ^ punctuation.section.set.end.dosbatch
 ::                                     ^^ keyword.control.loop.do.dosbatch
@@ -895,7 +895,7 @@ ECHO : Not a comment ^
 :: ^ punctuation.section.set.begin.dosbatch
 :: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.set.dosbatch
 ::         ^ punctuation.separator.comma.dosbatch
-::           ^^ variable.language.parent.path.dosbatch
+::           ^^ constant.other.path.parent.dosbatch
 ::                     ^ punctuation.separator.comma.dosbatch
 ::                                ^ punctuation.section.set.end.dosbatch
 ::                                  ^^ keyword.control.loop.do.dosbatch
@@ -909,7 +909,7 @@ ECHO : Not a comment ^
       folder1,
 ::           ^ punctuation.separator.comma.dosbatch
       ..\folder2,
-::    ^^ variable.language.parent.path.dosbatch
+::    ^^ constant.other.path.parent.dosbatch
 ::              ^ punctuation.separator.comma.dosbatch
       C:\folder
    ) ^
@@ -1204,7 +1204,7 @@ put arg1 arg2
 :: ^^^^^^^^^^^^^^^^^^^^^ - meta.function-call meta.function-call
 :: ^^^^^^^^^^^ meta.function-call.identifier.dosbatch variable.function.dosbatch
 ::            ^^^^^^^^^^ meta.function-call.arguments.dosbatch
-:: ^^ variable.language.parent.path.dosbatch
+:: ^^ constant.other.path.parent.dosbatch
 ::   ^ punctuation.separator.path.dosbatch
 ::        ^ punctuation.separator.path.dosbatch
 
@@ -1217,7 +1217,7 @@ put arg1 arg2
 :: ^^^ variable.function.dosbatch
 ::    ^^^^^^ - variable.function
 ::          ^^^^ variable.function.dosbatch
-:: ^^ variable.language.parent.path.dosbatch
+:: ^^ constant.other.path.parent.dosbatch
 ::   ^ punctuation.separator.path.dosbatch
 ::    ^ punctuation.section.interpolation.begin.dosbatch
 ::     ^^^^ variable.other.readwrite.dosbatch
@@ -1234,7 +1234,7 @@ put arg1 arg2
 ::     ^^^^^^ - variable.function
 ::           ^^^^^ variable.function.dosbatch
 :: ^ punctuation.definition.string.begin.dosbatch
-::  ^^ variable.language.parent.path.dosbatch
+::  ^^ constant.other.path.parent.dosbatch
 ::    ^ punctuation.separator.path.dosbatch
 ::     ^ punctuation.section.interpolation.begin.dosbatch
 ::      ^^^^ variable.other.readwrite.dosbatch
@@ -1251,7 +1251,7 @@ put arg1 arg2
 ::     ^^^^^^ - variable.function
 ::           ^^^^^ variable.function.dosbatch
 :: ^ punctuation.definition.string.begin.dosbatch
-::  ^^ variable.language.parent.path.dosbatch
+::  ^^ constant.other.path.parent.dosbatch
 ::    ^ punctuation.separator.path.dosbatch
 ::     ^ punctuation.section.interpolation.begin.dosbatch
 ::      ^^^^ variable.other.readwrite.dosbatch
@@ -1262,7 +1262,7 @@ put arg1 arg2
    %~dp0..\cmd
 :: ^^^^^^^^^^^ meta.function-call.identifier.dosbatch
 :: ^^^^^ meta.interpolation.dosbatch variable.parameter.dosbatch
-::      ^^ variable.language.parent.path.dosbatch
+::      ^^ constant.other.path.parent.dosbatch
 ::        ^ punctuation.separator.path.dosbatch
 ::         ^^^ variable.function.dosbatch
 
@@ -1365,7 +1365,7 @@ put arg1 arg2
 ::                          ^ meta.parameter.dosbatch
 ::                           ^^^^^ meta.parameter.value.dosbatch meta.path.dosbatch meta.string.dosbatch
 ::         ^^^^^^^^^^^ string.unquoted.dosbatch
-::         ^^ variable.language.parent.path.dosbatch
+::         ^^ constant.other.path.parent.dosbatch
 ::           ^ punctuation.separator.path.dosbatch
 ::                   ^ punctuation.separator.path.dosbatch
 ::                     ^^^^^ variable.parameter.option.dosbatch

--- a/Batch File/tests/syntax_test_batch_file.bat
+++ b/Batch File/tests/syntax_test_batch_file.bat
@@ -1825,7 +1825,7 @@ put arg1 arg2
 ::                                           ^^^^^^ - constant
 ::                                                 ^^ constant.character.escape.dosbatch
 ::                                                   ^^^ - constant
-::                                                      ^ constant.other.placeholder.dosbatch
+::                                                      ^ variable.language.wildcard.asterisk.dosbatch
 ::                                                       ^^ constant.character.escape.dosbatch
 ::                                                         ^ - constant
 ::                                                          ^^ constant.character.escape.dosbatch

--- a/Batch File/tests/syntax_test_batch_file.bat
+++ b/Batch File/tests/syntax_test_batch_file.bat
@@ -287,7 +287,7 @@ ECHO : Not a comment ^
 ::                    ^^^^^^^^^^ meta.function-call.arguments.dosbatch
 ::                              ^ - meta.function-call
 :: ^^^^ keyword.control.flow.call.dosbatch
-::      ^^ constant.language.path.parent.dosbatch
+::      ^^ variable.language.parent.path.dosbatch
 ::        ^ punctuation.separator.path.dosbatch
 ::            ^ punctuation.separator.path.dosbatch
 ::                ^ punctuation.separator.path.dosbatch
@@ -305,7 +305,7 @@ ECHO : Not a comment ^
 ::                      ^^^^^^^^^^^ meta.function-call.arguments.dosbatch
 ::                                 ^ - meta.function-call
 :: ^^^^ keyword.control.flow.call.dosbatch
-::      ^^ constant.language.path.parent.dosbatch
+::      ^^ variable.language.parent.path.dosbatch
 ::        ^ punctuation.separator.path.dosbatch
 ::         ^ punctuation.section.interpolation.begin.dosbatch
 ::          ^^^ variable.other.readwrite.dosbatch
@@ -835,7 +835,7 @@ ECHO : Not a comment ^
 ::                  ^ punctuation.section.set.begin.dosbatch
 ::                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.set.dosbatch
 ::                          ^ punctuation.separator.comma.dosbatch
-::                            ^^ constant.language.path.parent.dosbatch
+::                            ^^ variable.language.parent.path.dosbatch
 ::                                      ^ punctuation.separator.comma.dosbatch
 ::                                                 ^ punctuation.section.set.end.dosbatch
 ::                                                   ^^ keyword.control.loop.do.dosbatch
@@ -855,7 +855,7 @@ ECHO : Not a comment ^
 ::              ^ punctuation.section.set.begin.dosbatch
 ::              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.set.dosbatch
 ::                      ^ punctuation.separator.comma.dosbatch
-::                        ^^ constant.language.path.parent.dosbatch
+::                        ^^ variable.language.parent.path.dosbatch
 ::                                  ^ punctuation.separator.comma.dosbatch
 ::                                             ^ punctuation.section.set.end.dosbatch
 ::                                               ^^ keyword.control.loop.do.dosbatch
@@ -869,7 +869,7 @@ ECHO : Not a comment ^
 ::        ^ punctuation.section.set.begin.dosbatch
 ::        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.set.dosbatch
 ::                ^ punctuation.separator.comma.dosbatch
-::                  ^^ constant.language.path.parent.dosbatch
+::                  ^^ variable.language.parent.path.dosbatch
 ::                            ^ punctuation.separator.comma.dosbatch
 ::                                       ^ punctuation.section.set.end.dosbatch
 ::                                         ^^ keyword.control.loop.do.dosbatch
@@ -882,7 +882,7 @@ ECHO : Not a comment ^
 ::    ^ punctuation.section.set.begin.dosbatch
 ::    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.set.dosbatch
 ::            ^ punctuation.separator.comma.dosbatch
-::              ^^ constant.language.path.parent.dosbatch
+::              ^^ variable.language.parent.path.dosbatch
 ::                        ^ punctuation.separator.comma.dosbatch
 ::                                   ^ punctuation.section.set.end.dosbatch
 ::                                     ^^ keyword.control.loop.do.dosbatch
@@ -895,7 +895,7 @@ ECHO : Not a comment ^
 :: ^ punctuation.section.set.begin.dosbatch
 :: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.set.dosbatch
 ::         ^ punctuation.separator.comma.dosbatch
-::           ^^ constant.language.path.parent.dosbatch
+::           ^^ variable.language.parent.path.dosbatch
 ::                     ^ punctuation.separator.comma.dosbatch
 ::                                ^ punctuation.section.set.end.dosbatch
 ::                                  ^^ keyword.control.loop.do.dosbatch
@@ -909,7 +909,7 @@ ECHO : Not a comment ^
       folder1,
 ::           ^ punctuation.separator.comma.dosbatch
       ..\folder2,
-::    ^^ constant.language.path.parent.dosbatch
+::    ^^ variable.language.parent.path.dosbatch
 ::              ^ punctuation.separator.comma.dosbatch
       C:\folder
    ) ^
@@ -1204,7 +1204,7 @@ put arg1 arg2
 :: ^^^^^^^^^^^^^^^^^^^^^ - meta.function-call meta.function-call
 :: ^^^^^^^^^^^ meta.function-call.identifier.dosbatch variable.function.dosbatch
 ::            ^^^^^^^^^^ meta.function-call.arguments.dosbatch
-:: ^^ constant.language.path.parent.dosbatch
+:: ^^ variable.language.parent.path.dosbatch
 ::   ^ punctuation.separator.path.dosbatch
 ::        ^ punctuation.separator.path.dosbatch
 
@@ -1217,7 +1217,7 @@ put arg1 arg2
 :: ^^^ variable.function.dosbatch
 ::    ^^^^^^ - variable.function
 ::          ^^^^ variable.function.dosbatch
-:: ^^ constant.language.path.parent.dosbatch
+:: ^^ variable.language.parent.path.dosbatch
 ::   ^ punctuation.separator.path.dosbatch
 ::    ^ punctuation.section.interpolation.begin.dosbatch
 ::     ^^^^ variable.other.readwrite.dosbatch
@@ -1234,7 +1234,7 @@ put arg1 arg2
 ::     ^^^^^^ - variable.function
 ::           ^^^^^ variable.function.dosbatch
 :: ^ punctuation.definition.string.begin.dosbatch
-::  ^^ constant.language.path.parent.dosbatch
+::  ^^ variable.language.parent.path.dosbatch
 ::    ^ punctuation.separator.path.dosbatch
 ::     ^ punctuation.section.interpolation.begin.dosbatch
 ::      ^^^^ variable.other.readwrite.dosbatch
@@ -1251,7 +1251,7 @@ put arg1 arg2
 ::     ^^^^^^ - variable.function
 ::           ^^^^^ variable.function.dosbatch
 :: ^ punctuation.definition.string.begin.dosbatch
-::  ^^ constant.language.path.parent.dosbatch
+::  ^^ variable.language.parent.path.dosbatch
 ::    ^ punctuation.separator.path.dosbatch
 ::     ^ punctuation.section.interpolation.begin.dosbatch
 ::      ^^^^ variable.other.readwrite.dosbatch
@@ -1262,7 +1262,7 @@ put arg1 arg2
    %~dp0..\cmd
 :: ^^^^^^^^^^^ meta.function-call.identifier.dosbatch
 :: ^^^^^ meta.interpolation.dosbatch variable.parameter.dosbatch
-::      ^^ constant.language.path.parent.dosbatch
+::      ^^ variable.language.parent.path.dosbatch
 ::        ^ punctuation.separator.path.dosbatch
 ::         ^^^ variable.function.dosbatch
 
@@ -1365,7 +1365,7 @@ put arg1 arg2
 ::                          ^ meta.parameter.dosbatch
 ::                           ^^^^^ meta.parameter.value.dosbatch meta.path.dosbatch meta.string.dosbatch
 ::         ^^^^^^^^^^^ string.unquoted.dosbatch
-::         ^^ constant.language.path.parent.dosbatch
+::         ^^ variable.language.parent.path.dosbatch
 ::           ^ punctuation.separator.path.dosbatch
 ::                   ^ punctuation.separator.path.dosbatch
 ::                     ^^^^^ variable.parameter.option.dosbatch

--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -1118,7 +1118,7 @@ contexts:
 
   selector-variables:
     - match: \*
-      scope: variable.language.wildcard.asterisk.css
+      scope: constant.other.wildcard.asterisk.css
 
   vendor-prefixes:
     - match: '{{vendor_prefix}}'
@@ -2768,7 +2768,7 @@ contexts:
         - attr-name-identifier-content
         - attr-name-namespace-content
     - match: \*(?!=)
-      scope: variable.language.wildcard.asterisk.css
+      scope: constant.other.wildcard.asterisk.css
     - match: \|(?!=)
       scope: punctuation.separator.namespace.css
     - include: immediately-pop
@@ -3053,7 +3053,7 @@ contexts:
     - meta_scope: meta.string.css string.unquoted.css
     - include: string-content
     - match: \*
-      scope: variable.language.wildcard.asterisk.css
+      scope: constant.other.wildcard.asterisk.css
     - match: '{{break}}'
       pop: 1
 

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -85,9 +85,9 @@
 
     *.* {}
 /*  ^^^ meta.selector.css */
-/*  ^ variable.language.wildcard.asterisk.css - punctuation */
+/*  ^ constant.other.wildcard.asterisk.css - punctuation */
 /*   ^ entity.other.attribute-name.class.css punctuation.definition.entity.css */
-/*    ^ variable.language.wildcard.asterisk.css - punctuation */
+/*    ^ constant.other.wildcard.asterisk.css - punctuation */
 
     # {}
 /*^^ - meta.selector.css */
@@ -100,7 +100,7 @@
 /*  ^^^ meta.selector.css */
 /*     ^^ - meta.selector.css */
 /*  ^ entity.other.attribute-name.id.css punctuation.definition.entity.css */
-/*   ^ variable.language.wildcard.asterisk.css - punctuation */
+/*   ^ constant.other.wildcard.asterisk.css - punctuation */
 
     #01 {}
 /*^^ - meta.selector.css */
@@ -2138,29 +2138,29 @@
 /*                                               ^^ - meta.string - string */
 /*                                                 ^^^^^^^^^^ meta.string.css string.quoted.double.css */
 /*                                                           ^^^^ - meta.string - string */
-/*                              ^ variable.language.wildcard.asterisk.css */
+/*                              ^ constant.other.wildcard.asterisk.css */
 /*                                ^^ constant.character.escape.css */
 /*                                  ^ punctuation.separator.sequence.css */
 /*                                         ^ punctuation.separator.sequence.css */
-/*                                           ^ variable.language.wildcard.asterisk.css */
+/*                                           ^ constant.other.wildcard.asterisk.css */
 /*                                               ^ punctuation.separator.sequence.css */
-/*                                                     ^ - variable.language.wildcard */
+/*                                                     ^ - constant.other.wildcard */
 /*                                                        ^^ constant.character.escape.css */
 
 .test-pseudo-class-tag:not(*) {}
 /*                    ^ punctuation.definition.pseudo-class.css - entity */
 /*                     ^^^ entity.other.pseudo-class.css */
-/*                         ^ variable.language.wildcard.asterisk.css */
+/*                         ^ constant.other.wildcard.asterisk.css */
 
 .test-pseudo-class-tag:is(*) {}
 /*                    ^ punctuation.definition.pseudo-class.css - entity */
 /*                     ^^ entity.other.pseudo-class.css */
-/*                        ^ variable.language.wildcard.asterisk.css */
+/*                        ^ constant.other.wildcard.asterisk.css */
 
 .test-pseudo-class-tag:where(*) {}
 /*                    ^ punctuation.definition.pseudo-class.css - entity */
 /*                     ^^^^^ entity.other.pseudo-class.css */
-/*                           ^ variable.language.wildcard.asterisk.css */
+/*                           ^ constant.other.wildcard.asterisk.css */
 
 .test-pseudo-elements::before {}
 /*                   ^^ punctuation.definition.pseudo-element.css - entity */
@@ -2286,12 +2286,12 @@
 .test-attribute-selectors-namespaces[n|a=""][*|a=""][|att][*|*] {}
 /*                                   ^ entity.other.namespace-prefix.css */
 /*                                    ^ punctuation.separator.namespace.css */
-/*                                           ^ variable.language.wildcard.asterisk.css */
+/*                                           ^ constant.other.wildcard.asterisk.css */
 /*                                            ^ punctuation.separator.namespace.css */
 /*                                                   ^ punctuation.separator.namespace.css */
-/*                                                         ^ variable.language.wildcard.asterisk.css */
+/*                                                         ^ constant.other.wildcard.asterisk.css */
 /*                                                          ^ punctuation.separator.namespace.css */
-/*                                                           ^ variable.language.wildcard.asterisk.css */
+/*                                                           ^ constant.other.wildcard.asterisk.css */
 
 .test-attribute-selectors-operators[a=""][a~=""][a|=""][a^=""][a$=""][a*=""] {}
 /*                                   ^ keyword.operator.logical.css */
@@ -2332,7 +2332,7 @@
 /*                                                   ^ meta.selector.css - meta.group */
 
    *.test-universal-selector {}
-/* ^ variable.language.wildcard.asterisk.css */
+/* ^ constant.other.wildcard.asterisk.css */
 
 .test-combinators >>> a >> a > a + b ~ a || td {}
 /*                ^^^ keyword.operator.combinator.css */
@@ -3175,7 +3175,7 @@
 .test-attr-function {
     top: attr(*|c);
 /*       ^^^^ support.function.attr.css */
-/*            ^ variable.language.wildcard.asterisk.css */
+/*            ^ constant.other.wildcard.asterisk.css */
 /*             ^ punctuation.separator.namespace.css */
 /*              ^ entity.other.attribute-name.css */
 

--- a/Git Formats/Git Common.sublime-syntax
+++ b/Git Formats/Git Common.sublime-syntax
@@ -192,9 +192,9 @@ contexts:
     - match: \$\w+
       scope: variable.language.environment.other.fnmatch.git
     - match: '\*'         # unescapable operators
-      scope: variable.language.wildcard.asterisk.fnmatch.git
+      scope: constant.other.wildcard.asterisk.fnmatch.git
     - match: '\?'         # unescapable operators
-      scope: variable.language.wildcard.questionmark.fnmatch.git
+      scope: constant.other.wildcard.questionmark.fnmatch.git
     - match: '\\[^$*?]'   # backslash escapes nearly everything
       scope: constant.character.escape.path.fnmatch.git
     - match: ':'          # drive separators

--- a/Git Formats/Git Common.sublime-syntax
+++ b/Git Formats/Git Common.sublime-syntax
@@ -189,12 +189,14 @@ contexts:
     - match: '/'          # path separators
       scope: punctuation.separator.path.fnmatch.git
       push: fnmatch-dir-pattern
-    - match: '[*?]'       # unescapable operators
-      scope: keyword.operator.wildcard.fnmatch.git
-    - match: '\\[^$*?]'   # backslash escapes nearly everything
-      scope: constant.character.escape.path.fnmatch.git
     - match: \$\w+
       scope: variable.language.environment.other.fnmatch.git
+    - match: '\*'         # unescapable operators
+      scope: variable.language.wildcard.asterisk.fnmatch.git
+    - match: '\?'         # unescapable operators
+      scope: variable.language.wildcard.questionmark.fnmatch.git
+    - match: '\\[^$*?]'   # backslash escapes nearly everything
+      scope: constant.character.escape.path.fnmatch.git
     - match: ':'          # drive separators
       scope: invalid.illegal.separator.path.fnmatch.git
     - match: '\\(?=\s)'   # single backslash is invalid

--- a/Git Formats/Git Common.sublime-syntax
+++ b/Git Formats/Git Common.sublime-syntax
@@ -204,10 +204,10 @@ contexts:
 
   fnmatch-dir-pattern:
     - match: \.\.(?=/)
-      scope: variable.language.parent.path.fnmatch.git
+      scope: constant.other.path.parent.fnmatch.git
       pop: 1
     - match: \.(?=/)
-      scope: variable.language.self.path.fnmatch.git
+      scope: constant.other.path.self.fnmatch.git
       pop: 1
     - match: ''
       pop: 1

--- a/Git Formats/Git Common.sublime-syntax
+++ b/Git Formats/Git Common.sublime-syntax
@@ -204,10 +204,10 @@ contexts:
 
   fnmatch-dir-pattern:
     - match: \.\.(?=/)
-      scope: constant.language.path.parent.fnmatch.git
+      scope: variable.language.parent.path.fnmatch.git
       pop: 1
     - match: \.(?=/)
-      scope: constant.language.path.self.fnmatch.git
+      scope: variable.language.self.path.fnmatch.git
       pop: 1
     - match: ''
       pop: 1

--- a/Git Formats/Git Link.sublime-syntax
+++ b/Git Formats/Git Link.sublime-syntax
@@ -75,10 +75,10 @@ contexts:
 
   path-dir-pattern:
     - match: \.\.(?=[\\/])
-      scope: constant.language.path.parent.git
+      scope: variable.language.parent.path.git
       pop: 1
     - match: \.(?=[\\/])
-      scope: constant.language.path.self.git
+      scope: variable.language.self.path.git
       pop: 1
     - match: ''
       pop: 1

--- a/Git Formats/Git Link.sublime-syntax
+++ b/Git Formats/Git Link.sublime-syntax
@@ -75,10 +75,10 @@ contexts:
 
   path-dir-pattern:
     - match: \.\.(?=[\\/])
-      scope: variable.language.parent.path.git
+      scope: constant.other.path.parent.git
       pop: 1
     - match: \.(?=[\\/])
-      scope: variable.language.self.path.git
+      scope: constant.other.path.self.git
       pop: 1
     - match: ''
       pop: 1

--- a/Git Formats/tests/syntax_test_git_attributes
+++ b/Git Formats/tests/syntax_test_git_attributes
@@ -84,7 +84,7 @@
 # <- string.quoted.double.git.attributes punctuation.definition.string.begin.git.attributes - entity.name.pattern.git
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.git.attributes
 #^^^^^^^^^^^^^^^^^^^^^^^^^^ entity.name.pattern.git
-#  ^ keyword.operator.wildcard.fnmatch.git
+#  ^ variable.language.wildcard.questionmark.fnmatch.git
 #    ^^ constant.character.escape.path.fnmatch.git
 #       ^^^^ meta.char-class.fnmatch.git
 #       ^ keyword.control.char-class.begin.fnmatch.git
@@ -108,9 +108,9 @@
 #              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attributes-list.git.attributes - meta.pattern
 #^^^^^^^^^^^^^^ string.unquoted.git.attributes
 #    ^ punctuation.separator.path.fnmatch.git
-#     ^ keyword.operator.wildcard.fnmatch.git
+#     ^ variable.language.wildcard.asterisk.fnmatch.git
 #      ^ punctuation.separator.path.fnmatch.git
-#         ^ keyword.operator.wildcard.fnmatch.git
+#         ^ variable.language.wildcard.questionmark.fnmatch.git
 #              ^ - variable.language.attribute - keyword.operator.logical
 #               ^^^^^^ variable.language.attribute.git.attributes
 #                     ^ - variable.language.attribute - keyword.operator.logical

--- a/Git Formats/tests/syntax_test_git_attributes
+++ b/Git Formats/tests/syntax_test_git_attributes
@@ -84,7 +84,7 @@
 # <- string.quoted.double.git.attributes punctuation.definition.string.begin.git.attributes - entity.name.pattern.git
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.git.attributes
 #^^^^^^^^^^^^^^^^^^^^^^^^^^ entity.name.pattern.git
-#  ^ variable.language.wildcard.questionmark.fnmatch.git
+#  ^ constant.other.wildcard.questionmark.fnmatch.git
 #    ^^ constant.character.escape.path.fnmatch.git
 #       ^^^^ meta.char-class.fnmatch.git
 #       ^ keyword.control.char-class.begin.fnmatch.git
@@ -108,9 +108,9 @@
 #              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attributes-list.git.attributes - meta.pattern
 #^^^^^^^^^^^^^^ string.unquoted.git.attributes
 #    ^ punctuation.separator.path.fnmatch.git
-#     ^ variable.language.wildcard.asterisk.fnmatch.git
+#     ^ constant.other.wildcard.asterisk.fnmatch.git
 #      ^ punctuation.separator.path.fnmatch.git
-#         ^ variable.language.wildcard.questionmark.fnmatch.git
+#         ^ constant.other.wildcard.questionmark.fnmatch.git
 #              ^ - variable.language.attribute - keyword.operator.logical
 #               ^^^^^^ variable.language.attribute.git.attributes
 #                     ^ - variable.language.attribute - keyword.operator.logical

--- a/Git Formats/tests/syntax_test_git_codeowners
+++ b/Git Formats/tests/syntax_test_git_codeowners
@@ -6,7 +6,7 @@
 # These owners will be the default owners for everything in
 # the repo, unless a later match takes precedence.
 *       @global-owner1 @global-owner2
-# <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners variable.language.wildcard.asterisk.fnmatch.git
+# <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners constant.other.wildcard.asterisk.fnmatch.git
 #^^^^^^^ - meta.path - meta.owners
 #       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.owners.git.codeowners
 #       ^^^^^^^^^^^^^^ meta.reference.username.git entity.name.reference.username.git
@@ -19,7 +19,7 @@
 # modifies JS files, only @js-owner and not the global
 # owner(s) will be requested for a review.
 *.js    @js-owner
-# <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners variable.language.wildcard.asterisk.fnmatch.git
+# <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners constant.other.wildcard.asterisk.fnmatch.git
 #^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
 #^ punctuation.separator.path.fnmatch.git
 #   ^^^^ - meta.path - meta.owners
@@ -30,7 +30,7 @@
 # used to look up users just like we do for commit author
 # emails.
 *.go docs@example.com
-# <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners variable.language.wildcard.asterisk.fnmatch.git
+# <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners constant.other.wildcard.asterisk.fnmatch.git
 #^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
 #^ punctuation.separator.path.fnmatch.git
 #   ^ - meta.path - meta.owners
@@ -55,7 +55,7 @@ docs/*  docs@example.com
 # <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
 #^^^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
 #   ^ punctuation.separator.path.fnmatch.git
-#    ^ variable.language.wildcard.asterisk.fnmatch.git
+#    ^ constant.other.wildcard.asterisk.fnmatch.git
 #     ^^ - meta.path - meta.owners
 #       ^^^^^^^^^^^^^^^^ meta.owners.git.codeowners meta.reference.email.git entity.name.reference.email.git
 

--- a/Git Formats/tests/syntax_test_git_codeowners
+++ b/Git Formats/tests/syntax_test_git_codeowners
@@ -6,7 +6,7 @@
 # These owners will be the default owners for everything in
 # the repo, unless a later match takes precedence.
 *       @global-owner1 @global-owner2
-# <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners keyword.operator.wildcard.fnmatch.git
+# <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners variable.language.wildcard.asterisk.fnmatch.git
 #^^^^^^^ - meta.path - meta.owners
 #       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.owners.git.codeowners
 #       ^^^^^^^^^^^^^^ meta.reference.username.git entity.name.reference.username.git
@@ -19,7 +19,7 @@
 # modifies JS files, only @js-owner and not the global
 # owner(s) will be requested for a review.
 *.js    @js-owner
-# <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners keyword.operator.wildcard.fnmatch.git
+# <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners variable.language.wildcard.asterisk.fnmatch.git
 #^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
 #^ punctuation.separator.path.fnmatch.git
 #   ^^^^ - meta.path - meta.owners
@@ -30,7 +30,7 @@
 # used to look up users just like we do for commit author
 # emails.
 *.go docs@example.com
-# <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners keyword.operator.wildcard.fnmatch.git
+# <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners variable.language.wildcard.asterisk.fnmatch.git
 #^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
 #^ punctuation.separator.path.fnmatch.git
 #   ^ - meta.path - meta.owners
@@ -55,7 +55,7 @@ docs/*  docs@example.com
 # <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
 #^^^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
 #   ^ punctuation.separator.path.fnmatch.git
-#    ^ keyword.operator.wildcard.fnmatch.git
+#    ^ variable.language.wildcard.asterisk.fnmatch.git
 #     ^^ - meta.path - meta.owners
 #       ^^^^^^^^^^^^^^^^ meta.owners.git.codeowners meta.reference.email.git entity.name.reference.email.git
 

--- a/Git Formats/tests/syntax_test_git_ignore
+++ b/Git Formats/tests/syntax_test_git_ignore
@@ -17,15 +17,15 @@
 #^ - entity.name.pattern
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^ entity.name.pattern
 # ^ variable.language.environment.home.fnmatch.git
-#   ^^ constant.language.path.parent.fnmatch.git
-#       ^^ - constant.language.path.parent.fnmatch.git
+#   ^^ variable.language.parent.path.fnmatch.git
+#       ^^ - variable.language.parent.path.fnmatch.git
 #          ^^ constant.character.escape.path.fnmatch.git
 #              ^^ constant.character.escape.path.fnmatch.git
 #                     ^ - constant.character.escape.path.fnmatch.git - punctuation.separator.path.fnmatch.git
 #                      ^ variable.language.wildcard.asterisk.fnmatch.git
 #                        ^ - constant.character.escape.path.fnmatch.git - punctuation.separator.path.fnmatch.git
 #                         ^ variable.language.wildcard.questionmark.fnmatch.git
-#                                 ^^ - constant.language.path.parent.fnmatch.git
+#                                 ^^ - variable.language.parent.path.fnmatch.git
 #                                       ^ - entity.name.pattern
 
 # NO HOME pattern
@@ -39,27 +39,27 @@
   ~..fname
 # ^^^^^^^^ string.unquoted.git.ignore entity.name.pattern.git.ignore
 # ^ - variable.language.environment.home.fnmatch.git
-#  ^^ - constant.language.path.parent.fnmatch.git
+#  ^^ - variable.language.parent.path.fnmatch.git
   ~../fname
 # ^^^^^^^^^ string.unquoted.git.ignore entity.name.pattern.git.ignore
 # ^ - variable.language.environment.home.fnmatch.git
-#  ^^ - constant.language.path.parent.fnmatch.git
+#  ^^ - variable.language.parent.path.fnmatch.git
 #    ^ punctuation.separator.path.fnmatch.git
 
 # PARENT DIR TESTS
   ../..fname../../
 # ^^^^^^^^^^^^^^^^ string.unquoted.git.ignore entity.name.pattern.git.ignore
-# ^^ constant.language.path.parent.fnmatch.git
+# ^^ variable.language.parent.path.fnmatch.git
 #   ^ punctuation.separator.path.fnmatch.git
-#    ^^ - constant.language.path.parent.fnmatch.git
-#           ^^ - constant.language.path.parent.fnmatch.git
+#    ^^ - variable.language.parent.path.fnmatch.git
+#           ^^ - variable.language.parent.path.fnmatch.git
 #             ^ punctuation.separator.path.fnmatch.git
-#              ^^ constant.language.path.parent.fnmatch.git
+#              ^^ variable.language.parent.path.fnmatch.git
 #                ^ punctuation.separator.path.fnmatch.git
   ..fname../..
 # ^^^^^^^^^^^^ string.unquoted.git.ignore entity.name.pattern.git.ignore
-#        ^^ - constant.language.path.parent.fnmatch.git
-#           ^^ - constant.language.path.parent.fnmatch.git
+#        ^^ - variable.language.parent.path.fnmatch.git
+#           ^^ - variable.language.parent.path.fnmatch.git
 
 # DRIVE SEPARATOR TESTS
   c:/fo:lder:/

--- a/Git Formats/tests/syntax_test_git_ignore
+++ b/Git Formats/tests/syntax_test_git_ignore
@@ -8,9 +8,9 @@
 #  ^ variable.language.environment.home.fnmatch.git
 #   ^ punctuation.separator.path.fnmatch.git
 #    ^ - constant
-#       ^ keyword.operator.wildcard.fnmatch.git
+#       ^ variable.language.wildcard.questionmark.fnmatch.git
 #               ^ punctuation.separator.path.fnmatch.git
-#                ^ keyword.operator.wildcard.fnmatch.git
+#                ^ variable.language.wildcard.asterisk.fnmatch.git
 #                 ^ punctuation.separator.path.fnmatch.git
 
   ~/../f..o\'ld\"er/fo\*l\?der/fol../der
@@ -22,9 +22,9 @@
 #          ^^ constant.character.escape.path.fnmatch.git
 #              ^^ constant.character.escape.path.fnmatch.git
 #                     ^ - constant.character.escape.path.fnmatch.git - punctuation.separator.path.fnmatch.git
-#                      ^ keyword.operator.wildcard.fnmatch.git
+#                      ^ variable.language.wildcard.asterisk.fnmatch.git
 #                        ^ - constant.character.escape.path.fnmatch.git - punctuation.separator.path.fnmatch.git
-#                         ^ keyword.operator.wildcard.fnmatch.git
+#                         ^ variable.language.wildcard.questionmark.fnmatch.git
 #                                 ^^ - constant.language.path.parent.fnmatch.git
 #                                       ^ - entity.name.pattern
 
@@ -35,7 +35,7 @@
 #       ^ - variable.language.environment.home.fnmatch.git
 #         ^ punctuation.separator.path.fnmatch.git
 #          ^ - variable.language.environment.home.fnmatch.git
-#            ^ keyword.operator.wildcard.fnmatch.git
+#            ^ variable.language.wildcard.asterisk.fnmatch.git
   ~..fname
 # ^^^^^^^^ string.unquoted.git.ignore entity.name.pattern.git.ignore
 # ^ - variable.language.environment.home.fnmatch.git

--- a/Git Formats/tests/syntax_test_git_ignore
+++ b/Git Formats/tests/syntax_test_git_ignore
@@ -8,9 +8,9 @@
 #  ^ variable.language.environment.home.fnmatch.git
 #   ^ punctuation.separator.path.fnmatch.git
 #    ^ - constant
-#       ^ variable.language.wildcard.questionmark.fnmatch.git
+#       ^ constant.other.wildcard.questionmark.fnmatch.git
 #               ^ punctuation.separator.path.fnmatch.git
-#                ^ variable.language.wildcard.asterisk.fnmatch.git
+#                ^ constant.other.wildcard.asterisk.fnmatch.git
 #                 ^ punctuation.separator.path.fnmatch.git
 
   ~/../f..o\'ld\"er/fo\*l\?der/fol../der
@@ -22,9 +22,9 @@
 #          ^^ constant.character.escape.path.fnmatch.git
 #              ^^ constant.character.escape.path.fnmatch.git
 #                     ^ - constant.character.escape.path.fnmatch.git - punctuation.separator.path.fnmatch.git
-#                      ^ variable.language.wildcard.asterisk.fnmatch.git
+#                      ^ constant.other.wildcard.asterisk.fnmatch.git
 #                        ^ - constant.character.escape.path.fnmatch.git - punctuation.separator.path.fnmatch.git
-#                         ^ variable.language.wildcard.questionmark.fnmatch.git
+#                         ^ constant.other.wildcard.questionmark.fnmatch.git
 #                                 ^^ - variable.language.parent.path.fnmatch.git
 #                                       ^ - entity.name.pattern
 
@@ -35,7 +35,7 @@
 #       ^ - variable.language.environment.home.fnmatch.git
 #         ^ punctuation.separator.path.fnmatch.git
 #          ^ - variable.language.environment.home.fnmatch.git
-#            ^ variable.language.wildcard.asterisk.fnmatch.git
+#            ^ constant.other.wildcard.asterisk.fnmatch.git
   ~..fname
 # ^^^^^^^^ string.unquoted.git.ignore entity.name.pattern.git.ignore
 # ^ - variable.language.environment.home.fnmatch.git

--- a/Git Formats/tests/syntax_test_git_ignore
+++ b/Git Formats/tests/syntax_test_git_ignore
@@ -17,15 +17,15 @@
 #^ - entity.name.pattern
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^ entity.name.pattern
 # ^ variable.language.environment.home.fnmatch.git
-#   ^^ variable.language.parent.path.fnmatch.git
-#       ^^ - variable.language.parent.path.fnmatch.git
+#   ^^ constant.other.path.parent.fnmatch.git
+#       ^^ - constant.other.path.parent.fnmatch.git
 #          ^^ constant.character.escape.path.fnmatch.git
 #              ^^ constant.character.escape.path.fnmatch.git
 #                     ^ - constant.character.escape.path.fnmatch.git - punctuation.separator.path.fnmatch.git
 #                      ^ constant.other.wildcard.asterisk.fnmatch.git
 #                        ^ - constant.character.escape.path.fnmatch.git - punctuation.separator.path.fnmatch.git
 #                         ^ constant.other.wildcard.questionmark.fnmatch.git
-#                                 ^^ - variable.language.parent.path.fnmatch.git
+#                                 ^^ - constant.other.path.parent.fnmatch.git
 #                                       ^ - entity.name.pattern
 
 # NO HOME pattern
@@ -39,27 +39,27 @@
   ~..fname
 # ^^^^^^^^ string.unquoted.git.ignore entity.name.pattern.git.ignore
 # ^ - variable.language.environment.home.fnmatch.git
-#  ^^ - variable.language.parent.path.fnmatch.git
+#  ^^ - constant.other.path.parent.fnmatch.git
   ~../fname
 # ^^^^^^^^^ string.unquoted.git.ignore entity.name.pattern.git.ignore
 # ^ - variable.language.environment.home.fnmatch.git
-#  ^^ - variable.language.parent.path.fnmatch.git
+#  ^^ - constant.other.path.parent.fnmatch.git
 #    ^ punctuation.separator.path.fnmatch.git
 
 # PARENT DIR TESTS
   ../..fname../../
 # ^^^^^^^^^^^^^^^^ string.unquoted.git.ignore entity.name.pattern.git.ignore
-# ^^ variable.language.parent.path.fnmatch.git
+# ^^ constant.other.path.parent.fnmatch.git
 #   ^ punctuation.separator.path.fnmatch.git
-#    ^^ - variable.language.parent.path.fnmatch.git
-#           ^^ - variable.language.parent.path.fnmatch.git
+#    ^^ - constant.other.path.parent.fnmatch.git
+#           ^^ - constant.other.path.parent.fnmatch.git
 #             ^ punctuation.separator.path.fnmatch.git
-#              ^^ variable.language.parent.path.fnmatch.git
+#              ^^ constant.other.path.parent.fnmatch.git
 #                ^ punctuation.separator.path.fnmatch.git
   ..fname../..
 # ^^^^^^^^^^^^ string.unquoted.git.ignore entity.name.pattern.git.ignore
-#        ^^ - variable.language.parent.path.fnmatch.git
-#           ^^ - variable.language.parent.path.fnmatch.git
+#        ^^ - constant.other.path.parent.fnmatch.git
+#           ^^ - constant.other.path.parent.fnmatch.git
 
 # DRIVE SEPARATOR TESTS
   c:/fo:lder:/

--- a/Git Formats/tests/syntax_test_git_link
+++ b/Git Formats/tests/syntax_test_git_link
@@ -33,14 +33,14 @@ gitdir: ~/../sub..li~me/./packages/.git
 #                                      ^ - string.unquoted.git
 #       ^ variable.language.environment.home.git
 #        ^ punctuation.separator.path.git
-#         ^^ constant.language.path.parent.git
+#         ^^ variable.language.parent.path.git
 #           ^ punctuation.separator.path.git
-#               ^^ - constant.language.path.parent.git
+#               ^^ - variable.language.parent.path.git
 #                   ^ - variable.language.environment.home.git
 #                      ^ punctuation.separator.path.git
-#                       ^ constant.language.path.self.git
+#                       ^ variable.language.self.path.git
 #                        ^ punctuation.separator.path.git
-#                                  ^ - constant.language.path.self.git
+#                                  ^ - variable.language.self.path.git
 gitdir invalid : ../data/s?bl*me/packages/.git
 #^^^^^^^^^^^^^^ meta.mapping.key.git.link - meta.mapping.value.git.link
 #              ^ meta.mapping.git.link - meta.mapping.key.git.link - meta.mapping.value.git.link
@@ -49,7 +49,7 @@ gitdir invalid : ../data/s?bl*me/packages/.git
 #^^^^^ keyword.other.gitdir.git.link
 #      ^^^^^^^ invalid.illegal.separator-expected.git.link
 #              ^ punctuation.separator.key-value.git.link
-#                ^^ constant.language.path.parent.git
+#                ^^ variable.language.parent.path.git
 #                  ^ punctuation.separator.path.git
 #                       ^ punctuation.separator.path.git
 #                         ^ invalid.illegal.path.git

--- a/Git Formats/tests/syntax_test_git_link
+++ b/Git Formats/tests/syntax_test_git_link
@@ -33,14 +33,14 @@ gitdir: ~/../sub..li~me/./packages/.git
 #                                      ^ - string.unquoted.git
 #       ^ variable.language.environment.home.git
 #        ^ punctuation.separator.path.git
-#         ^^ variable.language.parent.path.git
+#         ^^ constant.other.path.parent.git
 #           ^ punctuation.separator.path.git
-#               ^^ - variable.language.parent.path.git
+#               ^^ - constant.other.path.parent.git
 #                   ^ - variable.language.environment.home.git
 #                      ^ punctuation.separator.path.git
-#                       ^ variable.language.self.path.git
+#                       ^ constant.other.path.self.git
 #                        ^ punctuation.separator.path.git
-#                                  ^ - variable.language.self.path.git
+#                                  ^ - constant.other.path.self.git
 gitdir invalid : ../data/s?bl*me/packages/.git
 #^^^^^^^^^^^^^^ meta.mapping.key.git.link - meta.mapping.value.git.link
 #              ^ meta.mapping.git.link - meta.mapping.key.git.link - meta.mapping.value.git.link
@@ -49,7 +49,7 @@ gitdir invalid : ../data/s?bl*me/packages/.git
 #^^^^^ keyword.other.gitdir.git.link
 #      ^^^^^^^ invalid.illegal.separator-expected.git.link
 #              ^ punctuation.separator.key-value.git.link
-#                ^^ variable.language.parent.path.git
+#                ^^ constant.other.path.parent.git
 #                  ^ punctuation.separator.path.git
 #                       ^ punctuation.separator.path.git
 #                         ^ invalid.illegal.path.git

--- a/Haskell/Cabal.sublime-syntax
+++ b/Haskell/Cabal.sublime-syntax
@@ -362,10 +362,10 @@ contexts:
 
   literal-path-dir-pattern:
     - match: \.\.(?=[\\/])
-      scope: variable.language.parent.path.cabal
+      scope: constant.other.path.parent.cabal
       pop: 1
     - match: \.(?=[\\/])
-      scope: variable.language.self.path.cabal
+      scope: constant.other.path.self.cabal
       pop: 1
     - match: ''
       pop: 1

--- a/Haskell/Cabal.sublime-syntax
+++ b/Haskell/Cabal.sublime-syntax
@@ -362,10 +362,10 @@ contexts:
 
   literal-path-dir-pattern:
     - match: \.\.(?=[\\/])
-      scope: constant.language.path.parent.cabal
+      scope: variable.language.parent.path.cabal
       pop: 1
     - match: \.(?=[\\/])
-      scope: constant.language.path.self.cabal
+      scope: variable.language.self.path.cabal
       pop: 1
     - match: ''
       pop: 1

--- a/Haskell/Cabal.sublime-syntax
+++ b/Haskell/Cabal.sublime-syntax
@@ -144,7 +144,7 @@ contexts:
 
   dependency-names:
     - match: \*(?!\.)
-      scope: variable.language.wildcard.asterisk.cabal
+      scope: constant.other.wildcard.asterisk.cabal
     - match: \ball\b  # synonym for `*`
       scope: constant.language.all.cabal
     - match: \bnone\b
@@ -421,5 +421,5 @@ contexts:
     - match: (?:\d+|(\*))(\.(?=[*\d]))?
       scope: meta.number.version.cabal constant.numeric.value.cabal
       captures:
-        1: variable.language.wildcard.asterisk.cabal
+        1: constant.other.wildcard.asterisk.cabal
         2: punctuation.separator.decimal.cabal

--- a/Haskell/tests/syntax_test_cabal.cabal
+++ b/Haskell/tests/syntax_test_cabal.cabal
@@ -291,7 +291,7 @@ preferences: pkg >= 2.*,
 --               ^^ keyword.operator.comparison.cabal
 --                  ^^^ meta.number.version.cabal constant.numeric.value.cabal
 --                   ^ punctuation.separator.decimal.cabal
---                    ^ variable.language.wildcard.asterisk.cabal
+--                    ^ constant.other.wildcard.asterisk.cabal
 --                     ^ punctuation.separator.sequence.cabal
 
 -- 'quux ^>= ...'-style constraints only.
@@ -341,19 +341,19 @@ allow-newer: all:bar, *:baz, *:^quux
 --              ^ keyword.operator.assignment.cabal
 --               ^^^ meta.path.package.cabal
 --                  ^ punctuation.separator.sequence.cabal
---                    ^ variable.language.wildcard.asterisk.cabal - constant.numeric
+--                    ^ constant.other.wildcard.asterisk.cabal - constant.numeric
 --                     ^ keyword.operator.assignment.cabal
 --                      ^^^ meta.path.package.cabal
 --                         ^ punctuation.separator.sequence.cabal
---                           ^ variable.language.wildcard.asterisk.cabal - constant.numeric
+--                           ^ constant.other.wildcard.asterisk.cabal - constant.numeric
 --                            ^ keyword.operator.assignment.cabal
 --                             ^ keyword.operator.bound.cabal
 --                              ^^^^ meta.path.package.cabal
 
 allow-newer: *:*
---           ^ variable.language.wildcard.asterisk.cabal - constant.numeric
+--           ^ constant.other.wildcard.asterisk.cabal - constant.numeric
 --            ^ keyword.operator.assignment.cabal
---             ^ variable.language.wildcard.asterisk.cabal - constant.numeric
+--             ^ constant.other.wildcard.asterisk.cabal - constant.numeric
 
 allow-newer: all:all
 --           ^^^ constant.language.all.cabal
@@ -361,10 +361,10 @@ allow-newer: all:all
 --               ^^^ constant.language.all.cabal
 
 allow-newer: *:^*
---           ^ variable.language.wildcard.asterisk.cabal - constant.numeric
+--           ^ constant.other.wildcard.asterisk.cabal - constant.numeric
 --            ^ keyword.operator.assignment.cabal
 --             ^ keyword.operator.bound.cabal
---              ^ variable.language.wildcard.asterisk.cabal - constant.numeric
+--              ^ constant.other.wildcard.asterisk.cabal - constant.numeric
 
 allow-newer: all:^all
 --           ^^^ constant.language.all.cabal
@@ -376,14 +376,14 @@ allow-newer: all:^all
 allow-newer: pkg-1.2.3:*
 --           ^^^^^^^^^ meta.path.package.cabal
 --                    ^ keyword.operator.assignment.cabal
---                     ^ variable.language.wildcard.asterisk.cabal - constant.numeric
+--                     ^ constant.other.wildcard.asterisk.cabal - constant.numeric
 
 -- Disregard only `^>=`-style upper bounds in pkg-1.2.3
 allow-newer: pkg-1.2.3:^*
 --           ^^^^^^^^^ meta.path.package.cabal
 --                    ^ keyword.operator.assignment.cabal
 --                     ^ keyword.operator.bound.cabal
---                      ^ variable.language.wildcard.asterisk.cabal - constant.numeric
+--                      ^ constant.other.wildcard.asterisk.cabal - constant.numeric
 
 allow-newer: pkg-1.2.3:dep-pkg, pkg-1.1.2:dep-pkg
 --           ^^^^^^^^^ meta.path.package.cabal
@@ -448,7 +448,7 @@ executable pandoc
   --       ^^^ constant.language.compiler.cabal
   --           ^ keyword.operator.comparison.cabal
   --             ^^^ meta.number.version.cabal constant.numeric.value.cabal
-  --               ^ variable.language.wildcard.asterisk.cabal
+  --               ^ constant.other.wildcard.asterisk.cabal
   --                ^ punctuation.section.group.end.cabal
      hs-source-dirs: prelude
      -- <- meta.mapping.key.cabal entity.name.tag.cabal

--- a/Haskell/tests/syntax_test_cabal.cabal
+++ b/Haskell/tests/syntax_test_cabal.cabal
@@ -234,7 +234,7 @@ data-files:
 --              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.value.paths.cabal
 --              ^ - meta.path - markup.underline.link - string
 --               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.path.file.cabal markup.underline.link.cabal
---               ^^ variable.language.parent.path.cabal
+--               ^^ constant.other.path.parent.cabal
 --                 ^ punctuation.separator.path.cabal
 --                      ^ punctuation.separator.path.cabal
 --                               ^ keyword.operator.wildcard.cabal

--- a/Haskell/tests/syntax_test_cabal.cabal
+++ b/Haskell/tests/syntax_test_cabal.cabal
@@ -234,7 +234,7 @@ data-files:
 --              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.value.paths.cabal
 --              ^ - meta.path - markup.underline.link - string
 --               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.path.file.cabal markup.underline.link.cabal
---               ^^ constant.language.path.parent.cabal
+--               ^^ variable.language.parent.path.cabal
 --                 ^ punctuation.separator.path.cabal
 --                      ^ punctuation.separator.path.cabal
 --                               ^ keyword.operator.wildcard.cabal

--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -575,7 +575,7 @@ contexts:
 
   import-wildcard:
     - match: \*
-      scope: variable.language.wildcard.asterisk.java
+      scope: constant.other.wildcard.asterisk.java
       pop: 2
       set: import-expect-terminator
 
@@ -3130,7 +3130,7 @@ contexts:
 
   type-argument-reference:
     - match: \?
-      scope: variable.language.wildcard.questionmark.java
+      scope: constant.other.wildcard.questionmark.java
       set: type-argument-bounds
     - include: maybe-reference-type
 

--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -575,7 +575,7 @@ contexts:
 
   import-wildcard:
     - match: \*
-      scope: keyword.operator.wildcard.java
+      scope: variable.language.wildcard.asterisk.java
       pop: 2
       set: import-expect-terminator
 
@@ -3130,7 +3130,7 @@ contexts:
 
   type-argument-reference:
     - match: \?
-      scope: keyword.operator.wildcard.java
+      scope: variable.language.wildcard.questionmark.java
       set: type-argument-bounds
     - include: maybe-reference-type
 

--- a/Java/tests/syntax_test_java.java
+++ b/Java/tests/syntax_test_java.java
@@ -588,7 +588,7 @@ import static no.terminator
 import * ;
 // <- meta.import.java keyword.declaration.import.java
 //^^^^^ meta.import.java - meta.path
-//     ^ meta.import.java meta.path.java variable.language.wildcard.asterisk.java
+//     ^ meta.import.java meta.path.java constant.other.wildcard.asterisk.java
 //      ^^ - meta.import - meta.path
 //       ^ punctuation.terminator.java
 
@@ -598,7 +598,7 @@ import *. ;
 //     ^ meta.import.java meta.path.java
 //      ^ meta.import - meta.path
 //       ^^ - meta.import - meta.path
-//     ^ variable.language.wildcard.asterisk.java
+//     ^ constant.other.wildcard.asterisk.java
 //      ^ invalid.illegal.expect-semicolon.java
 //        ^ punctuation.terminator.java
 
@@ -608,7 +608,7 @@ import *.* ;
 //     ^ meta.import.java meta.path.java
 //      ^^ meta.import - meta.path
 //        ^^ - meta.import - meta.path
-//     ^ variable.language.wildcard.asterisk.java
+//     ^ constant.other.wildcard.asterisk.java
 //      ^^ invalid.illegal.expect-semicolon.java
 //         ^ punctuation.terminator.java
 
@@ -618,7 +618,7 @@ import *.a ;
 //     ^ meta.import.java meta.path.java
 //      ^^ meta.import - meta.path
 //        ^^ - meta.import - meta.path
-//     ^ variable.language.wildcard.asterisk.java
+//     ^ constant.other.wildcard.asterisk.java
 //      ^^ invalid.illegal.expect-semicolon.java
 //         ^ punctuation.terminator.java
 
@@ -631,7 +631,7 @@ import a . * . b ;
 //     ^ variable.namespace.java
 //      ^^^ - variable
 //       ^ punctuation.accessor.dot.java
-//         ^ variable.language.wildcard.asterisk.java
+//         ^ constant.other.wildcard.asterisk.java
 //          ^^^^ - variable
 //           ^ invalid.illegal.expect-semicolon.java
 //             ^ invalid.illegal.expect-semicolon.java
@@ -650,7 +650,7 @@ import a . b . * ;
 //          ^ - variable - punctuation
 //           ^ punctuation.accessor.dot.java - entity - variable
 //            ^ - variable - punctuation
-//             ^ variable.language.wildcard.asterisk.java
+//             ^ constant.other.wildcard.asterisk.java
 //               ^ punctuation.terminator.java
 
 import a.b.Class;
@@ -673,7 +673,7 @@ import a.b.Class.*;
 //        ^ punctuation.accessor.dot.java - entity - variable
 //         ^^^^^ support.class.java
 //              ^ punctuation.accessor.dot.java - entity - variable
-//               ^ variable.language.wildcard.asterisk.java
+//               ^ constant.other.wildcard.asterisk.java
 
 import a.b.Class.SubClass;
 //^^^^^ meta.import.java - meta.path
@@ -826,7 +826,7 @@ import static a.b.Class.*;
 //               ^ punctuation.accessor.dot.java
 //                ^^^^^ support.class.java
 //                     ^ punctuation.accessor.dot.java
-//                      ^ variable.language.wildcard.asterisk.java
+//                      ^ constant.other.wildcard.asterisk.java
 
 import static C.d.ced
 //^^^^^^^^^^^^ meta.import.java
@@ -1156,7 +1156,7 @@ class GenericTest<@Anno A extends @Anno com . @Anno Foo<A, @Anno com . @Anno Bar
 //                                                                                   ^^^^ variable.annotation.java
 //                                                                                        ^^^ support.class.java
 //                                                                                           ^ punctuation.definition.generic.begin.java
-//                                                                                            ^ variable.language.wildcard.questionmark.java
+//                                                                                            ^ constant.other.wildcard.questionmark.java
 //                                                                                              ^^^^^ keyword.declaration.super.java
 //                                                                                                    ^^^ support.class.java
 //                                                                                                       ^ punctuation.definition.generic.end.java
@@ -1209,7 +1209,7 @@ class generictest<@anno a extends @anno com . @anno foo<a, @anno com . @anno bar
 //                                                                                   ^^^^ variable.annotation.java
 //                                                                                        ^^^ support.class.java
 //                                                                                           ^ punctuation.definition.generic.begin.java
-//                                                                                            ^ variable.language.wildcard.questionmark.java
+//                                                                                            ^ constant.other.wildcard.questionmark.java
 //                                                                                              ^^^^^ keyword.declaration.super.java
 //                                                                                                    ^^^ support.class.java
 //                                                                                                       ^ punctuation.definition.generic.end.java
@@ -1244,7 +1244,7 @@ class GenericTest<A> extends Foo<? extends A> {}
 //                          ^ - entity - keyword - storage
 //                           ^^^ entity.other.inherited-class.java
 //                              ^ punctuation.definition.generic.begin.java
-//                               ^ variable.language.wildcard.questionmark.java
+//                               ^ constant.other.wildcard.questionmark.java
 //                                 ^^^^^^^ storage.modifier.extends.java
 //                                         ^ support.class.java
 //                                          ^ punctuation.definition.generic.end.java
@@ -1281,7 +1281,7 @@ class GenericTest<A> extends @Anno com . @Anno Foo<@Anno ? extends @Anno SuperCl
 //                                                ^ punctuation.definition.generic.begin.java
 //                                                 ^ punctuation.definition.annotation.java
 //                                                  ^^^^ variable.annotation.java
-//                                                       ^ variable.language.wildcard.questionmark.java
+//                                                       ^ constant.other.wildcard.questionmark.java
 //                                                         ^^^^^^^ storage.modifier.extends.java
 //                                                                 ^ punctuation.definition.annotation.java
 //                                                                  ^^^^ variable.annotation.java
@@ -1807,7 +1807,7 @@ public enum TokenKind<T> extends MyEnum, FooBaz<? super T<TT>> implements Foo, B
 //                                       ^^^^^^ entity.other.inherited-class.java
 //                                             ^ punctuation.definition.generic.begin.java
 //                                             ^^^^^^^^^^ meta.generic.java - meta.generic meta.generic
-//                                              ^ variable.language.wildcard.questionmark.java
+//                                              ^ constant.other.wildcard.questionmark.java
 //                                                ^^^^^ keyword.declaration.super.java
 //                                                      ^ support.class.java
 //                                                       ^ punctuation.definition.generic.begin.java
@@ -4013,7 +4013,7 @@ class MethodDelcarationTests {
 //                    ^^^^^^^^^^^^^^^^^ entity.name.function.java
 //                                      ^^^^^^^^^^ support.class.java
 //                                                ^ punctuation.definition.generic.begin.java
-//                                                 ^ variable.language.wildcard.questionmark.java
+//                                                 ^ constant.other.wildcard.questionmark.java
 //                                                   ^^^^^^^ storage.modifier.extends.java
 //                                                           ^ support.class.java
 //                                                            ^ punctuation.definition.generic.end.java
@@ -4040,7 +4040,7 @@ class MethodDelcarationTests {
 //                    ^^^^^^^ storage.modifier.extends.java
 //                            ^^^^^^^^^^ support.class.java
 //                                      ^ punctuation.definition.generic.begin.java
-//                                       ^ variable.language.wildcard.questionmark.java
+//                                       ^ constant.other.wildcard.questionmark.java
 //                                         ^^^^^ keyword.declaration.super.java
 //                                               ^ support.class.java
 //                                                ^^ punctuation.definition.generic.end.java
@@ -5038,7 +5038,7 @@ class LocalVariableDeclarationTests {
 //                       ^ - meta.declaration
 //  ^^^^ support.class.java
 //      ^ punctuation.definition.generic.begin.java
-//       ^ variable.language.wildcard.questionmark.java
+//       ^ constant.other.wildcard.questionmark.java
 //         ^^^^^^^ storage.modifier.extends.java
 //                 ^^^ invalid.illegal.unexpected-keyword.java
 //                    ^ punctuation.definition.generic.end.java
@@ -8275,7 +8275,7 @@ class InstanceCreationExpressionsTests {
 //                ^^ meta.group.java
 //      ^^^^^^^ support.class.java
 //             ^ punctuation.definition.generic.begin.java
-//              ^ variable.language.wildcard.questionmark.java
+//              ^ constant.other.wildcard.questionmark.java
 //               ^ punctuation.definition.generic.end.java
 //                ^ punctuation.section.group.begin.java
 //                 ^ punctuation.section.group.end.java
@@ -8295,7 +8295,7 @@ class InstanceCreationExpressionsTests {
 //                   ^ punctuation.definition.generic.begin.java
 //                    ^ punctuation.definition.annotation.java
 //                     ^^^^ variable.annotation.java
-//                          ^ variable.language.wildcard.questionmark.java
+//                          ^ constant.other.wildcard.questionmark.java
 //                           ^ punctuation.definition.generic.end.java
 //                            ^ punctuation.section.group.begin.java
 //                             ^ punctuation.section.group.end.java
@@ -8306,7 +8306,7 @@ class InstanceCreationExpressionsTests {
 //             ^^^^^^^^^^^^^^^^ meta.instantiation.java meta.generic.java
 //                             ^^ meta.instantiation.java meta.group.java
 //             ^ punctuation.definition.generic.begin.java
-//              ^ variable.language.wildcard.questionmark.java
+//              ^ constant.other.wildcard.questionmark.java
 //                ^^^^^^^ storage.modifier.extends.java
 //                        ^^^^ support.class.java
 //                            ^ punctuation.definition.generic.end.java
@@ -8324,7 +8324,7 @@ class InstanceCreationExpressionsTests {
 //                   ^ punctuation.definition.generic.begin.java
 //                    ^ punctuation.definition.annotation.java
 //                     ^^^^ variable.annotation.java
-//                          ^ variable.language.wildcard.questionmark.java
+//                          ^ constant.other.wildcard.questionmark.java
 //                            ^^^^^^^ storage.modifier.extends.java
 //                                    ^ punctuation.definition.annotation.java
 //                                     ^^^^ variable.annotation.java
@@ -8344,7 +8344,7 @@ class InstanceCreationExpressionsTests {
 //                   ^ punctuation.definition.generic.begin.java
 //                    ^ punctuation.definition.annotation.java
 //                     ^^^^ variable.annotation.java
-//                          ^ variable.language.wildcard.questionmark.java
+//                          ^ constant.other.wildcard.questionmark.java
 //                            ^^^^^^^ storage.modifier.extends.java
 //                                    ^ punctuation.definition.annotation.java
 //                                     ^^^^ variable.annotation.java
@@ -8359,7 +8359,7 @@ class InstanceCreationExpressionsTests {
 //             ^^^^^^^^^^^^^^^^^^^^^^^^ meta.instantiation.java meta.generic.java
 //                                     ^^ meta.instantiation.java meta.group.java
 //             ^ punctuation.definition.generic.begin.java
-//              ^ variable.language.wildcard.questionmark.java
+//              ^ constant.other.wildcard.questionmark.java
 //                ^^^^^^^ storage.modifier.extends.java
 //                        ^^^^ support.class.java
 //                            ^ punctuation.separator.comma.java
@@ -8374,7 +8374,7 @@ class InstanceCreationExpressionsTests {
 //             ^^^^^^^^^^^^^^ meta.instantiation.java meta.generic.java
 //                           ^^ meta.instantiation.java meta.group.java
 //             ^ punctuation.definition.generic.begin.java
-//              ^ variable.language.wildcard.questionmark.java
+//              ^ constant.other.wildcard.questionmark.java
 //                ^^^^^ keyword.declaration.super.java
 //                      ^^^^ support.class.java
 //                          ^ punctuation.definition.generic.end.java
@@ -8474,7 +8474,7 @@ class InstanceCreationExpressionsTests {
 //  ^^^ keyword.other.storage.new.java
 //      ^^^^^^^^^ support.class.java
 //               ^ punctuation.definition.generic.begin.java
-//                ^ variable.language.wildcard.questionmark.java
+//                ^ constant.other.wildcard.questionmark.java
 //                 ^ punctuation.definition.generic.end.java
 //                  ^ punctuation.section.brackets.begin.java
 //                   ^ punctuation.section.brackets.end.java
@@ -9242,12 +9242,12 @@ class TypeComparisonExpressionsTests {
 //  ^^^^^^^^^^ keyword.other.storage.instanceof.java
 //             ^ support.class.java
 //              ^ punctuation.definition.generic.begin.java
-//               ^ variable.language.wildcard.questionmark.java
+//               ^ constant.other.wildcard.questionmark.java
 //                ^ punctuation.definition.generic.end.java
 //                 ^ punctuation.accessor.dot.java
 //                  ^ support.class.java
 //                   ^ punctuation.definition.generic.begin.java
-//                    ^ variable.language.wildcard.questionmark.java
+//                    ^ constant.other.wildcard.questionmark.java
 //                     ^ punctuation.definition.generic.end.java
   }
 //^ meta.class.java meta.block.java meta.function.java meta.block.java punctuation.section.block.end.java

--- a/Java/tests/syntax_test_java.java
+++ b/Java/tests/syntax_test_java.java
@@ -588,7 +588,7 @@ import static no.terminator
 import * ;
 // <- meta.import.java keyword.declaration.import.java
 //^^^^^ meta.import.java - meta.path
-//     ^ meta.import.java meta.path.java keyword.operator.wildcard.java
+//     ^ meta.import.java meta.path.java variable.language.wildcard.asterisk.java
 //      ^^ - meta.import - meta.path
 //       ^ punctuation.terminator.java
 
@@ -598,7 +598,7 @@ import *. ;
 //     ^ meta.import.java meta.path.java
 //      ^ meta.import - meta.path
 //       ^^ - meta.import - meta.path
-//     ^ keyword.operator.wildcard.java
+//     ^ variable.language.wildcard.asterisk.java
 //      ^ invalid.illegal.expect-semicolon.java
 //        ^ punctuation.terminator.java
 
@@ -608,7 +608,7 @@ import *.* ;
 //     ^ meta.import.java meta.path.java
 //      ^^ meta.import - meta.path
 //        ^^ - meta.import - meta.path
-//     ^ keyword.operator.wildcard.java
+//     ^ variable.language.wildcard.asterisk.java
 //      ^^ invalid.illegal.expect-semicolon.java
 //         ^ punctuation.terminator.java
 
@@ -618,7 +618,7 @@ import *.a ;
 //     ^ meta.import.java meta.path.java
 //      ^^ meta.import - meta.path
 //        ^^ - meta.import - meta.path
-//     ^ keyword.operator.wildcard.java
+//     ^ variable.language.wildcard.asterisk.java
 //      ^^ invalid.illegal.expect-semicolon.java
 //         ^ punctuation.terminator.java
 
@@ -631,7 +631,7 @@ import a . * . b ;
 //     ^ variable.namespace.java
 //      ^^^ - variable
 //       ^ punctuation.accessor.dot.java
-//         ^ keyword.operator.wildcard.java
+//         ^ variable.language.wildcard.asterisk.java
 //          ^^^^ - variable
 //           ^ invalid.illegal.expect-semicolon.java
 //             ^ invalid.illegal.expect-semicolon.java
@@ -650,7 +650,7 @@ import a . b . * ;
 //          ^ - variable - punctuation
 //           ^ punctuation.accessor.dot.java - entity - variable
 //            ^ - variable - punctuation
-//             ^ keyword.operator.wildcard.java
+//             ^ variable.language.wildcard.asterisk.java
 //               ^ punctuation.terminator.java
 
 import a.b.Class;
@@ -673,7 +673,7 @@ import a.b.Class.*;
 //        ^ punctuation.accessor.dot.java - entity - variable
 //         ^^^^^ support.class.java
 //              ^ punctuation.accessor.dot.java - entity - variable
-//               ^ keyword.operator.wildcard.java
+//               ^ variable.language.wildcard.asterisk.java
 
 import a.b.Class.SubClass;
 //^^^^^ meta.import.java - meta.path
@@ -826,7 +826,7 @@ import static a.b.Class.*;
 //               ^ punctuation.accessor.dot.java
 //                ^^^^^ support.class.java
 //                     ^ punctuation.accessor.dot.java
-//                      ^ keyword.operator.wildcard.java
+//                      ^ variable.language.wildcard.asterisk.java
 
 import static C.d.ced
 //^^^^^^^^^^^^ meta.import.java
@@ -1156,7 +1156,7 @@ class GenericTest<@Anno A extends @Anno com . @Anno Foo<A, @Anno com . @Anno Bar
 //                                                                                   ^^^^ variable.annotation.java
 //                                                                                        ^^^ support.class.java
 //                                                                                           ^ punctuation.definition.generic.begin.java
-//                                                                                            ^ keyword.operator.wildcard.java
+//                                                                                            ^ variable.language.wildcard.questionmark.java
 //                                                                                              ^^^^^ keyword.declaration.super.java
 //                                                                                                    ^^^ support.class.java
 //                                                                                                       ^ punctuation.definition.generic.end.java
@@ -1209,7 +1209,7 @@ class generictest<@anno a extends @anno com . @anno foo<a, @anno com . @anno bar
 //                                                                                   ^^^^ variable.annotation.java
 //                                                                                        ^^^ support.class.java
 //                                                                                           ^ punctuation.definition.generic.begin.java
-//                                                                                            ^ keyword.operator.wildcard.java
+//                                                                                            ^ variable.language.wildcard.questionmark.java
 //                                                                                              ^^^^^ keyword.declaration.super.java
 //                                                                                                    ^^^ support.class.java
 //                                                                                                       ^ punctuation.definition.generic.end.java
@@ -1244,7 +1244,7 @@ class GenericTest<A> extends Foo<? extends A> {}
 //                          ^ - entity - keyword - storage
 //                           ^^^ entity.other.inherited-class.java
 //                              ^ punctuation.definition.generic.begin.java
-//                               ^ keyword.operator.wildcard.java
+//                               ^ variable.language.wildcard.questionmark.java
 //                                 ^^^^^^^ storage.modifier.extends.java
 //                                         ^ support.class.java
 //                                          ^ punctuation.definition.generic.end.java
@@ -1281,7 +1281,7 @@ class GenericTest<A> extends @Anno com . @Anno Foo<@Anno ? extends @Anno SuperCl
 //                                                ^ punctuation.definition.generic.begin.java
 //                                                 ^ punctuation.definition.annotation.java
 //                                                  ^^^^ variable.annotation.java
-//                                                       ^ keyword.operator.wildcard.java
+//                                                       ^ variable.language.wildcard.questionmark.java
 //                                                         ^^^^^^^ storage.modifier.extends.java
 //                                                                 ^ punctuation.definition.annotation.java
 //                                                                  ^^^^ variable.annotation.java
@@ -1807,7 +1807,7 @@ public enum TokenKind<T> extends MyEnum, FooBaz<? super T<TT>> implements Foo, B
 //                                       ^^^^^^ entity.other.inherited-class.java
 //                                             ^ punctuation.definition.generic.begin.java
 //                                             ^^^^^^^^^^ meta.generic.java - meta.generic meta.generic
-//                                              ^ keyword.operator.wildcard.java
+//                                              ^ variable.language.wildcard.questionmark.java
 //                                                ^^^^^ keyword.declaration.super.java
 //                                                      ^ support.class.java
 //                                                       ^ punctuation.definition.generic.begin.java
@@ -4013,7 +4013,7 @@ class MethodDelcarationTests {
 //                    ^^^^^^^^^^^^^^^^^ entity.name.function.java
 //                                      ^^^^^^^^^^ support.class.java
 //                                                ^ punctuation.definition.generic.begin.java
-//                                                 ^ keyword.operator.wildcard.java
+//                                                 ^ variable.language.wildcard.questionmark.java
 //                                                   ^^^^^^^ storage.modifier.extends.java
 //                                                           ^ support.class.java
 //                                                            ^ punctuation.definition.generic.end.java
@@ -4040,7 +4040,7 @@ class MethodDelcarationTests {
 //                    ^^^^^^^ storage.modifier.extends.java
 //                            ^^^^^^^^^^ support.class.java
 //                                      ^ punctuation.definition.generic.begin.java
-//                                       ^ keyword.operator.wildcard.java
+//                                       ^ variable.language.wildcard.questionmark.java
 //                                         ^^^^^ keyword.declaration.super.java
 //                                               ^ support.class.java
 //                                                ^^ punctuation.definition.generic.end.java
@@ -5038,7 +5038,7 @@ class LocalVariableDeclarationTests {
 //                       ^ - meta.declaration
 //  ^^^^ support.class.java
 //      ^ punctuation.definition.generic.begin.java
-//       ^ keyword.operator.wildcard.java
+//       ^ variable.language.wildcard.questionmark.java
 //         ^^^^^^^ storage.modifier.extends.java
 //                 ^^^ invalid.illegal.unexpected-keyword.java
 //                    ^ punctuation.definition.generic.end.java
@@ -8275,7 +8275,7 @@ class InstanceCreationExpressionsTests {
 //                ^^ meta.group.java
 //      ^^^^^^^ support.class.java
 //             ^ punctuation.definition.generic.begin.java
-//              ^ keyword.operator.wildcard.java
+//              ^ variable.language.wildcard.questionmark.java
 //               ^ punctuation.definition.generic.end.java
 //                ^ punctuation.section.group.begin.java
 //                 ^ punctuation.section.group.end.java
@@ -8295,7 +8295,7 @@ class InstanceCreationExpressionsTests {
 //                   ^ punctuation.definition.generic.begin.java
 //                    ^ punctuation.definition.annotation.java
 //                     ^^^^ variable.annotation.java
-//                          ^ keyword.operator.wildcard.java
+//                          ^ variable.language.wildcard.questionmark.java
 //                           ^ punctuation.definition.generic.end.java
 //                            ^ punctuation.section.group.begin.java
 //                             ^ punctuation.section.group.end.java
@@ -8306,7 +8306,7 @@ class InstanceCreationExpressionsTests {
 //             ^^^^^^^^^^^^^^^^ meta.instantiation.java meta.generic.java
 //                             ^^ meta.instantiation.java meta.group.java
 //             ^ punctuation.definition.generic.begin.java
-//              ^ keyword.operator.wildcard.java
+//              ^ variable.language.wildcard.questionmark.java
 //                ^^^^^^^ storage.modifier.extends.java
 //                        ^^^^ support.class.java
 //                            ^ punctuation.definition.generic.end.java
@@ -8324,7 +8324,7 @@ class InstanceCreationExpressionsTests {
 //                   ^ punctuation.definition.generic.begin.java
 //                    ^ punctuation.definition.annotation.java
 //                     ^^^^ variable.annotation.java
-//                          ^ keyword.operator.wildcard.java
+//                          ^ variable.language.wildcard.questionmark.java
 //                            ^^^^^^^ storage.modifier.extends.java
 //                                    ^ punctuation.definition.annotation.java
 //                                     ^^^^ variable.annotation.java
@@ -8344,7 +8344,7 @@ class InstanceCreationExpressionsTests {
 //                   ^ punctuation.definition.generic.begin.java
 //                    ^ punctuation.definition.annotation.java
 //                     ^^^^ variable.annotation.java
-//                          ^ keyword.operator.wildcard.java
+//                          ^ variable.language.wildcard.questionmark.java
 //                            ^^^^^^^ storage.modifier.extends.java
 //                                    ^ punctuation.definition.annotation.java
 //                                     ^^^^ variable.annotation.java
@@ -8359,7 +8359,7 @@ class InstanceCreationExpressionsTests {
 //             ^^^^^^^^^^^^^^^^^^^^^^^^ meta.instantiation.java meta.generic.java
 //                                     ^^ meta.instantiation.java meta.group.java
 //             ^ punctuation.definition.generic.begin.java
-//              ^ keyword.operator.wildcard.java
+//              ^ variable.language.wildcard.questionmark.java
 //                ^^^^^^^ storage.modifier.extends.java
 //                        ^^^^ support.class.java
 //                            ^ punctuation.separator.comma.java
@@ -8374,7 +8374,7 @@ class InstanceCreationExpressionsTests {
 //             ^^^^^^^^^^^^^^ meta.instantiation.java meta.generic.java
 //                           ^^ meta.instantiation.java meta.group.java
 //             ^ punctuation.definition.generic.begin.java
-//              ^ keyword.operator.wildcard.java
+//              ^ variable.language.wildcard.questionmark.java
 //                ^^^^^ keyword.declaration.super.java
 //                      ^^^^ support.class.java
 //                          ^ punctuation.definition.generic.end.java
@@ -8474,7 +8474,7 @@ class InstanceCreationExpressionsTests {
 //  ^^^ keyword.other.storage.new.java
 //      ^^^^^^^^^ support.class.java
 //               ^ punctuation.definition.generic.begin.java
-//                ^ keyword.operator.wildcard.java
+//                ^ variable.language.wildcard.questionmark.java
 //                 ^ punctuation.definition.generic.end.java
 //                  ^ punctuation.section.brackets.begin.java
 //                   ^ punctuation.section.brackets.end.java
@@ -9242,12 +9242,12 @@ class TypeComparisonExpressionsTests {
 //  ^^^^^^^^^^ keyword.other.storage.instanceof.java
 //             ^ support.class.java
 //              ^ punctuation.definition.generic.begin.java
-//               ^ keyword.operator.wildcard.java
+//               ^ variable.language.wildcard.questionmark.java
 //                ^ punctuation.definition.generic.end.java
 //                 ^ punctuation.accessor.dot.java
 //                  ^ support.class.java
 //                   ^ punctuation.definition.generic.begin.java
-//                    ^ keyword.operator.wildcard.java
+//                    ^ variable.language.wildcard.questionmark.java
 //                     ^ punctuation.definition.generic.end.java
   }
 //^ meta.class.java meta.block.java meta.function.java meta.block.java punctuation.section.block.end.java

--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -208,7 +208,7 @@ contexts:
 
   highlight-wildcard-sign:
     - match: \*
-      scope: variable.language.wildcard.makefile
+      scope: variable.language.wildcard.asterisk.makefile
 
   expect-rule:
     # Anything before the colon is part of the rule's name.

--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -208,7 +208,7 @@ contexts:
 
   highlight-wildcard-sign:
     - match: \*
-      scope: variable.language.wildcard.asterisk.makefile
+      scope: constant.other.wildcard.asterisk.makefile
 
   expect-rule:
     # Anything before the colon is part of the rule's name.

--- a/Makefile/syntax_test_makefile.mak
+++ b/Makefile/syntax_test_makefile.mak
@@ -127,7 +127,7 @@ $(dir)_sources := $(wildcard $(dir)/*.c)
 #                 ^^ keyword.other.block.begin
 #                            ^^ keyword.other.block.begin
 #                                 ^ keyword.other.block.end
-#                                   ^ variable.language.wildcard.asterisk
+#                                   ^ constant.other.wildcard.asterisk
 #                                      ^ keyword.other.block.end
 define $(dir)_print =
 # ^ keyword.control
@@ -840,12 +840,12 @@ endif
 
 vpath dir/*/whatevs whatevs
 # ^ keyword.control.vpath
-#         ^ variable.language.wildcard.asterisk
+#         ^ constant.other.wildcard.asterisk
 #                   ^ string.unquoted.makefile
 
 vpath asdf/*
 # ^ keyword.control.vpath
-#          ^ variable.language.wildcard.asterisk
+#          ^ constant.other.wildcard.asterisk
 vpath
 # ^ keyword.control.vpath.makefile
 
@@ -901,7 +901,7 @@ kselftest-merge:
 search:
     @$(MAKE) --no-print-directory \
         -f core/core.mk $(addprefix -f,$(wildcard index/*.mk)) -f core/index.mk \
-    #                                                   ^ variable.language.wildcard.asterisk
+    #                                                   ^ constant.other.wildcard.asterisk
         search
 
 CC_VERSION := $(shell $(CC) -dumpversion)

--- a/Makefile/syntax_test_makefile.mak
+++ b/Makefile/syntax_test_makefile.mak
@@ -127,7 +127,7 @@ $(dir)_sources := $(wildcard $(dir)/*.c)
 #                 ^^ keyword.other.block.begin
 #                            ^^ keyword.other.block.begin
 #                                 ^ keyword.other.block.end
-#                                   ^ variable.language.wildcard
+#                                   ^ variable.language.wildcard.asterisk
 #                                      ^ keyword.other.block.end
 define $(dir)_print =
 # ^ keyword.control
@@ -840,12 +840,12 @@ endif
 
 vpath dir/*/whatevs whatevs
 # ^ keyword.control.vpath
-#         ^ variable.language.wildcard
+#         ^ variable.language.wildcard.asterisk
 #                   ^ string.unquoted.makefile
 
 vpath asdf/*
 # ^ keyword.control.vpath
-#          ^ variable.language.wildcard
+#          ^ variable.language.wildcard.asterisk
 vpath
 # ^ keyword.control.vpath.makefile
 
@@ -901,7 +901,7 @@ kselftest-merge:
 search:
     @$(MAKE) --no-print-directory \
         -f core/core.mk $(addprefix -f,$(wildcard index/*.mk)) -f core/index.mk \
-    #                                                   ^ variable.language.wildcard
+    #                                                   ^ variable.language.wildcard.asterisk
         search
 
 CC_VERSION := $(shell $(CC) -dumpversion)

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -5413,7 +5413,7 @@ echo <<<sql
 SELECT * FROM users WHERE first_name = 'John' LIMIT $limit
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.sql source.sql.embedded.php
 // <- keyword.other.DML
-//     ^ variable.language.wildcard.asterisk
+//     ^ constant.other.wildcard.asterisk
 //                                     ^^^^^^ string.quoted.single
 //                                                  ^^^^^^ variable.other.php
 sql;
@@ -5430,7 +5430,7 @@ echo <<<'SQL'
 SELECT * FROM users WHERE first_name = 'John'\n
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.sql source.sql.embedded.php
 // <- keyword.other.DML
-//     ^ variable.language.wildcard.asterisk
+//     ^ constant.other.wildcard.asterisk
 //                                     ^^^^^^ string.quoted.single
 //                                           ^^ - constant.character.escape.php
 SQL;

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -658,7 +658,7 @@ contexts:
     - meta_scope: meta.statement.import.python
     - include: line-continuation-or-pop
     - match: \*
-      scope: variable.language.wildcard.asterisk.python
+      scope: constant.other.wildcard.asterisk.python
       set: expect-import-end
     - match: (?=\()
       set: imports-from-import-list

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -658,7 +658,7 @@ contexts:
     - meta_scope: meta.statement.import.python
     - include: line-continuation-or-pop
     - match: \*
-      scope: constant.language.import-all.python
+      scope: variable.language.wildcard.asterisk.python
       set: expect-import-end
     - match: (?=\()
       set: imports-from-import-list

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -122,7 +122,7 @@ from os import *  # comment
 #^^^ keyword.control.import.from.python
 #    ^^ meta.import-name.python
 #       ^^^^^^ keyword.control.import.python
-#              ^ variable.language.wildcard.asterisk.python
+#              ^ constant.other.wildcard.asterisk.python
 #               ^^ - comment - constant - meta.statement
 #                 ^^^^^^^^^^ comment.line.number-sign.python
 from os import *, path # comment
@@ -132,7 +132,7 @@ from os import *, path # comment
 #      ^ meta.statement.import.python meta.import-source.python - meta.import-path
 #       ^^^^^^^^ meta.statement.import.python - meta.import-source - meta.import-path
 #               ^^^^^^^^^^^^^^^^^ - meta.statement
-#              ^ variable.language.wildcard.asterisk.python
+#              ^ constant.other.wildcard.asterisk.python
 #               ^ invalid.illegal.unexpected-import.python
 #                 ^^^^ invalid.illegal.unexpected-import.python
 #                      ^^^^^^^^^^ comment.line.number-sign.python
@@ -309,7 +309,7 @@ from sys import (version, # comment
 import path from os
 #           ^^^^ invalid.illegal.name
 from .sub import *
-#                ^ variable.language.wildcard.asterisk.python
+#                ^ constant.other.wildcard.asterisk.python
 import a as b
 #        ^^ keyword.control.import.as.python
 import a as b#comment

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -122,7 +122,7 @@ from os import *  # comment
 #^^^ keyword.control.import.from.python
 #    ^^ meta.import-name.python
 #       ^^^^^^ keyword.control.import.python
-#              ^ constant.language.import-all.python
+#              ^ variable.language.wildcard.asterisk.python
 #               ^^ - comment - constant - meta.statement
 #                 ^^^^^^^^^^ comment.line.number-sign.python
 from os import *, path # comment
@@ -132,7 +132,7 @@ from os import *, path # comment
 #      ^ meta.statement.import.python meta.import-source.python - meta.import-path
 #       ^^^^^^^^ meta.statement.import.python - meta.import-source - meta.import-path
 #               ^^^^^^^^^^^^^^^^^ - meta.statement
-#              ^ constant.language.import-all.python
+#              ^ variable.language.wildcard.asterisk.python
 #               ^ invalid.illegal.unexpected-import.python
 #                 ^^^^ invalid.illegal.unexpected-import.python
 #                      ^^^^^^^^^^ comment.line.number-sign.python
@@ -309,7 +309,7 @@ from sys import (version, # comment
 import path from os
 #           ^^^^ invalid.illegal.name
 from .sub import *
-#                ^ constant.language.import-all.python
+#                ^ variable.language.wildcard.asterisk.python
 import a as b
 #        ^^ keyword.control.import.as.python
 import a as b#comment

--- a/Rails/tests/syntax_test_rails.sql.erb
+++ b/Rails/tests/syntax_test_rails.sql.erb
@@ -3,7 +3,7 @@
     SELECT * FROM table
 #^^^^^^^^^^^^^^^^^^^^^^^ source.sql.rails
 #   ^^^^^^ keyword.other
-#          ^ variable.language.wildcard
+#          ^ constant.other.wildcard
 #            ^^^^ keyword.other
 
   <%# ruby comment %>

--- a/Regular Expressions/File Pattern.sublime-syntax
+++ b/Regular Expressions/File Pattern.sublime-syntax
@@ -31,11 +31,11 @@ contexts:
       scope: invalid.illegal.file-pattern
     - match: (\*)/|/(\*)(?!\*)
       captures:
-        1: variable.language.wildcard.asterisk.path.file-pattern
-        2: variable.language.wildcard.asterisk.path.file-pattern
+        1: constant.other.wildcard.asterisk.path.file-pattern
+        2: constant.other.wildcard.asterisk.path.file-pattern
     - match: \*
-      scope: variable.language.wildcard.asterisk.file.file-pattern
+      scope: constant.other.wildcard.asterisk.file.file-pattern
     - match: \?
-      scope: variable.language.wildcard.questionmark.file-pattern
+      scope: constant.other.wildcard.questionmark.file-pattern
     - match: <(?:current file|open files|open folders|project filters)>
       scope: support.constant.file-pattern

--- a/Regular Expressions/File Pattern.sublime-syntax
+++ b/Regular Expressions/File Pattern.sublime-syntax
@@ -25,15 +25,13 @@ contexts:
     - meta_content_scope: meta.path.file-pattern
     - match: (?=\s*(?:,|$))
       pop: true
-    - match: \*{2,}
-      scope: invalid.illegal.file-pattern
     - match: \[|\]
       scope: invalid.illegal.file-pattern
-    - match: (\*)/|/(\*)(?!\*)
-      captures:
-        1: variable.language.wildcard.file-pattern
-        2: variable.language.wildcard.file-pattern
-    - match: '[*?]'
-      scope: keyword.operator.wildcard.file-pattern
+    - match: \*{2,}
+      scope: invalid.illegal.file-pattern
+    - match: \*
+      scope: variable.language.wildcard.asterisk.file-pattern
+    - match: \?
+      scope: variable.language.wildcard.questionmark.file-pattern
     - match: <(?:current file|open files|open folders|project filters)>
       scope: support.constant.file-pattern

--- a/Regular Expressions/File Pattern.sublime-syntax
+++ b/Regular Expressions/File Pattern.sublime-syntax
@@ -29,8 +29,12 @@ contexts:
       scope: invalid.illegal.file-pattern
     - match: \*{2,}
       scope: invalid.illegal.file-pattern
+    - match: (\*)/|/(\*)(?!\*)
+      captures:
+        1: variable.language.wildcard.asterisk.path.file-pattern
+        2: variable.language.wildcard.asterisk.path.file-pattern
     - match: \*
-      scope: variable.language.wildcard.asterisk.file-pattern
+      scope: variable.language.wildcard.asterisk.file.file-pattern
     - match: \?
       scope: variable.language.wildcard.questionmark.file-pattern
     - match: <(?:current file|open files|open folders|project filters)>

--- a/Regular Expressions/syntax_test.sublime-file-patterns
+++ b/Regular Expressions/syntax_test.sublime-file-patterns
@@ -1,11 +1,11 @@
 # SYNTAX TEST "Packages/Regular Expressions/File Pattern.sublime-syntax"
 
 *.py
-# <- variable.language.wildcard.asterisk
+# <- variable.language.wildcard.asterisk.file
 #^^^ meta.path
 #   ^ - meta.path
 */bar.py
-# <- variable.language.wildcard.asterisk
+# <- variable.language.wildcard.asterisk.path
 src/**/foo.java
 #   ^^ invalid.illegal
 *.cs, *.py

--- a/Regular Expressions/syntax_test.sublime-file-patterns
+++ b/Regular Expressions/syntax_test.sublime-file-patterns
@@ -1,11 +1,11 @@
 # SYNTAX TEST "Packages/Regular Expressions/File Pattern.sublime-syntax"
 
 *.py
-# <- variable.language.wildcard.asterisk.file
+# <- constant.other.wildcard.asterisk.file
 #^^^ meta.path
 #   ^ - meta.path
 */bar.py
-# <- variable.language.wildcard.asterisk.path
+# <- constant.other.wildcard.asterisk.path
 src/**/foo.java
 #   ^^ invalid.illegal
 *.cs, *.py
@@ -17,7 +17,7 @@ src/**/foo.java
 *.cs,-*.aspx.cs
 #   ^ punctuation.separator - meta.path
 #    ^ keyword.operator.logical
-#     ^ variable.language.wildcard.asterisk
+#     ^ constant.other.wildcard.asterisk
 -node_modules/
 # <- keyword.operator.logical
 ssh-agent

--- a/Regular Expressions/syntax_test.sublime-file-patterns
+++ b/Regular Expressions/syntax_test.sublime-file-patterns
@@ -1,11 +1,11 @@
 # SYNTAX TEST "Packages/Regular Expressions/File Pattern.sublime-syntax"
 
 *.py
-# <- keyword.operator.wildcard
+# <- variable.language.wildcard.asterisk
 #^^^ meta.path
 #   ^ - meta.path
 */bar.py
-# <- variable.language
+# <- variable.language.wildcard.asterisk
 src/**/foo.java
 #   ^^ invalid.illegal
 *.cs, *.py
@@ -17,7 +17,7 @@ src/**/foo.java
 *.cs,-*.aspx.cs
 #   ^ punctuation.separator - meta.path
 #    ^ keyword.operator.logical
-#     ^ keyword.operator.wildcard
+#     ^ variable.language.wildcard.asterisk
 -node_modules/
 # <- keyword.operator.logical
 ssh-agent

--- a/SQL/SQL.sublime-syntax
+++ b/SQL/SQL.sublime-syntax
@@ -123,7 +123,7 @@ contexts:
     - match: (?i)\b(asc|desc)\b
       scope: keyword.other.order.sql
     - match: \*
-      scope: variable.language.wildcard.asterisk.sql
+      scope: constant.other.wildcard.asterisk.sql
     - match: "<=>|[!<>]?=|<>|<|>"
       scope: keyword.operator.comparison.sql
     - match: '-|\+|/'

--- a/SQL/syntax_test_sql.sql
+++ b/SQL/syntax_test_sql.sql
@@ -180,7 +180,7 @@ select
 
 SELECT  *,
 -- ^^^ keyword.other.DML.sql
---      ^ variable.language.wildcard.asterisk.sql
+--      ^ constant.other.wildcard.asterisk.sql
         f.id AS database_id
 --           ^^ keyword.operator.assignment.alias.sql
 FROM    foo


### PR DESCRIPTION
This PR implements RFC #3766 by ...

1. adjusting path wildcard scopes to `variable.language.wildcard`
2. modifying scopes of `.` to `variable.langauge.self`
3. modifying scopes of `..` to `variable.langauge.parent`

The current scopes are chosen ...

1. to fullfill requirements outlined in https://github.com/sublimehq/Packages/issues/3766#issuecomment-1554226973
2. because `variable.language.wildcard` has been used by majority of syntaxes for quite a while 
3. as they fit into a common naming scheme
   
   ```
   variable
      language
         anonymous      - empty throwaway variables (e.g. `_`)
         self           - `self`, `this`, `.`, ...
         parent         - `super`, `..`, `&` in CSS, ...
         wildcard       - `*`, `?`, ...
   ```

   Those scopes may be used by path like tokens such as path strings or qualified identifiers as `meta.path` is.

Note: It partly reverts #3768 and #3769.

#### Alternative

An alternative would be to move them all under the `constant.other.placeholder` scope if `variable` feels too odd within string constants, but this may require scope modifications to placeholders of format strings to make them distinguishalbe. The idea would be to

```
constant
  other
    placeholder
      format
      parent
      self
      wildcard
        asterisk
        questionmark
```

Disadvantages:

1. Scope names become longer 
2. Can't re-use existing self/parent scopes
3. More syntaxes would be effected/need to be changed

---

### EDIT 2023/07/10

This PR finally follows proposed scope naming of https://github.com/sublimehq/Packages/pull/3803#issuecomment-1627711666

```
constant
  other
    path
      parent
      self
    wildcard
      asterisk
      questionmark
```