### PR TITLE
[ShellScript] Fix test expressions

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -723,10 +723,10 @@ contexts:
     - match: \(
       scope: punctuation.section.group.begin.shell
       push: cmd-test-args-group-body
-    - match: ([=!]=|=~)\s*
-      captures:
-        1: keyword.operator.comparison.shell
-      push: cmd-test-args-pattern
+    - match: '[=!]='
+      scope: keyword.operator.comparison.shell
+    - match: =~
+      scope: invalid.illegal.operator.shell
     - include: test-expression-common
 
   cmd-test-args-group-body:
@@ -735,11 +735,6 @@ contexts:
       scope: punctuation.section.group.end.shell
       pop: 1
     - include: cmd-test-args-common
-    - include: eoc-pop
-
-  cmd-test-args-pattern:
-    - meta_content_scope: meta.pattern.regexp.shell
-    - include: test-pattern-common
     - include: eoc-pop
 
   test-expression-body:
@@ -834,9 +829,8 @@ contexts:
     - include: comments
     - include: booleans
     - include: numbers
-    - include: strings
     - include: expansions-variables
-    - include: variables
+    - include: strings-unquoted
     - include: line-continuations
 
 ###[ UNALIAS BUILTINS ]########################################################

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -2061,26 +2061,27 @@ test-=
 test+=
 #^^^^^ - support.function
 
-test var != 0
+test $var != 0
 #<- meta.function-call.identifier.shell support.function.test.shell
 #^^^ meta.function-call.identifier.shell support.function.test.shell
-#   ^^^^^^^^ meta.function-call.arguments.shell - meta.pattern
-#           ^ meta.function-call.arguments.shell meta.pattern.regexp.shell
-#            ^ - meta.function-call
-#        ^^ keyword.operator.comparison.shell
-#           ^ - constant.numeric
+#   ^^^^^^^^^ meta.function-call.arguments.shell - meta.pattern
+#            ^ meta.function-call.arguments.shell
+#             ^ - meta.function-call
+#         ^^ keyword.operator.comparison.shell
+#            ^ constant.numeric.value.shell
 
-test var == true
+test $var == true
 #<- meta.function-call.identifier.shell support.function.test.shell
 #^^^ meta.function-call.identifier.shell support.function.test.shell
-#   ^^^^^^^^^^^^ meta.function-call.arguments.shell - meta.pattern
-#        ^^ keyword.operator.comparison.shell
-#           ^^^^ constant.language.boolean.shell
+#   ^^^^^^^^^^^^^ meta.function-call.arguments.shell - meta.pattern
+#         ^^ keyword.operator.comparison.shell
+#            ^^^^ constant.language.boolean.shell
 
 test str == "str"
 #<- meta.function-call.identifier.shell support.function.test.shell
 #^^^ meta.function-call.identifier.shell support.function.test.shell
 #   ^^^^^^^^^^^^^ meta.function-call.arguments.shell
+#    ^^^ meta.string.shell string.unquoted.shell
 #        ^^ keyword.operator.comparison.shell
 #           ^^^^^ string.quoted.double.shell
 
@@ -2088,50 +2089,19 @@ test var[0] != var[^0-9]*$
 #<- meta.function-call.identifier.shell support.function.test.shell
 #^^^ meta.function-call.identifier.shell support.function.test.shell
 #   ^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell
-#       ^^^ meta.item-access.shell
+#    ^^^^^^ meta.string.shell string.unquoted.shell
 #           ^^ keyword.operator.comparison.shell
-#              ^^^^^^^^^^^ meta.pattern.regexp.shell
+#              ^^^^^^^^^^^ meta.string.shell string.unquoted.shell - meta.pattern
 
-test var == [
-# <- meta.function-call.identifier.shell support.function.test.shell
+test ${var[0]} != var[^0-9]*$
+#<- meta.function-call.identifier.shell support.function.test.shell
 #^^^ meta.function-call.identifier.shell support.function.test.shell
-#   ^^^^^^^^^ meta.function-call.arguments.shell
-#    ^^^ meta.variable.shell variable.other.readwrite.shell
-#        ^^ keyword.operator.comparison.shell
-#           ^ meta.pattern.regexp.shell - meta.set
-
-test var == ]
-# <- meta.function-call.identifier.shell support.function.test.shell
-#^^^ meta.function-call.identifier.shell support.function.test.shell
-#   ^^^^^^^^^ meta.function-call.arguments.shell
-#    ^^^ meta.variable.shell variable.other.readwrite.shell
-#        ^^ keyword.operator.comparison.shell
-#           ^ meta.pattern.regexp.shell - meta.set
-
-test var == [[:alpha:
-# <- meta.function-call.identifier.shell support.function.test.shell
-#^^^ meta.function-call.identifier.shell support.function.test.shell
-#   ^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell
-#    ^^^ meta.variable.shell variable.other.readwrite.shell
-#        ^^ keyword.operator.comparison.shell
-#           ^^^^^^^^^ meta.pattern.regexp.shell - meta.set
-
-test var == [[:alpha:]
-# <- meta.function-call.identifier.shell support.function.test.shell
-#^^^ meta.function-call.identifier.shell support.function.test.shell
-#   ^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell
-#    ^^^ meta.variable.shell variable.other.readwrite.shell
-#        ^^ keyword.operator.comparison.shell
-#           ^ meta.pattern.regexp.shell - meta.set
-#            ^^^^^^^^^ meta.pattern.regexp.shell meta.set.regexp.shell
-
-test var == [[:alpha:]]
-# <- meta.function-call.identifier.shell support.function.test.shell
-#^^^ meta.function-call.identifier.shell support.function.test.shell
-#   ^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell
-#    ^^^ meta.variable.shell variable.other.readwrite.shell
-#        ^^ keyword.operator.comparison.shell
-#           ^^^^^^^^^^^ meta.pattern.regexp.shell meta.set.regexp.shell
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell
+#    ^^^^^^^^^ meta.interpolation.parameter.shell
+#      ^^^ variable.other.readwrite.shell
+#         ^^^ meta.item-access.shell
+#              ^^ keyword.operator.comparison.shell
+#                 ^^^^^^^^^^^ meta.string.shell string.unquoted.shell - meta.pattern
 
 test expr -a expr -o expr -- | cmd |& cmd
 # <- meta.function-call.identifier.shell support.function.test.shell
@@ -2155,8 +2125,8 @@ test ! ($line =~ ^[0-9]+$)
 #    ^ keyword.operator.logical.shell
 #      ^ punctuation.section.group.begin.shell
 #       ^^^^^ variable.other.readwrite.shell
-#             ^^ keyword.operator.comparison.shell
-#                ^^^^^^^^ meta.pattern.regexp.shell
+#             ^^ invalid.illegal.operator.shell
+#                ^^^^^^^^ meta.string.shell string.unquoted.shell
 
 test ! ($line =~ ^[0-9]+$) >> /file
 # <- meta.function-call.identifier.shell support.function.test.shell
@@ -2169,8 +2139,8 @@ test ! ($line =~ ^[0-9]+$) >> /file
 #    ^ keyword.operator.logical.shell
 #      ^ punctuation.section.group.begin.shell
 #       ^^^^^ variable.other.readwrite.shell
-#             ^^ keyword.operator.comparison.shell
-#                ^^^^^^^^ meta.pattern.regexp.shell
+#             ^^ invalid.illegal.operator.shell
+#                ^^^^^^^^ meta.string.shell string.unquoted.shell
 #                        ^ punctuation.section.group.end.shell
 #                          ^^ keyword.operator.assignment.redirection.shell
 


### PR DESCRIPTION
Fixes #3804

This commit ...

1. scopes unquoted identifiers in test expressions `string.unquoted` instead of `variable.parameter`.
2. removes pattern matching (`=~ ...`) from `test ...` command as the command supports basic string comparisons only.