### PR TITLE
[PHP] PHP 8.3 new syntax

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -134,9 +134,9 @@ variables:
     | MongoGridFSFile | MongoGridfsFile | MongoId | MongoInt32 | MongoInt64 | MongoRegex
     | MongoTimestamp | MultipleIterator | NoRewindIterator | Normalizer | NumberFormatter
     | OCI-Collection | OCI-Lob | OutOfBoundsException | OutOfRangeException | OuterIterator
-    | OverflowException | PDO | PDOStatement | ParentIterator | ParseError | Phar | PharData
-    | PharFileInfo  | PhpCompilerAttribute | PhpToken | RRDCreator | RRDGraph | RRDUpdater
-    | RangeException | RecursiveArrayIterator | RecursiveCachingIterator
+    | OverflowException | Override | PDO | PDOStatement | ParentIterator | ParseError | Phar
+    | PharData | PharFileInfo  | PhpCompilerAttribute | PhpToken | RRDCreator | RRDGraph
+    | RRDUpdater | RangeException | RecursiveArrayIterator | RecursiveCachingIterator
     | RecursiveDirectoryIterator | RecursiveFilterIterator | RecursiveIterator
     | RecursiveIteratorIterator | RecursiveRegexIterator | RecursiveTreeIterator | Reflection
     | ReflectionClass | ReflectionEnum | ReflectionEnumBackedCase | ReflectionEnumUnitCase

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -1726,6 +1726,9 @@ contexts:
   instantiation-body:
     - include: attributes
     - include: comments
+    # such as "readonly" anonymous class
+    - match: '{{storage_modifiers}}'
+      scope: storage.modifier.php
     # anonymous class ( http://php.net/manual/en/language.oop5.anonymous.php )
     - match: (?i:class)\b
       scope: meta.class.php keyword.declaration.class.php

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -921,12 +921,44 @@ contexts:
   constant-declarations:
     - match: (?i:const)\b
       scope: keyword.declaration.constant.php
-      push: constant-declaration-name
+      push: constant-declaration-body
+
+  constant-declaration-body:
+    - include: attributes
+    - include: comments
+    - match: (?=\S)
+      branch_point: constant-declaration
+      branch:
+        - untyped-constant-declaration
+        - typed-constant-declaration
+      pop: 1
+
+  untyped-constant-declaration:
+    - match: '{{guarded_identifier}}'
+      scope: entity.name.constant.php
+      set: untyped-constant-declaration-check
+    - match: (?=\S)
+      fail: constant-declaration
+
+  untyped-constant-declaration-check:
+    - include: comments
+    - match: (?=[=;}]|{{access_modifier}}|{{property_modifier}}|{{static_modifier}})
+      pop: 1
+    - match: (?=\S)
+      fail: constant-declaration
+
+  typed-constant-declaration:
+    - meta_include_prototype: false
+    - match: ''
+      set:
+        - constant-declaration-name
+        - type-hint-body
+        - type-hint-simple-type
 
   constant-declaration-name:
     - match: '{{guarded_identifier}}'
       scope: entity.name.constant.php
-      set: nested-expressions
+      pop: 1
     - include: attributes
     - include: comments
     - include: else-pop

--- a/PHP/PHP.sublime-completions
+++ b/PHP/PHP.sublime-completions
@@ -11224,6 +11224,12 @@
 			"details": "Split multibyte string using regular expression"
 		},
 		{
+			"trigger": "mb_str_pad()",
+			"contents": "mb_str_pad(${1:string}, ${2:length}, string ${3:pad_string})",
+			"kind": "function",
+			"details": "Pad a string to a certain length with another string"
+		},
+		{
 			"trigger": "mb_strcut()",
 			"contents": "mb_strcut(${1:str}, ${2:start})",
 			"kind": "function",

--- a/PHP/PHP.sublime-completions
+++ b/PHP/PHP.sublime-completions
@@ -9983,6 +9983,12 @@
 			"details": "Returns the last error occurred"
 		},
 		{
+			"trigger": "json_validate()",
+			"contents": "json_validate(${1:json})",
+			"kind": "function",
+			"details": "Validates if the string contains a valid json."
+		},
+		{
 			"trigger": "judy_type()",
 			"contents": "judy_type(${1:array})",
 			"kind": "function",

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -1382,6 +1382,22 @@ class B
 //   ^^^^^^^^^^^^^^^^^^ meta.class.php meta.block.php - meta.use
 //    ^ storage.modifier
 
+    public const STR_1
+//  ^^^^^^ storage.modifier
+//         ^^^^^ keyword.declaration.constant.php
+//               ^^^^^ entity.name.constant.php
+
+    public
+//  ^^^^^^ storage.modifier
+      const
+//    ^^^^^ keyword.declaration.constant.php
+      STR_1
+//    ^^^^^ entity.name.constant.php
+      =
+//    ^ keyword.operator.assignment.php
+      '';
+//    ^^ string.quoted.single.php
+
     public const STR_1 = '';
 //  ^^^^^^ storage.modifier
 //         ^^^^^ keyword.declaration.constant.php
@@ -1400,6 +1416,79 @@ class B
 //                     ^^^^^ entity.name.constant.php
 //                           ^ keyword.operator.assignment
 //                             ^^^^^ support.function.array.php
+
+    // typed class constants
+
+    private const int A
+//  ^^^^^^^ storage.modifier.access.php
+//          ^^^^^ keyword.declaration.constant.php
+//                ^^^ meta.type.php storage.type.primitive.php
+//                    ^ entity.name.constant.php
+
+    private const int A = 1;
+//  ^^^^^^^ storage.modifier.access.php
+//          ^^^^^ keyword.declaration.constant.php
+//                ^^^ meta.type.php storage.type.primitive.php
+//                    ^ entity.name.constant.php
+//                      ^ keyword.operator.assignment.php
+//                        ^ constant.numeric.value.php
+//                         ^ punctuation.terminator.statement.php
+
+    public const mixed B = 1;
+//  ^^^^^^ storage.modifier.access.php
+//         ^^^^^ keyword.declaration.constant.php
+//               ^^^^^ meta.type.php storage.type.primitive.php
+//                     ^ entity.name.constant.php
+//                       ^ keyword.operator.assignment.php
+//                         ^ constant.numeric.value.php
+//                          ^ punctuation.terminator.statement.php
+
+    public
+//  ^^^^^^ storage.modifier.access.php
+      const
+//    ^^^^^ keyword.declaration.constant.php
+      mixed
+//    ^^^^^ meta.type.php storage.type.primitive.php
+      B
+//    ^ entity.name.constant.php
+      =
+//    ^ keyword.operator.assignment.php
+      1;
+//    ^ constant.numeric.value.php
+//     ^ punctuation.terminator.statement.php
+
+    public const Foo|Stringable|null D = null;
+//  ^^^^^^ storage.modifier.access.php
+//         ^^^^^ keyword.declaration.constant.php
+//               ^^^^^^^^^^^^^^^^^^^ meta.block.php meta.type.php
+//               ^^^ support.class.php
+//                  ^ punctuation.separator.type.union.php
+//                   ^^^^^^^^^^ support.class.builtin.php
+//                             ^ punctuation.separator.type.union.php
+//                              ^^^^ storage.type.primitive.php
+//                                   ^ entity.name.constant.php
+//                                     ^ keyword.operator.assignment.php
+//                                       ^^^^ constant.language.null.php
+//                                           ^ punctuation.terminator.statement.php
+
+    public
+//  ^^^^^^ storage.modifier.access.php
+      const
+//    ^^^^^ keyword.declaration.constant.php
+      Foo|Stringable|null
+//    ^^^^^^^^^^^^^^^^^^^ meta.block.php meta.type.php
+//    ^^^ support.class.php
+//       ^ punctuation.separator.type.union.php
+//        ^^^^^^^^^^ support.class.builtin.php
+//                  ^ punctuation.separator.type.union.php
+//                   ^^^^ storage.type.primitive.php
+      D
+//    ^ entity.name.constant.php
+      =
+//    ^ keyword.operator.assignment.php
+      null;
+//    ^^^^ constant.language.null.php
+//        ^ punctuation.terminator.statement.php
 
     public function __construct(
         public readonly int $val = 1

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -3282,18 +3282,19 @@ $test = new Test1;
 //          ^^^^^ support.class.php - meta.path
 //          ^ support.class.php
 
-$anon = new class{};
-//      ^^^^^^^^^^^ - meta.class meta.class
-//      ^^^^ meta.instantiation.php - meta.class
-//          ^^^^^ meta.instantiation.php meta.class.php - meta.block
-//               ^^ meta.instantiation.php meta.class.php meta.block.php
-//                 ^ - meta.instantiation - meta.class - meta.block
+$anon = new readonly class{};
+//      ^^^^^^^^^^^^^^^^^^^^ - meta.class meta.class
+//      ^^^^          meta.instantiation.php - meta.class
+//          ^^^^^^^^ meta.instantiation.php storage.modifier.php - meta.class
+//                   ^^^^^ meta.instantiation.php meta.class.php - meta.block
+//                        ^^ meta.instantiation.php meta.class.php meta.block.php
+//                          ^ - meta.instantiation - meta.class - meta.block
 //      ^ keyword.other.new.php
-//          ^ keyword.declaration.class
-//               ^^ meta.class.php
-//               ^^ meta.block.php
-//               ^ punctuation.section.block.begin.php
-//                ^ punctuation.section.block.end.php
+//                   ^ keyword.declaration.class
+//                        ^^ meta.class.php
+//                        ^^ meta.block.php
+//                        ^ punctuation.section.block.begin.php
+//                         ^ punctuation.section.block.end.php
 
 $anon = new class};
 //      ^^^^^^^^^^ - meta.class meta.class


### PR DESCRIPTION
PHP 8.3 is scheduled to be 

- first alpha on `Jun 08 2023`
- feature freeze on `Jul 18 2023`
- stable release on `Nov 23 2023`

**References**:

- PHP RFCs: https://wiki.php.net/rfc#php_83
- PHP milestone: https://github.com/php/php-src/milestone/5?closed=1
- PHP release schedule: https://wiki.php.net/todo/php83

## PHP 8.3 new syntax-related things

### Need new parsing paths

- [x] [PHP RFC: Readonly amendments](https://wiki.php.net/rfc/readonly_amendments)
- [x] [PHP RFC: Typed class constants](https://wiki.php.net/rfc/typed_class_constants) (by @deathaxe)

### Just some simple supplements

- [X] [PHP RFC: Marking overridden methods (#[\Override])](https://wiki.php.net/rfc/marking_overriden_methods)
- [X] [PHP RFC: mb_str_pad](https://wiki.php.net/rfc/mb_str_pad)
- [X] [PHP RFC: json_validate](https://wiki.php.net/rfc/json_validate)
