### PR TITLE
[ShellScript] Fix indented HEREDOC termination

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -1371,11 +1371,11 @@ contexts:
     - meta_scope: meta.string.heredoc.shell
     - meta_content_scope: string.unquoted.heredoc.shell
     - include: heredocs-body-common-with-expansion
-    - match: ^\s*(\3)$ # the third capture from redirections-here-document
+    - match: ^\t*(\3)$ # the third capture from redirections-here-document
       captures:
         1: meta.tag.heredoc.shell entity.name.tag.heredoc.shell
       pop: 1
-    - match: ^\s*\3(\s+)\n # the third capture from redirections-here-document
+    - match: ^\t*\3(\s+)\n # the third capture from redirections-here-document
       captures:
         1: invalid.illegal.unexpected-whitespace.shell
       # rather not pop, but sublime throws an error otherwise.
@@ -1404,11 +1404,11 @@ contexts:
   heredocs-body-allow-tabs-no-expansion:
     - meta_scope: meta.string.heredoc.shell
     - meta_content_scope: string.unquoted.heredoc.shell
-    - match: ^\s*(\5)$ # the fourth capture from redirections-here-document
+    - match: ^\t*(\5)$ # the fourth capture from redirections-here-document
       captures:
         1: meta.tag.heredoc.shell entity.name.tag.heredoc.shell
       pop: 1
-    - match: ^\s*\5(\s+)\n # the fourth capture from redirections-here-document
+    - match: ^\t*\5(\s+)\n # the fourth capture from redirections-here-document
       captures:
         1: invalid.illegal.unexpected-whitespace.shell
       # rather not pop, but sublime throws an error otherwise.

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -5806,10 +5806,10 @@ cat <<- INDENTED
   say what now ${foo}
 # ^^^^^^^^^^^^^ meta.function-call.arguments.shell meta.string.heredoc.shell string.unquoted.heredoc.shell - meta.interpolation
 #              ^^^^^^ meta.function-call.arguments.shell meta.string.heredoc.shell meta.interpolation.parameter.shell - string
-  INDENTED
-#^ meta.function-call.arguments.shell meta.string.heredoc.shell - meta.tag
-# ^^^^^^^^ meta.function-call.arguments.shell meta.string.heredoc.shell meta.tag.heredoc.shell entity.name.tag.heredoc.shell
-#         ^ - meta.function-call - meta.string - meta.tag - entity
+	INDENTED
+# <- meta.function-call.arguments.shell meta.string.heredoc.shell - meta.tag
+#^^^^^^^^ meta.function-call.arguments.shell meta.string.heredoc.shell meta.tag.heredoc.shell entity.name.tag.heredoc.shell
+#        ^ - meta.function-call - meta.string - meta.tag - entity
 
 cat <<-  'indented_without_expansions'
 #^^^^^^^^ - meta.string - meta.tag
@@ -5822,10 +5822,10 @@ cat <<-  'indented_without_expansions'
     ${foo}
 #^^^^^^^^^^ meta.function-call.arguments.shell meta.string.heredoc.shell string.unquoted.heredoc.shell - meta.interpolation
 #     ^^^ - variable.other
-    indented_without_expansions
-#^^^ meta.function-call.arguments.shell meta.string.heredoc.shell - meta.tag
-#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell meta.string.heredoc.shell meta.tag.heredoc.shell entity.name.tag.heredoc.shell
-#                              ^ - meta.function-call - meta.string - meta.tag - entity
+		indented_without_expansions
+#^ meta.function-call.arguments.shell meta.string.heredoc.shell - meta.tag
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell meta.string.heredoc.shell meta.tag.heredoc.shell entity.name.tag.heredoc.shell
+#                            ^ - meta.function-call - meta.string - meta.tag - entity
 
 variable=$(cat <<SETVAR
 This variable
@@ -5846,7 +5846,7 @@ cat <<- "FOO"
     no \"escape\'\$ and $expansion
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.heredoc.shell - meta.interpolation
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.heredoc.shell - constant - keyword - variable
-  FOO
+		FOO
 # ^^^ meta.function-call.arguments.shell meta.string.heredoc.shell meta.tag.heredoc.shell entity.name.tag.heredoc.shell
 #    ^ - meta.function-call - meta.string - meta.tag - entity
 
@@ -5861,7 +5861,7 @@ cat <<- \FOO
     no \"escape\'\$ and $expansion
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.heredoc.shell - meta.interpolation
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.heredoc.shell - constant - keyword - variable
-  FOO
+		FOO
 # ^^^ meta.function-call.arguments.shell meta.string.heredoc.shell meta.tag.heredoc.shell entity.name.tag.heredoc.shell
 #    ^ - meta.function-call - meta.string - meta.tag - entity
 

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -5861,6 +5861,12 @@ cat <<- \FOO
     no \"escape\'\$ and $expansion
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.heredoc.shell - meta.interpolation
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.heredoc.shell - constant - keyword - variable
+    FOO
+#^^^^^^^ meta.function-call.arguments.shell meta.string.heredoc.shell string.unquoted.heredoc.shell
+	  FOO
+#^^^^^^^ meta.function-call.arguments.shell meta.string.heredoc.shell string.unquoted.heredoc.shell
+  	FOO
+#^^^^^^^ meta.function-call.arguments.shell meta.string.heredoc.shell string.unquoted.heredoc.shell
 		FOO
 # ^^^ meta.function-call.arguments.shell meta.string.heredoc.shell meta.tag.heredoc.shell entity.name.tag.heredoc.shell
 #    ^ - meta.function-call - meta.string - meta.tag - entity


### PR DESCRIPTION
Fixes #3808

This commit restricts HEREDOC end tag indentation to `\t`.

If any other whitespace is found, a HEREDOC end tag does not match.