### PR TITLE
[Rust] fix highlighting when calling a function named "union"

### DIFF
--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -81,7 +81,7 @@ contexts:
       scope: storage.type.struct.rust
       push: struct-identifier
 
-    - match: '\bunion\b'
+    - match: '\bunion\b(?!\s*\()'
       scope: storage.type.union.rust
       push: union-identifier
 

--- a/Rust/tests/syntax_test_union.rs
+++ b/Rust/tests/syntax_test_union.rs
@@ -36,5 +36,17 @@ pub union Foo<'a, Y: Baz>
 fn union() {}
 // ^^^^^ meta.function entity.name.function
 
+(Scopes::Character.union(Scopes::Unit).union(Scopes::Legion), "add_legion_history", Unchecked)
+//                ^ meta.group punctuation.accessor.dot
+//                 ^^^^^ variable.function - storage.type.union
+//                      ^ punctuation.section.group.begin
+//                       ^^^^^^ storage.type.source
+//                             ^^ punctuation.accessor
+//                               ^^^^ storage.type.source
+//                                   ^ punctuation.section.group.end
+//                                    ^ punctuation.accessor.dot
+//                                     ^^^^^ variable.function - storage.type.union
+
+
 union /*comment*/ U {}
 //    ^^^^^^^^^^^ meta.union comment.block


### PR DESCRIPTION
Fixes #3821 