### PR TITLE
[Markdown] Fix syntax based folding of fenced code blocks

### DIFF
--- a/Markdown/Fold.tmPreferences
+++ b/Markdown/Fold.tmPreferences
@@ -17,9 +17,9 @@
             </dict>
             <dict>
                 <key>begin</key>
-                <string>meta.code-fence.definition.begin</string>
+                <string>meta.fold.code-fence.begin</string>
                 <key>end</key>
-                <string>meta.code-fence.definition.end</string>
+                <string>meta.fold.code-fence.end</string>
                 <key>excludeTrailingNewlines</key>
                 <true/>
             </dict>

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -135,10 +135,10 @@ variables:
       |              # or
         (~){3,}      #   3 or more tildas
       )
-      \s*            # allow for whitespace between code block start and info string
     )
   fenced_code_block_language: |-
     (?x:             # first word of an infostring is used as language specifier
+      \s*            # allow for whitespace between code block start and info string
       (
         [[:alpha:]]  # starts with a letter to make sure not to hit any attribute annotation
         [^\s:;`]*    # optionally followed by any nonwhitespace character (except backticks)
@@ -146,12 +146,11 @@ variables:
     )
   fenced_code_block_trailing_infostring_characters: |-
     (?x:
-      (
-        \s*          # any whitespace, or ..
-      |
-        [\s:;][^`]*  # any characters (except backticks), separated by colon, semicolon or whitespace ...
-      )
-      $\n?           # ... until EOL
+      (?:
+        (?: \s+ | (?=[:;]) ) # separated by colon, semicolon or whitespace ...
+        ([^`]+?)             # any characters (except backticks)
+      )?
+      (\s*$\n?)              # ... until EOL (fold begin marker)
     )
   fenced_code_block_end: |-
     (?x:
@@ -160,7 +159,7 @@ variables:
         \2           # the backtick/tilde combination that opened the code fence
         (?:\3|\4)*   # plus optional additional closing characters
       )
-      \s*$           # any amount of whitespace until EOL
+      (\s*$\n?)      # any amount of whitespace until EOL (fold end marker)
     )
   fenced_code_block_escape: ^{{fenced_code_block_end}}
 
@@ -428,11 +427,12 @@ contexts:
          (?x)
           {{fenced_code_block_start}}
           {{fenced_code_block_language}}?
-          .*$\n?       # all characters until EOL
+          .*?(\s*$\n?)   # all characters until EOL
       captures:
         0: meta.code-fence.definition.begin.text.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: meta.fold.code-fence.begin.markdown
       push: block-quote-fenced-code-block-body
 
   block-quote-fenced-code-block-body:
@@ -450,6 +450,7 @@ contexts:
       captures:
         0: meta.code-fence.definition.end.text.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
       pop: 1
 
 ###[ CONTAINER BLOCKS: BLOCK QUOTES > REFERENCE DEFINITIONS ]#################
@@ -1016,12 +1017,14 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:actionscript|as))
+          (?i:\s*(actionscript|as))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.actionscript.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
       embed: scope:source.actionscript.2
       embed_scope:
         markup.raw.code-fence.actionscript.markdown-gfm
@@ -1030,17 +1033,20 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.actionscript.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
 
   fenced-applescript:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:applescript|osascript))
+          (?i:\s*(applescript|osascript))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.applescript.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
       embed: scope:source.applescript
       embed_scope:
         markup.raw.code-fence.applescript.markdown-gfm
@@ -1049,17 +1055,20 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.applescript.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
 
   fenced-clojure:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:clojure|clj))
+          (?i:\s*(clojure|clj))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.clojure.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
       embed: scope:source.clojure
       embed_scope:
         markup.raw.code-fence.clojure.markdown-gfm
@@ -1068,17 +1077,20 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.clojure.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
 
   fenced-c:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:c|h))
+          (?i:\s*(c|h))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.c.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
       embed: scope:source.c
       embed_scope:
         markup.raw.code-fence.c.markdown-gfm
@@ -1087,17 +1099,20 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.c.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
 
   fenced-cpp:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:c\+\+|cc|cpp|cxx|h\+\+|hpp|hxx))
+          (?i:\s*(c\+\+|cc|cpp|cxx|h\+\+|hpp|hxx))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.c++.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
       embed: scope:source.c++
       embed_scope:
         markup.raw.code-fence.c++.markdown-gfm
@@ -1106,17 +1121,20 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.c++.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
 
   fenced-csharp:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:csharp|c\#|cs))
+          (?i:\s*(csharp|c\#|cs))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.csharp.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
       embed: scope:source.cs
       embed_scope:
         markup.raw.code-fence.csharp.markdown-gfm
@@ -1125,17 +1143,20 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.csharp.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
 
   fenced-css:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:css))
+          (?i:\s*(css))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.css.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
       embed: scope:source.css
       embed_scope:
         markup.raw.code-fence.css.markdown-gfm
@@ -1144,17 +1165,20 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.css.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
 
   fenced-diff:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:diff|patch))
+          (?i:\s*(diff|patch))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.diff.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
       embed: scope:source.diff
       embed_scope:
         markup.raw.code-fence.diff.markdown-gfm
@@ -1163,17 +1187,20 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.diff.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
 
   fenced-dosbatch:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:bat|cmd|dos))
+          (?i:\s*(bat|cmd|dos))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.dosbatch.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
       embed: scope:source.dosbatch
       embed_scope:
         markup.raw.code-fence.dosbatch.markdown-gfm
@@ -1182,17 +1209,20 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.dosbatch.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
 
   fenced-erlang:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:erlang|escript))
+          (?i:\s*(erlang|escript))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.erlang.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
       embed: scope:source.erlang
       embed_scope:
         markup.raw.code-fence.erlang.markdown-gfm
@@ -1201,17 +1231,20 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.erlang.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
 
   fenced-graphviz:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:graphviz))
+          (?i:\s*(graphviz))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.graphviz.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
       embed: scope:source.dot
       embed_scope:
         markup.raw.code-fence.graphviz.markdown-gfm
@@ -1220,17 +1253,20 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.graphviz.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
 
   fenced-golang:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:go(?:lang)?))
+          (?i:\s*(go(?:lang)?))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.go.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
       embed: scope:source.go
       embed_scope:
         markup.raw.code-fence.go.markdown-gfm
@@ -1239,17 +1275,20 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.go.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
 
   fenced-haskell:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:haskell))
+          (?i:\s*(haskell))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.haskell.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
       embed: scope:source.haskell
       embed_scope:
         markup.raw.code-fence.haskell.markdown-gfm
@@ -1258,17 +1297,20 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.haskell.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
 
   fenced-html-php:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:html\+php))
+          (?i:\s*(html\+php))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.html-php.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
       embed: scope:embedding.php
       embed_scope:
         markup.raw.code-fence.html-php.markdown-gfm
@@ -1277,17 +1319,20 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.html-php.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
 
   fenced-html:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:html))
+          (?i:\s*(html))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.html.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
       embed: scope:text.html.basic
       embed_scope:
         markup.raw.code-fence.html.markdown-gfm
@@ -1296,17 +1341,20 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.html.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
 
   fenced-java:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:java))
+          (?i:\s*(java))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.java.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
       embed: scope:source.java
       embed_scope:
         markup.raw.code-fence.java.markdown-gfm
@@ -1315,17 +1363,20 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.java.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
 
   fenced-javascript:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:javascript|js))
+          (?i:\s*(javascript|js))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.javascript.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
       embed: scope:source.js
       embed_scope:
         markup.raw.code-fence.javascript.markdown-gfm
@@ -1334,17 +1385,20 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.javascript.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
 
   fenced-jsonc:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:jsonc?))
+          (?i:\s*(jsonc?))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.json.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
       embed: scope:source.json
       embed_scope:
         markup.raw.code-fence.json.markdown-gfm
@@ -1353,17 +1407,20 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.json.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
 
   fenced-jspx:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:jspx?))
+          (?i:\s*(jspx?))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.jsp.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
       embed: scope:text.html.jsp
       embed_scope:
         markup.raw.code-fence.jsp.markdown-gfm
@@ -1372,17 +1429,20 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.jsp.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
 
   fenced-jsx:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:jsx))
+          (?i:\s*(jsx))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.jsx.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
       embed: scope:source.jsx
       embed_scope:
         markup.raw.code-fence.jsx.markdown-gfm
@@ -1391,17 +1451,20 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.jsx.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
 
   fenced-lisp:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:lisp))
+          (?i:\s*(lisp))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.lisp.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
       embed: scope:source.lisp
       embed_scope:
         markup.raw.code-fence.lisp.markdown-gfm
@@ -1410,17 +1473,20 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.lisp.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
 
   fenced-lua:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:lua))
+          (?i:\s*(lua))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.lua.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
       embed: scope:source.lua
       embed_scope:
         markup.raw.code-fence.lua.markdown-gfm
@@ -1429,17 +1495,20 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.lua.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
 
   fenced-makefile:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:makefile))
+          (?i:\s*(makefile))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.makefile.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
       embed: scope:source.makefile
       embed_scope:
         markup.raw.code-fence.makefile.markdown-gfm
@@ -1448,17 +1517,20 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.makefile.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
 
   fenced-matlab:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:matlab))
+          (?i:\s*(matlab))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.matlab.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
       embed: scope:source.matlab
       embed_scope:
         markup.raw.code-fence.matlab.markdown-gfm
@@ -1467,17 +1539,20 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.matlab.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
 
   fenced-objc:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:objc|obj-c|objectivec|objective-c))
+          (?i:\s*(objc|obj-c|objectivec|objective-c))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.objc.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
       embed: scope:source.objc
       embed_scope:
         markup.raw.code-fence.objc.markdown-gfm
@@ -1486,17 +1561,20 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.objc.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
 
   fenced-objcpp:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:objc\+\+|obj-c\+\+|objectivec\+\+|objective-c\+\+))
+          (?i:\s*(objc\+\+|obj-c\+\+|objectivec\+\+|objective-c\+\+))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.objc++.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
       embed: scope:source.objc++
       embed_scope:
         markup.raw.code-fence.objc++.markdown-gfm
@@ -1505,17 +1583,20 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.objc++.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
 
   fenced-ocaml:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:ocaml))
+          (?i:\s*(ocaml))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.ocaml.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
       embed: scope:source.ocaml
       embed_scope:
         markup.raw.code-fence.ocaml.markdown-gfm
@@ -1524,17 +1605,20 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.ocaml.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
 
   fenced-perl:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:perl))
+          (?i:\s*(perl))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.perl.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
       embed: scope:source.perl
       embed_scope:
         markup.raw.code-fence.perl.markdown-gfm
@@ -1543,17 +1627,20 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.perl.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
 
   fenced-php:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:php|inc))
+          (?i:\s*(php|inc))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.php.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
       embed: scope:source.php
       embed_scope:
         markup.raw.code-fence.php.markdown-gfm
@@ -1562,17 +1649,20 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.php.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
 
   fenced-python:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:python|py))
+          (?i:\s*(python|py))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.python.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
       embed: scope:source.python
       embed_scope:
         markup.raw.code-fence.python.markdown-gfm
@@ -1581,17 +1671,20 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.python.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
 
   fenced-regexp:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:regexp?))
+          (?i:\s*(regexp?))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.regexp.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
       embed: scope:source.regexp
       embed_scope:
         markup.raw.code-fence.regexp.markdown-gfm
@@ -1600,17 +1693,20 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.regexp.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
 
   fenced-rscript:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:rscript|r|splus))
+          (?i:\s*(rscript|r|splus))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.r.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
       embed: scope:source.r
       embed_scope:
         markup.raw.code-fence.r.markdown-gfm
@@ -1619,17 +1715,20 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.r.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
 
   fenced-ruby:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:ruby|rb|rbx))
+          (?i:\s*(ruby|rb|rbx))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.ruby.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
       embed: scope:source.ruby
       embed_scope:
         markup.raw.code-fence.ruby.markdown-gfm
@@ -1638,17 +1737,20 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.ruby.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
 
   fenced-rust:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:rust|rs))
+          (?i:\s*(rust|rs))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.rust.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
       embed: scope:source.rust
       embed_scope:
         markup.raw.code-fence.rust.markdown-gfm
@@ -1657,17 +1759,20 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.rust.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
 
   fenced-scala:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:scala))
+          (?i:\s*(scala))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.scala.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
       embed: scope:source.scala
       embed_scope:
         markup.raw.code-fence.scala.markdown-gfm
@@ -1676,17 +1781,20 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.scala.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
 
   fenced-shell:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:console|shell))
+          (?i:\s*(console|shell))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.shell.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
       embed: scope:source.shell.interactive.markdown
       embed_scope:
         markup.raw.code-fence.shell.markdown-gfm
@@ -1695,17 +1803,20 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.shell.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
 
   fenced-shell-script:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:shell-script|sh|bash|zsh))
+          (?i:\s*(shell-script|sh|bash|zsh))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.shell-script.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
       embed: scope:source.shell.bash
       embed_scope:
         markup.raw.code-fence.shell-script.markdown-gfm
@@ -1714,17 +1825,20 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.shell-script.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
 
   fenced-sql:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:sql))
+          (?i:\s*(sql))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.sql.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
       embed: scope:source.sql
       embed_scope:
         markup.raw.code-fence.sql.markdown-gfm
@@ -1733,17 +1847,20 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.sql.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
 
   fenced-tsx:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:tsx))
+          (?i:\s*(tsx))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.tsx.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
       embed: scope:source.tsx
       embed_scope:
         markup.raw.code-fence.tsx.markdown-gfm
@@ -1752,17 +1869,20 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.tsx.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
 
   fenced-typescript:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:typescript|ts))
+          (?i:\s*(typescript|ts))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.typescript.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
       embed: scope:source.ts
       embed_scope:
         markup.raw.code-fence.typescript.markdown-gfm
@@ -1771,17 +1891,20 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.typescript.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
 
   fenced-xml:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:atom|plist|svg|xjb|xml|xsd|xsl))
+          (?i:\s*(atom|plist|svg|xjb|xml|xsd|xsl))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.xml.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
       embed: scope:text.xml
       embed_scope:
         markup.raw.code-fence.xml.markdown-gfm
@@ -1790,17 +1913,20 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.xml.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
 
   fenced-yaml:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:yaml|yml))
+          (?i:\s*(yaml|yml))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.yaml.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
       embed: scope:source.yaml
       embed_scope:
         markup.raw.code-fence.yaml.markdown-gfm
@@ -1809,17 +1935,19 @@ contexts:
       escape_captures:
         0: meta.code-fence.definition.end.yaml.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
 
   fenced-raw:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
           {{fenced_code_block_language}}?
-          .*$\n?       # all characters until EOL
+          .*?(\s*$\n?)   # all characters until EOL
       captures:
         0: meta.code-fence.definition.begin.text.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
+        6: meta.fold.code-fence.begin.markdown
       push: fenced-raw-content
 
   fenced-raw-content:
@@ -1828,6 +1956,7 @@ contexts:
       captures:
         0: meta.code-fence.definition.end.text.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
       pop: 1
 
 ###[ LEAF BLOCKS: HTML BLOCKS ]###############################################

--- a/Markdown/tests/syntax_test_markdown.md
+++ b/Markdown/tests/syntax_test_markdown.md
@@ -1352,7 +1352,7 @@ paragraph
 ```
 | <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
 |^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|  ^ meta.code-fence.definition.begin.text.markdown-gfm - punctuation
+|  ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
 <
 | <- markup.raw.code-fence.markdown-gfm - punctuation
  >
@@ -1360,14 +1360,14 @@ paragraph
 ```
 | <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 |^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
+|  ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-120
 
 ~~~
 | <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
 |^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|  ^ meta.code-fence.definition.begin.text.markdown-gfm - punctuation
+|  ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
 <
 | <- markup.raw.code-fence.markdown-gfm - punctuation
  >
@@ -1375,7 +1375,7 @@ paragraph
 ~~~
 | <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 |^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
+|  ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-121
 
@@ -1390,28 +1390,28 @@ foo
 ```
 | <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
 |^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|  ^ meta.code-fence.definition.begin.text.markdown-gfm - punctuation
+|  ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
 aaa
 ~~~
 | <- markup.raw.code-fence.markdown-gfm - punctuation
 ```
 | <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 |^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
+|  ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-123
 
 ~~~
 | <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
 |^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|  ^ meta.code-fence.definition.begin.text.markdown-gfm - punctuation
+|  ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
 aaa
 ```
 | <- markup.raw.code-fence.markdown-gfm - punctuation
 ~~~
 | <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 |^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
+|  ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ~~~~ 
 | <- punctuation.definition.raw.code-fence.begin
@@ -1423,21 +1423,21 @@ aaa
 ````
 | <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
 |^^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|   ^ meta.code-fence.definition.begin.text.markdown-gfm - punctuation
+|   ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
 aaa
 ```
 | <- markup.raw.code-fence.markdown-gfm - punctuation
 ``````
 | <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 |^^^^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|     ^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
+|     ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-125
 
 ~~~~
 | <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
 |^^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|   ^ meta.code-fence.definition.begin.text.markdown-gfm - punctuation
+|   ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
 |
 aaa
 ~~~
@@ -1445,7 +1445,7 @@ aaa
 ~~~~
 | <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 |^^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|   ^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
+|   ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-128
 
@@ -1463,13 +1463,13 @@ bbb
 ```
 | <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
 |^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|  ^ meta.code-fence.definition.begin.text.markdown-gfm - punctuation
+|  ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
 
   
 ```
 | <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 |^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
+|  ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-130
 
@@ -1477,7 +1477,7 @@ bbb
 ```
 | <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 |^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
+|  ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-131
 
@@ -1487,7 +1487,7 @@ aaa
 ```
 | <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 |^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
+|  ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-132
 
@@ -1499,7 +1499,7 @@ aaa
 | <- meta.code-fence.definition.end.text.markdown-gfm - punctuation
 |^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
 | ^^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|    ^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
+|    ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-133
 
@@ -1511,7 +1511,7 @@ aaa
 | <- meta.code-fence.definition.end.text.markdown-gfm - punctuation
 |^^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
 |  ^^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|     ^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
+|     ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-134
 
@@ -1526,14 +1526,14 @@ aaa
 ```
 | <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
 |^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|  ^ meta.code-fence.definition.begin.text.markdown-gfm - punctuation
+|  ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
 aaa
 | <- markup.raw.code-fence.markdown-gfm
   ```
 | <- meta.code-fence.definition.end.text.markdown-gfm - punctuation
 |^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
 | ^^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|    ^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
+|    ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-136
 
@@ -1541,28 +1541,28 @@ aaa
 | <- meta.code-fence.definition.begin.text.markdown-gfm - punctuation
 |^^ meta.code-fence.definition.begin.text.markdown-gfm - punctuation
 |  ^^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|     ^ meta.code-fence.definition.begin.text.markdown-gfm - punctuation
+|     ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
 aaa
 | <- markup.raw.code-fence.markdown-gfm
   ```
 | <- meta.code-fence.definition.end.text.markdown-gfm - punctuation
 |^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
 | ^^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|    ^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
+|    ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-137
 
 ```
 | <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
 |^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|  ^ meta.code-fence.definition.begin.text.markdown-gfm - punctuation
+|  ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
 aaa
 | <- markup.raw.code-fence.markdown-gfm
     ```
 | <- meta.code-fence.definition.end.text.markdown-gfm - punctuation
 |^^^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
 |   ^^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|      ^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
+|      ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-138
 
@@ -1586,7 +1586,7 @@ aaa
 ~~~~~~
 | <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 |^^^^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|     ^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
+|     ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-140
 
@@ -1594,7 +1594,7 @@ foo
 ```
 | <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
 |^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|  ^ meta.code-fence.definition.begin.text.markdown-gfm - punctuation
+|  ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
 bar
 ```
 baz
@@ -1679,7 +1679,7 @@ foo
 ~~~
 | <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
 |^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|  ^ meta.code-fence.definition.begin.text.markdown-gfm - punctuation
+|  ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
 bar
 |^^^ markup.raw.code-fence.markdown-gfm
 ~~~
@@ -1693,7 +1693,7 @@ bar
 | <- meta.code-fence.definition.begin.ruby.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
 |^^ meta.code-fence.definition.begin.ruby.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
 |  ^^^^ meta.code-fence.definition.begin.ruby.markdown-gfm constant.other.language-name.markdown
-|      ^ meta.code-fence.definition.begin.ruby.markdown-gfm - constant
+|      ^ meta.code-fence.definition.begin.ruby.markdown-gfm meta.fold.code-fence.begin - constant
 def foo(x)
 | <- markup.raw.code-fence.ruby.markdown-gfm source.ruby meta.function
   return 3
@@ -1702,6 +1702,7 @@ end
 ```
 | <- meta.code-fence.definition.end.ruby.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 |^^ meta.code-fence.definition.end.ruby.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.ruby.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-143
 
@@ -1710,7 +1711,8 @@ end
 |^^^ meta.code-fence.definition.begin.ruby.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
 |   ^^^^ meta.code-fence.definition.begin.ruby.markdown-gfm - punctuation - constant
 |       ^^^^ meta.code-fence.definition.begin.ruby.markdown-gfm constant.other.language-name.markdown
-|           ^^^^^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.ruby.markdown-gfm - constant
+|           ^^^^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.ruby.markdown-gfm - meta.fold - constant
+|                             ^ meta.code-fence.definition.begin.ruby.markdown-gfm meta.fold.code-fence.begin - constant
 def foo(x)
 | <- markup.raw.code-fence.ruby.markdown-gfm source.ruby meta.function
   return 3
@@ -1725,10 +1727,12 @@ end
 ````;
 | <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
 |^^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|   ^^ meta.code-fence.definition.begin.text.markdown-gfm
+|   ^ meta.code-fence.definition.begin.text.markdown-gfm - meta.fold
+|    ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
 ````
 | <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 |^^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|   ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-145
 
@@ -1746,33 +1750,43 @@ foo
 | <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
 |^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
 |   ^^ meta.code-fence.definition.begin.text.markdown-gfm constant.other.language-name.markdown
-|     ^^^^^^^^^ meta.code-fence.definition.begin.text.markdown-gfm - punctuation
+|     ^^^^^^^^ meta.code-fence.definition.begin.text.markdown-gfm - meta.fold - punctuation
+|             ^ meta.code-fence.definition.begin.text.markdown-gfm - punctuation meta.fold.code-fence.begin.markdown
 foo
 ~~~
 | <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 |^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ~~~~~foo~
 |^^^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
 |    ^^^^ meta.code-fence.definition.begin.text.markdown-gfm constant.other.language-name.markdown
+|        ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
 
 ~~~~~
 |^^^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|    ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-147
 
 ```
 | <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
 |^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|  ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
 ``` aaa
 | <- markup.raw.code-fence.markdown-gfm - punctuation
 ```
 | <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 |^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://fenced-code-block-embedded-syntaxes-tests
 
 ```bash
+| <- meta.code-fence.definition.begin.shell-script.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^ meta.code-fence.definition.begin.shell-script.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|  ^^^^ meta.code-fence.definition.begin.shell-script.markdown-gfm constant.other.language-name.markdown
+|      ^ meta.code-fence.definition.begin.shell-script.markdown-gfm meta.fold.code-fence.begin
 # test
 | ^^^^^ source.shell comment.line.number-sign
 echo hello, \
@@ -1784,30 +1798,41 @@ echo This is a smiley :-\) \(I have to escape the parentheses, though!\)
 |^^ meta.code-fence.definition.end.shell-script.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 
 ```clojure
-|^^^^^^^^^ meta.code-fence.definition.begin.clojure
+|^^^^^^^^^ meta.code-fence.definition.begin - meta.fold
 |  ^^^^^^^ constant.other.language-name
+|         ^ meta.code-fence.definition.begin meta.fold.code-fence.begin
  (/ 10 3.0)
 | <- source.clojure
 |^^^^^^^^^^ source.clojure
 ```
 | <- meta.code-fence.definition.end.clojure.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 |^^ meta.code-fence.definition.end.clojure.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.clojure.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```cmd
+|^^^^^ meta.code-fence.definition.begin - meta.fold
+|     ^ meta.code-fence.definition.begin meta.fold.code-fence.begin
 
 | <- markup.raw.code-fence.dosbatch.markdown-gfm source.dosbatch
 ```
 | <- meta.code-fence.definition.end.dosbatch.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 |^^ meta.code-fence.definition.end.dosbatch.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.dosbatch.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```css
+|^^^^^ meta.code-fence.definition.begin - meta.fold
+|     ^ meta.code-fence.definition.begin meta.fold.code-fence.begin
 
 | <- markup.raw.code-fence.css.markdown-gfm source.css
 ```
 | <- meta.code-fence.definition.end.css.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 |^^ meta.code-fence.definition.end.css.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.css.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```diff
+|^^^^^^ meta.code-fence.definition.begin - meta.fold
+|      ^ meta.code-fence.definition.begin meta.fold.code-fence.begin
+
 + inserted
 | <- source.diff markup.inserted.diff punctuation.definition.inserted.diff
 - deleted
@@ -1815,32 +1840,45 @@ echo This is a smiley :-\) \(I have to escape the parentheses, though!\)
 ```
 | <- meta.code-fence.definition.end.diff.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 |^^ meta.code-fence.definition.end.diff.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.diff.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```Graphviz
+|^^^^^^^^^^ meta.code-fence.definition.begin - meta.fold
+|          ^ meta.code-fence.definition.begin meta.fold.code-fence.begin
+
 graph n {}
 | ^^^ storage.type.dot
 ```
 | <- meta.code-fence.definition.end.graphviz.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 |^^ meta.code-fence.definition.end.graphviz.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.graphviz.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```haskell
+|^^^^^^^^^ meta.code-fence.definition.begin - meta.fold
+|         ^ meta.code-fence.definition.begin meta.fold.code-fence.begin
 
 | <- markup.raw.code-fence.haskell.markdown-gfm source.haskell
 ```
 | <- meta.code-fence.definition.end.haskell.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 |^^ meta.code-fence.definition.end.haskell.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.haskell.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```html
+|^^^^^^ meta.code-fence.definition.begin - meta.fold
+|      ^ meta.code-fence.definition.begin meta.fold.code-fence.begin
   <html>
 | <- markup.raw.code-fence.html.markdown-gfm text.html
 | ^^^^^^ text.html meta.tag
 ```
 | <- meta.code-fence.definition.end.html.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 |^^ meta.code-fence.definition.end.html.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.html.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```html+php
+|^^^^^^^^^^ meta.code-fence.definition.begin - meta.fold
+|          ^ meta.code-fence.definition.begin meta.fold.code-fence.begin
 <div></div>
-|^^^ entity.name.tag.block.any.html
+|^^^ entity.name.tag.block
 <?php
 | <- markup.raw.code-fence.html-php.markdown-gfm embedding.php text.html meta.embedded punctuation.section.embedded.begin.php
 var_dump(expression);
@@ -1850,6 +1888,8 @@ var_dump(expression);
 |^^ meta.code-fence.definition.end.html-php.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 
 ```js
+|^^^^ meta.code-fence.definition.begin - meta.fold
+|    ^ meta.code-fence.definition.begin meta.fold.code-fence.begin
 | <- punctuation.definition.raw.code-fence.begin
 |  ^^ constant.other.language-name
 for (var i = 0; i < 10; i++) {
@@ -1859,59 +1899,82 @@ for (var i = 0; i < 10; i++) {
 ```
 | <- meta.code-fence.definition.end.javascript.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 |^^ meta.code-fence.definition.end.javascript.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.javascript.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```jsx
+|^^^^^ meta.code-fence.definition.begin - meta.fold
+|     ^ meta.code-fence.definition.begin meta.fold.code-fence.begin
 
 | <- markup.raw.code-fence.jsx.markdown-gfm
 ```
 | <- meta.code-fence.definition.end.jsx.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 |^^ meta.code-fence.definition.end.jsx.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.jsx.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```lisp
+|^^^^^^ meta.code-fence.definition.begin - meta.fold
+|      ^ meta.code-fence.definition.begin meta.fold.code-fence.begin
 
 | <- markup.raw.code-fence.lisp.markdown-gfm source.lisp
 ```
 | <- meta.code-fence.definition.end.lisp.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 |^^ meta.code-fence.definition.end.lisp.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.lisp.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```lua
+|^^^^^ meta.code-fence.definition.begin - meta.fold
+|     ^ meta.code-fence.definition.begin meta.fold.code-fence.begin
 
 | <- markup.raw.code-fence.lua.markdown-gfm source.lua
 ```
 | <- meta.code-fence.definition.end.lua.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 |^^ meta.code-fence.definition.end.lua.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.lua.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```makefile
+|^^^^^^^^^^ meta.code-fence.definition.begin - meta.fold
+|          ^ meta.code-fence.definition.begin meta.fold.code-fence.begin
 
 | <- markup.raw.code-fence.makefile.markdown-gfm source.makefile
 ```
 | <- meta.code-fence.definition.end.makefile.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 |^^ meta.code-fence.definition.end.makefile.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.makefile.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```matlab
+|^^^^^^^^ meta.code-fence.definition.begin - meta.fold
+|        ^ meta.code-fence.definition.begin meta.fold.code-fence.begin
 
 | <- markup.raw.code-fence.matlab.markdown-gfm source.matlab
 ```
 | <- meta.code-fence.definition.end.matlab.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 |^^ meta.code-fence.definition.end.matlab.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.matlab.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```ocaml
+|^^^^^^^ meta.code-fence.definition.begin - meta.fold
+|       ^ meta.code-fence.definition.begin meta.fold.code-fence.begin
 
 | <- markup.raw.code-fence.ocaml.markdown-gfm source.ocaml
 ```
 | <- meta.code-fence.definition.end.ocaml.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 |^^ meta.code-fence.definition.end.ocaml.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.ocaml.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```php
+|^^^^^ meta.code-fence.definition.begin - meta.fold
+|     ^ meta.code-fence.definition.begin meta.fold.code-fence.begin
 var_dump(expression);
 | <- markup.raw.code-fence.php.markdown-gfm source.php meta.function-call
 ```
 | <- meta.code-fence.definition.end.php.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 |^^ meta.code-fence.definition.end.php.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.php.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```python
+|^^^^^^^^ meta.code-fence.definition.begin - meta.fold - markup
+|        ^ meta.code-fence.definition.begin meta.fold.code-fence.begin - merkup
 |^^ punctuation.definition.raw.code-fence.begin
-|^^^^^^^^^ meta.code-fence.definition.begin.python - markup
 |  ^^^^^^ constant.other.language-name
 def function():
     pass
@@ -1921,23 +1984,32 @@ unclosed_paren = (
 ```
 | <- meta.code-fence.definition.end.python.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 |^^ meta.code-fence.definition.end.python.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.python.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```regex
+|^^^^^^^ meta.code-fence.definition.begin - meta.fold - markup
+|       ^ meta.code-fence.definition.begin meta.fold.code-fence.begin - merkup
 (?x)
 \s+
 | <- markup.raw.code-fence.regexp.markdown-gfm source.regexp
 ```
 | <- meta.code-fence.definition.end.regexp.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 |^^ meta.code-fence.definition.end.regexp.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.regexp.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```scala
+|^^^^^^^ meta.code-fence.definition.begin - meta.fold - markup
+|       ^ meta.code-fence.definition.begin meta.fold.code-fence.begin - merkup
 
 | <- markup.raw.code-fence.scala.markdown-gfm source.scala
 ```
 | <- meta.code-fence.definition.end.scala.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 |^^ meta.code-fence.definition.end.scala.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.scala.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```sh
+|^^^^ meta.code-fence.definition.begin - meta.fold - markup
+|    ^ meta.code-fence.definition.begin meta.fold.code-fence.begin - merkup
 
 | <- markup.raw.code-fence.shell-script.markdown-gfm source.shell.bash
 ```
@@ -1945,6 +2017,9 @@ unclosed_paren = (
 |^^ meta.code-fence.definition.end.shell-script.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 
 ```shell
+|^^^^^^^ meta.code-fence.definition.begin - meta.fold - markup
+|       ^ meta.code-fence.definition.begin meta.fold.code-fence.begin - merkup
+
 function foo () {
 | <- markup.raw.code-fence.shell.markdown-gfm source.shell.interactive.markdown meta.function.shell keyword.declaration.function.shell 
 }
@@ -1976,13 +2051,18 @@ function foo () {}
 ```
 | <- meta.code-fence.definition.end.shell.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 |^^ meta.code-fence.definition.end.shell.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.shell.markdown-gfm meta.fold.code-fence.end - punctuation
 
    ```shell
+|  ^^^^^^^^ meta.code-fence.definition.begin - meta.fold - markup
+|          ^ meta.code-fence.definition.begin meta.fold.code-fence.begin - merkup
    $ ls
 |  ^^^^^ markup.raw.code-fence.shell.markdown-gfm source.shell.interactive.markdown
 |  ^ comment.other.shell
 |    ^^ meta.function-call.identifier.shell variable.function.shell
    ```
+|  ^^^ meta.code-fence.definition.end.shell.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|     ^ meta.code-fence.definition.end.shell.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```shell-script
 
@@ -1992,7 +2072,9 @@ function foo () {}
 |^^ meta.code-fence.definition.end.shell-script.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 
 ```sql
-|^^^^^ meta.code-fence.definition.begin.sql
+|^^^^^ meta.code-fence.definition.begin - meta.fold - markup
+|     ^ meta.code-fence.definition.begin meta.fold.code-fence.begin - merkup
+|^^ punctuation.definition.raw.code-fence.begin.markdown
 |  ^^^ constant.other.language-name
 SELECT TOP 10 *
 |^^^^^^^^^^^^^^^ markup.raw.code-fence.sql source.sql
@@ -2000,6 +2082,7 @@ FROM TableName
 ```
 | <- meta.code-fence.definition.end.sql.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 |^^ meta.code-fence.definition.end.sql.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.sql.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```ts
 declare type foo = 'bar'
@@ -2016,7 +2099,9 @@ declare type foo = 'bar'
 |^^ meta.code-fence.definition.end.tsx.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 
 ```xml
-|^^^^^ meta.code-fence.definition.begin.xml
+|^^^^^ meta.code-fence.definition.begin - meta.fold - markup
+|     ^ meta.code-fence.definition.begin meta.fold.code-fence.begin - merkup
+|^^ punctuation.definition.raw.code-fence.begin.markdown
 |  ^^^ constant.other.language-name
 <?xml version="1.0" ?>
 |^^^^^^^^^^^^^^^^^^^^^^ markup.raw.code-fence.xml
@@ -2027,39 +2112,63 @@ declare type foo = 'bar'
 ```
 | <- meta.code-fence.definition.end.xml.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 |^^ meta.code-fence.definition.end.xml.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.xml.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```jsx:file.jsx
-|^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.jsx.markdown-gfm
+|^^^^^^^^^^^^^^ meta.code-fence.definition.begin - meta.fold - markup
+|              ^ meta.code-fence.definition.begin meta.fold.code-fence.begin - merkup
 |^^ punctuation.definition.raw.code-fence.begin.markdown
 |  ^^^ constant.other.language-name.markdown
-|     ^ - constant
+|     ^^^^^^^^^ comment.line.infostring.markdown
 
 | <- markup.raw.code-fence.jsx.markdown-gfm source.jsx
 ```
+| <- meta.code-fence.definition.end.jsx.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.jsx.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.jsx.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```jldoctest; filter = r"Stacktrace:(\n \[[0-9]+\].*)*"
 | <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.text.markdown-gfm
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.text.markdown-gfm - meta.fold
+|                                                      ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin.markdown - punctuation
 |^^ punctuation.definition.raw.code-fence.begin.markdown
 |  ^^^^^^^^^ constant.other.language-name.markdown
 |           ^ - constant
 ```
+| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```R%&?! weired language name
-|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.text.markdown-gfm
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.text.markdown-gfm - meta.fold
+|                            ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin
+|^^ punctuation.definition.raw.code-fence.begin.markdown
 |  ^^^^^ constant.other.language-name.markdown
 |        ^^^^^^^^^^^^^^^^^^^^^ - constant
 ```
+| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```{key: value}
-|^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.text.markdown-gfm
+|^^^^^^^^^^^^^^ meta.code-fence.definition.begin.text.markdown-gfm - meta.fold
+|              ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin
+|^^ punctuation.definition.raw.code-fence.begin.markdown
 |  ^^^^^^^^^^^^ - constant
 ```
+| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ``` {key: value}
-|^^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.text.markdown-gfm
+|^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.text.markdown-gfm - meta.fold
+|               ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin
+|^^ punctuation.definition.raw.code-fence.begin.markdown
 |   ^^^^^^^^^^^^ - constant
 ```
+| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
 
 
 # TEST: HTML BLOCKS ###########################################################
@@ -5770,7 +5879,7 @@ blah*
 | ^ punctuation.definition.raw.begin.markdown
 |      ^ punctuation.definition.raw.end.markdown
 |        ^ - punctuation
-|          ^^^^^^^^^^^^^^^^^^^ meta.tag.inline.any.html 
+|          ^^^^^^^^^^^^^^^^^^^ meta.tag.inline
 
 - list item
 
@@ -6040,7 +6149,7 @@ foo
 ## https://spec.commonmark.org/0.30/#example-344
 
 <a href="`">`
-| ^^^^^^^^^^ meta.tag.inline.any
+| ^^^^^^^^^^ meta.tag.inline
 |           ^^ - meta.tag - markup.raw - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-345


### PR DESCRIPTION
This commit adjusts fenced code block related patterns to scope EOL `meta.fold`, to provide reliable single char tokens for syntax based folding and adjusts fold rules accordingly.

Reported at https://github.com/SublimeText-Markdown/MarkdownEditing/issues/733