### PR TITLE
[JavaScript] Don't try to scope entire call paths

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1086,8 +1086,6 @@ contexts:
         - async-arrow-function
         - literal-variable
 
-    - include: literal-call
-
     - match: (?={{possible_arrow_function_begin}})
       pop: 1
       branch_point: arrow-function
@@ -1955,7 +1953,7 @@ contexts:
         1: punctuation.accessor.js
         2: punctuation.section.group.begin.js
       set:
-        - meta_scope: meta.group.js
+        - meta_scope: meta.function-call.arguments.js meta.group.js
         - match: \)
           scope: punctuation.section.group.end.js
           pop: 1
@@ -1986,14 +1984,7 @@ contexts:
 
     - match: '{{dot_accessor}}'
       scope: punctuation.accessor.js
-      push:
-        - match: '(?={{identifier_name}}\s*(?:{{dot_accessor}})?\()'
-          set:
-            - call-method-meta
-            - function-call-arguments
-            - call-path
-            - object-property
-        - include: object-property
+      push: object-property
 
   literal-number:
     # floats
@@ -2066,52 +2057,22 @@ contexts:
       scope: invalid.illegal.numeric.decimal.js
       pop: 1
 
-  literal-call:
-    - match: (?={{identifier_name}}\s*(?:{{dot_accessor}})?\()
-      set:
-        - call-function-meta
-        - function-call-arguments
-        - literal-variable
-
-    - match: (?={{identifier_name}}\s*(?:{{dot_accessor}}\s*#?{{identifier_name}}\s*)+(?:{{dot_accessor}})?\()
-      set:
-        - call-method-meta
-        - function-call-arguments
-        - call-path
-        - literal-variable
-
-  call-path:
-    - match: '{{dot_accessor}}'
-      scope: punctuation.accessor.js
-      push: object-property
-    - include: else-pop
-
-  call-function-meta:
-    - meta_include_prototype: false
-    - meta_scope: meta.function-call.js
-    - include: immediately-pop
-
-  call-method-meta:
-    - meta_include_prototype: false
-    - meta_scope: meta.function-call.method.js
-    - include: immediately-pop
-
   call-function-name:
     - match: '{{dollar_only_identifier}}'
-      scope: variable.function.js variable.other.dollar.only.js punctuation.dollar.js
+      scope: meta.function-call.js variable.function.js variable.other.dollar.only.js punctuation.dollar.js
       pop: 1
     - match: '{{identifier_name}}'
-      scope: variable.function.js
+      scope: meta.function-call.js variable.function.js
       pop: 1
     - include: else-pop
 
   call-method-name:
     - include: support-property
     - match: '{{identifier_name}}'
-      scope: variable.function.js
+      scope: meta.function-call.js variable.function.js
       pop: 1
     - match: '(#){{identifier_name}}'
-      scope: variable.function.js
+      scope: meta.function-call.js variable.function.js
       captures:
         1: punctuation.definition.js
       pop: 1
@@ -2372,37 +2333,37 @@ contexts:
       pop: 1
 
     - match: (?:eval|isFinite|isNaN|parseFloat|parseInt|decodeURI|decodeURIComponent|encodeURI|encodeURIComponent){{identifier_break}}
-      scope: support.function.js
+      scope: meta.function-call.js support.function.js
       pop: 1
 
   support-property-ecma-array:
     - match: (?:from|isArray|of){{identifier_break}}
-      scope: support.function.builtin.js
+      scope: meta.function-call.js support.function.builtin.js
       pop: 1
 
   support-property-ecma-arraybuffer:
     - match: isView{{identifier_break}}
-      scope: support.function.builtin.js
+      scope: meta.function-call.js support.function.builtin.js
       pop: 1
 
   support-property-ecma-atomics:
     - match: (?:and|add|compareExchange|exchange|isLockFree|load|or|store|sub|wait|wake|xor){{identifier_break}}
-      scope: support.function.builtin.js
+      scope: meta.function-call.js support.function.builtin.js
       pop: 1
 
   support-property-ecma-bigint:
     - match: (?:asUintN|asIntN){{identifier_break}}
-      scope: support.function.builtin.js
+      scope: meta.function-call.js support.function.builtin.js
       pop: 1
 
   support-property-ecma-date:
     - match: (?:now|parse|UTC){{identifier_break}}
-      scope: support.function.builtin.js
+      scope: meta.function-call.js support.function.builtin.js
       pop: 1
 
   support-property-ecma-json:
     - match: (?:parse|stringify){{identifier_break}}
-      scope: support.function.builtin.js
+      scope: meta.function-call.js support.function.builtin.js
       pop: 1
 
   support-property-ecma-math:
@@ -2410,7 +2371,7 @@ contexts:
       scope: support.constant.builtin.js
       pop: 1
     - match: (?:abs|acos|acosh|asin|asin|atan|atanh|atan2|cbrt|ceil|clz32|cos|cosh|exp|expm1|floor|fround|hypot|imul|log|log1p|log10|log2|max|min|pow|random|round|sign|sin|sinh|sqrt|tan|tanh|trunc){{identifier_break}}
-      scope: support.function.builtin.js
+      scope: meta.function-call.js support.function.builtin.js
       pop: 1
 
   support-property-ecma-number:
@@ -2418,32 +2379,32 @@ contexts:
       scope: support.constant.builtin.js
       pop: 1
     - match: (?:isFinite|isInteger|isNaN|isSafeInteger|NaN|parseFloat|parseInt){{identifier_break}}
-      scope: support.function.builtin.js
+      scope: meta.function-call.js support.function.builtin.js
       pop: 1
 
   support-property-ecma-object:
     - match: (?:assign|create|defineProperties|defineProperty|entries|freeze|fromEntries|getOwnPropertyDescriptors?|getOwnPropertyNames|getOwnPropertySymbols|getPrototypeOf|is|isExtensible|isFrozen|isSealed|keys|preventExtensions|seal|setPrototypeOf|values){{identifier_break}}
-      scope: support.function.builtin.js
+      scope: meta.function-call.js support.function.builtin.js
       pop: 1
 
   support-property-ecma-promise:
     - match: (?:all|race|reject|resolve|allSettled|any){{identifier_break}}
-      scope: support.function.builtin.js
+      scope: meta.function-call.js support.function.builtin.js
       pop: 1
 
   support-property-ecma-proxy:
     - match: revocable{{identifier_break}}
-      scope: support.function.builtin.js
+      scope: meta.function-call.js support.function.builtin.js
       pop: 1
 
   support-property-ecma-reflect:
     - match: (?:apply|construct|defineProperty|deleteProperty|get|getOwnPropertyDescriptor|getPrototypeOf|has|isExtensible|ownKeys|preventExtensions|set|setPrototypeOf){{identifier_break}}
-      scope: support.function.builtin.js
+      scope: meta.function-call.js support.function.builtin.js
       pop: 1
 
   support-property-ecma-string:
     - match: (?:fromCharCode|fromCodePoint|raw){{identifier_break}}
-      scope: support.function.builtin.js
+      scope: meta.function-call.js support.function.builtin.js
       pop: 1
 
   support-property-ecma-symbol:
@@ -2451,7 +2412,7 @@ contexts:
       scope: support.constant.builtin.js
       pop: 1
     - match: (?:for|keyFor){{identifier_break}}
-      scope: support.function.builtin.js
+      scope: meta.function-call.js support.function.builtin.js
       pop: 1
 
   support-property-ecma-typedarray:
@@ -2477,7 +2438,7 @@ contexts:
       scope: support.type.object.dom.js
       pop: 1
     - match: (?:clearTimeout|clearInterval|setTimeout|setInterval){{identifier_break}}
-      scope: support.function.dom.js
+      scope: meta.function-call.js support.function.dom.js
       pop: 1
 
   support-variable-node:
@@ -2515,7 +2476,7 @@ contexts:
             - include: else-pop
         - include: else-pop
     - match: require{{identifier_break}}
-      scope: support.function.node.js
+      scope: meta.function-call.js support.function.node.js
       pop: 1
 
   support-property-node-process:
@@ -2523,7 +2484,7 @@ contexts:
       scope: support.constant.node.js
       pop: 1
     - match: (?:abort|chdir|cpuUsage|cwd|disconnect|dlopen|emitWarning|exit|getegid|geteuid|getgit|getgroups|getuid|hasUncaughtExceptionCaptureCallback|hrtime|initGroups|kill|memoryUsage|nextTick|send|setegid|seteuid|setgid|setgroups|setuid|hasUncaughtExceptionCaptureCallback|umask|uptime){{identifier_break}}
-      scope: support.function.node.js
+      scope: meta.function-call.js support.function.node.js
       pop: 1
 
   support-property-node-module:
@@ -2531,12 +2492,12 @@ contexts:
       scope: support.constant.node.js
       pop: 1
     - match: require{{identifier_break}}
-      scope: support.function.node.js
+      scope: meta.function-call.js support.function.node.js
       pop: 1
 
   builtin-console-properties:
     - match: (?:warn|info|log|error|time|timeEnd|assert|count|dir|group|groupCollapsed|groupEnd|profile|profileEnd|table|trace|timeStamp){{identifier_break}}
-      scope: support.function.console.js
+      scope: meta.function-call.js support.function.console.js
       pop: 1
     - include: object-property
 
@@ -2548,7 +2509,7 @@ contexts:
         - function-name-meta
         - object-property-base
 
-    - match: '(?=#?{{identifier_name}}\s*(?:{{dot_accessor}})?\()'
+    - match: '(?=#?{{function_call_lookahead}})'
       set: call-method-name
 
     - match: '{{identifier_name}}(?={{nothing}}`)'
@@ -2591,7 +2552,7 @@ contexts:
       pop: 1
 
     - match: (?:hasOwnProperty|isPrototypeOf|propertyIsEnumerable|toLocaleString|toString|valueOf){{identifier_break}}
-      scope: support.function.js
+      scope: meta.function-call.js support.function.js
       pop: 1
 
     # Annex B
@@ -2599,7 +2560,7 @@ contexts:
       scope: invalid.deprecated.js variable.language.prototype.js
       pop: 1
     - match: (?:__defineGetter__|__defineSetter__|__lookupGetter__){{identifier_break}}
-      scope: invalid.deprecated.js support.function.js
+      scope: invalid.deprecated.js meta.function-call.js support.function.js
       pop: 1
 
   import-meta-expression:

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1948,10 +1948,10 @@ contexts:
           push: expression
 
   function-call-arguments:
-    - match: ({{dot_accessor}})?(\()
-      captures:
-        1: punctuation.accessor.js
-        2: punctuation.section.group.begin.js
+    - match: '{{dot_accessor}}(?=\()'
+      scope: meta.function-call.js punctuation.accessor.js
+    - match: \(
+      scope: punctuation.section.group.begin.js
       set:
         - meta_scope: meta.function-call.arguments.js meta.group.js
         - match: \)
@@ -2074,6 +2074,8 @@ contexts:
         1: punctuation.definition.js
       pop: 1
     - include: else-pop
+
+
 
   literal-variable:
     - include: special-identifier

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -96,7 +96,7 @@ variables:
       =>
     )
 
-  function_call_lookahead: (?={{identifier_name}}\s*(?:{{dot_accessor}})?\()
+  function_call_after_lookahead: (?=\s*(?:{{dot_accessor}}\s*)?\()
 
   function_assignment_lookahead: |-
     (?x:(?=
@@ -965,7 +965,7 @@ contexts:
     - match: (?=`)
       push: literal-string-template
 
-    - match: (?=(?:{{dot_accessor}})?\()
+    - match: (?={{function_call_after_lookahead}})
       push: function-call-arguments
 
     - match: '{{line_ending_ahead}}'
@@ -1025,7 +1025,7 @@ contexts:
     - match: (?=`)
       push: literal-string-template
 
-    - match: (?=(?:{{dot_accessor}})?\()
+    - match: '{{function_call_after_lookahead}}'
       push: function-call-arguments
 
     - include: property-access
@@ -1948,8 +1948,9 @@ contexts:
           push: expression
 
   function-call-arguments:
-    - match: '{{dot_accessor}}(?=\()'
-      scope: meta.function-call.js punctuation.accessor.js
+    - meta_content_scope: meta.function-call.js
+    - match: '{{dot_accessor}}'
+      scope: punctuation.accessor.js
     - match: \(
       scope: punctuation.section.group.begin.js
       set:
@@ -2057,26 +2058,6 @@ contexts:
       scope: invalid.illegal.numeric.decimal.js
       pop: 1
 
-  call-function-name:
-    - match: '{{dollar_only_identifier}}'
-      scope: meta.function-call.js variable.function.js variable.other.dollar.only.js punctuation.dollar.js
-      pop: 1
-    - match: '{{identifier_name}}'
-      scope: meta.function-call.js variable.function.js
-      pop: 1
-    - include: else-pop
-
-  call-method-name:
-    - include: support-property
-    - match: '(#)?{{identifier_name}}'
-      scope: meta.function-call.js variable.function.js
-      captures:
-        1: punctuation.definition.js
-      pop: 1
-    - include: else-pop
-
-
-
   literal-variable:
     - include: special-identifier
     - include: support
@@ -2094,8 +2075,18 @@ contexts:
       scope: support.class.js
       pop: 1
 
-    - match: '{{function_call_lookahead}}'
-      set: call-function-name
+    # If we don't capture the trailing space here,
+    # it'll get eaten by the arrow function detection.
+    - match: '({{dollar_only_identifier}}){{nothing}}{{function_call_after_lookahead}}'
+      scope: meta.function-call.js
+      captures:
+        1: variable.function.js variable.other.dollar.only.js punctuation.dollar.js
+      pop: 1
+    - match: '({{identifier_name}}){{nothing}}{{function_call_after_lookahead}}'
+      scope: meta.function-call.js
+      captures:
+       1: variable.function.js
+      pop: 1
 
     - include: literal-variable-base
 
@@ -2508,7 +2499,7 @@ contexts:
         - function-name-meta
         - object-property-base
 
-    - match: '(?=#?{{function_call_lookahead}})'
+    - match: '(?=#?{{identifier_name}}{{function_call_after_lookahead}})'
       set: call-method-name
 
     - match: '{{identifier_name}}(?={{nothing}}`)'
@@ -2516,6 +2507,15 @@ contexts:
       pop: 1
 
     - include: object-property-base
+    - include: else-pop
+
+  call-method-name:
+    - include: support-property
+    - match: '(#)?{{identifier_name}}'
+      scope: meta.function-call.js variable.function.js
+      captures:
+        1: punctuation.definition.js
+      pop: 1
     - include: else-pop
 
   object-property-base:

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -2068,10 +2068,7 @@ contexts:
 
   call-method-name:
     - include: support-property
-    - match: '{{identifier_name}}'
-      scope: meta.function-call.js variable.function.js
-      pop: 1
-    - match: '(#){{identifier_name}}'
+    - match: '(#)?{{identifier_name}}'
       scope: meta.function-call.js variable.function.js
       captures:
         1: punctuation.definition.js

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -21,9 +21,8 @@ variables:
   dot_accessor: (?:[?!]?\.)
   possible_arrow_function_begin: (?:\(|{{identifier_start}}|<)
 
-  function_call_lookahead: >-
+  function_call_after_lookahead: >-
     (?x:(?=
-      {{identifier_name}}
       \s*
       (?:
         <
@@ -31,7 +30,7 @@ variables:
         >
         \s*
       )?
-      (?:{{dot_accessor}})?
+      (?:{{dot_accessor}}\s*)?
       \(
     ))
 

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -187,19 +187,6 @@ contexts:
     - match: type{{identifier_break}}
       scope: keyword.control.import-export.ts
 
-  property-access:
-    - meta_prepend: true
-    - match: \!\.
-      scope: punctuation.accessor.js
-      push:
-        - match: '(?={{identifier_name}}\s*(?:\.\?)?\()'
-          set:
-            - call-method-meta
-            - function-call-arguments
-            - call-path
-            - object-property
-        - include: object-property
-
   ts-type-declaration:
     - match: type{{identifier_break}}
       scope: keyword.declaration.type.js

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -1702,12 +1702,12 @@ debugger
 //   ^^ punctuation.accessor
 //     ^ punctuation.section.brackets.begin
 
-    a?.();
-//  ^^^^^ meta.function-call
+    a ?. ();
+//  ^^^^^^^ meta.function-call
 //  ^ variable.function
-//   ^^ punctuation.accessor - meta.function-call.arguments
-//     ^^ meta.function-call.arguments meta.group
-//     ^ punctuation.section.group.begin
+//    ^^ punctuation.accessor - meta.function-call.arguments
+//       ^^ meta.function-call.arguments meta.group
+//       ^ punctuation.section.group.begin
 
     a.b?.();
 //    ^^^^^ meta.function-call

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -1703,10 +1703,10 @@ debugger
 //     ^ punctuation.section.brackets.begin
 
     a?.();
+//  ^^^^^ meta.function-call
 //  ^ variable.function
-//   ^^^^ meta.group
-//   ^^ punctuation.accessor
-//    ^^^ meta.function-call
+//   ^^ punctuation.accessor - meta.function-call.arguments
+//     ^^ meta.function-call.arguments meta.group
 //     ^ punctuation.section.group.begin
 
     a.b?.();

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -439,6 +439,7 @@ var obj = {
     ...bar(baz),
 //  ^^^ keyword.operator.spread
 //     ^^^^^^^^ meta.function-call
+//        ^^^^^ meta.function-call.arguments
 //     ^^^ variable.function
 //             ^ punctuation.separator.comma
 
@@ -1028,11 +1029,12 @@ sources.DOM.status()
 sources.DOM
 // <- variable.other.readwrite
     .status()
-    // ^ meta.function-call.method variable.function
+    // ^ meta.function-call variable.function
     //       ^ - meta.function-call
 
     foo.#bar();
-//  ^^^^^^^^^^ meta.function-call.method.js
+//      ^^^^^^ meta.function-call
+//          ^^ meta.function-call.arguments
 //      ^^^^ variable.function.js
 //      ^ punctuation.definition.js
 //          ^^ meta.group.js
@@ -1208,7 +1210,7 @@ foo.bar().baz
 width/2 + lineStart * Math.sin(i * 30 * π/180)
 //   ^ keyword.operator.arithmetic
 //                  ^ keyword.operator.arithmetic
-//                         ^^^^^^^^^^^^^^^^^^^ meta.function-call.method
+//                         ^^^^^^^^^^^^^^^^^^^ meta.function-call
 
 var reg = /a+/gimy.exec('aabb')
 //        ^^^^^^^^ meta.string string.regexp
@@ -1701,13 +1703,13 @@ debugger
 //     ^ punctuation.section.brackets.begin
 
     a?.();
-//  ^^^^^ meta.function-call
 //  ^ variable.function
 //   ^^^^ meta.group
 //   ^^ punctuation.accessor
+//    ^^^ meta.function-call
 //     ^ punctuation.section.group.begin
 
     a.b?.();
-//  ^^^^^^^ meta.function-call.method
+//    ^^^^^ meta.function-call
 //    ^ variable.function
 //

--- a/JavaScript/tests/syntax_test_js_support_builtin.js
+++ b/JavaScript/tests/syntax_test_js_support_builtin.js
@@ -1,16 +1,17 @@
 // SYNTAX TEST "Packages/JavaScript/JavaScript.sublime-syntax"
 
     isNaN;
-//  ^^^^^ support.function - meta.function-call
+//  ^^^^^ support.function
 
     isNaN();
-//  ^^^^^^^ meta.function-call - meta.function-call.method
+//  ^^^^^^^ meta.function-call
 //  ^^^^^ support.function
 //       ^^ meta.group
 
     isNaN.call();
-//  ^^^^^^^^^^^^ meta.function-call.method - meta.function-call meta.function-call
+//  ^^^^^ meta.function-call - meta.function-call meta.function-call
 //  ^^^^^ support.function
+//        ^^^^^^ meta.function-call - meta.function-call meta.function-call
 
     new Error();
 //      ^^^^^ support.class.builtin

--- a/JavaScript/tests/syntax_test_js_support_console.js
+++ b/JavaScript/tests/syntax_test_js_support_console.js
@@ -4,21 +4,19 @@
 //  ^^^^^^^ support.type.object.console
 
     console.log();
-//  ^^^^^^^^^^^^^ meta.function-call.method
 //  ^^^^^^^ support.type.object.console
 //         ^ punctuation.accessor
+//          ^^^^^ meta.function-call
 //          ^^^ support.function.console
 //             ^^ meta.group
 
     console.log;
-//  ^^^^^^^^^^^ - meta.function-call
-//  ^^^^^^^ support.type.object.console
+//  ^^^^^^^ support.type.object.console - meta.function-call
 //         ^ punctuation.accessor
 //          ^^^ support.function.console
 
     console.log.toString();
-//  ^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.method - meta.function-call meta.function-call
-//  ^^^^^^^ support.type.object.console
+//  ^^^^^^^ support.type.object.console - meta.function-call
 //         ^ punctuation.accessor
 //          ^^^ support.function.console
 

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -6029,12 +6029,12 @@ h1 {
 
 <p onclick="foo(<?php echo "red" ?>)">text</p>
 //         ^ meta.attribute-with-value.event.html meta.string.html string.quoted.double.html punctuation.definition.string.begin.html - meta.interpolation
-//          ^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.event.html meta.string.html meta.interpolation.html source.js.embedded.html meta.function-call.js
+//          ^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.event.html meta.string.html meta.interpolation.html source.js.embedded.html meta.function-call
 //                                  ^ meta.attribute-with-value.event.html meta.string.html string.quoted.double.html punctuation.definition.string.end.html - meta.interpolation
 
 <p onclick='foo(<?php echo 'red' ?>)'>text</p>
 //         ^ meta.attribute-with-value.event.html meta.string.html string.quoted.single.html punctuation.definition.string.begin.html - meta.interpolation
-//          ^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.event.html meta.string.html meta.interpolation.html source.js.embedded.html meta.function-call.js
+//          ^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.event.html meta.string.html meta.interpolation.html source.js.embedded.html meta.function-call
 //                                  ^ meta.attribute-with-value.event.html meta.string.html string.quoted.single.html punctuation.definition.string.end.html - meta.interpolation
 
 <![CDATA[Text with <? $php ?> interpolation.]]>


### PR DESCRIPTION
Fix #3790.

The scope naming guidelines recommend giving e.g. all of `foo.bar.baz()` the scope `meta.function-call`. For reasons discussed in #3790 and in #2575, this is quite difficult to implement in a reliable manner. Currently, the JavaScript syntax definition tries to do this using lookaheads, but it is far from reliable, leading to observable highlighting bugs such as #3790.

This PR rips out the existing code scoping function call paths and instead just scopes the function/method identifier and arguments. This should be sufficient for any of the actual use cases discussed in the linked issues while also being much more reliable. Notes:

- It's still not *perfectly* reliable, because we're still detecting the function parens (and in TS, type arguments) via a lookahead, but at least it's a simpler lookahead. It should work well in most cases and fail gracefully in other cases.
- Originally, the JavaScript syntax scoped method calls as `meta.function-call.method`. This is not in the guidelines and no other core syntax did this, so I removed it for simplicity.
- Also, the JavaScript syntax did *not* scope the arguments list as the more specific `meta.function-call.arguments`, which is widely done, so I added that in.
- This does result in over-scoping when referring to, but not calling, a builtin method. The solution there, if we care, is probably to slightly restructure the way those support scopes work.