### PR TITLE
[CSS] Fix nested at-rules highlighting

### DIFF
--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -275,15 +275,6 @@ variables:
   counter_system_constants: |-
     \b(?xi: cyclic | numeric | alphabetic | symbolic | additive | fixed ){{break}}
 
-  # @font-face Property Names
-  # https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face
-  font_face_property_names: |-
-    \b(?xi:
-      ascent-override | descent-override | font-display | (?# font-family | ) src
-    | font-feature-settings | font-variation-settings | font-stretch | font-style
-    | font-weight | font-variant | line-gap-override | size-adjust | unicode-range
-    ){{break}}
-
   # @page Margin Names
   # https://developer.mozilla.org/en-US/docs/Web/CSS/@page
   page_margin_names: |-
@@ -291,21 +282,6 @@ variables:
       (?: bottom | top ) - (?: left-corner | left | center | right | right-corner )
     | (?: left | right ) - (?: top | middle | bottom )
     ){{break}}
-
-  # @page Property Names
-  # https://developer.mozilla.org/en-US/docs/Web/CSS/@page
-  page_property_names: |-
-    \b(?xi: bleed | margin | marks | size ){{break}}
-
-  # @property Property Names
-  # https://developer.mozilla.org/en-US/docs/Web/CSS/@property
-  property_property_names: |-
-    \b(?xi: syntax | inherits | initial-value ){{break}}
-
-  # @scroll-timeline Property Names
-  # https://developer.mozilla.org/en-US/docs/Web/CSS/@scroll-timeline
-  scroll_timeline_property_names: |-
-    \b(?xi: source | orientation | scroll-offsets ){{break}}
 
   global_property_constants:  |-
     \b(?xi: inherit | initial | revert | revert-layer | unset ){{break}}
@@ -644,29 +620,14 @@ contexts:
       scope: keyword.control.directive.css
       captures:
         1: punctuation.definition.keyword.css
-      push: at-font-face-body
+      push:
+        - at-font-face-meta
+        - maybe-property-list
 
-  at-font-face-body:
+  at-font-face-meta:
+    - meta_include_prototype: false
     - meta_scope: meta.at-rule.font-face.css
-    - match: \{
-      scope: punctuation.section.block.begin.css
-      push: at-font-face-block-body
-    - include: at-rule-end
-
-  at-font-face-block-body:
-    - meta_scope: meta.property-list.css meta.block.css
-    - include: block-end2
-    - include: comments
-    - include: font-family-properties
-    - include: at-font-face-property-names
-    - include: property-values
-    - include: rule-terminators
-    - include: illegal-blocks
-    - include: illegal-groups
-
-  at-font-face-property-names:
-    - match: '{{font_face_property_names}}'
-      scope: meta.property-name.css support.type.property-name.css
+    - include: immediately-pop
 
 ###[ IMPORT AT-RULE ]##########################################################
 
@@ -872,16 +833,17 @@ contexts:
       scope: keyword.control.directive.css
       captures:
         1: punctuation.definition.keyword.css
-      push: at-page-body
+      push:
+        - at-page-meta
+        - maybe-property-list
+        - at-page-name-list
 
-  at-page-body:
+  at-page-meta:
+    - meta_include_prototype: false
     - meta_scope: meta.at-rule.page.css
-    - include: comma-delimiters
-    - include: at-page-block
-    - include: at-page-names
-    - include: at-rule-end
+    - include: immediately-pop
 
-  at-page-names:
+  at-page-name-list:
     - match: (:)(?i:blank|first|left|right|recto|verso){{break}}
       scope: entity.other.pseudo-class.css
       captures:
@@ -892,54 +854,27 @@ contexts:
         1: punctuation.definition.entity.css
     - match: '{{ident_begin}}'
       push: at-page-name-content
+    - include: comma-delimiters
+    - include: comments
+    - include: else-pop
 
   at-page-name-content:
     - meta_scope: entity.other.page-name.css
     - include: identifier-content
-
-  at-page-block:
-    - match: \{
-      scope: punctuation.section.block.begin.css
-      push: at-page-block-body
-
-  at-page-block-body:
-    - meta_scope: meta.property-list.css meta.block.css
-    - include: at-page-margin
-    - include: at-page-property-list-body
-    - include: at-other
 
   at-page-margin:
     - match: (@){{page_margin_names}}
       scope: keyword.control.directive.css
       captures:
         1: punctuation.definition.keyword.css
-      push: at-page-margin-body
+      push:
+        - at-page-margin-meta
+        - maybe-property-list
 
-  at-page-margin-body:
+  at-page-margin-meta:
+    - meta_include_prototype: false
     - meta_scope: meta.at-rule.margin.css
-    - include: at-page-property-lists
-    - include: at-rule-end
-
-  at-page-property-lists:
-    - match: \{
-      scope: punctuation.section.block.begin.css
-      push: at-page-property-list-body
-
-  at-page-property-list-body:
-    - meta_scope: meta.property-list.css meta.block.css
-    - include: block-end2
-    - include: comments
-    - include: at-page-property-names
-    - include: property-values
-    - include: rule-terminators
-    - include: illegal-blocks
-    - include: illegal-groups
-
-  at-page-property-names:
-    - match: '{{page_property_names}}'
-      scope: meta.property-name.css support.type.property-name.css
-    # Note: Consume unknown identifiers to maintain word boundaries.
-    - match: '{{generic_ident}}'
+    - include: immediately-pop
 
 ###[ PROPERTY AT-RULE ]########################################################
 
@@ -951,38 +886,20 @@ contexts:
       captures:
         1: punctuation.definition.keyword.css
       push:
-        - at-property-property-list
+        - at-property-property-meta
+        - maybe-property-list
         - at-property-name
+
+  at-property-property-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.at-rule.property.css
+    - include: immediately-pop
 
   at-property-name:
     - match: '{{custom_ident_begin}}'
       set: custom-property-content
     - include: comments
     - include: else-pop
-
-  at-property-property-list:
-    - meta_scope: meta.at-rule.property.css
-    - match: \{
-      scope: punctuation.section.block.begin.css
-      push: at-property-property-list-body
-    - include: comments
-    - include: else-pop
-
-  at-property-property-list-body:
-    - meta_scope: meta.property-list.css meta.block.css
-    - include: block-end2
-    - include: comments
-    - include: at-property-property-names
-    - include: property-values
-    - include: rule-terminators
-    - include: illegal-blocks
-    - include: illegal-groups
-
-  at-property-property-names:
-    - match: '{{property_property_names}}'
-      scope: meta.property-name.css support.type.property-name.css
-    # Note: Consume unknown identifiers to maintain word boundaries.
-    - match: '{{generic_ident}}'
 
 ###[ SCROLL-TIMELINE AT-RULE ]#################################################
 
@@ -994,8 +911,14 @@ contexts:
       captures:
         1: punctuation.definition.keyword.css
       push:
-        - at-scroll-timeline-property-list
+        - at-scroll-timeline-meta
+        - maybe-property-list
         - at-scroll-timeline-name
+
+  at-scroll-timeline-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.at-rule.scroll-timeline.css
+    - include: immediately-pop
 
   at-scroll-timeline-name:
     - meta_include_prototype: false
@@ -1007,30 +930,6 @@ contexts:
   at-scroll-timeline-name-content:
     - meta_scope: entity.other.scroll-timeline.css
     - include: identifier-content
-
-  at-scroll-timeline-property-list:
-    - meta_scope: meta.at-rule.scroll-timeline.css
-    - match: \{
-      scope: punctuation.section.block.begin.css
-      push: at-scroll-timeline-property-list-body
-    - include: comments
-    - include: else-pop
-
-  at-scroll-timeline-property-list-body:
-    - meta_scope: meta.property-list.css meta.block.css
-    - include: block-end2
-    - include: comments
-    - include: at-scroll-timeline-property-names
-    - include: property-values
-    - include: rule-terminators
-    - include: illegal-blocks
-    - include: illegal-groups
-
-  at-scroll-timeline-property-names:
-    - match: '{{scroll_timeline_property_names}}'
-      scope: meta.property-name.css support.type.property-name.css
-    # Note: Consume unknown identifiers to maintain word boundaries.
-    - match: '{{generic_ident}}'
 
 ###[ SUPPORTS AT-RULE ]########################################################
 

--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -371,9 +371,9 @@ contexts:
   at-rules:
     # top-level-only
     - include: at-import
+    - include: at-document
     # with stylesheet blocks
     - include: at-container
-    - include: at-document
     - include: at-layer
     - include: at-media
     - include: at-supports
@@ -393,7 +393,6 @@ contexts:
   nested-at-rules:
     # with style-rule blocks
     - include: nested-at-container
-    - include: nested-at-document
     - include: nested-at-layer
     - include: nested-at-media
     - include: nested-at-supports
@@ -574,16 +573,6 @@ contexts:
       push:
         - at-document-meta
         - maybe-style-block
-        - at-document-query
-
-  nested-at-document:
-    - match: (@)(?i:document){{break}}
-      scope: keyword.control.directive.css
-      captures:
-        1: punctuation.definition.keyword.css
-      push:
-        - at-document-meta
-        - maybe-property-list
         - at-document-query
 
   at-document-meta:

--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -361,15 +361,8 @@ variables:
 contexts:
 
   main:
+    - meta_include_prototype: false
     - include: stylesheet
-
-  stylesheet:
-    - include: comments
-    - include: property-lists
-    - include: selectors
-    - include: at-rules
-    - include: rule-terminators
-    - include: illegal-groups
 
 ###[ COMMENTS ]################################################################
 
@@ -394,26 +387,75 @@ contexts:
       captures:
         1: punctuation.definition.comment.css
 
+###[ STYLESHEETS ]#############################################################
+
+  maybe-stylesheet-block:
+    - meta_include_prototype: false
+    - match: \{
+      scope: punctuation.section.block.begin.css
+      set: stylesheet-block-body
+    - include: comments
+    - include: else-pop
+
+  stylesheet-block-body:
+    - meta_include_prototype: false
+    - meta_scope: meta.block.css
+    - include: block-end
+    - include: stylesheet
+
+  stylesheet:
+    - include: comments
+    - include: property-lists
+    - include: selectors
+    - include: at-rules
+    - include: rule-terminators
+    - include: illegal-groups
+
 ###[ AT RULES ]################################################################
 
   at-rules:
-    - include: at-charset
-    - include: at-container
-    - include: at-counter-style
-    - include: at-custom-media
-    - include: at-document
-    - include: at-font-face
+    # top-level-only
     - include: at-import
-    - include: at-keyframes
+    # with stylesheet blocks
+    - include: at-container
+    - include: at-document
     - include: at-layer
     - include: at-media
+    - include: at-supports
+    # common
+    - include: at-charset
+    - include: at-counter-style
+    - include: at-custom-media
+    - include: at-font-face
+    - include: at-keyframes
     - include: at-namespace
     - include: at-page
     - include: at-page-margin
     - include: at-property
     - include: at-scroll-timeline
-    - include: at-supports
     - include: at-other
+
+  nested-at-rules:
+    # with style-rule blocks
+    - include: nested-at-container
+    - include: nested-at-document
+    - include: nested-at-layer
+    - include: nested-at-media
+    - include: nested-at-supports
+    # common
+    - include: at-charset
+    - include: at-counter-style
+    - include: at-custom-media
+    - include: at-font-face
+    - include: at-keyframes
+    - include: at-namespace
+    - include: at-page
+    - include: at-page-margin
+    - include: at-property
+    - include: at-scroll-timeline
+    - include: at-other
+
+###[ CHARSET AT-RULE ]#########################################################
 
   # @charset
   # https://www.w3.org/TR/css-syntax-3/#at-ruledef-charset
@@ -422,12 +464,20 @@ contexts:
       scope: keyword.control.directive.css
       captures:
         1: punctuation.definition.keyword.css
-      push: at-charset-body
+      push:
+        - at-charset-meta
+        - at-charset-body
+
+  at-charset-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.at-rule.charset.css
+    - include: immediately-pop
 
   at-charset-body:
-    - meta_scope: meta.at-rule.charset.css
-    - include: quoted-strings
-    - include: at-rule-end
+    - include: quoted-string
+    - include: else-pop
+
+###[ CONTAINER AT-RULE ]#######################################################
 
   # @container
   # https://drafts.csswg.org/css-contain-3/#container-rule
@@ -437,8 +487,26 @@ contexts:
       captures:
         1: punctuation.definition.keyword.css
       push:
-        - at-container-body
+        - at-container-meta
+        - maybe-stylesheet-block
+        - container-query
         - at-container-identifier
+
+  nested-at-container:
+    - match: (@)(?i:container){{break}}
+      scope: keyword.control.directive.css
+      captures:
+        1: punctuation.definition.keyword.css
+      push:
+        - at-container-meta
+        - maybe-property-list
+        - container-query
+        - at-container-identifier
+
+  at-container-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.at-rule.container.css
+    - include: immediately-pop
 
   at-container-identifier:
     - meta_include_prototype: false
@@ -453,11 +521,7 @@ contexts:
     - meta_scope: entity.other.container.css
     - include: identifier-content
 
-  at-container-body:
-    - meta_scope: meta.at-rule.container.css
-    - include: at-rule-block
-    - include: container-queries
-    - include: else-pop
+###[ COUNTER STYLE AT-RULE ]###################################################
 
   # @counter-style
   # https://drafts.csswg.org/css-counter-styles-3/#the-counter-style-rule
@@ -475,7 +539,8 @@ contexts:
       scope: punctuation.section.block.begin.css
       push: at-counter-style-block-body
     - include: at-counter-style-names
-    - include: at-rule-end
+    - include: comments
+    - include: else-pop
 
   at-counter-style-block-body:
     - meta_scope: meta.property-list.css meta.block.css
@@ -504,6 +569,8 @@ contexts:
     - match: '{{counter_style_property_names}}'
       scope: meta.property-name.css support.type.property-name.css
 
+###[ CUSTOM MEDIA AT-RULE ]####################################################
+
   # @custom-media
   # https://??
   at-custom-media:
@@ -528,8 +595,9 @@ contexts:
 
   at-custom-media-body:
     - meta_scope: meta.at-rule.custom-media.css
-    - include: media-queries
-    - include: at-rule-end
+    - include: media-query-list
+
+###[ DOCUMENT AT-RULE ]########################################################
 
   # @document
   # https://www.w3.org/TR/2012/WD-css3-conditional-20120911/#at-document
@@ -538,17 +606,36 @@ contexts:
       scope: keyword.control.directive.css
       captures:
         1: punctuation.definition.keyword.css
-      push: at-document-body
+      push:
+        - at-document-meta
+        - maybe-stylesheet-block
+        - at-document-query
 
-  at-document-body:
+  nested-at-document:
+    - match: (@)(?i:document){{break}}
+      scope: keyword.control.directive.css
+      captures:
+        1: punctuation.definition.keyword.css
+      push:
+        - at-document-meta
+        - maybe-property-list
+        - at-document-query
+
+  at-document-meta:
+    - meta_include_prototype: false
     - meta_scope: meta.at-rule.document.css
-    - include: comma-delimiters
+    - include: immediately-pop
+
+  at-document-query:
     - include: url-functions
     - include: url-domain-functions
     - include: url-prefix-functions
     - include: url-regexp-functions
-    - include: at-rule-block
-    - include: at-rule-end
+    - include: comma-delimiters
+    - include: comments
+    - include: else-pop
+
+###[ FONT FACE AT-RULE ]#######################################################
 
   # @font-face
   # https://www.w3.org/TR/css-fonts-4/#at-font-face-rule
@@ -581,6 +668,8 @@ contexts:
     - match: '{{font_face_property_names}}'
       scope: meta.property-name.css support.type.property-name.css
 
+###[ IMPORT AT-RULE ]##########################################################
+
   # @import
   # https://www.w3.org/TR/css-cascade-4/#at-ruledef-import
   # https://developer.mozilla.org/en-US/docs/Web/CSS/@import
@@ -589,16 +678,23 @@ contexts:
       scope: keyword.control.directive.css
       captures:
         1: punctuation.definition.keyword.css
-      push: at-import-body
+      push:
+        - at-import-media-query
+        - at-import-body
 
   at-import-body:
-    - meta_scope: meta.at-rule.import.css
     - include: quoted-strings
     - include: url-functions
-    - include: media-queries
     - include: layer-functions
     - include: supports-functions
-    - include: at-rule-end
+    - include: comments
+    - include: else-pop
+
+  at-import-media-query:
+    - meta_scope: meta.at-rule.import.css
+    - include: media-query-list
+
+###[ KEYFRAMES AT-RULE ]#######################################################
 
   # @keyframes
   # https://www.w3.org/TR/css3-animations/#at-ruledef-keyframes
@@ -610,32 +706,29 @@ contexts:
       push: at-keyframe-body
 
   at-keyframe-body:
+    - meta_include_prototype: false
     - meta_scope: meta.at-rule.keyframe.css
-    - include: comma-delimiters
-    - include: at-keyframe-block
+    - match: \{
+      scope: punctuation.section.block.begin.css
+      push: at-keyframe-block-body
     - include: at-keyframe-names
-    - include: at-rule-end
+    - include: comma-delimiters
+    - include: comments
+    - include: else-pop
 
   at-keyframe-names:
-    - meta_include_prototype: false
     - match: '{{illegal_custom_ident}}'
       scope: invalid.illegal.identifier.css
     - match: '{{ident_begin}}'
       push: at-keyframe-name-content
     - include: quoted-strings
-    - include: comments
-    - include: else-pop
 
   at-keyframe-name-content:
     - meta_scope: entity.other.animation-name.css
     - include: identifier-content
 
-  at-keyframe-block:
-    - match: \{
-      scope: punctuation.section.block.begin.css
-      push: at-keyframe-block-body
-
   at-keyframe-block-body:
+    - meta_include_prototype: false
     - meta_scope: meta.block.css
     - include: block-end2
     - include: comments
@@ -655,6 +748,8 @@ contexts:
     - match: \b(?i:from|to){{break}}
       scope: keyword.other.selector.css
 
+###[ LAYER AT-RULE ]###########################################################
+
   # @layer
   # https://developer.mozilla.org/en-US/docs/Web/CSS/@layer
   at-layer:
@@ -662,14 +757,31 @@ contexts:
       scope: keyword.control.directive.css
       captures:
         1: punctuation.definition.keyword.css
-      push: at-layer-body
+      push:
+        - at-layer-meta
+        - maybe-stylesheet-block
+        - at-layer-name-list
 
-  at-layer-body:
+  nested-at-layer:
+    - match: (@)(?i:layer){{break}}
+      scope: keyword.control.directive.css
+      captures:
+        1: punctuation.definition.keyword.css
+      push:
+        - at-layer-meta
+        - maybe-property-list
+        - at-layer-name-list
+
+  at-layer-meta:
+    - meta_include_prototype: false
     - meta_scope: meta.at-rule.layer.css
-    - include: comma-delimiters
+    - include: immediately-pop
+
+  at-layer-name-list:
     - include: at-layer-names
-    - include: at-rule-block
-    - include: at-rule-end
+    - include: comma-delimiters
+    - include: comments
+    - include: else-pop
 
   at-layer-names:
     - match: '{{ident_begin}}'
@@ -693,6 +805,8 @@ contexts:
       push: clear-pop
     - include: identifier-content
 
+###[ MEDIA AT-RULE ]###########################################################
+
   # @media
   # https://drafts.csswg.org/css-conditional-3/#at-ruledef-media
   at-media:
@@ -700,13 +814,27 @@ contexts:
       scope: keyword.control.directive.css
       captures:
         1: punctuation.definition.keyword.css
-      push: at-media-body
+      push:
+        - at-media-meta
+        - maybe-stylesheet-block
+        - media-query-list
 
-  at-media-body:
+  nested-at-media:
+    - match: (@)(?i:media){{break}}
+      scope: keyword.control.directive.css
+      captures:
+        1: punctuation.definition.keyword.css
+      push:
+        - at-media-meta
+        - maybe-property-list
+        - media-query-list
+
+  at-media-meta:
+    - meta_include_prototype: false
     - meta_scope: meta.at-rule.media.css
-    - include: media-queries
-    - include: at-rule-block
-    - include: at-rule-end
+    - include: immediately-pop
+
+###[ NAMESPACE AT-RULE ]#######################################################
 
   # @namespace
   # https://www.w3.org/TR/css3-namespace/
@@ -731,7 +859,10 @@ contexts:
     - include: var-functions
     - include: url-functions
     - include: quoted-urls
-    - include: at-rule-end
+    - include: comments
+    - include: else-pop
+
+###[ PAGE AT-RULE ]############################################################
 
   # @page
   # https://www.w3.org/TR/css3-page/#at-ruledef-page
@@ -810,6 +941,8 @@ contexts:
     # Note: Consume unknown identifiers to maintain word boundaries.
     - match: '{{generic_ident}}'
 
+###[ PROPERTY AT-RULE ]########################################################
+
   # @property Property Names
   # https://developer.mozilla.org/en-US/docs/Web/CSS/@property
   at-property:
@@ -850,6 +983,8 @@ contexts:
       scope: meta.property-name.css support.type.property-name.css
     # Note: Consume unknown identifiers to maintain word boundaries.
     - match: '{{generic_ident}}'
+
+###[ SCROLL-TIMELINE AT-RULE ]#################################################
 
   # @scroll-timeline
   # https://developer.mozilla.org/en-US/docs/Web/CSS/@scroll-timeline
@@ -897,6 +1032,8 @@ contexts:
     # Note: Consume unknown identifiers to maintain word boundaries.
     - match: '{{generic_ident}}'
 
+###[ SUPPORTS AT-RULE ]########################################################
+
   # @supports
   # https://drafts.csswg.org/css-conditional-3/#at-supports
   at-supports:
@@ -904,16 +1041,33 @@ contexts:
       scope: keyword.control.directive.css
       captures:
         1: punctuation.definition.keyword.css
-      push: at-supports-body
+      push:
+        - at-supports-meta
+        - maybe-stylesheet-block
+        - at-supports-query
 
-  at-supports-body:
+  nested-at-supports:
+    - match: (@)(?i:supports){{break}}
+      scope: keyword.control.directive.css
+      captures:
+        1: punctuation.definition.keyword.css
+      push:
+        - at-supports-meta
+        - maybe-property-list
+        - at-supports-query
+
+  at-supports-meta:
+    - meta_include_prototype: false
     - meta_scope: meta.at-rule.supports.css
+    - include: immediately-pop
+
+  at-supports-query:
     - include: at-supports-groups
     - include: logical-operators
     - include: font-format-functions
     - include: selector-functions
-    - include: at-rule-block
-    - include: at-rule-end
+    - include: comments
+    - include: else-pop
 
   at-supports-groups:
     - match: \(
@@ -924,12 +1078,15 @@ contexts:
     - meta_include_prototype: false
     - meta_scope: meta.group.css
     - include: group-end
-    - include: at-rule-end
     - include: at-supports-groups
     - include: logical-operators
     - include: font-format-functions
     - include: selector-functions
     - include: rule-list-body
+    - include: comments
+    - include: else-pop
+
+###[ OTHER AT-RULE ]###########################################################
 
   # @<ident>
   # Fallback context for incomplete or unknown at-rules.
@@ -950,25 +1107,15 @@ contexts:
     - meta_scope: meta.block.css
     - include: block-end2
 
-  at-rule-block:
-    - match: \{
-      scope: punctuation.section.block.begin.css
-      push: at-rule-block-body
-
-  at-rule-block-body:
-    - meta_scope: meta.block.css
-    - include: block-end2
-    - include: stylesheet
-
   at-rule-end:
-    - match: (?=[;{}])
+    - match: (?=[;{}@])
       pop: 1
     - include: comments
 
 ###[ CONTAINER QUERIES ]#######################################################
 
   # https://drafts.csswg.org/css-contain-3/#container-rule
-  container-queries:
+  container-query:
     - match: \(
       scope: punctuation.section.group.begin.css
       push: container-query-group-body
@@ -978,12 +1125,12 @@ contexts:
     - include: container-style-functions
     - include: property-identifiers
     - include: property-values
+    - include: else-pop
 
   container-query-group-body:
     - meta_scope: meta.group.css
     - include: group-end
-    - include: container-queries
-    - include: else-pop
+    - include: container-query
 
   container-style-functions:
     - match: \b(?i:style)(?=\()
@@ -1015,15 +1162,17 @@ contexts:
 ###[ MEDIA QUERIES ]###########################################################
 
   # https://drafts.csswg.org/mediaqueries-4/#media
-  media-queries:
+  media-query-list:
     - include: comma-delimiters
     - include: media-query-conditions
     - include: media-query-media-types
+    - include: else-pop
 
   media-query-conditions:
     - match: \(
       scope: punctuation.section.group.begin.css
       push: media-query-group-body
+    - include: comments
     - include: comparison-operators
     - include: logical-operators
 
@@ -1032,7 +1181,6 @@ contexts:
     - match: (?=[,;{}])
       pop: 1
     - include: group-end
-    - include: comments
     - include: media-query-conditions
     - include: media-query-property-names
     - include: media-query-property-values
@@ -1446,6 +1594,14 @@ contexts:
 
 ###[ PROPERTY LISTS ]##########################################################
 
+  maybe-property-list:
+    - meta_include_prototype: false
+    - match: \{
+      scope: punctuation.section.block.begin.css
+      set: property-list-body
+    - include: comments
+    - include: else-pop
+
   property-lists:
     - match: \{
       scope: punctuation.section.block.begin.css
@@ -1459,7 +1615,7 @@ contexts:
     - include: property-lists
     - include: property-identifiers
     - include: nested-selectors
-    - include: at-rules
+    - include: nested-at-rules
     - include: rule-terminators
     - include: illegal-groups
 

--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -334,6 +334,15 @@ contexts:
     - meta_include_prototype: false
     - include: stylesheet
 
+  stylesheet:
+    - include: comments
+    - include: property-lists
+    - include: selectors
+    - include: at-rules
+    - include: rule-terminators
+    - include: illegal-commas
+    - include: illegal-groups
+
 ###[ COMMENTS ]################################################################
 
   comments:
@@ -356,31 +365,6 @@ contexts:
     - match: ^\s*(\*)(?!/)
       captures:
         1: punctuation.definition.comment.css
-
-###[ STYLESHEETS ]#############################################################
-
-  maybe-stylesheet-block:
-    - meta_include_prototype: false
-    - match: \{
-      scope: punctuation.section.block.begin.css
-      set: stylesheet-block-body
-    - include: comments
-    - include: else-pop
-
-  stylesheet-block-body:
-    - meta_include_prototype: false
-    - meta_scope: meta.block.css
-    - include: block-end
-    - include: stylesheet
-
-  stylesheet:
-    - include: comments
-    - include: property-lists
-    - include: selectors
-    - include: at-rules
-    - include: rule-terminators
-    - include: illegal-commas
-    - include: illegal-groups
 
 ###[ AT RULES ]################################################################
 
@@ -459,7 +443,7 @@ contexts:
         1: punctuation.definition.keyword.css
       push:
         - at-container-meta
-        - maybe-stylesheet-block
+        - maybe-style-block
         - container-query
         - at-container-identifier
 
@@ -589,7 +573,7 @@ contexts:
         1: punctuation.definition.keyword.css
       push:
         - at-document-meta
-        - maybe-stylesheet-block
+        - maybe-style-block
         - at-document-query
 
   nested-at-document:
@@ -737,7 +721,7 @@ contexts:
         1: punctuation.definition.keyword.css
       push:
         - at-layer-meta
-        - maybe-stylesheet-block
+        - maybe-style-block
         - at-layer-name-list
 
   nested-at-layer:
@@ -795,7 +779,7 @@ contexts:
         1: punctuation.definition.keyword.css
       push:
         - at-media-meta
-        - maybe-stylesheet-block
+        - maybe-style-block
         - media-query-list
 
   nested-at-media:
@@ -960,7 +944,7 @@ contexts:
         1: punctuation.definition.keyword.css
       push:
         - at-supports-meta
-        - maybe-stylesheet-block
+        - maybe-style-block
         - at-supports-query
 
   nested-at-supports:
@@ -1508,6 +1492,24 @@ contexts:
     - match: (?=\()
       fail: pseudo-element
     - include: identifier-content
+
+###[ STYLE BLOCKS ]############################################################
+
+  maybe-style-block:
+    # https://www.w3.org/TR/css-syntax-3/#declaration-rule-list
+    # https://www.w3.org/TR/css-syntax-3/#typedef-style-block
+    - meta_include_prototype: false
+    - match: \{
+      scope: punctuation.section.block.begin.css
+      set: style-block-body
+    - include: comments
+    - include: else-pop
+
+  style-block-body:
+    - meta_include_prototype: false
+    - meta_scope: meta.block.css
+    - include: block-end
+    - include: stylesheet
 
 ###[ PROPERTY LISTS ]##########################################################
 

--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -88,6 +88,8 @@ variables:
   nested_selector_begin: (?={{nested_selector_start}})
   nested_selector_start: '[.:#&*\[{{combinator_char}}]'
 
+  keyframe_selector_begin: (?=\b(?i:from|to){{break}}|\.?[\d,%])
+
   # Combinators
   # https://drafts.csswg.org/selectors-4/#combinators
   combinators: (?:>{1,3}|[~+]|\|{2})
@@ -385,6 +387,7 @@ contexts:
     - include: selectors
     - include: at-rules
     - include: rule-terminators
+    - include: illegal-commas
     - include: illegal-groups
 
 ###[ AT RULES ]################################################################
@@ -664,40 +667,52 @@ contexts:
       scope: keyword.control.directive.css
       captures:
         1: punctuation.definition.keyword.css
-      push: at-keyframe-body
+      push:
+        - at-keyframe-meta
+        - at-keyframe-block
+        - at-keyframe-identifier
 
-  at-keyframe-body:
+  at-keyframe-meta:
     - meta_include_prototype: false
     - meta_scope: meta.at-rule.keyframe.css
-    - match: \{
-      scope: punctuation.section.block.begin.css
-      push: at-keyframe-block-body
-    - include: at-keyframe-names
-    - include: comma-delimiters
+    - include: immediately-pop
+
+  at-keyframe-identifier:
+    - meta_include_prototype: false
+    - match: '{{illegal_custom_ident}}'
+      scope: invalid.illegal.identifier.css
+      pop: 1
+    - match: '{{ident_begin}}'
+      set: at-keyframe-identifier-content
+    - include: quoted-string
     - include: comments
     - include: else-pop
 
-  at-keyframe-names:
-    - match: '{{illegal_custom_ident}}'
-      scope: invalid.illegal.identifier.css
-    - match: '{{ident_begin}}'
-      push: at-keyframe-name-content
-    - include: quoted-strings
-
-  at-keyframe-name-content:
+  at-keyframe-identifier-content:
     - meta_scope: entity.other.animation-name.css
     - include: identifier-content
+
+  at-keyframe-block:
+    - meta_include_prototype: false
+    - match: \{
+      scope: punctuation.section.block.begin.css
+      set: at-keyframe-block-body
+    - include: comments
+    - include: else-pop
 
   at-keyframe-block-body:
     - meta_include_prototype: false
     - meta_scope: meta.block.css
-    - include: block-end2
+    - include: block-end
     - include: comments
     - include: property-lists
     - include: at-keyframe-selectors
+    - include: rule-terminators
+    - include: illegal-commas
+    - include: illegal-groups
 
   at-keyframe-selectors:
-    - match: (?=[[:alnum:].,%])
+    - match: '{{keyframe_selector_begin}}'
       push: at-keyframe-selector-body
 
   at-keyframe-selector-body:
@@ -706,7 +721,7 @@ contexts:
     - include: comments
     - include: comma-delimiters
     - include: percentage-constants
-    - match: \b(?i:from|to){{break}}
+    - match: (?i:from|to){{break}}
       scope: keyword.other.selector.css
 
 ###[ LAYER AT-RULE ]###########################################################
@@ -739,6 +754,7 @@ contexts:
     - include: immediately-pop
 
   at-layer-name-list:
+    - meta_include_prototype: false
     - include: at-layer-names
     - include: comma-delimiters
     - include: comments
@@ -1516,6 +1532,7 @@ contexts:
     - include: nested-selectors
     - include: nested-at-rules
     - include: rule-terminators
+    - include: illegal-commas
     - include: illegal-groups
 
   rule-list-body:
@@ -1525,6 +1542,7 @@ contexts:
     - include: property-identifiers
     - include: property-values
     - include: rule-terminators
+    - include: illegal-commas
     - include: illegal-blocks
     - include: illegal-groups
 
@@ -3424,6 +3442,10 @@ contexts:
   rule-terminators:
     - match: ;
       scope: punctuation.terminator.rule.css
+
+  illegal-commas:
+    - match: ','
+      scope: invalid.illegal.unexpected-token.css
 
   illegal-blocks:
     # https://www.w3.org/TR/CSS22/syndata.html#parsing-errors

--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -259,14 +259,6 @@ variables:
     | upper-alpha | upper-armenian | upper-latin | upper-roman
     ){{break}}
 
-  # @counter-style Property Names
-  # https://developer.mozilla.org/en-US/docs/Web/CSS/@counter-style
-  counter_style_property_names: |-
-    \b(?xi:
-      additive-symbols | negative | pad | prefix | range
-    | suffix | symbols (?# | fallback | speak-as | system )
-    ){{break}}
-
   # Predefined Counter Speak As Property Constants
   # https://drafts.csswg.org/css-counter-styles-3/#counter-style-speak-as
   counter_speak_as_constants: |-
@@ -509,44 +501,54 @@ contexts:
       scope: keyword.control.directive.css
       captures:
         1: punctuation.definition.keyword.css
-      push: at-counter-style-body
+      push:
+        - at-counter-style-meta
+        - at-counter-style-declaration-list
+        - at-counter-style-identifier
 
-  at-counter-style-body:
+  at-counter-style-meta:
     - meta_include_prototype: false
     - meta_scope: meta.at-rule.counter-style.css
-    - match: \{
-      scope: punctuation.section.block.begin.css
-      push: at-counter-style-block-body
-    - include: at-counter-style-names
+    - include: immediately-pop
+
+  at-counter-style-identifier:
+    - meta_include_prototype: false
+    - match: '{{counter_style_illegal_names}}'
+      scope: invalid.illegal.identifier.css
+      pop: 1
+    - match: '{{generic_ident_begin}}'
+      set: at-counter-style-identifier-content
     - include: comments
     - include: else-pop
 
-  at-counter-style-block-body:
-    - meta_scope: meta.property-list.css meta.block.css
-    - include: block-end2
-    - include: comments
-    - include: at-counter-style-property-names
-    - include: property-values
-    - include: rule-terminators
-    - include: illegal-blocks
-    - include: illegal-groups
-
-  at-counter-style-names:
-    - match: '{{counter_style_illegal_names}}'
-      scope: invalid.illegal.identifier.css
-    - match: '{{generic_ident_begin}}'
-      push: at-counter-style-name-content
-
-  at-counter-style-name-content:
+  at-counter-style-identifier-content:
     - meta_scope: entity.other.counter-style-name.css
     - include: identifier-content
 
-  at-counter-style-property-names:
+  at-counter-style-declaration-list:
+    # https://www.w3.org/TR/css-syntax-3/#typedef-declaration-list
+    - meta_include_prototype: false
+    - match: \{
+      scope: punctuation.section.block.begin.css
+      set: at-counter-style-declaration-list-body
+    - include: comments
+    - include: else-pop
+
+  at-counter-style-declaration-list-body:
+    - meta_include_prototype: false
+    - meta_scope: meta.property-list.css meta.block.css
+    - include: block-end
+    - include: comments
     - include: counter-style-fallback-properties
     - include: counter-style-system-properties
     - include: counter-style-speak-as-properties
-    - match: '{{counter_style_property_names}}'
-      scope: meta.property-name.css support.type.property-name.css
+    - include: property-identifiers
+    - include: property-values
+    - include: nested-at-rules
+    - include: rule-terminators
+    - include: illegal-commas
+    - include: illegal-blocks
+    - include: illegal-groups
 
 ###[ CUSTOM MEDIA AT-RULE ]####################################################
 

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -679,6 +679,77 @@
 /*                                                                                                                               ^^^^ comment.block.css */
 /*                                                                                                                                      ^^^^ comment.block.css */
 
+    @container name { table {}; > span { font-size: 1.25rem; }; color: red }
+/*  ^^^^^^^^^^^^^^^^ meta.at-rule.container.css - meta.block - meta.group */
+/*                  ^^ meta.at-rule.container.css meta.block.css - meta.selector */
+/*                    ^^^^^^ meta.at-rule.container.css meta.block.css meta.selector.css */
+/*                          ^^ meta.at-rule.container.css meta.block.css meta.property-list.css meta.block.css */
+/*                            ^^ meta.at-rule.container.css meta.block.css - meta.selector */
+/*                              ^^^^^^^ meta.at-rule.container.css meta.block.css meta.selector.css */
+/*                                     ^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.container.css meta.block.css meta.property-list.css meta.block.css */
+/*                                                            ^^ meta.at-rule.container.css meta.block.css - meta.selector */
+/*                                                              ^^^^^^^^^^^ meta.at-rule.container.css meta.block.css meta.selector.css */
+/*                                                                         ^ meta.at-rule.container.css meta.block.css - meta.selector */
+/*                                                                          ^ - meta.at-rule */
+/*  ^ keyword.control.directive.css punctuation.definition.keyword.css */
+/*   ^^^^^^^^^ keyword.control.directive.css - punctuation */
+/*             ^^^^ entity.other.container.css*/
+/*                  ^ punctuation.section.block.begin.css */
+/*                    ^^^^^ entity.name.tag.html.css */
+/*                          ^ punctuation.section.block.begin.css */
+/*                           ^ punctuation.section.block.end.css */
+/*                            ^ punctuation.terminator.rule.css */
+/*                              ^ keyword.operator.combinator.css */
+/*                                ^^^^ entity.name.tag.html.css */
+/*                                     ^ punctuation.section.block.begin.css */
+/*                                       ^^^^^^^^^ support.type.property-name.css */
+/*                                                ^ punctuation.separator.key-value.css */
+/*                                                  ^^^^^^^ meta.number.float.decimal.css */
+/*                                                         ^ punctuation.terminator.rule.css */
+/*                                                           ^ punctuation.section.block.end.css */
+/*                                                            ^ punctuation.terminator.rule.css */
+/*                                                              ^^^^^ entity.name.tag.other.css - support.property-name */
+/*                                                                   ^ punctuation.definition.pseudo-class.css */
+/*                                                                     ^^^ entity.name.tag.other.css - support - constant */
+/*                                                                         ^ punctuation.section.block.end.css */
+
+    .test-nested-container { @container name { table {}; > span { font-size: 1.25rem; }; color: red } }
+/*                         ^^ meta.property-list.css meta.block.css - meta.at-rule */
+/*                           ^^^^^^^^^^^^^^^^ meta.property-list.css meta.block.css meta.at-rule.container.css - meta.group - meta.block meta.block */
+/*                                           ^^ meta.property-list.css meta.block.css meta.at-rule.container.css meta.block.css - meta.block.css meta.block.css meta.block.css - meta.sepector */
+/*                                             ^^^^^^ meta.property-list.css meta.block.css meta.at-rule.container.css meta.property-list.css meta.block.css - meta.selector */
+/*                                                   ^^ meta.property-list.css meta.block.css meta.at-rule.container.css meta.property-list.css meta.block.css meta.property-list.css meta.block.css */
+/*                                                     ^^ meta.property-list.css meta.block.css meta.at-rule.container.css meta.property-list.css meta.block.css - meta.selector */
+/*                                                       ^^^^^^^ meta.property-list.css meta.block.css meta.at-rule.container.css meta.property-list.css meta.block.css meta.selector.css */
+/*                                                              ^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.css meta.block.css meta.at-rule.container.css meta.block.css meta.property-list.css meta.block.css */
+/*                                                                                     ^^ meta.property-list.css meta.block.css meta.at-rule.container.css meta.block.css - meta.block.css meta.block.css meta.block.css - meta.property-name */
+/*                                                                                       ^^^^^ meta.property-list.css meta.block.css meta.at-rule.container.css meta.property-list.css meta.block.css meta.property-name.css */
+/*                                                                                            ^ meta.property-list.css meta.block.css meta.at-rule.container.css meta.property-list.css meta.block.css - meta.property-name - meta.property-value */
+/*                                                                                              ^^^ meta.property-list.css meta.block.css meta.at-rule.container.css meta.property-list.css meta.block.css meta.property-value.css */
+/*                                                                                                   ^^ meta.property-list.css meta.block.css - meta.at-rule */
+/*                                                                                                     ^ - meta.property-list - meta.block */
+/*                           ^^^^^^^^^^ keyword.control.directive.css */
+/*                                      ^^^^ entity.other.container.css */
+/*                                           ^ punctuation.section.block.begin.css */
+/*                                             ^^^^^ support.type.property-name.css - entity.name.tag */
+/*                                                   ^ punctuation.section.block.begin.css */
+/*                                                    ^ punctuation.section.block.end.css */
+/*                                                     ^ punctuation.terminator.rule.css */
+/*                                                       ^ keyword.operator.combinator.css */
+/*                                                         ^^^^ entity.name.tag.html.css */
+/*                                                              ^ punctuation.section.block.begin.css */
+/*                                                                ^^^^^^^^^ support.type.property-name.css */
+/*                                                                         ^ punctuation.separator.key-value.css */
+/*                                                                           ^^^^^^^ meta.number.float.decimal.css */
+/*                                                                                  ^ punctuation.terminator.rule.css */
+/*                                                                                    ^ punctuation.section.block.end.css */
+/*                                                                                     ^ punctuation.terminator.rule.css */
+/*                                                                                       ^^^^^ support.type.property-name.css */
+/*                                                                                            ^ punctuation.separator.key-value.css */
+/*                                                                                              ^^^ support.constant.color.w3c.standard.css */
+/*                                                                                                  ^ punctuation.section.block.end.css */
+/*                                                                                                    ^ punctuation.section.block.end.css */
+
     @media onlyℜ screenℜ screen\211C {}
 /*  ^^^^^^^ meta.at-rule.media.css - meta.block */
 /*         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.at-rule  */
@@ -848,12 +919,22 @@
 /*   ^ meta.at-rule.media.css meta.block.css punctuation.section.block.end.css */
 /*    ^ - meta.at-rule - meta.block */
 
-    @media only screen and (width <= 100px or (height > 20px));
+    @media only screen and (width <= 100px or (height > 20px)) { table {}; > span { font-size: 1.25rem; }; color: red }
 /*  ^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.media.css - meta.group */
 /*                         ^^^^^^^^^^^^^^^^^^^ meta.at-rule.media.css meta.group.css - meta.group meta.group */
 /*                                            ^^^^^^^^^^^^^^^ meta.at-rule.media.css meta.group.css meta.group.css */
 /*                                                           ^ meta.at-rule.media.css meta.group.css - meta.group meta.group */
-/*                                                            ^ - meta.at-rule */
+/*                                                            ^ meta.at-rule.media.css - meta.block - meta.group */
+/*                                                             ^^ meta.at-rule.media.css meta.block.css - meta.selector */
+/*                                                               ^^^^^^ meta.at-rule.media.css meta.block.css meta.selector.css */
+/*                                                                     ^^ meta.at-rule.media.css meta.block.css meta.property-list.css meta.block.css */
+/*                                                                       ^^ meta.at-rule.media.css meta.block.css - meta.selector */
+/*                                                                         ^^^^^^^ meta.at-rule.media.css meta.block.css meta.selector.css */
+/*                                                                                ^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.media.css meta.block.css meta.property-list.css meta.block.css */
+/*                                                                                                       ^^ meta.at-rule.media.css meta.block.css - meta.selector */
+/*                                                                                                         ^^^^^^^^^^^ meta.at-rule.media.css meta.block.css meta.selector.css */
+/*                                                                                                                    ^ meta.at-rule.media.css meta.block.css - meta.selector */
+/*                                                                                                                     ^ - meta.at-rule */
 /*  ^ keyword.control.directive.css punctuation.definition.keyword.css */
 /*   ^^^^^ keyword.control.directive.css - punctuation */
 /*         ^^^^ keyword.operator.logical.css */
@@ -869,17 +950,67 @@
 /*                                                    ^ keyword.operator.comparison.css */
 /*                                                      ^^^^ meta.number.integer.decimal.css */
 /*                                                          ^^ punctuation.section.group.end.css */
-/*                                                            ^ punctuation.terminator.rule.css */
+/*                                                             ^ punctuation.section.block.begin.css */
+/*                                                               ^^^^^ entity.name.tag.html.css */
+/*                                                                     ^ punctuation.section.block.begin.css */
+/*                                                                      ^ punctuation.section.block.end.css */
+/*                                                                       ^ punctuation.terminator.rule.css */
+/*                                                                         ^ keyword.operator.combinator.css */
+/*                                                                           ^^^^ entity.name.tag.html.css */
+/*                                                                                ^ punctuation.section.block.begin.css */
+/*                                                                                  ^^^^^^^^^ support.type.property-name.css */
+/*                                                                                           ^ punctuation.separator.key-value.css */
+/*                                                                                             ^^^^^^^ meta.number.float.decimal.css */
+/*                                                                                                    ^ punctuation.terminator.rule.css */
+/*                                                                                                      ^ punctuation.section.block.end.css */
+/*                                                                                                       ^ punctuation.terminator.rule.css */
+/*                                                                                                         ^^^^^ entity.name.tag.other.css - support.property-name */
+/*                                                                                                              ^ punctuation.definition.pseudo-class.css */
+/*                                                                                                                ^^^ entity.name.tag.other.css - support - constant */
+/*                                                                                                                    ^ punctuation.section.block.end.css */
 
-    .test-nested-media { @media (width >= 1024px) { span { font-size: 1.25rem; } } }
+    .test-nested-media { @media (width >= 1024px) { table {}; > span { font-size: 1.25rem; }; color: red } }
 /*                     ^^ meta.property-list.css meta.block.css - meta.at-rule */
 /*                       ^^^^^^^ meta.property-list.css meta.block.css meta.at-rule.media.css - meta.group - meta.block meta.block */
 /*                              ^^^^^^^^^^^^^^^^^ meta.property-list.css meta.block.css meta.at-rule.media.css meta.group.css */
 /*                                               ^ meta.property-list.css meta.block.css meta.at-rule.media.css - meta.group - meta.block meta.block */
-/*                                                ^^^^^^^ meta.property-list.css meta.block.css meta.at-rule.media.css meta.block.css - meta.block.css meta.block.css meta.block.css */
-/*                                                       ^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.css meta.block.css meta.at-rule.media.css meta.block.css meta.property-list.css meta.block.css */
-/*                                                                              ^^ meta.property-list.css meta.block.css meta.at-rule.media.css meta.block.css - meta.block.css meta.block.css meta.block.css */
-/*                                                                                ^^ meta.property-list.css meta.block.css - meta.at-rule */
+/*                                                ^^ meta.property-list.css meta.block.css meta.at-rule.media.css meta.block.css - meta.block.css meta.block.css meta.block.css - meta.sepector */
+/*                                                  ^^^^^^ meta.property-list.css meta.block.css meta.at-rule.media.css meta.property-list.css meta.block.css - meta.selector */
+/*                                                        ^^ meta.property-list.css meta.block.css meta.at-rule.media.css meta.property-list.css meta.block.css meta.property-list.css meta.block.css */
+/*                                                          ^^ meta.property-list.css meta.block.css meta.at-rule.media.css meta.property-list.css meta.block.css - meta.selector */
+/*                                                            ^^^^^^^ meta.property-list.css meta.block.css meta.at-rule.media.css meta.property-list.css meta.block.css meta.selector.css */
+/*                                                                   ^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.css meta.block.css meta.at-rule.media.css meta.block.css meta.property-list.css meta.block.css */
+/*                                                                                          ^^ meta.property-list.css meta.block.css meta.at-rule.media.css meta.block.css - meta.block.css meta.block.css meta.block.css - meta.property-name */
+/*                                                                                            ^^^^^ meta.property-list.css meta.block.css meta.at-rule.media.css meta.property-list.css meta.block.css meta.property-name.css */
+/*                                                                                                 ^ meta.property-list.css meta.block.css meta.at-rule.media.css meta.property-list.css meta.block.css - meta.property-name - meta.property-value */
+/*                                                                                                   ^^^ meta.property-list.css meta.block.css meta.at-rule.media.css meta.property-list.css meta.block.css meta.property-value.css */
+/*                                                                                                        ^^ meta.property-list.css meta.block.css - meta.at-rule */
+/*                                                                                                          ^ - meta.property-list - meta.block */
+/*                       ^^^^^^ keyword.control.directive.css */
+/*                              ^ punctuation.section.group.begin.css */
+/*                               ^^^^^ support.type.property-name.css */
+/*                                     ^^ keyword.operator.comparison.css */
+/*                                        ^^^^^^ meta.number.integer.decimal.css */
+/*                                              ^ punctuation.section.group.end.css */
+/*                                                ^ punctuation.section.block.begin.css */
+/*                                                  ^^^^^ support.type.property-name.css - entity.name.tag */
+/*                                                        ^ punctuation.section.block.begin.css */
+/*                                                         ^ punctuation.section.block.end.css */
+/*                                                          ^ punctuation.terminator.rule.css */
+/*                                                            ^ keyword.operator.combinator.css */
+/*                                                              ^^^^ entity.name.tag.html.css */
+/*                                                                   ^ punctuation.section.block.begin.css */
+/*                                                                     ^^^^^^^^^ support.type.property-name.css */
+/*                                                                              ^ punctuation.separator.key-value.css */
+/*                                                                                ^^^^^^^ meta.number.float.decimal.css */
+/*                                                                                       ^ punctuation.terminator.rule.css */
+/*                                                                                         ^ punctuation.section.block.end.css */
+/*                                                                                          ^ punctuation.terminator.rule.css */
+/*                                                                                            ^^^^^ support.type.property-name.css */
+/*                                                                                                 ^ punctuation.separator.key-value.css */
+/*                                                                                                   ^^^ support.constant.color.w3c.standard.css */
+/*                                                                                                       ^ punctuation.section.block.end.css */
+/*                                                                                                         ^ punctuation.section.block.end.css */
 
     @custom-media --a-b (width: 1px);
 /*  ^^^^^^^^^^^^^^^^^^^^ meta.at-rule.custom-media.css - meta.group */
@@ -1414,7 +1545,7 @@
 /*                   ^^^^^^^ meta.property-value.css constant.other.color.rgb-value.css */
 /*                          ^ punctuation.terminator.rule.css */
 
-    /* not a supported prototype, but syntax is no linter */
+    /* not a supported property, but syntax is no linter */
       font: value;
 /*   ^^^^^^^^^^^^^^ meta.at-rule.property.css meta.property-list.css meta.block.css */
 /*    ^^^^ meta.property-name.css support.type.property-name.css */
@@ -1611,6 +1742,76 @@
 /*                    ^ meta.function-call.arguments.css meta.group.css - meta.selector */
 /*                     ^ meta.function-call.arguments.css meta.group.css meta.selector */
 /*                      ^ - meta.at-rule - meta.function-call */
+
+
+    @supports { table {}; > span { font-size: 1.25rem; }; color: red }
+/*  ^^^^^^^^^^ meta.at-rule.supports.css - meta.block - meta.group */
+/*            ^^ meta.at-rule.supports.css meta.block.css - meta.selector */
+/*              ^^^^^^ meta.at-rule.supports.css meta.block.css meta.selector.css */
+/*                    ^^ meta.at-rule.supports.css meta.block.css meta.property-list.css meta.block.css */
+/*                      ^^ meta.at-rule.supports.css meta.block.css - meta.selector */
+/*                        ^^^^^^^ meta.at-rule.supports.css meta.block.css meta.selector.css */
+/*                               ^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.supports.css meta.block.css meta.property-list.css meta.block.css */
+/*                                                      ^^ meta.at-rule.supports.css meta.block.css - meta.selector */
+/*                                                        ^^^^^^^^^^^ meta.at-rule.supports.css meta.block.css meta.selector.css */
+/*                                                                   ^ meta.at-rule.supports.css meta.block.css - meta.selector */
+/*                                                                    ^ - meta.at-rule */
+/*  ^ keyword.control.directive.css punctuation.definition.keyword.css */
+/*   ^^^^^^^^ keyword.control.directive.css - punctuation */
+/*            ^ punctuation.section.block.begin.css */
+/*              ^^^^^ entity.name.tag.html.css */
+/*                    ^ punctuation.section.block.begin.css */
+/*                     ^ punctuation.section.block.end.css */
+/*                      ^ punctuation.terminator.rule.css */
+/*                        ^ keyword.operator.combinator.css */
+/*                          ^^^^ entity.name.tag.html.css */
+/*                               ^ punctuation.section.block.begin.css */
+/*                                 ^^^^^^^^^ support.type.property-name.css */
+/*                                          ^ punctuation.separator.key-value.css */
+/*                                            ^^^^^^^ meta.number.float.decimal.css */
+/*                                                   ^ punctuation.terminator.rule.css */
+/*                                                     ^ punctuation.section.block.end.css */
+/*                                                      ^ punctuation.terminator.rule.css */
+/*                                                        ^^^^^ entity.name.tag.other.css - support.property-name */
+/*                                                             ^ punctuation.definition.pseudo-class.css */
+/*                                                               ^^^ entity.name.tag.other.css - support - constant */
+/*                                                                   ^ punctuation.section.block.end.css */
+
+    .test-nested-supports { @supports { table {}; > span { font-size: 1.25rem; }; color: red } }
+/*                        ^^ meta.property-list.css meta.block.css - meta.at-rule */
+/*                          ^^^^^^^^^^ meta.property-list.css meta.block.css meta.at-rule.supports.css - meta.group - meta.block meta.block */
+/*                                    ^^ meta.property-list.css meta.block.css meta.at-rule.supports.css meta.block.css - meta.block.css meta.block.css meta.block.css - meta.sepector */
+/*                                      ^^^^^^ meta.property-list.css meta.block.css meta.at-rule.supports.css meta.property-list.css meta.block.css - meta.selector */
+/*                                            ^^ meta.property-list.css meta.block.css meta.at-rule.supports.css meta.property-list.css meta.block.css meta.property-list.css meta.block.css */
+/*                                              ^^ meta.property-list.css meta.block.css meta.at-rule.supports.css meta.property-list.css meta.block.css - meta.selector */
+/*                                                ^^^^^^^ meta.property-list.css meta.block.css meta.at-rule.supports.css meta.property-list.css meta.block.css meta.selector.css */
+/*                                                       ^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.css meta.block.css meta.at-rule.supports.css meta.block.css meta.property-list.css meta.block.css */
+/*                                                                              ^^ meta.property-list.css meta.block.css meta.at-rule.supports.css meta.block.css - meta.block.css meta.block.css meta.block.css - meta.property-name */
+/*                                                                                ^^^^^ meta.property-list.css meta.block.css meta.at-rule.supports.css meta.property-list.css meta.block.css meta.property-name.css */
+/*                                                                                     ^ meta.property-list.css meta.block.css meta.at-rule.supports.css meta.property-list.css meta.block.css - meta.property-name - meta.property-value */
+/*                                                                                       ^^^ meta.property-list.css meta.block.css meta.at-rule.supports.css meta.property-list.css meta.block.css meta.property-value.css */
+/*                                                                                            ^^ meta.property-list.css meta.block.css - meta.at-rule */
+/*                                                                                              ^ - meta.property-list - meta.block */
+/*                          ^^^^^^^^^ keyword.control.directive.css */
+/*                                    ^ punctuation.section.block.begin.css */
+/*                                      ^^^^^ support.type.property-name.css - entity.name.tag */
+/*                                            ^ punctuation.section.block.begin.css */
+/*                                             ^ punctuation.section.block.end.css */
+/*                                              ^ punctuation.terminator.rule.css */
+/*                                                ^ keyword.operator.combinator.css */
+/*                                                  ^^^^ entity.name.tag.html.css */
+/*                                                       ^ punctuation.section.block.begin.css */
+/*                                                         ^^^^^^^^^ support.type.property-name.css */
+/*                                                                  ^ punctuation.separator.key-value.css */
+/*                                                                    ^^^^^^^ meta.number.float.decimal.css */
+/*                                                                           ^ punctuation.terminator.rule.css */
+/*                                                                             ^ punctuation.section.block.end.css */
+/*                                                                              ^ punctuation.terminator.rule.css */
+/*                                                                                ^^^^^ support.type.property-name.css */
+/*                                                                                     ^ punctuation.separator.key-value.css */
+/*                                                                                       ^^^ support.constant.color.w3c.standard.css */
+/*                                                                                           ^ punctuation.section.block.end.css */
+/*                                                                                             ^ punctuation.section.block.end.css */
 
     @counter-style {}
 /*  ^^^^^^^^^^^^^^^ meta.at-rule.counter-style.css - meta.block */

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -907,19 +907,47 @@
 /*                                              ^ meta.number.integer.decimal.css constant.numeric.value.css */
 /*                                               ^^ meta.number.integer.decimal.css constant.numeric.suffix.css */
 
-    @keyframes beat, "bounce", none {}
-/*  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.keyframe.css - meta.block */
-/*                                  ^^ meta.at-rule.keyframe.css meta.block.css - meta.property-list */
-/*                                    ^ - meta.at-rule - meta.block */
+    @keyframes beat {}
+/*  ^^^^^^^^^^^^^^^^ meta.at-rule.keyframe.css - meta.block */
+/*                  ^^ meta.at-rule.keyframe.css meta.block.css */
+/*                    ^ - meta.at-rule - meta.block */
 /*  ^ keyword.control.directive.css punctuation.definition.keyword.css */
 /*   ^^^^^^^^^ keyword.control.directive.css - punctuation */
 /*             ^^^^ entity.other.animation-name.css */
-/*                 ^ punctuation.separator.sequence.css */
-/*                   ^^^^^^^^ meta.string.css string.quoted.double.css */
-/*                           ^ punctuation.separator.sequence.css */
-/*                             ^^^^ invalid.illegal.identifier.css */
-/*                                  ^ punctuation.section.block.begin.css */
-/*                                   ^ punctuation.section.block.end.css */
+/*                  ^ punctuation.section.block.begin.css */
+/*                   ^ punctuation.section.block.end.css */
+
+    @keyframes "beat" {}
+/*  ^^^^^^^^^^^^^^^^^^ meta.at-rule.keyframe.css - meta.block */
+/*                    ^^ meta.at-rule.keyframe.css meta.block.css */
+/*                      ^ - meta.at-rule - meta.block */
+/*  ^ keyword.control.directive.css punctuation.definition.keyword.css */
+/*   ^^^^^^^^^ keyword.control.directive.css - punctuation */
+/*             ^^^^^^ meta.string.css string.quoted.double.css */
+/*                    ^ punctuation.section.block.begin.css */
+/*                     ^ punctuation.section.block.end.css */
+
+    @keyframes none {}
+/*  ^^^^^^^^^^^^^^^^ meta.at-rule.keyframe.css - meta.block */
+/*                  ^^ meta.at-rule.keyframe.css meta.block.css */
+/*                    ^ - meta.at-rule - meta.block */
+/*  ^ keyword.control.directive.css punctuation.definition.keyword.css */
+/*   ^^^^^^^^^ keyword.control.directive.css - punctuation */
+/*             ^^^^ invalid.illegal.identifier.css */
+/*                  ^ punctuation.section.block.begin.css */
+/*                   ^ punctuation.section.block.end.css */
+
+    @keyframes beat, none {}
+/*  ^^^^^^^^^^^^^^^ meta.at-rule.keyframe.css - meta.block */
+/*                 ^^^^^^^ - meta.at-rule - meta.block */
+/*                        ^^ meta.property-list.css meta.block.css - meta.at-rule */
+/*  ^ keyword.control.directive.css punctuation.definition.keyword.css */
+/*   ^^^^^^^^^ keyword.control.directive.css - punctuation */
+/*             ^^^^ entity.other.animation-name.css */
+/*                 ^ invalid.illegal.unexpected-token.css */
+/*                   ^^^^ entity.name.tag.other.css */
+/*                        ^ punctuation.section.block.begin.css */
+/*                         ^ punctuation.section.block.end.css */
 
     @keyframes- beat, bounce {}
 /*  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.other.css */
@@ -980,10 +1008,24 @@
 /*    ^^ keyword.other.selector.css */
 
     @media ;
-/*  ^^^^^^^^ - keyword - punctuation */
+/*  ^^^^^^ - keyword - punctuation */
+/*         ^ punctuation.terminator.rule.css */
 
     body {}
-/*  ^^^^^^^^ - entity - support */
+/*  ^^^^^^^^ - meta.selector - entity - support */
+/*       ^ punctuation.section.block.begin.css */
+/*        ^ punctuation.section.block.end.css */
+
+    .nested {}
+/*  ^^^^^^^^ - meta.selector - entity - support */
+
+    > nested {}
+/*  ^^^^^^^^^ - meta.selector - entity - support */
+
+    ( group )
+/*  ^ invalid.illegal.unexpected-token.css */
+/*          ^ invalid.illegal.unexpected-token.css */
+
 }
 
     @document url(http://) { }

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -455,9 +455,10 @@
 /*            ^^^^^^^^ support.constant.property-value.css */
 /*                    ^ punctuation.terminator.rule.css */
 
+        /* not a valid property, but a syntax definition is no linter */
         font-family: ;
-/*     ^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.page.css meta.property-list.css meta.block.css */
-/*      ^^^^^^^^^^^ - support.type */
+/*     ^^^^^^^^^^^^^^^^ meta.at-rule.page.css meta.property-list.css meta.block.css */
+/*      ^^^^^^^^^^^ support.type.property-name.css */
 /*                 ^ punctuation.separator.key-value.css */
 /*                   ^ punctuation.terminator.rule.css */
 
@@ -538,7 +539,7 @@
 /*       ^^^^^^^^^^^^ keyword.control.directive.css - punctuation */
 /*                    ^^^^^^^^^^^^^^^^^^ meta.at-rule.page.css meta.property-list.css meta.block.css meta.at-rule.margin.css meta.property-list.css meta.block.css */
 /*                    ^ punctuation.section.block.begin.css */
-/*                      ^^^^^^^^^^^ - support.type */
+/*                      ^^^^^^^^^^^ support.type */
 /*                                 ^ punctuation.separator.key-value.css */
 /*                                   ^ punctuation.terminator.rule.css */
 /*                                     ^ punctuation.section.block.end.css */
@@ -555,10 +556,10 @@
 /*               ^ punctuation.section.block.begin.css */
 /*                ^ punctuation.section.block.end.css */
 
+        /* not a supported without preceeding at-rule,
+         * but treated normally to improve incomplete code experience */
         { margin: 5pt; }
-/*     ^^^^^^^^^^^^^^^^^^ meta.at-rule.page.css meta.property-list.css meta.block.css - meta.block meta.block */
-/*      ^ invalid.illegal.unexpected-token.css */
-/*                     ^ invalid.illegal.unexpected-token.css */
+/*      ^^^^^^^^^^^^^^^^ meta.at-rule.page.css meta.property-list.css meta.block.css meta.property-list.css meta.block.css */
     }
 /*  ^ meta.at-rule.page.css meta.property-list.css meta.block.css punctuation.section.block.end.css*/
 
@@ -1370,11 +1371,13 @@
 /*                 ^ punctuation.separator.key-value.css */
 /*                   ^^^^^^^ meta.property-value.css constant.other.color.rgb-value.css */
 /*                          ^ punctuation.terminator.rule.css */
+
+    /* not a supported prototype, but syntax is no linter */
       font: value;
 /*   ^^^^^^^^^^^^^^ meta.at-rule.property.css meta.property-list.css meta.block.css */
-/*    ^^^^ - meta.property-name - support.type.property-name */
+/*    ^^^^ meta.property-name.css support.type.property-name.css */
 /*        ^ punctuation.separator.key-value.css */
-/*          ^^^^^ meta.property-value.css support.constant.property-value.css */
+/*          ^^^^^ meta.property-value.css meta.string.css string.unquoted.css */
 /*               ^ punctuation.terminator.rule.css */
 }
 

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -183,6 +183,11 @@
 /*  ^^^^^ - keyword - punctuation */
 /*        ^ punctuation.terminator.rule.css */
 
+    @charset
+/*  ^^^^^^^^^ meta.at-rule.charset.css */
+/*  ^ keyword.control.directive.css punctuation.definition.keyword.css */
+/*   ^^^^^^^ keyword.control.directive.css - punctuation */
+
     @charset "UTF-8";
 /*  ^^^^^^^^^^^^^^^^ meta.at-rule.charset.css */
 /*                  ^ - meta.at-rule */
@@ -190,6 +195,14 @@
 /*   ^^^^^^^ keyword.control.directive.css - punctuation */
 /*           ^^^^^^^ meta.string.css string.quoted.double.css */
 /*                  ^ punctuation.terminator.rule.css */
+
+    @charset "UTF-8""value"
+/*  ^^^^^^^^^^^^^^^^ meta.at-rule.charset.css */
+/*                  ^^^^^^^ - meta.at-rule */
+/*  ^ keyword.control.directive.css punctuation.definition.keyword.css */
+/*   ^^^^^^^ keyword.control.directive.css - punctuation */
+/*           ^^^^^^^ meta.string.css string.quoted.double.css */
+/*                  ^^^^^^^ - string */
 
     @import "x" print;
 /*  ^^^^^^^^^^^^^^^^^ meta.at-rule.import.css */
@@ -666,14 +679,10 @@
 /*                                                                                                                                      ^^^^ comment.block.css */
 
     @media onlyℜ screenℜ screen\211C {}
-/*  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.media.css - meta.block */
-/*                                   ^^ meta.at-rule.media.css meta.block.css - meta.property-list */
-/*                                     ^ - meta.at-rule - meta.block */
+/*  ^^^^^^^ meta.at-rule.media.css - meta.block */
+/*         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.at-rule  */
 /*  ^ keyword.control.directive.css punctuation.definition.keyword.css */
 /*   ^^^^^ keyword.control.directive.css - punctuation */
-/*         ^^^^^^^^^^^^^^^^^^^^^^^^^ - keyword - support */
-/*                                   ^ punctuation.section.block.begin.css */
-/*                                    ^ punctuation.section.block.end.css */
 
     @media only screen {}
 /*  ^^^^^^^^^^^^^^^^^^^ meta.at-rule.media.css - meta.block */
@@ -1243,6 +1252,26 @@
 /*    ^^^^^^ keyword.control.directive.css */
 /*           ^^^^^^ entity.other.layer.css */
 /*                  ^ punctuation.section.block.begin.css */
+        table {
+/*      ^^^^^ meta.selector.css entity.name.tag */
+
+            @layer foo {
+/*         ^ meta.at-rule.layer.css meta.block.css meta.at-rule.layer.css meta.block.css meta.property-list.css meta.block.css */
+/*          ^^^^^^^^^^^ meta.at-rule.layer.css meta.block.css meta.at-rule.layer.css meta.block.css meta.property-list.css meta.block.css meta.at-rule.layer.css */
+/*                     ^^ meta.at-rule.layer.css meta.block.css meta.at-rule.layer.css meta.block.css meta.property-list.css meta.block.css meta.at-rule.layer.css meta.property-list.css meta.block.css */
+                table {}
+/*              ^^^^^ - entity.name.tag */
+
+                > table {}
+/*              ^^^^^^^^ meta.selector.css */
+
+                font: inherit;
+/*              ^^^^ meta.property-name.css support.type.property-name.css */
+/*                  ^ punctuation.separator.key-value.css */
+/*                   ^^^^^^^^ meta.property-value.css */
+            }
+        }
+
         .foo {
             font: status-bar;
 /*         ^^^^^^^^^^^^^^^^^^^ meta.at-rule.layer.css meta.block.css meta.at-rule.layer.css meta.block.css meta.property-list.css meta.block.css */
@@ -1256,6 +1285,26 @@
 /*    ^ punctuation.section.block.end.css */
     }
 /* ^^ meta.at-rule.layer.css meta.block.css */
+
+    button {
+        font: inherit;
+/*      ^^^^ meta.property-name.css support.type.property-name.css */
+/*          ^ punctuation.separator.key-value.css */
+/*           ^^^^^^^^ meta.property-value.css */
+
+        @layer defaults {
+/*     ^ meta.property-list.css meta.block.css - meta.at-rule */
+/*      ^^^^^^^^^^^^^^^^ meta.property-list.css meta.block.css meta.at-rule.layer.css - meta.property-list meta.property-list */
+/*                      ^^ meta.property-list.css meta.block.css meta.at-rule.layer.css meta.property-list.css meta.block.css */
+
+            font: monospace;
+/*          ^^^^ meta.property-name.css support.type.property-name.css */
+/*              ^ punctuation.separator.key-value.css */
+/*               ^^^^^^^^^^ meta.property-value.css */
+        }
+/*     ^^ meta.property-list.css meta.block.css meta.at-rule.layer.css meta.property-list.css meta.block.css */
+    }
+/* ^^ meta.property-list.css meta.block.css */
 
     @property
 /* ^ - meta.at-rule */


### PR DESCRIPTION
Fixes #3820

This PR...

1. adds separate contexts for nested at-rules.

   Global at-rules push [&lt;style-blocks&gt;](https://www.w3.org/TR/css-syntax-3/#typedef-style-block) on stack while nested at-rules push [&lt;rule-lists&gt;](https://www.w3.org/TR/css-syntax-3/#typedef-rule-list) represented by `property-lists` context.

2. refactors at-rules to make use of multi-push statements so more general purpose contexts can be created and re-used more often, which reduces syntax cache size and should limit amount of special purpose contexts, which might need to be addressed by inheriting 3rd-party syntaxes.

3. replaces `at-rule-end` by `else-pop` to follow a fail as early as possible approach, which may help to bail-out from statements more reliably.

   e.g. at-rules with missing semi-colon suffered leaking into following at-rules or selectors, before.

4. applies lazier parsing of various at-rules' property-lists in order to reduce complexity/special casing and increase re-using existing contexts.

   While it doesn't improve performance, syntax cache size is reduced and re-using existing contexts is increased.


#### Notes:

Overall parsing performance keeps unchanged.