### PR TITLE
[JavaScript] Add osascript to shebang

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -13,12 +13,12 @@ file_extensions:
 
 first_line_match: |-
   (?xi:
-    ^ \#! .* \b(?:node|js)\b                              # shebang
+    ^ \#! .* \b(?:node|js|osascript\s+-l\s+JavaScript)\b  # shebang
   | ^ \s* // .*? -\*- .*? \b(?:js|javascript)\b .*? -\*-  # editorconfig
   )
 
 variables:
-  shebang_lang: \b(?:node|js)\b
+  shebang_lang: \b(?:node|js|osascript\s+-l\s+JavaScript)\b
 
   bin_digit: '[01_]'
   oct_digit: '[0-7_]'


### PR DESCRIPTION
This commit updates `first_line_match` and shebang scope to automatically apply JavaScript syntax to apple scripts with:

    #!osascript -l JavaScript

This is a follow-up of #3829.