### PR TITLE
[TypeScript] Implement labeled tuple members

### DIFF
--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -925,14 +925,42 @@ contexts:
           scope: punctuation.section.sequence.end.js
           pop: 1
         - include: comma-separator
-        - match: \.\.\.
-          scope: keyword.operator.spread.js
         - match: (?=\S)
           push:
             - ts-type-annotation-optional
             - ts-type-expression-end
             - ts-type-expression-end-no-line-terminator
             - ts-type-expression-begin
+            - ts-type-tuple-spread
+            - ts-type-tuple-possible-member-label
+
+  ts-type-tuple-possible-member-label:
+    - match: (?={{identifier_name}})
+      branch_point: ts-type-tuple-member-label
+      branch:
+        - ts-type-tuple-member-label
+        - immediately-pop
+      pop: 1
+    - include: else-pop
+
+  ts-type-tuple-member-label:
+    - match: ''
+      set:
+        - - match: ':'
+            scope: punctuation.separator.type.ts
+            pop: 1
+          - match: (?=\S)
+            fail: ts-type-tuple-member-label
+        - ts-type-annotation-optional
+        - - match: '{{identifier_name}}'
+            scope: meta.mapping.key.ts
+            pop: 1
+
+  ts-type-tuple-spread:
+    - match: \.\.\.
+      scope: keyword.operator.spread.js
+      pop: 1
+    - include: else-pop
 
   ts-type-object:
     - match: \{

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -947,13 +947,13 @@ contexts:
     - match: ''
       set:
         - - match: ':'
-            scope: punctuation.separator.type.ts
+            scope: punctuation.separator.type.js
             pop: 1
           - match: (?=\S)
             fail: ts-type-tuple-member-label
         - ts-type-annotation-optional
         - - match: '{{identifier_name}}'
-            scope: meta.mapping.key.ts
+            scope: meta.mapping.key.js
             pop: 1
 
   ts-type-tuple-spread:

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -935,26 +935,27 @@ contexts:
             - ts-type-tuple-possible-member-label
 
   ts-type-tuple-possible-member-label:
-    - match: (?={{identifier_name}})
+    - match: ''
       branch_point: ts-type-tuple-member-label
       branch:
         - ts-type-tuple-member-label
         - immediately-pop
       pop: 1
-    - include: else-pop
 
   ts-type-tuple-member-label:
-    - match: ''
+    - match: '{{identifier_name}}'
+      scope: variable.other.member.js
       set:
-        - - match: ':'
-            scope: punctuation.separator.type.js
-            pop: 1
-          - match: (?=\S)
-            fail: ts-type-tuple-member-label
+        - ts-type-tuple-member-label-separator
         - ts-type-annotation-optional
-        - - match: '{{identifier_name}}'
-            scope: meta.mapping.key.js
-            pop: 1
+    - include: else-pop
+
+  ts-type-tuple-member-label-separator:
+    - match: ':'
+      scope: punctuation.separator.type.js
+      pop: 1
+    - match: (?=\S)
+      fail: ts-type-tuple-member-label
 
   ts-type-tuple-spread:
     - match: \.\.\.

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -853,6 +853,37 @@ let x: [ any , any ? , ... any [] ];
 //                             ^^ storage.modifier.array
 //                                ^ punctuation.section.sequence.end
 
+let x: [ first: any, rest: ...any ];
+//^ keyword.declaration
+//  ^ meta.binding.name variable.other.readwrite
+//   ^ punctuation.separator.type
+//    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type
+//     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence
+//     ^ punctuation.section.sequence.begin
+//       ^^^^^ meta.mapping.key
+//            ^ punctuation.separator.type
+//              ^^^ support.type.any
+//                 ^ punctuation.separator.comma
+//                   ^^^^ meta.mapping.key
+//                       ^ punctuation.separator.type
+//                         ^^^ keyword.operator.spread
+//                            ^^^ support.type.any
+//                                ^ punctuation.section.sequence.end
+//                                 ^ punctuation.terminator.statement
+
+let x: [
+    label
+//  ^^^^^ meta.mapping.key
+    ?
+//  ^ storage.modifier.optional
+    :
+//  ^ punctuation.separator.type
+    ...
+//  ^^^ keyword.operator.spread
+    any
+//  ^^^ support.type.any
+];
+
 let x: any & any;
 //     ^^^^^^^^^ meta.type
 //     ^^^ support.type.any

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -872,7 +872,7 @@ let x: [ first: any, rest: ...any ];
 //                                 ^ punctuation.terminator.statement
 
 let x: [
-    label
+    typeof
 //  ^^^^^ meta.mapping.key
     ?
 //  ^ storage.modifier.optional

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -860,11 +860,11 @@ let x: [ first: any, rest: ...any ];
 //    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type
 //     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence
 //     ^ punctuation.section.sequence.begin
-//       ^^^^^ meta.mapping.key
+//       ^^^^^ variable.other.member
 //            ^ punctuation.separator.type
 //              ^^^ support.type.any
 //                 ^ punctuation.separator.comma
-//                   ^^^^ meta.mapping.key
+//                   ^^^^ variable.other.member
 //                       ^ punctuation.separator.type
 //                         ^^^ keyword.operator.spread
 //                            ^^^ support.type.any
@@ -873,7 +873,7 @@ let x: [ first: any, rest: ...any ];
 
 let x: [
     typeof
-//  ^^^^^ meta.mapping.key
+//  ^^^^^ variable.other.member
     ?
 //  ^ storage.modifier.optional
     :


### PR DESCRIPTION
E.g. `type Rational = [numerator: bigint, denominator: bigint];`

Introduced in [TypeScript 4.0](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-0.html#labeled-tuple-elements) more than three years ago, but documented nowhere outside those release notes (plus the recent [5.2 release notes](https://devblogs.microsoft.com/typescript/announcing-typescript-5-2/#named-and-anonymous-tuple-elements)).

I used the scope `meta.mapping.key` for the labels, which doesn't seem quite right but I don't know what would be more right.

The implementation uses branching because a lookahead would have to span multiple lines. I initially intended to use a cover grammar approach, but that would be a mess if the label were the name of a type operator (which you would think wouldn't be allowed, but here we are).