### PR TITLE
[Python] Add syntax support for sphinx-style doc comments

### DIFF
--- a/Python/Comments.tmPreferences
+++ b/Python/Comments.tmPreferences
@@ -19,6 +19,17 @@
 				<key>value</key>
 				<string>:</string>
 			</dict>
+			<dict>
+				<!--
+					Cannot be undone using `toggle_comment` at the moment
+					because the earlier `TM_COMMENT_START` is tested first
+					and is a true prefix of this one.
+				-->
+				<key>name</key>
+				<string>TM_COMMENT_START_2</string>
+				<key>value</key>
+				<string>#: </string>
+			</dict>
 		</array>
 	</dict>
 </dict>

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -364,6 +364,11 @@ contexts:
 ###[ COMMENTS ]###############################################################
 
   comments:
+    # Special Sphinx comment syntax to denote documentation
+    # https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#directive-autoattribute
+    - match: '#:'
+      scope: punctuation.definition.comment.python
+      push: comment-sphinxdoc-body
     - match: \#
       scope: punctuation.definition.comment.python
       push:
@@ -372,6 +377,11 @@ contexts:
 
   comment-body:
     - meta_scope: comment.line.number-sign.python
+    - match: \n
+      pop: 1
+
+  comment-sphinxdoc-body:
+    - meta_scope: comment.line.documentation.python
     - match: \n
       pop: 1
 

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -68,6 +68,14 @@ This is a variable docstring, as supported by sphinx and epydoc
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation
 """
 
+#: This is a prefixed "doc comment", supported by sphinx
+# <- comment.line.documentation.python punctuation.definition.comment.python
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.documentation.python
+#^ punctuation.definition.comment.python
+attribute = ... #: also supported on the same line
+#               ^^ comment.line.documentation.python punctuation.definition.comment.python
+#                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.documentation.python
+
 r'''This is a syntax test file.
 # <- storage.type.string - comment
 #^^^ comment.block.documentation.python punctuation.definition.comment.begin.python


### PR DESCRIPTION
Sphinx (the most common Python documentation tool) uses `#:` comments to signal documentation comments for its "autodoc" module.

There is no known overlap with other comment punctuation, so this should be a safe addition.

`TM_COMMENT_START_2` is also added to be able to undo the comment using `toggle_comment`, but unfortunately it does not work like this currently because `Default/comment.py` does not prioritize the longest prefix match of all available comment styles.

https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#directive-autoattribute

Discovered via https://github.com/sublimehq/sublime_text/issues/5587#issuecomment-1259180246