### PR TITLE
[Go] Assign .tmpl extension to Go templates

### DIFF
--- a/Go/HTML (Go).sublime-syntax
+++ b/Go/HTML (Go).sublime-syntax
@@ -10,6 +10,7 @@ extends: Packages/HTML/HTML.sublime-syntax
 file_extensions:
   - gohtml
   - go.html
+  - tmpl
 
 contexts:
 


### PR DESCRIPTION
Go templates use `*.tmpl` file extension by default according to https://docs.gomplate.ca/usage/.