### PR TITLE
[Go] Fix slice date type highlighting

### DIFF
--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -1374,42 +1374,33 @@ contexts:
       set: [pop-after-type, pop-type-single]
 
   pop-type-single:
-    - include: pop-before-semicolon
-
     # Note: Go allows wrapping types in an arbitrary number of parens.
     - match: \(
       scope: punctuation.section.parens.begin.go
       push: [pop-type-nested-in-parens, pop-type]
 
+    # Note: Go allows multiple levels of slices
+    - match: \[
+      scope: punctuation.section.brackets.begin.go
+      push: pop-brackets-inner
+
     - include: match-type-operators
     - include: match-operators
 
-    - match: (?=\bchan\b)
-      set: pop-chan
-
-    - match: (?=\binterface\b)
-      set: pop-interface
-
-    - match: (?=\bmap\b)
-      set: pop-map
-
-    - match: (?=\bstruct\b)
-      set: pop-struct
+    - include: pop-chan
+    - include: pop-interface
+    - include: pop-map
+    - include: pop-struct
 
     - match: \bfunc\b
       scope: keyword.declaration.function.go
       set: pop-func-parameter-and-return-lists
 
-    - match: (?={{ident}})
-      set: pop-type-identifier
     - match: \btype\b
       scope: keyword.operator.type.go
 
-    - match: \[
-      scope: punctuation.section.brackets.begin.go
-      set: [pop-after-brackets, pop-brackets-inner]
-
-    - include: pop-before-nonblank
+    # Note: must be the last one as it pops unconditionally
+    - include: pop-type-identifier
 
   pop-after-type:
     - match: \|{{operator_break}}

--- a/Go/tests/syntax_test_go.go
+++ b/Go/tests/syntax_test_go.go
@@ -3176,9 +3176,19 @@ by accident, but if necessary, such support could be sacrificed.
 
     []func(
 //    ^^^^ keyword.declaration.function.go
-        param typ
+        param typ,
 //      ^^^^^ variable.parameter.go
 //            ^^^ storage.type.go
+//               ^ punctuation.separator.go
+        param [][][]typ
+//      ^^^^^ variable.parameter.go
+//            ^ punctuation.section.brackets.begin.go
+//             ^ punctuation.section.brackets.end.go
+//              ^ punctuation.section.brackets.begin.go
+//               ^ punctuation.section.brackets.end.go
+//                ^ punctuation.section.brackets.begin.go
+//                 ^ punctuation.section.brackets.end.go
+//                  ^^^ storage.type.go
     ) typ ident
 //    ^^^ storage.type.go
 //        ^^^^^ variable.other.go


### PR DESCRIPTION
Fixes #3842

This commit refactors `pop-type-single` context:

1. don't pop it off stack when matching `[` so arbitrary numbers of bracket pairs (slices) can be contained.

2. removes `pop-after-brackets` after `]` is matched as all its content is also part of `pop-type-single`.

3. simplify the context by removing some unneeded lookaheads.

   `pop-type-identifier` is included directly at last position as it also includes the `pop-before-nonblank`.