### PR TITLE
[D] Fix token strings

### DIFF
--- a/D/D.sublime-syntax
+++ b/D/D.sublime-syntax
@@ -523,18 +523,12 @@ contexts:
       scope: punctuation.accessor.dot.d
     - match: '\('
       scope: punctuation.section.parens.begin.d
-      push:
-        - match: '\)'
-          scope: punctuation.section.parens.end.d
-          pop: true
-        - include: tokens-in
+    - match: '\)'
+      scope: punctuation.section.parens.end.d
     - match: '\['
       scope: punctuation.section.brackets.begin.d
-      push:
-        - match: '\]'
-          scope: punctuation.section.brackets.end.d
-          pop: true
-        - include: tokens-in
+    - match: '\]'
+      scope: punctuation.section.brackets.end.d
     - match: '\{'
       scope: punctuation.section.braces.begin.d
       push:

--- a/D/tests/syntax_test_d.d
+++ b/D/tests/syntax_test_d.d
@@ -154,6 +154,52 @@ auto tokenString = q{
 };
 // <- meta.string.d string.unquoted.embedded.d punctuation.definition.string.end.d
 
+auto tokenString = q{ if (params.help.}~n~q{) return printHelpUsage(CLIUsage.}~n~q{Usage); };
+//                 ^^^^^^^^^^^^^^^^^^^^ meta.string.d
+//                                     ^^^ - meta.string
+//                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.d
+//                                                                            ^^^ - meta.string
+//                                                                               ^^^^^^^^^^^ meta.string.d
+//                 ^^ string.unquoted.embedded.d
+//                 ^ storage.modifier.string.d
+//                  ^ punctuation.definition.string.begin.d
+//                   ^^^^^^^^^^^^^^^^^ - string
+//                    ^^ keyword.d
+//                       ^ punctuation.section.parens.begin.d
+//                                    ^ string.unquoted.embedded.d punctuation.definition.string.end.d
+//                                        ^^ string.unquoted.embedded.d
+//                                        ^ storage.modifier.string.d
+//                                         ^ punctuation.definition.string.begin.d
+//                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - string
+//                                          ^ punctuation.section.parens.end.d
+//                                            ^^^^^^ keyword.d
+//                                                                 ^ punctuation.section.parens.begin.d
+//                                                                           ^ string.unquoted.embedded.d punctuation.definition.string.end.d
+//                                                                               ^^ string.unquoted.embedded.d
+//                                                                               ^ storage.modifier.string.d
+//                                                                                ^ punctuation.definition.string.begin.d
+//                                                                                 ^^^^^^^^ - string
+//                                                                                      ^ punctuation.section.parens.end.d
+//                                                                                       ^ punctuation.terminator.d
+//                                                                                         ^ string.unquoted.embedded.d punctuation.definition.string.end.d
+//                                                                                          ^ punctuation.terminator.d - string
+
+auto tokenString = q{ if { () /*}*/ else /*{*/ } };
+//                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.d
+//                 ^^ string.unquoted.embedded.d
+//                 ^ storage.modifier.string.d
+//                  ^ punctuation.definition.string.begin.d
+//                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - string
+//                       ^ punctuation.section.braces.begin.d
+//                         ^ punctuation.section.parens.begin.d
+//                          ^ punctuation.section.parens.end.d
+//                            ^^^^^ comment.block.d
+//                                  ^^^^ keyword.d
+//                                       ^^^^^ comment.block.d
+//                                             ^ punctuation.section.braces.end.d
+//                                               ^ string.unquoted.embedded.d punctuation.definition.string.end.d
+//                                                ^ punctuation.terminator.d
+
 auto c = 'a';
 //       ^^^ meta.string.d string.quoted.single.d
 c = 'Ó';


### PR DESCRIPTION
Fixes #3844

Brackets and parentheses don't have special meaning nor do they group expressions within token strings. They may appear in unbalanced numbers.

This commit therefore removes pushing dedicated contexts on stack if ( or [ is matched.

According to https://dlang.org/spec/lex.html#token_strings nested braces are however valid. Thus keep pushing a context if { is matched.