### PR TITLE
[TypeScript] Support placeholder in LSP type output

### DIFF
--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -854,6 +854,11 @@ contexts:
             - ts-type-expression-begin
 
   ts-type-expression-begin:
+    # Placeholder in LSP output. This should never occur in actual TypeScript code.
+    - match: '\.\.\. \d+ more \.\.\.'
+      scope: comment.other.ts
+      pop: true
+
     - match: keyof{{identifier_break}}
       scope: keyword.operator.type.js
     - match: typeof{{identifier_break}}

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -1390,3 +1390,12 @@ type T<in out U> = V;
 //        ^^^ storage.modifier.variance
 //            ^ variable.parameter.generic
 //             ^ punctuation.definition.generic.end
+
+type T = Foo | ... 100 more ... | Bar;
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type-alias
+//       ^^^ support.class
+//           ^ keyword.operator.type.union
+//             ^^^^^^^^^^^^^^^^ comment.other.ts
+//                              ^ keyword.operator.type.union
+//                                ^^^ support.class
+//                                   ^ punctuation.terminator.statement.empty


### PR DESCRIPTION
LSP output, such as is displayed in tooltips, truncated long types with syntax like the following:

```ts
type T = Foo | ... 100 more ... | Bar;
```

This is not valid TypeScript syntax, but LSP highlights tooltips using the core TS syntax, and this causes highlighting to break. (The TS type expression syntax is deliberately rigid to prevent false positives.)

This PR adds support for the `... 100 more ...` bit to the TS syntax definition. Ordinarily, I'd hesitate to put something that's not actually TS syntax in the core definition, but in this case I think it makes sense — given the tight coupling between the language and the language server, I'm not concerned about this conflicting with other syntax extensions.

I used a comment scope, though not for any particular reasons. The regexp seems to work in practice. I have inquired on the official TypeScript Discord about whether there is any documentation for this, or whether the placeholder is localizable, and so on, but I am not holding my breath for a helpful response.