### PR TITLE
[TypeScript] Fix bugs in object/interface types

### DIFF
--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -354,68 +354,78 @@ contexts:
     - match: '[,;]'
       scope: punctuation.separator.js
 
+    - match: (?=\S)
+      push:
+        - ts-type-annotation
+        - function-declaration-expect-parameters
+        - ts-type-parameter-list
+        - ts-type-annotation-optional
+        - ts-type-annotation-modifier
+        - ts-type-member-name
+        - ts-type-element-modifiers
+
+  ts-type-element-modifiers:
     - match: '\+|-'
       scope: storage.modifier.js
-
     - match: (?={{modifier}})
-      push: class-element-modifiers
+      pop: 1
+      branch_point: ts-type-member-modifier
+      branch:
+        - ts-type-member-modifier
+        - immediately-pop
+    - include: else-pop
 
-    - match: (?=[<(])
-      push:
-        - ts-type-annotation
-        - function-declaration-expect-parameters
-        - ts-type-parameter-list
-
-    - match: \[
-      scope: punctuation.section.brackets.begin.js
-      push:
-        - - include: immediately-pop
-        -  ts-type-annotation
-        -  ts-type-annotation-optional
-        - - match: '\+|-'
-            scope: storage.modifier.js
-            pop: 1
-          - include: else-pop
-        - - meta_scope: meta.brackets.js
-          - match: \]
-            scope: punctuation.section.brackets.end.js
-            pop: 1
-          - match: '{{identifier_name}}'
-            scope: variable.other.readwrite.js
-            push:
-              - match: in{{identifier_break}}
-                scope: keyword.operator.type.js
-                set:
-                  - ts-type-expression-end
-                  - ts-type-expression-end-no-line-terminator
-                  - ts-type-expression-begin
-              - include: ts-type-annotation
-
-    - match: new{{identifier_break}}
-      scope: keyword.operator.new.js
-      push:
-        - ts-type-annotation
-        - function-declaration-expect-parameters
-        - ts-type-parameter-list
-
-    - match: (?={{identifier_start}}|['"]|\d)
-      push:
-        - - match: (?=[<(])
-            set:
-              - ts-type-annotation
-              - function-declaration-expect-parameters
-              - ts-type-parameter-list
-          - match: (?=\S)
-            set: ts-type-annotation
-        - ts-type-annotation-optional
-        - ts-type-member-name
+  ts-type-member-modifier:
+    - match: '{{modifier}}'
+      scope: storage.modifier.js
+      set:
+        - match: (?={{identifier_start}}|[-+*''"\[\d])
+          set: ts-type-element-modifiers
+        - match: (?=\S)
+          fail: ts-type-member-modifier
 
   ts-type-member-name:
+    - match: new{{identifier_break}}
+      scope: keyword.operator.new.js
+      pop: 1
+
     - match: '{{identifier_name}}'
       scope: variable.other.readwrite.js
       pop: 1
     - include: literal-string
     - include: literal-number
+
+    - match: \[
+      scope: punctuation.section.brackets.begin.js
+      set:
+        - - meta_scope: meta.brackets.js
+          - match: \]
+            scope: punctuation.section.brackets.end.js
+            pop: 1
+        - - meta_include_prototype: false
+          - match: ''
+            pop: 1
+            branch_point: ts-mapped-or-indexed-member
+            branch:
+              - ts-mapped-or-indexed-member
+              - ts-type-expression
+
+    - include: else-pop
+
+  ts-mapped-or-indexed-member:
+    - match: '{{identifier_name}}'
+      scope: variable.other.readwrite.js
+      set:
+        - match: in{{identifier_break}}
+          scope: keyword.operator.type.js
+          set: ts-type-expression
+        - match: ':'
+          scope: punctuation.separator.type.js
+          set: ts-type-expression
+        - match: (?=\S)
+          fail: ts-mapped-or-indexed-member
+    - match: (?=\S)
+      fail: ts-mapped-or-indexed-member
 
   ts-enum:
     - match: enum{{identifier_break}}
@@ -759,10 +769,24 @@ contexts:
       pop: 1
     - include: else-pop
 
+  ts-type-annotation-modifier:
+    - match: '\+|-'
+      scope: storage.modifier.js
+      pop: 1
+    - include: else-pop
+
   ts-type-meta:
     - meta_include_prototype: false
     - meta_content_scope: meta.type.js
     - include: immediately-pop
+
+  ts-type-expression:
+    - meta_include_prototype: false
+    - match: ''
+      set:
+        - ts-type-expression-end
+        - ts-type-expression-end-no-line-terminator
+        - ts-type-expression-begin
 
   ts-type-expression-end:
     - match: (?=\|\||&&)

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -348,10 +348,10 @@ import foo;
     // https://github.com/sublimehq/Packages/issues/3598
     type x = {
         bar: (cb: (
-//     ^^^^^^ meta.type-alias meta.mapping - meta.group
-//           ^^^ meta.type-alias meta.mapping meta.type meta.group
-//              ^^ meta.type-alias meta.mapping - meta.group
-//                ^ meta.type-alias meta.function.parameters
+//^^^^^^^^^^^^^^^^^^ meta.type-alias meta.mapping
+//     ^^^^^^ - meta.group
+//           ^^^ meta.type meta.group
+//              ^^ - meta.group
 //      ^^^ variable.other.readwrite
 //         ^ punctuation.separator.type
 //           ^ punctuation.section.group.begin
@@ -980,6 +980,12 @@ let x: {
 //               ^^^ support.type.any
 //                   ^ punctuation.separator
 
+    readonly: any;
+//  ^^^^^^^^ variable.other.readwrite - storage.modifier
+//          ^ punctuation.separator.type
+//            ^^^ support.type.any
+//               ^ punctuation.separator
+
     ( foo : any ) : any ;
 //  ^ punctuation.section.group.begin
 //    ^^^ meta.binding.name variable.parameter.function
@@ -1031,6 +1037,14 @@ let x: {
 //                     ^ punctuation.separator.type
 //                       ^^^ support.type.any
 //                           ^ punctuation.separator
+
+    a ? () : any ;
+//  ^ variable.other.readwrite
+//    ^ storage.modifier.optional
+//      ^^ meta.function.parameters
+//         ^ punctuation.separator.type
+//           ^^^ support.type.any
+//               ^ punctuation.separator
 
     new ( foo : any ) : any ;
 //      ^ punctuation.section.group.begin
@@ -1124,6 +1138,23 @@ let x: {
 //                                        ^ support.class
 //                                          ^ punctuation.section.brackets.end
 //                                            ^ punctuation.separator
+
+        private +readonly x;
+//      ^^^^^^^ storage.modifier
+//              ^^^^^^^^^ storage.modifier
+//                        ^ variable.other.readwrite
+
+        [Symbol.iterator](): any;
+//      ^^^^^^^^^^^^^^^^^ meta.brackets
+//      ^ punctuation.section.brackets.begin
+//       ^^^^^^ support.class
+//             ^ punctuation.accessor
+//              ^^^^^^^^ support.class
+//                      ^ punctuation.section.brackets.end
+//                       ^^ meta.function.parameters
+//                         ^ punctuation.separator.type
+//                           ^^^ support.type.any
+//                              ^ punctuation.separator
 
     }
 //  ^ meta.type punctuation.section.mapping.end


### PR DESCRIPTION
The code for the contents of object and interface types has grown as new TypeScript features were added. This PR rewrites the `ts-type-members` context to handle things in a more robust and coherent fashion. Specific notes:

- Previously, a bracketed member name was taken to be a mapped type member or indexed type member. But instead of a mapped/indexed member, you can have any arbitrary type in the brackets. This worked by coincidence in most practical cases, but it failed to highlight e.g. `[Symbol.iterator]`, which is how I started on this whole thing. The new implementation branches, tries to match a mapped/indexed member, and if that fails matches a type expression.
- The previous implementation had separate handling for call signatures, construction signatures, mapped/indexed signatures, and all other signatures. This implementation unifies all of them, detecting `new` and handling brackets in the `ts-type-member-name` context.
- The new system for handling modifiers is cleaner and correctly handles cases like `private +readonly`. At some point, I might rewrite the class modifiers code in the base JavaScript syntax to work more like this.
- The new `ts-type-expression` context could in principle be used in all sorts of places and would make the syntax more compact. I think at some point we stopped using it, but I don't recall why.