### PR TITLE
[JavaScript] [TypeScript] Clean up export code and support more cases

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -257,13 +257,6 @@ contexts:
       fail: import-statement
     - include: else-pop
 
-  export-statement:
-    - match: export{{identifier_break}}
-      scope: keyword.control.import-export.js
-      set:
-        - export-meta
-        - export-extended
-
   import-meta:
     - meta_include_prototype: false
     - meta_scope: meta.import.js
@@ -272,15 +265,17 @@ contexts:
   import-export-alias:
     - match: as{{identifier_break}}
       scope: keyword.control.import-export.js
-      set:
-        - match: default{{identifier_break}}
-          scope: keyword.control.import-export.js
-          pop: 1
-        - match: '{{identifier_name}}'
-          scope: variable.other.readwrite.js
-          pop: 1
-        - include: literal-string
-        - include: else-pop
+      set: import-export-name
+    - include: else-pop
+
+  import-export-name:
+    - match: default{{identifier_break}}
+      scope: keyword.control.import-export.js
+      pop: 1
+    - match: '{{identifier_name}}'
+      scope: variable.other.readwrite.js
+      pop: 1
+    - include: literal-string
     - include: else-pop
 
   import-export-from:
@@ -340,12 +335,19 @@ contexts:
         - include: else-pop
     - include: else-pop
 
+  export-statement:
+    - match: export{{identifier_break}}
+      scope: keyword.control.import-export.js
+      set:
+        - export-meta
+        - export-body
+
   export-meta:
     - meta_include_prototype: false
     - meta_scope: meta.export.js
     - include: immediately-pop
 
-  export-extended:
+  export-body:
     - include: declaration
 
     - match: 'default{{identifier_break}}'
@@ -359,28 +361,15 @@ contexts:
       set:
         - expect-semicolon
         - import-export-from
-        - export-list
-        - import-export-alias
         - export-item
-
-  export-list:
-    - match: ','
-      scope: punctuation.separator.comma.js
-      push:
-        - import-export-alias
-        - export-item
-    - include: else-pop
 
   export-item:
     - match: '\{'
       scope: punctuation.section.block.begin.js
       set: export-brace
-    - match: '{{non_reserved_identifier}}'
-      scope: variable.other.readwrite.js
-      pop: 1
     - match: '\*'
       scope: constant.other.js
-      pop: 1
+      set: import-export-alias
     - include: else-pop
 
   export-brace:
@@ -389,12 +378,10 @@ contexts:
     - match: '\}'
       scope: punctuation.section.block.end.js
       pop: 1
-    - match: '{{identifier_name}}'
-      scope: variable.other.readwrite.js
-      push: import-export-alias
-    - match: '\*'
-      scope: constant.other.js
-      push: import-export-alias
+    - match: (?={{identifier_start}}|'|")
+      push:
+        - import-export-alias
+        - import-export-name
     - include: else-pop
 
   statements:

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -69,13 +69,20 @@ contexts:
     - include: comments
     - include: else-pop
 
-  export-extended:
+  export-body:
     - meta_prepend: true
+
     - match: as{{identifier_break}}
       scope: storage.modifier.js
       set:
         - expect-semicolon
         - ts-export-as-namespace
+
+    - match: (?=type{{identifier_break}})
+      branch_point: ts-export-type-from
+      branch:
+        - ts-export-type-from
+        - ts-type-declaration
 
   ts-export-as-namespace:
     - match: namespace{{identifier_break}}
@@ -84,6 +91,18 @@ contexts:
         - ts-namespace-name-end
         - ts-namespace-name
     - include: else-pop
+
+  ts-export-type-from:
+    - match: type{{identifier_break}}
+      scope: keyword.control.import-export.js
+      set:
+        - match: (?=\{|\*)
+          set:
+            - expect-semicolon
+            - import-export-from
+            - export-item
+        - match: (?=\S)
+          fail: ts-export-type-from
 
   parenthesized-expression:
     - match: \(

--- a/JavaScript/tests/syntax_test_js_import_export.js
+++ b/JavaScript/tests/syntax_test_js_import_export.js
@@ -54,16 +54,17 @@ import;
 import;/**/
 //     ^ - meta.import
 
-export { name1, name2 as name3, name4 as '+', name5 as "+" };
-//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.export
+export { name1, name2 as name3, name4 as '+', 'name5' as "+" };
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.export
 //^ keyword.control.import-export
-//     ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block
+//     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block
 //            ^ punctuation.separator.comma
 //                    ^^ keyword.control.import-export
 //                                    ^^ keyword.control.import-export
 //                                       ^^^ meta.string string.quoted.single
-//                                                  ^^ keyword.control.import-export
-//                                                     ^^^ meta.string string.quoted.double
+//                                            ^^^^^^^ meta.string string.quoted.single
+//                                                    ^^ keyword.control.import-export
+//                                                       ^^^ meta.string string.quoted.double
 
 export let name1, name2;
 //^^^^^^^^^^^^^^^^^^^^^^ meta.export
@@ -214,9 +215,6 @@ import from from "./othermod";
 
 import { from } from "./othermod";
 //       ^^^^ variable.other.readwrite.js
-
-export from from "./othermod";
-//     ^^^^ variable.other.readwrite.js
 
 export { from } from "./othermod";
 //       ^^^^ variable.other.readwrite.js

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -135,10 +135,37 @@ import foo;
 //                                    ^ punctuation.terminator.statement
 
     export type T = any;
-//  ^^^^^^^^^^^^^^^^^^^ meta.export
+//  ^^^^^^^^^^^^^^^^^^^^ meta.export
 //  ^^^^^^ keyword.control.import-export
 //         ^^^^^^^^^^^^ meta.type-alias
-//                     ^ punctuation.terminator.statement.empty - meta.export
+//                     ^ punctuation.terminator.statement - punctuation.terminator.statement.empty
+
+    export type { T } from 'somewhere';
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.export
+//  ^^^^^^ keyword.control.import-export
+//         ^^^^ keyword.control.import-export
+//              ^^^^^ meta.block
+//              ^ punctuation.section.block.begin
+//                ^ variable.other.readwrite
+//                  ^ punctuation.section.block.end
+//                    ^^^^ keyword.control.import-export
+//                         ^^^^^^^^^^^ meta.string string.quoted.single
+//                         ^ punctuation.definition.string.begin
+//                                   ^ punctuation.definition.string.end
+//                                    ^ punctuation.terminator.statement - punctuation.terminator.statement.empty
+
+    export type * as T from 'somewhere';
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.export
+//  ^^^^^^ keyword.control.import-export
+//         ^^^^ keyword.control.import-export
+//              ^ constant.other
+//                ^^ keyword.control.import-export
+//                   ^ variable.other.readwrite
+//                     ^^^^ keyword.control.import-export
+//                          ^^^^^^^^^^^ meta.string string.quoted.single
+//                          ^ punctuation.definition.string.begin
+//                                    ^ punctuation.definition.string.end
+//                                     ^ punctuation.terminator.statement - punctuation.terminator.statement.empty
 
     export interface Foo {}
 //  ^^^^^^^^^^^^^^^^^^^^^^^ meta.export


### PR DESCRIPTION
The existing code handling export declarations was weirdly overbroad, explicitly handling cases that aren't proper syntax. (Probably this is the legacy of copy-pasting from the import declaration code.) On the other hand, it failed to support at least one case involving strings in place of identifiers. In addition, `export type {}` wan't properly supported in TypeScript, which is how I started on this.

This PR fixes the known export bugs/missing features and generally cleans up the code. It also removes a test that's invalid syntax, and fixes the semicolon scoping on a test that wasn't correct.

I should probably give the import declaration code a good cleaning as well, but I'll put that off until after this PR.