### PR TITLE
[JavaScript] Clean up imports

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -248,7 +248,7 @@ contexts:
       set:
         - import-meta
         - expect-semicolon
-        - import-assert
+        - import-export-assert
         - import-string-or-items
         - import-check-branch
 
@@ -290,45 +290,43 @@ contexts:
       set:
         - import-export-from
         - import-list
-        - import-export-alias
-        - import-item
+        - import-export-item
 
   import-list:
     - match: ','
       scope: punctuation.separator.comma.js
-      push:
-        - import-export-alias
-        - import-item
+      push: import-export-item
     - include: else-pop
 
-  import-item:
+  import-export-item:
     - match: '\{'
       scope: punctuation.section.block.begin.js
-      set: import-brace
+      set: import-export-brace
     - match: '{{non_reserved_identifier}}'
       scope: variable.other.readwrite.js
       pop: 1
     - match: '\*'
-      scope: constant.other.js
-      pop: 1
+      scope: constant.other.wildcard.asterisk.js
+      set: import-export-alias
     - include: else-pop
 
-  import-brace:
+  import-export-brace:
     - meta_scope: meta.block.js
     - include: comma-separator
     - match: '\}'
       scope: punctuation.section.block.end.js
       pop: 1
-    - match: '{{identifier_name}}'
-      scope: variable.other.readwrite.js
-      push: import-export-alias
+    - match: (?={{identifier_start}}|'|")
+      push:
+        - import-export-alias
+        - import-export-name
     - match: '\*'
-      scope: constant.other.js
+      scope: constant.other.wildcard.asterisk.js
       push: import-export-alias
     - include: else-pop
 
-  import-assert:
-    - match: assert{{identifier_break}}
+  import-export-assert:
+    - match: (?:assert|with){{identifier_break}}
       scope: keyword.control.import-export.js
       set:
         - include: object-literal
@@ -350,7 +348,7 @@ contexts:
   export-body:
     - include: declaration
 
-    - match: 'default{{identifier_break}}'
+    - match: default{{identifier_break}}
       scope: keyword.control.import-export.js
       set:
         - include: declaration
@@ -360,29 +358,9 @@ contexts:
     - match: (?=\S)
       set:
         - expect-semicolon
+        - import-export-assert
         - import-export-from
-        - export-item
-
-  export-item:
-    - match: '\{'
-      scope: punctuation.section.block.begin.js
-      set: export-brace
-    - match: '\*'
-      scope: constant.other.js
-      set: import-export-alias
-    - include: else-pop
-
-  export-brace:
-    - meta_scope: meta.block.js
-    - include: comma-separator
-    - match: '\}'
-      scope: punctuation.section.block.end.js
-      pop: 1
-    - match: (?={{identifier_start}}|'|")
-      push:
-        - import-export-alias
-        - import-export-name
-    - include: else-pop
+        - import-export-item
 
   statements:
     - match: '\)|\}|\]'

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -100,7 +100,7 @@ contexts:
           set:
             - expect-semicolon
             - import-export-from
-            - export-item
+            - import-export-item
         - match: (?=\S)
           fail: ts-export-type-from
 
@@ -180,8 +180,18 @@ contexts:
         - ts-type-parameter-list
 
   ts-import-type:
-    - match: type{{identifier_break}}
-      scope: keyword.control.import-export.js
+    - match: (?=type{{identifier_break}})
+      pop: 1
+      branch_point: ts-import-type
+      branch:
+        - - match: type{{identifier_break}}
+            scope: keyword.control.import-export.js
+            set:
+              - match: (?=,|from{{identifier_break}})
+                fail: ts-import-type
+              - include: else-pop
+        - immediately-pop
+
     - include: else-pop
 
   import-statement:
@@ -190,20 +200,20 @@ contexts:
       set:
         - import-meta
         - expect-semicolon
-        - import-assert
+        - import-export-assert
         - import-string-or-items
         - ts-import-type
         - import-check-branch
 
-  import-brace:
+  import-export-brace:
     - meta_prepend: true
     - match: type{{identifier_break}}
       scope: keyword.control.import-export.js
-
-  export-brace:
-    - meta_prepend: true
-    - match: type{{identifier_break}}
-      scope: keyword.control.import-export.js
+    - match: (?={{identifier_start}}|'|")
+      push:
+        - import-export-alias
+        - import-export-name
+        - ts-import-type
 
   ts-type-declaration:
     - match: type{{identifier_break}}

--- a/JavaScript/tests/syntax_test_js_import_export.js
+++ b/JavaScript/tests/syntax_test_js_import_export.js
@@ -21,7 +21,7 @@ import thing, {identifier as otherIdentifier}, * as otherName from "otherplace";
 //                ^ variable.other.readwrite
 //                        ^ keyword.control.import-export
 //                                     ^ variable.other.readwrite
-//                                             ^ constant.other.js
+//                                             ^ constant.other.wildcard.asterisk
 //                                                             ^ keyword.control.import-export
 
 import 'module';
@@ -45,6 +45,10 @@ import foo from 'bar' assert { type: "json" };
 //                                        ^ punctuation.definition.string.end.js
 //                                          ^ punctuation.section.mapping.end.js
 //                                           ^ punctuation.terminator.statement.js
+
+
+import foo from 'bar' assert { type: "json" };
+//                    ^^^^^^ meta.import keyword.control.import-export
 
 // Better highlighting while typing.
 import
@@ -160,7 +164,7 @@ export { name1 as default };
 export * from "./othermod";
 //^^^^^^^^^^^^^^^^^^^^^^^^^ meta.export
 //^ keyword.control.import-export
-//     ^ constant.other
+//     ^ constant.other.wildcard.asterisk
 //       ^ keyword.control.import-export
 
 export { name1, name2 } from "./othermod";
@@ -216,8 +220,15 @@ import from from "./othermod";
 import { from } from "./othermod";
 //       ^^^^ variable.other.readwrite.js
 
-export { from } from "./othermod";
-//       ^^^^ variable.other.readwrite.js
+export {} from "./othermod" with {};
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.export
+//^^^^ keyword.control.import-export
+//     ^^ meta.block
+//        ^^^^ keyword.control.import-export
+//             ^^^^^^^^^^^^ meta.string string.quoted.double
+//                          ^^^^ keyword.control.import-export
+//                               ^^ meta.mapping
+//                                 ^ punctuation.terminator.statement
 
 export default$
 //     ^^^^^^^^ - keyword

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -109,6 +109,14 @@ import foo;
 //                ^^^^ keyword.control.import-export
 //                     ^^^^^^^^^^^ meta.string string.quoted.single
 
+    import type from 'somewhere';
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.import
+//  ^^^^^^ keyword.control.import-export
+//         ^^^^ variable.other.readwrite
+//              ^^^^ keyword.control.import-export
+//                   ^^^^^^^^^^^ meta.string string.quoted.single
+//                              ^ punctuation.terminator.statement
+
     import type { U, V } from 'somewhere';
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.import
 //  ^^^^^^ keyword.control.import-export


### PR DESCRIPTION
- Consolidate `import/export-brace` and `import/export-item`. They're not identical in the grammar, but they're close enough and they don't conflict.
- Handle `import type from 'somewhere';` in TypeScript. (`import type` and `export type` cannot share an implementation because they have different corner cases.)
- Use the new more-specific scope for wildcards.
- Support the `with` keyword for import assertions. This is a breaking change in the import assertions proposal. Currently, TypeScript supports both, but `assert` is deprecated; this PR supports both.
- Support import assertions in re-exports.