### PR TITLE
[Rust] Refactor path matching

### DIFF
--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -55,17 +55,6 @@ contexts:
 
     - include: lifetime
 
-    - match: '\b(mod)\s+({{identifier}})\b'
-      captures:
-        1: storage.type.module.rust
-        2: entity.name.module.rust
-      push:
-        - meta_scope: meta.module.rust
-        - match: ';'
-          scope: punctuation.terminator.rust
-          pop: true
-        - include: statements-block
-
     - match: '\b({{identifier}})\s*(=)\s*(?=\|)'
       captures:
         1: entity.name.function.rust
@@ -114,7 +103,6 @@ contexts:
     # - match: '\b((?:debug_)?assert_(?:eq|ne)!)\s*(\()'
 
     - include: macro-identifiers
-
     - include: types
     - include: basic-identifiers
     - include: numbers
@@ -136,22 +124,28 @@ contexts:
           scope: punctuation.separator.rust
         - include: statements
 
-    - include: return-type
     - include: keywords
 
     - match: ','
       scope: punctuation.separator.rust
       push: after-operator
 
+    - include: return-type
+
     - include: symbols
 
     - match: '\b[[:lower:]_][[:lower:][:digit:]_]*(?=\()'
       scope: variable.function.rust
 
-    - match: '{{identifier}}'
+    - include: identifiers
 
     - match: '\.'
       scope: punctuation.accessor.dot.rust
+
+    - match: '::'
+      scope: punctuation.accessor.rust
+
+  ##[ DECLARATIONS ]##########################################################
 
   visibility:
     - match: '\b(pub)\s*(\()'
@@ -172,7 +166,28 @@ contexts:
     - match: '\bpub\b'
       scope: storage.modifier.rust
 
+  modules:
+    - match: '\b(mod)\s+({{identifier}})\b'
+      captures:
+        1: storage.type.module.rust
+        2: entity.name.module.rust
+      push:
+        - meta_scope: meta.module.rust
+        - match: ';'
+          scope: punctuation.terminator.rust
+          pop: true
+        - include: module-block
+
+  module-block:
+    - match: \{
+      scope: punctuation.section.block.begin.rust
+      set:
+        - meta_scope: meta.module.rust meta.block.rust
+        - include: block-body
+
   declarations:
+    - include: modules
+
     - match: '\b(fn)\s+(?={{identifier}})'
       captures:
         1: storage.type.function.rust
@@ -209,7 +224,7 @@ contexts:
           push: impl-where
         - match: '(?=<)'
           push: generic-angles
-        - include: statements-block
+        - include: trait-block
 
     - match: '\bimpl\b'
       scope: storage.type.impl.rust
@@ -247,6 +262,15 @@ contexts:
         1: support.function.rust
         2: entity.name.macro.rust
       push: macro-block
+
+  trait-block:
+    - match: '\{'
+      scope: punctuation.section.block.begin.rust
+      set:
+        - meta_scope: meta.trait.rust meta.block.rust
+        - include: block-body
+
+  ##[ ARRRIBUTES ]############################################################
 
   attributes:
     - match: '(#)\s*(!?)\s*(\[)'
@@ -317,17 +341,22 @@ contexts:
     - include: keywords
     - include: symbols
 
+  ##[ EXPRESSION GROUPS ]#####################################################
+
   block:
-    - match: '\}'
-      scope: meta.block.rust punctuation.section.block.end.rust
-      pop: true
+    - match: '\{'
+      scope: punctuation.section.block.begin.rust
+      set: [block-body, try-closure]
+
+  blocks:
     - match: '\{'
       scope: punctuation.section.block.begin.rust
       push: [block-body, try-closure]
 
   block-body:
     - meta_scope: meta.block.rust
-    - match: '(?=\})'
+    - match: '\}'
+      scope: punctuation.section.block.end.rust
       pop: true
     - include: statements
     - include: attributes
@@ -367,27 +396,7 @@ contexts:
     - match: '(?=\S)'
       pop: true
 
-  return-type:
-    - match: '\bimpl\b'
-      scope: storage.type.impl.rust
-      push:
-        - include: comments
-        - include: impl-generic
-        - match: '(?=\S)'
-          pop: true
-    - match: '->'
-      scope: punctuation.separator.rust
-      push:
-        - meta_scope: meta.function.return-type.rust
-        - match: '(?=\s*\{|\bwhere\b)'
-          pop: true
-        - match: '(?=<)'
-          push: generic-angles
-        - include: types-any
-        - match: '{{identifier}}'
-        # Escape for incomplete expression
-        - match: '(?=\S)'
-          pop: true
+  ##[ PATTERNS ]###########################################################
 
   pattern-param:
     # A pattern used in a function or closure parameter.
@@ -462,6 +471,8 @@ contexts:
     - match: ','
       scope: punctuation.separator.rust
 
+  ##[ CLOSURES ]##############################################################
+
   closure:
     - meta_content_scope: meta.function.closure.rust
     - match: '\|'
@@ -488,7 +499,8 @@ contexts:
       set: closure-body
 
   closure-body:
-    - match: '(?=\{)'
+    - match: '\{'
+      scope: punctuation.section.block.begin
       set: closure-explicit-body
     - match: (?=\S)
       set: closure-implicit-body
@@ -500,66 +512,10 @@ contexts:
     - include: statements
 
   closure-explicit-body:
-    - meta_scope: meta.function.closure.rust
-    - include: block
+    - meta_scope: meta.function.closure.rust meta.block.rust
+    - include: block-body
 
-  generic-angles:
-    - meta_scope: meta.generic.rust
-    - match: '>'
-      scope: punctuation.definition.generic.end.rust
-      pop: true
-    - match: '<'
-      scope: punctuation.definition.generic.begin.rust
-      push: generic-angles-contents
-    - match: '(?=\S)'
-      pop: true
-
-  generic-angles-contents:
-    - include: comments
-    - include: attributes
-    - match: '(?=>)'
-      pop: true
-    - match: '<'
-      scope: punctuation.definition.generic.begin.rust
-      push:
-        - match: '>'
-          scope: punctuation.definition.generic.end.rust
-          pop: true
-        - include: generic-angles-contents
-    - include: bool
-    # byte must be before type-any-identifier since it doesn't know about byte tokens
-    - include: byte
-    - include: types-any
-    # char must be after type-any-identifier to deal with conflict with lifetimes
-    - include: char
-    # Handle negative integers (technically unary negative expression with a literal expression)
-    - match: '-'
-      scope: keyword.operator.arithmetic.rust
-    - include: integers
-    - include: block
-    - match: ':|,'
-      scope: punctuation.separator.rust
-    - match: '\+|='
-      scope: keyword.operator.rust
-    - match: '(?=\S)'
-      pop: true
-
-  constant-integer-expression:
-    - include: integers
-    - match: \(
-      scope: punctuation.section.group.begin.rust
-      push:
-        - meta_scope: meta.group.rust
-        - match: \)
-          scope: punctuation.section.group.end.rust
-          pop: true
-        - include: constant-integer-expression
-    - match: '{{identifier}}'
-      scope: variable.other.constant.rust
-    - match: '::'
-      scope: punctuation.accessor.double-colon.rust
-    - match: '[-+%/*]'
-      scope: keyword.operator.arithmetic.rust
+  ##[ TYPES ]#################################################################
 
   types:
     # more relaxed take on types-any
@@ -587,6 +543,7 @@ contexts:
   types-any:
     # also matches stray identifiers because a type is expected
     - include: comments
+    - include: types-impl
     - include: return-type
     - match: '&'
       scope: keyword.operator.rust
@@ -642,6 +599,15 @@ contexts:
     - include: type-slice-or-array
     - include: type-any-identifiers
 
+  types-impl:
+    - match: '\bimpl\b'
+      scope: storage.type.impl.rust
+      push:
+        - include: comments
+        - include: impl-generic
+        - match: '(?=\S)'
+          pop: true
+
   type-any-identifier-path:
     - meta_scope: meta.path.rust
     - match: '::'
@@ -692,9 +658,46 @@ contexts:
     - match: '\bdyn\b(?!\s*::)(?=\s*(?:\(|{{lifetime}}|{{identifier}}))'
       scope: storage.type.trait.rust
 
-  raw-pointer:
-    - match: '\*\s*(?:const|mut)\b'
-      scope: storage.modifier.rust
+  generic-angles:
+    - meta_scope: meta.generic.rust
+    - match: '>'
+      scope: punctuation.definition.generic.end.rust
+      pop: true
+    - match: '<'
+      scope: punctuation.definition.generic.begin.rust
+      push: generic-angles-contents
+    - match: '(?=\S)'
+      pop: true
+
+  generic-angles-contents:
+    - include: comments
+    - include: attributes
+    - match: '(?=>)'
+      pop: true
+    - match: '<'
+      scope: punctuation.definition.generic.begin.rust
+      push:
+        - match: '>'
+          scope: punctuation.definition.generic.end.rust
+          pop: true
+        - include: generic-angles-contents
+    - include: bool
+    # byte must be before type-any-identifier since it doesn't know about byte tokens
+    - include: byte
+    - include: types-any
+    # char must be after type-any-identifier to deal with conflict with lifetimes
+    - include: char
+    # Handle negative integers (technically unary negative expression with a literal expression)
+    - match: '-'
+      scope: keyword.operator.arithmetic.rust
+    - include: integers
+    - include: blocks
+    - match: ':|,'
+      scope: punctuation.separator.rust
+    - match: '\+|='
+      scope: keyword.operator.rust
+    - match: '(?=\S)'
+      pop: true
 
   hrtb:
     - match: \bfor\b
@@ -724,6 +727,25 @@ contexts:
               pop: true
             - include: constant-integer-expression
         - include: types-any
+
+  constant-integer-expression:
+    - include: integers
+    - match: \(
+      scope: punctuation.section.group.begin.rust
+      push:
+        - meta_scope: meta.group.rust
+        - match: \)
+          scope: punctuation.section.group.end.rust
+          pop: true
+        - include: constant-integer-expression
+    - match: '{{identifier}}'
+      scope: variable.other.constant.rust
+    - match: '::'
+      scope: punctuation.accessor.double-colon.rust
+    - match: '[-+%/*]'
+      scope: keyword.operator.arithmetic.rust
+
+  ##[ STRUCTS ]###############################################################
 
   struct-identifier:
     - meta_scope: meta.struct.rust
@@ -778,9 +800,6 @@ contexts:
 
   struct-classic:
     - meta_scope: meta.struct.rust
-    - match: '\}'
-      scope: meta.block.rust punctuation.section.block.end.rust
-      pop: true
     - match: '\{'
       scope: punctuation.section.block.begin.rust
       push: struct-classic-body
@@ -790,7 +809,8 @@ contexts:
 
   struct-classic-body:
     - meta_scope: meta.block.rust
-    - match: '(?=\})'
+    - match: '\}'
+      scope: punctuation.section.block.end.rust
       pop: true
     - include: comments
     - include: attributes
@@ -811,6 +831,8 @@ contexts:
       # Abort for an invalid match.
       pop: true
 
+  ##[ UNIONS ]#################################################################
+
   union-identifier:
     - meta_scope: meta.union.rust
     - include: comments
@@ -821,24 +843,27 @@ contexts:
         - match: '(?=<)'
           push: generic-angles
         - match: ''
-          set: union-body
+          set: union-extra
     - match: '{{identifier}}'
       scope: entity.name.union.rust
-      set: union-body
+      set: union-extra
 
-  union-body:
-    - meta_scope: meta.union.rust
+  union-extra:
+    - meta_content_scope: meta.union.rust
     - include: comments
     - match: '(?=\bwhere\b)'
       push: impl-where
     - match: '\{'
       scope: punctuation.section.block.begin.rust
-      push: struct-classic-body
-    - match: '\}'
-      scope: meta.block.rust punctuation.section.block.end.rust
-      pop: true
+      set: union-body
     - match: '(?=;)'
       pop: true
+
+  union-body:
+    - meta_scope: meta.union.rust meta.block.rust
+    - include: struct-classic-body
+
+  ##[ ENUMS ]#################################################################
 
   enum-identifier:
     - meta_scope: meta.enum.rust
@@ -907,6 +932,8 @@ contexts:
       pop: true
     # This is just constant-expression, but we don't have that defined.
     - include: statements
+
+  ##[ MACROS DEFINITIONS ]####################################################
 
   macro-block:
     - meta_scope: meta.macro.rust
@@ -1088,6 +1115,8 @@ contexts:
       # This is intended to help make it evident when you forget a semicolon.
       scope: invalid.illegal.rust
 
+  ##[ IMPL DEFINITIONS ]######################################################
+
   impl-definition:
     - meta_scope: meta.impl.rust
     - include: comments
@@ -1121,8 +1150,7 @@ contexts:
   impl-identifier:
     - meta_content_scope: meta.impl.rust
     - include: comments
-    - match: '(?=\{)'
-      set: impl-body
+    - include: impl-block
     - match: '(?=\bwhere\b)'
       push: impl-where
     - match: \b(mut|ref)\b
@@ -1150,9 +1178,16 @@ contexts:
     - match: ':'
       scope: punctuation.separator.rust
 
+  impl-block:
+    - match: \{
+      scope: punctuation.section.block.begin.rust
+      set: impl-body
+
   impl-body:
-    - meta_scope: meta.impl.rust
-    - include: statements-block
+    - meta_scope: meta.impl.rust meta.block.rust
+    - include: block-body
+
+  ##[ FUNCTION DEFINITIONS ]###################################################
 
   fn-definition:
     - meta_scope: meta.function.rust
@@ -1167,7 +1202,7 @@ contexts:
       push: generic-angles
     - match: '(?=\()'
       set: fn-parameters
-    - match: \bwhere\b
+    - match: (?=\bwhere\b)
       set: fn-where
     # Escape for incomplete expression
     - match: '(?=;)'
@@ -1190,22 +1225,23 @@ contexts:
   fn-return:
     - meta_scope: meta.function.rust
     - include: comments
-    - match: '(?=\{)'
+    - match: '\{'
+      scope: punctuation.section.block.begin.rust
       set: fn-body
-    - match: '(?=\bwhere\b)'
-      set: fn-where
     - include: return-type
+    - match: (?=\bwhere\b)
+      push: fn-where
     # Escape for incomplete expression, or ';'
     - match: '(?=\S)'
       pop: true
 
   fn-where:
-    - meta_scope: meta.function.rust meta.where.rust
-    - include: comments
-    - match: '(?=\{)'
-      set: fn-body
+    - meta_scope: meta.where.rust
     - match: \bwhere\b
       scope: keyword.other.rust
+    - include: comments
+    - match: '(?=\{)'
+      pop: true
     - include: types-any
     - match: '[:,]'
       scope: punctuation.separator.rust
@@ -1213,31 +1249,36 @@ contexts:
     - match: '(?=\S)'
       pop: true
 
-  fn-body:
-    - meta_scope: meta.function.rust
-    - match: '\}'
-      scope: meta.block.rust punctuation.section.block.end.rust
-      pop: true
-    - match: '\{'
-      scope: punctuation.section.block.begin.rust
+  return-type:
+    - match: '->'
+      scope: punctuation.separator.rust
       push:
-        - meta_scope: meta.block.rust
-        - match: '(?=\})'
+        - meta_scope: meta.function.return-type.rust
+        - match: '(?=\s*\{|\bwhere\b)'
           pop: true
-        - include: statements
+        - match: '(?=<)'
+          push: generic-angles
+        - include: types-any
+        - match: '{{identifier}}'
+        # Escape for incomplete expression
+        - match: '(?=\S)'
+          pop: true
 
-  statements-block:
-    - include: comments
+  fn-body:
+    - meta_scope: meta.function.rust meta.block.rust
     - match: '\}'
-      scope: meta.block.rust punctuation.section.block.end.rust
+      scope: punctuation.section.block.end.rust
       pop: true
-    - match: '\{'
-      scope: punctuation.section.block.begin.rust
-      push: [block-body, try-closure]
+    - include: statements
+
+  ##[ COMMENTS ]##############################################################
 
   comments:
+    - include: line-comments
     - include: block-comments
-    - match: "//[!/]"
+
+  line-comments:
+    - match: //[!/]
       scope: punctuation.definition.comment.rust
       push:
         - meta_scope: comment.line.documentation.rust
@@ -1251,7 +1292,7 @@ contexts:
           pop: true
 
   block-comments:
-    - match: '/\*[!\*][^\*/]'
+    - match: /\*[!\*][^\*/]
       scope: punctuation.definition.comment.rust
       push:
         - meta_scope: comment.block.documentation.rust
@@ -1271,6 +1312,8 @@ contexts:
           scope: punctuation.definition.comment.rust
           pop: true
         - include: block-comments
+
+  ##[ STRING LITERALS ]#######################################################
 
   strings:
     - include: byte-string
@@ -1448,6 +1491,8 @@ contexts:
         \}
       scope: constant.other.placeholder.rust
 
+  ##[ NUMERIC LITERALS ]######################################################
+
   numbers:
     - include: floats
     - include: integers
@@ -1486,6 +1531,11 @@ contexts:
     - match: '{{lifetime}}'
       scope: storage.modifier.lifetime.rust
 
+  ##[ IDENTIFIERS ]###########################################################
+
+  identifiers:
+    - match: '{{identifier}}'
+
   basic-identifiers:
     - match: '\b(?:(?:r#)?[[:upper:]_][[:upper:][:digit:]_]+)\b'
       scope: constant.other.rust
@@ -1500,7 +1550,7 @@ contexts:
         - match: '::'
           scope: punctuation.accessor.rust
           set: no-type-names
-    - match: '(::)(?={{identifier}})'
+    - match: '(::)\s*(?={{identifier}})'
       scope: meta.path.rust
       captures:
         1: punctuation.accessor.rust
@@ -1528,6 +1578,8 @@ contexts:
       push: generic-angles
     - match: ''
       pop: true
+
+  ##[ KEYWORDS AND SYMBOLS ]##################################################
 
   symbols:
     - match: '=>'
@@ -1568,6 +1620,10 @@ contexts:
   bool:
     - match: \b(true|false)\b
       scope: constant.language.rust
+
+  raw-pointer:
+    - match: '\*\s*(?:const|mut)\b'
+      scope: storage.modifier.rust
 
   keywords:
     # All keywords.  Note in `statements` some of these are superseded by more

--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -291,10 +291,14 @@ contexts:
     - match: \)
       scope: meta.function-call.rust meta.group.rust punctuation.section.group.end.rust
       pop: true
+    - match: ({{identifier}})\s*(::)\s*
+      scope: meta.path.rust
+      captures:
+        2: punctuation.accessor.rust
     - match: '({{identifier}})\s*(\()'
       scope: meta.function-call.rust
       captures:
-        1: variable.function.rust
+        1: meta.path.rust variable.function.rust
         2: meta.group.rust punctuation.section.group.begin.rust
       push:
         - meta_content_scope: meta.function-call.rust

--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -257,10 +257,12 @@ contexts:
   inside-attribute:
     # https://github.com/sublimehq/Packages/issues/709#issuecomment-266835130
     - meta_scope: meta.annotation.rust
-    - match: '(?:{{identifier}}\s*::\s*)*({{identifier}})'
+    - match: ({{identifier}})\s*(::)\s*
       scope: meta.path.rust
       captures:
-        1: variable.annotation.rust
+        2: punctuation.accessor.rust
+    - match: '{{identifier}}'
+      scope: meta.path.rust variable.annotation.rust
     - match: '\('
       scope: meta.annotation.parameters.rust meta.group.rust punctuation.section.group.begin.rust
       push:

--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -64,8 +64,7 @@ contexts:
     - include: keywords
     - include: numbers
 
-    - match: '(?=\{)'
-      push: block
+    - include: blocks
 
     - match: '(?=\()'
       push: group
@@ -155,7 +154,7 @@ contexts:
           push: generic-angles
         - match: '=(?!=)'
           scope: keyword.operator.assignment.rust
-          push: type-declaration-body
+          set: type-declaration-body
         - include: else-pop
 
     - match: '\b(trait)\s+({{identifier}})\b'
@@ -1540,8 +1539,9 @@ contexts:
   identifier-path:
     - meta_scope: meta.path.rust
     - include: comments
-    - match: \.
-      scope: punctuation.accessor.dot.rust
+    - match: \s*(\.)
+      captures:
+        1: punctuation.accessor.dot.rust
       push: [identifier-path-second, path-after-accessor]
     - include: identifier-names
     - include: immediately-pop
@@ -1549,8 +1549,9 @@ contexts:
   identifier-path-second:
     - meta_scope: meta.path.rust
     - include: comments
-    - match: \.
-      scope: punctuation.accessor.dot.rust
+    - match: \s*(\.)
+      captures:
+        1: punctuation.accessor.dot.rust
       push: path-after-accessor
     - include: in-path-identifier-names
     - include: immediately-pop
@@ -1558,8 +1559,9 @@ contexts:
   static-identifier-path:
     - meta_scope: meta.path.rust
     - include: comments
-    - match: '::'
-      scope: punctuation.accessor.rust
+    - match: \s*(::)
+      captures:
+        1: punctuation.accessor.rust
       set: [static-identifier-path-second, path-after-accessor]
     - include: type-names
     - include: identifier-names
@@ -1580,8 +1582,7 @@ contexts:
 
   path-after-accessor:
     - include: comments
-    - match: \s+
-    - include: immediately-pop
+    - include: else-pop
 
   identifier-names:
     - include: no-path-identifier-names

--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -72,81 +72,7 @@ contexts:
         2: keyword.operator.assignment.rust
       push: closure
 
-    - match: '\b(fn)\s+(?={{identifier}})'
-      captures:
-        1: storage.type.function.rust
-      push: fn-definition
-
-    - match: '\bstruct\b'
-      scope: storage.type.struct.rust
-      push: struct-identifier
-
-    - match: '\bunion\b(?!\s*\()'
-      scope: storage.type.union.rust
-      push: union-identifier
-
-    - match: '\b(type)\s+({{identifier}})\b'
-      captures:
-        1: storage.type.type.rust
-        2: entity.name.type.rust
-      push:
-        - match: '=(?!=)'
-          scope: keyword.operator.assignment.rust
-          push: after-operator
-        - match: '(?=\S)'
-          pop: true
-
-    - match: '\b(trait)\s+({{identifier}})\b'
-      captures:
-        1: storage.type.trait.rust
-        2: entity.name.trait.rust
-      push:
-        - meta_scope: meta.trait.rust
-        - match: '(?=:)'
-          push: impl-where
-        - match: '(?=\bwhere\b)'
-          push: impl-where
-        - match: '(?=<)'
-          push: generic-angles
-        - include: statements-block
-
-    - match: '\bimpl\b'
-      scope: storage.type.impl.rust
-      push: impl-definition
-
-    - match: '\benum\b'
-      scope: storage.type.enum.rust
-      push: enum-identifier
-
-    - include: raw-pointer
-
-    # `const` in a function header has a different scope from `const` values.
-    - match: '\b(const)\s+(?=unsafe|extern|fn)'
-      captures:
-        1: storage.modifier.rust
-
-    - match: '\b(const)\s+({{identifier}})'
-      captures:
-        1: storage.type.rust
-        2: entity.name.constant.rust
-
-    - match: '\b(static)\s+(?:(mut)\s+)?({{identifier}})'
-      captures:
-        1: storage.type.rust
-        2: storage.modifier.rust
-        3: entity.name.constant.rust
-
-    - match: '\b(break|continue)\b(?:\s+(''{{non_raw_ident}}))?'
-      captures:
-        1: keyword.control.rust
-        2: entity.name.label.rust
-
-    - match: '\b(macro_rules!)\s+({{identifier}})\b'
-      captures:
-        1: support.function.rust
-        2: entity.name.macro.rust
-      push: macro-block
-
+    - include: declarations
     - include: comments
     - include: attributes
     - include: strings
@@ -245,6 +171,82 @@ contexts:
           scope: meta.path.rust
     - match: '\bpub\b'
       scope: storage.modifier.rust
+
+  declarations:
+    - match: '\b(fn)\s+(?={{identifier}})'
+      captures:
+        1: storage.type.function.rust
+      push: fn-definition
+
+    - match: '\bstruct\b'
+      scope: storage.type.struct.rust
+      push: struct-identifier
+
+    - match: '\bunion\b(?!\s*\()'
+      scope: storage.type.union.rust
+      push: union-identifier
+
+    - match: '\b(type)\s+({{identifier}})\b'
+      captures:
+        1: storage.type.type.rust
+        2: entity.name.type.rust
+      push:
+        - match: '=(?!=)'
+          scope: keyword.operator.assignment.rust
+          push: after-operator
+        - match: '(?=\S)'
+          pop: true
+
+    - match: '\b(trait)\s+({{identifier}})\b'
+      captures:
+        1: storage.type.trait.rust
+        2: entity.name.trait.rust
+      push:
+        - meta_scope: meta.trait.rust
+        - match: '(?=:)'
+          push: impl-where
+        - match: '(?=\bwhere\b)'
+          push: impl-where
+        - match: '(?=<)'
+          push: generic-angles
+        - include: statements-block
+
+    - match: '\bimpl\b'
+      scope: storage.type.impl.rust
+      push: impl-definition
+
+    - match: '\benum\b'
+      scope: storage.type.enum.rust
+      push: enum-identifier
+
+    - include: raw-pointer
+
+    # `const` in a function header has a different scope from `const` values.
+    - match: '\b(const)\s+(?=unsafe|extern|fn)'
+      captures:
+        1: storage.modifier.rust
+
+    - match: '\b(const)\s+({{identifier}})'
+      captures:
+        1: storage.type.rust
+        2: entity.name.constant.rust
+
+    - match: '\b(static)\s+(?:(mut)\s+)?({{identifier}})'
+      captures:
+        1: storage.type.rust
+        2: storage.modifier.rust
+        3: entity.name.constant.rust
+
+    - match: '\b(break|continue)\b(?:\s+(''{{non_raw_ident}}))?'
+      captures:
+        1: keyword.control.rust
+        2: entity.name.label.rust
+
+    - match: '\b(macro_rules!)\s+({{identifier}})\b'
+      captures:
+        1: support.function.rust
+        2: entity.name.macro.rust
+      push: macro-block
 
   attributes:
     - match: '(#)\s*(!?)\s*(\[)'

--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -16,7 +16,7 @@ variables:
   non_raw_ident: '[[:alpha:]][_[:alnum:]]*|_[_[:alnum:]]+'
   # include a word boundary at the end to ensure all possible characters are
   # consumed, to prevent catastrophic backtracking
-  identifier: '(?:(?:(?:r\#)?{{non_raw_ident}})\b)'
+  identifier: '(?:(?:r\#)?{{non_raw_ident}}\b)'
   camel_ident: '\b_*[A-Z][a-zA-Z0-9_]*[a-z][a-zA-Z0-9_]*\b'
   lifetime: '''(?:_|{{non_raw_ident}})(?!\'')\b'
   escaped_byte: '\\([nrt0\"''\\]|x\h{2})'
@@ -55,56 +55,13 @@ contexts:
 
     - include: lifetime
 
-    - match: '\b({{identifier}})\s*(=)\s*(?=\|)'
-      captures:
-        1: entity.name.function.rust
-        2: keyword.operator.assignment.rust
-      push: closure
-
     - include: declarations
     - include: comments
     - include: attributes
     - include: strings
     - include: chars
-
-    # macros which take format specs as the only parameter
-    - match: '\b((?:format(?:_args)?|e?print(?:ln)?|panic|unreachable|unimplemented)!)\s*(\()'
-      captures:
-        1: support.macro.rust
-        2: meta.group.rust punctuation.section.group.begin.rust
-      push:
-        - meta_content_scope: meta.group.rust
-        - include: comments
-        - include: format-string
-        - include: format-raw-string
-        - match: '(?=\S)'
-          set: group-tail
-
-    # macros which take format specs as the second parameter
-    - match: '\b((?:write(?:ln)?|(?:debug_)?assert)!)\s*(\()'
-      captures:
-        1: support.macro.rust
-        2: meta.group.rust punctuation.section.group.begin.rust
-      push:
-        - meta_scope: meta.group.rust
-        - include: comments
-        - match: ','
-          set:
-            - meta_content_scope: meta.group.rust
-            - include: format-string
-            - include: format-raw-string
-            - match: '(?=\S)'
-              set: group-tail
-        - include: group-tail
-
-    # macros which take format specs as the third parameter
-    # - match: '\b((?:assert_eq|assert_ne|debug_assert_eq|debug_assert_ne)!)\s*(\()'
-    # is more performant as the below
-    # - match: '\b((?:debug_)?assert_(?:eq|ne)!)\s*(\()'
-
-    - include: macro-identifiers
-    - include: types
-    - include: basic-identifiers
+    - include: bytes
+    - include: keywords
     - include: numbers
 
     - match: '(?=\{)'
@@ -124,26 +81,14 @@ contexts:
           scope: punctuation.separator.rust
         - include: statements
 
-    - include: keywords
-
     - match: ','
       scope: punctuation.separator.rust
       push: after-operator
 
     - include: return-type
-
-    - include: symbols
-
-    - match: '\b[[:lower:]_][[:lower:][:digit:]_]*(?=\()'
-      scope: variable.function.rust
-
+    - include: types-relaxed
     - include: identifiers
-
-    - match: '\.'
-      scope: punctuation.accessor.dot.rust
-
-    - match: '::'
-      scope: punctuation.accessor.rust
+    - include: symbols
 
   ##[ DECLARATIONS ]##########################################################
 
@@ -206,11 +151,12 @@ contexts:
         1: storage.type.type.rust
         2: entity.name.type.rust
       push:
+        - match: (?=<)
+          push: generic-angles
         - match: '=(?!=)'
           scope: keyword.operator.assignment.rust
-          push: after-operator
-        - match: '(?=\S)'
-          pop: true
+          push: type-declaration-body
+        - include: else-pop
 
     - match: '\b(trait)\s+({{identifier}})\b'
       captures:
@@ -245,12 +191,20 @@ contexts:
       captures:
         1: storage.type.rust
         2: entity.name.constant.rust
+      push: declaration-after-identifier
 
     - match: '\b(static)\s+(?:(mut)\s+)?({{identifier}})'
       captures:
         1: storage.type.rust
         2: storage.modifier.rust
         3: entity.name.constant.rust
+      push: declaration-after-identifier
+
+    - match: \b(let)\s+(?:(mut)\s+)?
+      captures:
+        1: storage.type.rust
+        2: storage.modifier.rust
+      push: declaration-identifier
 
     - match: '\b(break|continue)\b(?:\s+(''{{non_raw_ident}}))?'
       captures:
@@ -262,6 +216,31 @@ contexts:
         1: support.function.rust
         2: entity.name.macro.rust
       push: macro-block
+
+  declaration-identifier:
+    - match: '\b({{identifier}})\s*(=)\s*(?=\|)'
+      captures:
+        1: entity.name.function.rust
+        2: keyword.operator.assignment.rust
+      set: closure
+    # highligght (potentially invalid) keywords
+    - include: keywords
+    - match: '{{identifier}}'
+      set: declaration-after-identifier
+    - include: else-pop
+
+  declaration-after-identifier:
+    - match: ':'
+      scope: punctuation.separator.rust
+      set: declaration-type
+    - include: else-pop
+
+  declaration-type:
+    - match: '=(?!=)'
+      scope: keyword.operator.assignment.rust
+      set: after-operator
+    - include: types
+    - include: else-pop
 
   trait-block:
     - match: '\{'
@@ -303,6 +282,7 @@ contexts:
         - meta_content_scope: meta.annotation.rust
         - include: strings
         - include: chars
+        - include: bytes
         - include: numbers
         - include: comments
         - match: '\]'
@@ -335,6 +315,7 @@ contexts:
       scope: keyword.operator.assignment.rust
     - include: strings
     - include: chars
+    - include: bytes
     - include: numbers
     - include: comments
     - include: lifetime
@@ -466,7 +447,7 @@ contexts:
       push:
         - match: '(?=,|\)|\]|\}|\|)'
           pop: true
-        - include: types-any
+        - include: types
 
     - match: ','
       scope: punctuation.separator.rust
@@ -517,33 +498,26 @@ contexts:
 
   ##[ TYPES ]#################################################################
 
+  type-declaration-body:
+    - include: types
+    - include: else-pop
+
+  types-relaxed:
+    # only the most obvious type constructs (for fallback matching)
+    - match: (?=[!?]\s*{{type_identifier}})
+      push: type-mark
+    - include: dyn-types
+    - match: (?={{type_identifier}}\s*<)
+      push:
+        - include: type-names
+        - match: (?=<)
+          push: generic-angles
+        - include: else-pop
+
   types:
-    # more relaxed take on types-any
-    - match: '(?=[!?]?{{type_identifier}}::)'
-      push: type-identifier-path
-    - include: type-identifiers
-
-  type-identifier-path:
-    - meta_scope: meta.path.rust
-    - match: '::'
-      scope: punctuation.accessor.rust
-      pop: true
-    - include: type-identifiers
-
-  type-identifiers:
-    - match: '(?:(!)|(\?))(?={{type_identifier}})'
-      captures:
-        1: keyword.operator.negated-type.rust
-        2: storage.modifier.relaxed-bounds.rust
-    - include: support-type
-    - include: type
-    - match: '{{type_identifier}}'
-      scope: storage.type.source.rust
-
-  types-any:
-    # also matches stray identifiers because a type is expected
+    # matches stray identifiers as a types because a type is expected
     - include: comments
-    - include: types-impl
+    - include: impl-types
     - include: return-type
     - match: '&'
       scope: keyword.operator.rust
@@ -565,13 +539,15 @@ contexts:
             - include: return-type
             - match: '(?=\S)'
               pop: true
-        - include: types-any
+        - include: types
+        - include: pattern-param
+    - include: dyn-types
     - include: lifetime
-    - match: (?=[?!]?{{identifier}}::)
-      push: type-any-identifier-path
-    - match: ::(?={{identifier}})
-      scope: meta.path.rust punctuation.accessor.rust
-    - match: '(?=<)'
+    - match: (?={{identifier}}::)
+      push: type-path
+    - match: (?=::)
+      push: type-path-second
+    - match: (?=<)
       push: generic-angles
     - match: '\('
       scope: punctuation.section.group.begin.rust
@@ -582,68 +558,77 @@ contexts:
           pop: true
         - match: ','
           scope: punctuation.separator.rust
-        - include: types-any
+        - include: types
     - match: '\+'
       scope: keyword.operator.arithmetic.union.rust
     - match: '\b_\b'
       scope: storage.type.inference.rust
     - match: '!(?!\w)'
       scope: storage.type.never.rust
+    - include: type-marks
     - match: \bextern\b
       scope: keyword.other.rust
       push:
         - include: strings
-        - match: '(?=\S)'
-          pop: true
+        - include: else-pop
     - include: hrtb
     - include: type-slice-or-array
-    - include: type-any-identifiers
+    - include: type-names
+    - include: all-generic-type-names
 
-  types-impl:
-    - match: '\bimpl\b'
-      scope: storage.type.impl.rust
-      push:
-        - include: comments
-        - include: impl-generic
-        - match: '(?=\S)'
-          pop: true
+  type-mark:
+    - include: type-marks
+    - include: else-pop
 
-  type-any-identifier-path:
-    - meta_scope: meta.path.rust
-    - match: '::'
-      scope: punctuation.accessor.rust
-      pop: true
-    - match: '!'
-      scope: keyword.operator.negated-type.rust
-    - include: type-any-identifiers
-
-  type-any-identifiers:
+  type-marks:
     - match: '!'
       scope: keyword.operator.negated-type.rust
     - match: '\?'
       scope: storage.modifier.relaxed-bounds.rust
-    - include: support-type
-    - include: type
-    - match: '{{type_identifier}}'
-      scope: storage.type.rust
-    - match: '{{identifier}}'
-      scope: meta.identifier.expected-type.rust
 
-  support-type:
-    - match: '(Vec|Option|Result|BTreeMap|HashMap|Box|Rc|Arc|AsRef|AsMut|Into|From)\s*(?=<)'
+  type-path:
+    - meta_scope: meta.path.rust
+    - include: comments
+    - match: '::'
+      scope: punctuation.accessor.rust
+      set: [type-path-second, path-after-accessor]
+    - include: type-names
+    - include: else-pop
+
+  type-path-second:
+    - meta_scope: meta.path.rust
+    - match: '::'
+      scope: punctuation.accessor.rust
+      push: path-after-accessor
+    - include: in-path-type-names
+    - include: immediately-pop
+
+  type-names:
+    - include: no-path-type-names
+    - include: in-path-type-names
+
+  type-names-relaxed:
+    - include: no-path-type-names
+    - include: support-type-names
+    - include: generic-type-names
+
+  in-path-type-names:
+    - include: support-type-names
+    - include: generic-type-names
+
+  no-path-type-names:
+    - match: \bSelf\b
+      scope: storage.type.rust
+    - include: low-level-type-names
+    - include: stdsimd-type-names
+
+  support-type-names:
+    - match: \b(Vec|Option|Result|BTreeMap|HashMap|Box|Rc|Arc|AsRef|AsMut|Into|From)\b
       scope: support.type.rust
-      push: generic-angles
     - match: \b(Copy|Send|Sized|Sync|Drop|Fn|FnMut|FnOnce|Box|ToOwned|Clone|PartialEq|PartialOrd|Eq|Ord|AsRef|AsMut|Into|From|Default|Iterator|Extend|IntoIterator|DoubleEndedIterator|ExactSizeIterator|Option|Some|None|Result|Ok|Err|SliceConcatExt|String|ToString|Vec)\b
       scope: support.type.rust
 
-  type:
-    # A low-level type. Typically you want types-any for the full type grammar.
-    - match: '{{identifier}}(?=<)'
-      scope: storage.type.rust
-      push: generic-angles
-    - match: \b(Self|{{int_suffixes}}|{{float_suffixes}}|bool|char|str)\b
-      scope: storage.type.rust
-    # stdsimd types
+  stdsimd-type-names:
     - match: |-
         (?x)
         \b(?:
@@ -655,38 +640,56 @@ contexts:
           __m(?:64|128|256)[di]? # __m512 should come later
         )\b
       scope: storage.type.rust
-    - match: '\bdyn\b(?!\s*::)(?=\s*(?:\(|{{lifetime}}|{{identifier}}))'
+
+  specentifier-names:
+    - match: '\b(c_[[:lower:][:digit:]_]+|[[:lower:]_][[:lower:][:digit:]_]*_t)\b'
+      scope: storage.type.rust
+
+  low-level-type-names:
+    - match: \b({{int_suffixes}}|{{float_suffixes}}|bool|char|str)\b
+      scope: storage.type.rust
+
+  all-generic-type-names:
+    - match: '{{identifier}}'
+      scope: storage.type.rust
+
+  generic-type-names:
+    - match: '\b(?:r#)?_*{{type_identifier}}'
+      scope: storage.type.rust
+
+  impl-types:
+    - match: '\bimpl\b'
+      scope: storage.type.impl.rust
+      push:
+        - include: comments
+        - include: impl-generic
+        - match: '(?=\S)'
+          pop: true
+
+  dyn-types:
+    - match: '\bdyn\b(?=\s*(?:\(|{{lifetime}}|{{identifier}}))'
       scope: storage.type.trait.rust
 
   generic-angles:
     - meta_scope: meta.generic.rust
+    - match: '<'
+      scope: punctuation.definition.generic.begin.rust
+      push: generic-angles-body
+    - include: else-pop
+
+  generic-angles-body:
+    - include: comments
+    - include: attributes
     - match: '>'
       scope: punctuation.definition.generic.end.rust
       pop: true
-    - match: '<'
-      scope: punctuation.definition.generic.begin.rust
-      push: generic-angles-contents
-    - match: '(?=\S)'
-      pop: true
-
-  generic-angles-contents:
-    - include: comments
-    - include: attributes
-    - match: '(?=>)'
-      pop: true
-    - match: '<'
-      scope: punctuation.definition.generic.begin.rust
-      push:
-        - match: '>'
-          scope: punctuation.definition.generic.end.rust
-          pop: true
-        - include: generic-angles-contents
+    # match a few constants
     - include: bool
-    # byte must be before type-any-identifier since it doesn't know about byte tokens
-    - include: byte
-    - include: types-any
-    # char must be after type-any-identifier to deal with conflict with lifetimes
-    - include: char
+    # bytes must be before types to match the leading `b`
+    - include: bytes
+    - include: types
+    # chars must be after type-any-identifier to deal with conflict with lifetimes
+    - include: chars
     # Handle negative integers (technically unary negative expression with a literal expression)
     - match: '-'
       scope: keyword.operator.arithmetic.rust
@@ -705,7 +708,7 @@ contexts:
       push:
         - match: '(?=<)'
           push: generic-angles
-        - include: types-any
+        - include: types
         - match: '&'
           scope: keyword.operator.rust
         - include: lifetime
@@ -716,17 +719,19 @@ contexts:
     - match: '\['
       scope: punctuation.section.group.begin.rust
       push:
+        - meta_scope: meta.group.rust
         - match: '\]'
           scope: punctuation.section.group.end.rust
           pop: true
         - match: ';'
           scope: punctuation.separator.rust
           set:
+            - meta_scope: meta.group.rust
             - match: '\]'
               scope: punctuation.section.group.end.rust
               pop: true
             - include: constant-integer-expression
-        - include: types-any
+        - include: types
 
   constant-integer-expression:
     - include: integers
@@ -794,7 +799,7 @@ contexts:
     - include: comments
     - include: attributes
     - include: visibility
-    - include: types-any
+    - include: types
     - match: ','
       scope: punctuation.separator.rust
 
@@ -826,7 +831,7 @@ contexts:
         - include: comments
         - match: ':'
           scope: punctuation.separator.rust
-        - include: types-any
+        - include: types
     - match: '(?=\S)'
       # Abort for an invalid match.
       pop: true
@@ -906,7 +911,7 @@ contexts:
       scope: entity.name.constant.rust
       push: enum-variant-type
     - match: '{{camel_ident}}'
-      scope: storage.type.source.rust
+      scope: storage.type.rust
       push: enum-variant-type
     - match: '{{identifier}}'
       push: enum-variant-type
@@ -1143,7 +1148,7 @@ contexts:
         - match: \bfor\b
           scope: keyword.other.rust
           set: impl-identifier
-        - include: types-any
+        - include: types
     - match: ''
       set: impl-identifier
 
@@ -1163,9 +1168,7 @@ contexts:
     - match: '&'
       scope: keyword.operator.rust
     - include: lifetime
-    - match: '(?=\S)'
-      # Abort on unexpected character.
-      pop: true
+    - include: else-pop
 
   impl-where:
     - meta_scope: meta.where.rust
@@ -1174,7 +1177,7 @@ contexts:
       pop: true
     - match: \bwhere\b
       scope: keyword.other.rust
-    - include: types-any
+    - include: types
     - match: ':'
       scope: punctuation.separator.rust
 
@@ -1204,15 +1207,13 @@ contexts:
       set: fn-parameters
     - match: (?=\bwhere\b)
       set: fn-where
-    # Escape for incomplete expression
-    - match: '(?=;)'
-      pop: true
+    - include: else-pop
 
   fn-parameters:
     - meta_scope: meta.function.rust
     - match: '\)'
       scope: meta.function.parameters.rust punctuation.section.parameters.end.rust
-      set: fn-return
+      set: fn-after-parameters
     - match: '\('
       scope: punctuation.section.parameters.begin.rust
       push:
@@ -1222,7 +1223,7 @@ contexts:
           pop: true
         - include: pattern-param
 
-  fn-return:
+  fn-after-parameters:
     - meta_scope: meta.function.rust
     - include: comments
     - match: '\{'
@@ -1231,9 +1232,7 @@ contexts:
     - include: return-type
     - match: (?=\bwhere\b)
       push: fn-where
-    # Escape for incomplete expression, or ';'
-    - match: '(?=\S)'
-      pop: true
+    - include: else-pop
 
   fn-where:
     - meta_scope: meta.where.rust
@@ -1242,12 +1241,10 @@ contexts:
     - include: comments
     - match: '(?=\{)'
       pop: true
-    - include: types-any
+    - include: types
     - match: '[:,]'
       scope: punctuation.separator.rust
-    # Escape for incomplete expression, or ';'
-    - match: '(?=\S)'
-      pop: true
+    - include: else-pop
 
   return-type:
     - match: '->'
@@ -1258,7 +1255,7 @@ contexts:
           pop: true
         - match: '(?=<)'
           push: generic-angles
-        - include: types-any
+        - include: types
         - match: '{{identifier}}'
         # Escape for incomplete expression
         - match: '(?=\S)'
@@ -1321,11 +1318,7 @@ contexts:
     - include: string
     - include: raw-string
 
-  chars:
-    - include: char
-    - include: byte
-
-  byte:
+  bytes:
     - match: "(b)(')"
       captures:
         1: storage.type.string.rust
@@ -1393,7 +1386,7 @@ contexts:
     - match: '\\.'
       scope: invalid.illegal.character.escape.rust
 
-  char:
+  chars:
     - match: "'"
       scope: punctuation.definition.string.begin.rust
       push:
@@ -1531,53 +1524,133 @@ contexts:
     - match: '{{lifetime}}'
       scope: storage.modifier.lifetime.rust
 
-  ##[ IDENTIFIERS ]###########################################################
+  ##[ IDENTIFIERS AND FUNCTION CALLS ]########################################
 
   identifiers:
-    - match: '{{identifier}}'
+    - match: (?={{identifier}}\s*\.)
+      push: identifier-path
+    - match: (?=\.(?!\.))
+      push: identifier-path-second
+    - match: (?={{identifier}}\s*::)
+      push: static-identifier-path
+    - match: (?=::)
+      push: static-identifier-path-second
+    - include: identifier-names
 
-  basic-identifiers:
-    - match: '\b(?:(?:r#)?[[:upper:]_][[:upper:][:digit:]_]+)\b'
-      scope: constant.other.rust
-    - match: '\b(c_[[:lower:][:digit:]_]+|[[:lower:]_][[:lower:][:digit:]_]*_t)\b'
-      scope: storage.type.rust
-    - match: '\b(?:r#)?_*[A-Z][a-zA-Z0-9_]*[a-z][a-zA-Z0-9_]*\b'
-      scope: storage.type.source.rust
-    - match: (?={{identifier}}::)
-      push:
-        - meta_scope: meta.path.rust
-        - include: no-path-identifiers
-        - match: '::'
-          scope: punctuation.accessor.rust
-          set: no-type-names
-    - match: '(::)\s*(?={{identifier}})'
-      scope: meta.path.rust
-      captures:
-        1: punctuation.accessor.rust
-      push: no-type-names
-    - include: no-path-identifiers
+  identifier-path:
+    - meta_scope: meta.path.rust
+    - include: comments
+    - match: \.
+      scope: punctuation.accessor.dot.rust
+      push: [identifier-path-second, path-after-accessor]
+    - include: identifier-names
+    - include: immediately-pop
 
-  macro-identifiers:
-    - match: '\b{{identifier}}!(?=\s*(\(|\{|\[))'
-      scope: support.macro.rust
+  identifier-path-second:
+    - meta_scope: meta.path.rust
+    - include: comments
+    - match: \.
+      scope: punctuation.accessor.dot.rust
+      push: path-after-accessor
+    - include: in-path-identifier-names
+    - include: immediately-pop
 
-  no-path-identifiers:
+  static-identifier-path:
+    - meta_scope: meta.path.rust
+    - include: comments
+    - match: '::'
+      scope: punctuation.accessor.rust
+      set: [static-identifier-path-second, path-after-accessor]
+    - include: type-names
+    - include: identifier-names
+    - include: immediately-pop
+
+  static-identifier-path-second:
+    # does not include no-path-identifier-names
+    - meta_scope: meta.path.rust
+    - include: comments
+    - match: '::'
+      scope: punctuation.accessor.rust
+      push: path-after-accessor
+    - include: in-path-type-names
+    - include: in-path-identifier-names
+    - match: (?=<)
+      push: generic-angles
+    - include: immediately-pop
+
+  path-after-accessor:
+    - include: comments
+    - match: \s+
+    - include: immediately-pop
+
+  identifier-names:
+    - include: no-path-identifier-names
+    - include: no-path-type-names
+    - include: in-path-identifier-names
+
+  in-path-identifier-names:
+    - include: keywords
+    - include: macro-identifiers
+    - include: in-path-type-names
+    - include: function-identifiers
+    - include: constant-identifier-names
+    - include: generic-identifier-names
+
+  no-path-identifier-names:
     - match: \b(self)\b
       scope: variable.language.rust
     - match: \b(super)\b
       scope: keyword.other.rust
 
-  no-type-names:
-    # This push state prevents highlighting basic types like
-    # i32, etc when following ::
-    - include: comments
-    - include: macro-identifiers
-    - include: basic-identifiers
+  constant-identifier-names:
+    - match: '\b(?:(?:r#)?[[:upper:]_][[:upper:][:digit:]_]+)\b'
+      scope: constant.other.rust
+
+  macro-identifiers:
+    # macros which take format specs as the only parameter
+    - match: '\b((?:format(?:_args)?|e?print(?:ln)?|panic|unreachable|unimplemented)!)\s*(\()'
+      captures:
+        1: support.macro.rust
+        2: meta.group.rust punctuation.section.group.begin.rust
+      push:
+        - meta_content_scope: meta.group.rust
+        - include: comments
+        - include: format-string
+        - include: format-raw-string
+        - match: '(?=\S)'
+          set: group-tail
+
+    # macros which take format specs as the second parameter
+    - match: '\b((?:write(?:ln)?|(?:debug_)?assert)!)\s*(\()'
+      captures:
+        1: support.macro.rust
+        2: meta.group.rust punctuation.section.group.begin.rust
+      push:
+        - meta_scope: meta.group.rust
+        - include: comments
+        - match: ','
+          set:
+            - meta_content_scope: meta.group.rust
+            - include: format-string
+            - include: format-raw-string
+            - match: '(?=\S)'
+              set: group-tail
+        - include: group-tail
+
+    # macros which take format specs as the third parameter
+    # - match: '\b((?:assert_eq|assert_ne|debug_assert_eq|debug_assert_ne)!)\s*(\()'
+    # is more performant as the below
+    # - match: '\b((?:debug_)?assert_(?:eq|ne)!)\s*(\()'
+    - match: '\b{{identifier}}!(?=\s*(\(|\{|\[))'
+      scope: support.macro.rust
+
+  function-identifiers:
+    - match: '{{identifier}}(?=\s*\()'
+      scope: variable.function.rust
+
+  generic-identifier-names:
     - match: '{{identifier}}'
-    - match: '(?=<)'
-      push: generic-angles
-    - match: ''
-      pop: true
+      scope: debug.variable.rust
 
   ##[ KEYWORDS AND SYMBOLS ]##################################################
 
@@ -1675,5 +1748,19 @@ contexts:
     - match: \b(virtual|become|priv|typeof|unsized|do|abstract|final|override|macro)\b
       scope: invalid.illegal.rust
 
-    - match: \b(super|self|Self)\b
+    - match: \b(super|Self)\b
       scope: keyword.other.rust
+
+    - include: reserved-keywords
+
+  reserved-keywords:
+    - match: \b(virtual|become|priv|typeof|unsized|do|abstract|final|override|macro|for)\b
+      scope: invalid.illegal.rust
+
+  else-pop:
+    - match: (?=\S)
+      pop: true
+
+  immediately-pop:
+    - match: ''
+      pop: true

--- a/Rust/tests/syntax_test_attributes.rs
+++ b/Rust/tests/syntax_test_attributes.rs
@@ -144,4 +144,5 @@ unsafe impl<#[may_dangle] T: ?Sized> Drop for Box<T> { }
 #[rustfmt::skip]
 //^^^^^^^^^^^^^^ meta.annotation
 //^^^^^^^^^^^^^ meta.path
+//       ^^ punctuation.accessor
 //         ^^^^ variable.annotation

--- a/Rust/tests/syntax_test_attributes.rs
+++ b/Rust/tests/syntax_test_attributes.rs
@@ -146,3 +146,14 @@ unsafe impl<#[may_dangle] T: ?Sized> Drop for Box<T> { }
 //^^^^^^^^^^^^^ meta.path
 //       ^^ punctuation.accessor
 //         ^^^^ variable.annotation
+
+
+#[rustfmt::skip(rust::fmt::skip())]
+//             ^^^^^^^^^^^^^^^^^^^ meta.annotation meta.annotation.parameters meta.group
+//              ^^^^^^^^^^^^^^^ meta.path
+//                  ^^ punctuation.accessor
+//                       ^^ punctuation.accessor
+//                         ^^^^^^ meta.function-call
+//                         ^^^^ variable.function
+//                             ^ meta.group meta.group punctuation.section.group.begin
+//                              ^ meta.group meta.group punctuation.section.group.end

--- a/Rust/tests/syntax_test_closures.rs
+++ b/Rust/tests/syntax_test_closures.rs
@@ -163,7 +163,7 @@ let x = |a: i32, b: Foo, c: Option<i32>, d: extern "C" fn (), e: *const u8| {};
 //          ^^^ storage.type
 //               ^ variable.parameter
 //                       ^ variable.parameter
-//                          ^^^^^^ meta.generic support.type
+//                          ^^^^^^ support.type
 //                                 ^^^ meta.generic storage.type
 //                                       ^ variable.parameter
 //                                          ^^^^^^ keyword.other

--- a/Rust/tests/syntax_test_dyn.rs
+++ b/Rust/tests/syntax_test_dyn.rs
@@ -33,13 +33,15 @@ type A1 = dyn::dyn;
 //        ^^^^^ meta.path -storage.type.trait
 //             ^^^ -storage.type.trait
 type A2 = dyn<dyn, dyn>;
-//        ^^^ meta.generic -storage.type.trait
+//        ^^^ -storage.type.trait
 //            ^^^ meta.generic -storage.type.trait
 //                 ^^^ meta.generic -storage.type.trait
 // This is incorrect.  `identifier` should not match on the keyword `as`.
 // However, avoiding keywords is a little complicated and slow.
 type A3 = dyn<<dyn as dyn>::dyn>;
-//        ^^^ meta.generic -storage.type.trait
-//             ^^^ meta.generic storage.type.trait
-//                    ^^^ meta.generic -storage.type.trait
-//                          ^^^ meta.generic -storage.type.trait
+//        ^^^ -storage.type.trait
+//           ^^^^^^^^^^^^^^^^^^^ meta.generic
+//            ^^^^^^^^^^^^ meta.generic meta.generic
+//             ^^^ storage.type.trait
+//                    ^^^ -storage.type.trait
+//                          ^^^ -storage.type.trait

--- a/Rust/tests/syntax_test_enum.rs
+++ b/Rust/tests/syntax_test_enum.rs
@@ -7,7 +7,7 @@ enum OperatingSystem
 {
 // <- meta.block meta.enum punctuation.section.block.begin
     Osx,
-//  ^^^ meta.enum storage.type.source
+//  ^^^ meta.enum storage.type.rust
     Windows,
     Linux,
     Bsd(String),
@@ -21,16 +21,21 @@ enum OperatingSystem
 // <- meta.block meta.enum punctuation.section.block.end
 
 let q = Message::Quit;
-//      ^^^^^^^^^ meta.path
-//      ^^^^^^^ storage.type.source
-//               ^^^^ storage.type.source
+//      ^^^^^^^^^^^^^ meta.path
+//      ^^^^^^^ storage.type.rust
+//             ^^ punctuation.accessor
+//               ^^^^ storage.type.rust
 //                   ^ punctuation.terminator
 let w = Message::WriteString("Some string".to_string());
-//               ^^^^^^^^^^^ storage.type.source
+//      ^^^^^^^^^^^^^^^^^^^^ meta.path
+//             ^^ punctuation.accessor
+//               ^^^^^^^^^^^ storage.type.rust
 //                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group
 //                           ^^^^^^^^^^^^^ string.quoted.double
 //                                         ^^^^^^^^^ variable.function
 let m = Message::Move { x: 50, y: 200 };
+//      ^^^^^^^^^^^^^ meta.path
+//             ^^ punctuation.accessor
 //                    ^^^^^^^^^^^^^^^^^ meta.block
 //                         ^^ constant.numeric.integer.decimal
 //                                ^^^ constant.numeric.integer.decimal
@@ -45,7 +50,7 @@ enum Discriminant {
     V2,
 //  ^^ meta.enum entity.name.constant
     SomeValue = 123,
-//  ^^^^^^^^^ meta.enum storage.type.source
+//  ^^^^^^^^^ meta.enum storage.type.rust
 //              ^^^ meta.enum constant.numeric.integer.decimal
     V3 = (1<<4),
 //  ^^ meta.enum entity.name.constant

--- a/Rust/tests/syntax_test_functions.rs
+++ b/Rust/tests/syntax_test_functions.rs
@@ -153,12 +153,3 @@ fn sum((x, y): (i32, i32)) -> i32 {
 //                   ^^^ storage.type
 //                      ^ punctuation.section.group.end
 }
-
-input.parse::<SnailNum>()
-//           ^^^^^^^^^^ meta.generic.rust
-//           ^ punctuation.definition.generic.begin.rust
-//            ^^^^^^^^ storage.type.rust
-//                    ^ punctuation.definition.generic.end.rust
-//                     ^^ meta.group.rust
-//                     ^ punctuation.section.group.begin.rust
-//                      ^ punctuation.section.group.end.rust

--- a/Rust/tests/syntax_test_generics.rs
+++ b/Rust/tests/syntax_test_generics.rs
@@ -213,7 +213,10 @@ impl<T> From<AsRef<T>> for CliError<T> { }
 //                                 ^^^ meta.generic
 
 fn legal_dates_iter() -> Box<Iterator<Item = Date<UTC>>> {
-//                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.return-type meta.generic
+//                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.return-type
+//                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.generic
+//                                   ^^^^^^^^^^^^^^^^^^ meta.generic meta.generic
+//                                               ^^^^^ meta.generic meta.generic meta.generic
 //                                         ^ keyword.operator
     unimplemented!()
 }
@@ -229,7 +232,7 @@ fn numbers() -> impl Iterator<Item = u64> {
 
 fn collect_vec() {
     let _: Vec<(usize, usize)> = (0..10).enumerate().collect::<Vec<_>>();
-//         ^^^^^^^^^^^^^^^^^^^ meta.generic
+//            ^^^^^^^^^^^^^^^^ meta.generic
 //         ^^^ support.type
 //             ^ punctuation.section.group.begin
 //              ^^^^^ storage.type
@@ -248,7 +251,7 @@ fn collect_vec() {
 //                                                          ^^ punctuation.accessor
 //                                                             ^^^ support.type
 //                                                            ^^^^^^^^ meta.generic
-//                                                             ^^^^^^ meta.generic meta.generic
+//                                                                ^^^ meta.generic meta.generic
 //                                                                 ^ storage.type.inference.rust
     let _: Vec<(usize, usize)> = vec!();
 //                               ^^^^ support.macro

--- a/Rust/tests/syntax_test_identifiers.rs
+++ b/Rust/tests/syntax_test_identifiers.rs
@@ -1,0 +1,58 @@
+// SYNTAX TEST "Packages/Rust/Rust.sublime-syntax"
+
+let line = Cow::from(x);
+//         ^^^^^^^^^ meta.path
+//         ^^^ storage.type
+//            ^^ punctuation.accessor
+//              ^^^^ variable.function
+//                  ^^^ meta.group
+//                  ^ punctuation.section.group.begin
+
+
+buffer.rope.char();
+//^^^^^^^^^^^^^^ meta.path
+//    ^ punctuation.accessor.dot
+//         ^ punctuation.accessor.dot
+//          ^^^^ variable.function
+//              ^^ meta.group
+//                ^ punctuation.terminator
+
+env::current_dir()
+//^^^^^^^^^^^^^^ meta.path
+// ^^ punctuation.accessor
+//   ^^^^^^^^^^^ variable.function
+
+let file_bytes = fs::read(&path_buf)?;
+//               ^^^^^^^^ meta.path
+//                 ^^ punctuation.accessor
+//                   ^^^^ variable.function
+//                       ^^^^^^^^^^^ meta.group
+//                                  ^ keyword.operator
+//                                   ^ punctuation.terminator
+
+u8::try_from(), f64::from()
+// <- meta.path storage.type
+ // <- meta.path storage.type
+//^^^^^^^^^^ meta.path
+//  ^^^^^^^^ variable.function
+//          ^^^^ -meta.path
+//            ^ punctuation.separator
+//              ^^^^^^^^^ meta.path
+//              ^^^ storage.type
+//                 ^^ punctuation.accessor
+//                   ^^^^ variable.function
+
+Vec::with_capacity()
+//^^^^^^^^^^^^^^^^ meta.path
+//^ support.type
+// ^^ punctuation.accessor
+
+// The following should eventually recognize `parse` as the function name
+input.parse::<SnailNum>()
+//           ^^^^^^^^^^ meta.generic.rust
+//           ^ punctuation.definition.generic.begin.rust
+//            ^^^^^^^^ storage.type.rust
+//                    ^ punctuation.definition.generic.end.rust
+//                     ^^ meta.group.rust
+//                     ^ punctuation.section.group.begin.rust
+//                      ^ punctuation.section.group.end.rust

--- a/Rust/tests/syntax_test_identifiers.rs
+++ b/Rust/tests/syntax_test_identifiers.rs
@@ -17,6 +17,20 @@ buffer.rope.char();
 //              ^^ meta.group
 //                ^ punctuation.terminator
 
+
+buffer . rope . char ();
+//^^^^^^^^^^^^^^^^^^ meta.path
+//     ^ punctuation.accessor.dot
+//            ^ punctuation.accessor.dot
+//              ^^^^ variable.function
+//                   ^^ meta.group
+//                     ^ punctuation.terminator
+
+path . with_a_break s.path ();
+//^^^^^^^^^^^^^^^^^ meta.path
+//                 ^ -meta.path
+//                  ^^^^^^ meta.path
+
 env::current_dir()
 //^^^^^^^^^^^^^^ meta.path
 // ^^ punctuation.accessor
@@ -30,17 +44,17 @@ let file_bytes = fs::read(&path_buf)?;
 //                                  ^ keyword.operator
 //                                   ^ punctuation.terminator
 
-u8::try_from(), f64::from()
+u8::try_from(), f64 :: from ()
 // <- meta.path storage.type
  // <- meta.path storage.type
 //^^^^^^^^^^ meta.path
 //  ^^^^^^^^ variable.function
 //          ^^^^ -meta.path
 //            ^ punctuation.separator
-//              ^^^^^^^^^ meta.path
+//              ^^^^^^^^^^^ meta.path
 //              ^^^ storage.type
-//                 ^^ punctuation.accessor
-//                   ^^^^ variable.function
+//                  ^^ punctuation.accessor
+//                     ^^^^ variable.function
 
 Vec::with_capacity()
 //^^^^^^^^^^^^^^^^ meta.path

--- a/Rust/tests/syntax_test_identifiers.rs
+++ b/Rust/tests/syntax_test_identifiers.rs
@@ -47,6 +47,13 @@ Vec::with_capacity()
 //^ support.type
 // ^^ punctuation.accessor
 
+for x in a.union(&b) {
+    //   ^^^^^^^ meta.path
+    //    ^ punctuation.accessor.dot
+    //     ^^^^^ variable.function
+    println!("{}", x);
+}
+
 // The following should eventually recognize `parse` as the function name
 input.parse::<SnailNum>()
 //           ^^^^^^^^^^ meta.generic.rust

--- a/Rust/tests/syntax_test_macros.rs
+++ b/Rust/tests/syntax_test_macros.rs
@@ -209,7 +209,7 @@ macro_rules! forward_ref_binop [
 //                        ^ keyword.operator
 //                         ^^ storage.modifier.lifetime
 //                            ^^ variable.other
-//                                ^^^ keyword.other
+//                                ^^^ entity.name.impl
 //                                    ^ keyword.operator
 //                                     ^^ storage.modifier.lifetime
 //                                        ^^ variable.other
@@ -379,7 +379,6 @@ macro_rules! designators {
 //                                              ^^^ string.quoted.single
 //                                                  ^ keyword.operator
 //                                                    ^^^^^^ storage.type.struct
-//                                                           ^^^^ keyword.other
 //                                                               ^ punctuation.section.block.end
 //                                                                 ^^ meta.macro keyword.operator
 //                                                                    ^^ meta.macro meta.macro.transcribers

--- a/Rust/tests/syntax_test_modules.rs
+++ b/Rust/tests/syntax_test_modules.rs
@@ -41,25 +41,24 @@ pub use self::trafile::*;
 
 use std::fmt;
 // <- keyword.other
-//  ^^^^^ meta.path
+//  ^^^^^^^^ meta.path
 //     ^^ punctuation.accessor
-//       ^^^ - meta.path
 //          ^ punctuation.terminator
 use foo::i32;
 //  ^^^^^ meta.path
 //     ^^ punctuation.accessor
-//       ^^^ - meta.path storage.type
+//       ^^^ - storage.type
 use foo::Bar;
 //  ^^^^^ meta.path
 //     ^^ punctuation.accessor
-//       ^^^ storage.type.source
+//       ^^^ storage.type.rust
 
 use foo::{Baz, QUX, quux};
 //  ^^^^^ meta.path
 //     ^^ punctuation.accessor.rust
 //       ^^^^^^^^^^^^^^^^ meta.block
 //       ^ punctuation.section.block.begin
-//        ^^^ storage.type.source
+//        ^^^ storage.type.rust
 //             ^^^ constant.other
 //                  ^^^^ meta.block
 //                      ^ punctuation.section.block.end
@@ -78,8 +77,8 @@ use std::{
     path::{Path, PathBuf},
 //  ^^^^^^ meta.block meta.path
 //        ^ meta.block meta.block punctuation.section.block.begin
-//         ^^^^ meta.block meta.block storage.type.source
-//               ^^^^^^^ meta.block meta.block storage.type.source
+//         ^^^^ meta.block meta.block storage.type.rust
+//               ^^^^^^^ meta.block meta.block storage.type.rust
 //                      ^ meta.block meta.block punctuation.section.block.end
    };
 // ^ meta.block punctuation.section.block.end

--- a/Rust/tests/syntax_test_raw.rs
+++ b/Rust/tests/syntax_test_raw.rs
@@ -14,7 +14,7 @@ fn main() {
 
     let r#local = r#Struct { r#struct: () };
 //      ^^^^^^^^ -keyword
-//                ^^^^^^^^ storage.type.source -keyword
+//                ^^^^^^^^ storage.type.rust -keyword
 //                           ^^^^^^^^ -keyword
     let r#async = r#foo(r#local);
 //      ^^^^^^^^ -keyword
@@ -27,13 +27,13 @@ fn main() {
 
     if let r#sub_pat @ Foo(_) = r#Foo(3) {}
 //         ^^^^^^^^^^ -keyword
-//                              ^^^^^ storage.type.source
+//                              ^^^^^ storage.type.rust
 
     match r#async {
 //        ^^^^^^^^ -keyword
         r#Foo | r#Bar => r#foo(),
-//      ^^^^^ storage.type.source -keyword
-//              ^^^^^ storage.type.source -keyword
+//      ^^^^^ storage.type.rust -keyword
+//              ^^^^^ storage.type.rust -keyword
 //                       ^^^^^ -keyword
     }
 }
@@ -77,11 +77,11 @@ impl r#Trait for r#Impl {
 //               ^^^^^^ meta.impl entity.name.impl -keyword
     type r#Type = r#u32;
 //       ^^^^^^ meta.impl meta.block entity.name.type
-//                ^^^^^ meta.impl meta.block -keyword -storage
+//                ^^^^^ meta.impl meta.block storage.type
     fn r#xxx(r#fjio: r#u32) {}
 //     ^^^^^ meta.impl meta.block meta.function entity.name.function -keyword
 //           ^^^^^^ meta.impl meta.block meta.function meta.function.parameters variable.parameter -keyword
-//                   ^^^^^ meta.impl meta.block meta.function meta.function.parameters -keyword -storage
+//                   ^^^^^ meta.impl meta.block meta.function meta.function.parameters storage.type
 }
 
 extern "C" {

--- a/Rust/tests/syntax_test_struct.rs
+++ b/Rust/tests/syntax_test_struct.rs
@@ -15,8 +15,8 @@ struct PrintableStruct(Box<i32>);
 //^^^^ storage.type.struct
 //     ^^^^^^^^^^^^^^^ entity.name.struct
 //                    ^ punctuation.section.group.begin
-//                     ^^^^^^^^ meta.generic
 //                     ^^^ support.type
+//                        ^^^^^ meta.generic
 //                        ^ punctuation.definition.generic.begin
 //                         ^^^ storage.type
 //                            ^ punctuation.definition.generic.end
@@ -107,18 +107,18 @@ let mut j = BasicStruct(10);
 //                      ^^ constant.numeric.integer.decimal
 
 let p = Point {x: 10.0, y: 20.0};
-//      ^^^^^ storage.type.source
+//      ^^^^^ storage.type.rust
 //            ^^^^^^^^^^^^^^^^^^ meta.block
 //            ^ punctuation.section.block.begin
 //              ^ punctuation.separator
 //                ^^^^ constant.numeric.float
 //                             ^ punctuation.section.block.end
 let n = NothingInMe {};
-//      ^^^^^^^^^^^ storage.type.source
+//      ^^^^^^^^^^^ storage.type.rust
 //                  ^^ meta.block
 let tp = TuplePoint { 0: 10.0, 1: 20.0 };
 //                    ^constant.numeric.integer.decimal
 //                             ^ constant.numeric.integer.decimal
 let p = Point { x, y };
-//      ^^^^^ storage.type.source
+//      ^^^^^ storage.type.rust
 //            ^^^^^^^^ meta.block

--- a/Rust/tests/syntax_test_traits.rs
+++ b/Rust/tests/syntax_test_traits.rs
@@ -85,7 +85,7 @@ impl<T: ?Sized> !marker::Sync for Rc<T> {}
 //       ^^^^^ support.type.rust
 //            ^ punctuation.definition.generic.end.rust
 //              ^ meta.impl.rust keyword.operator.rust meta.impl.opt-out.rust
-//               ^^^^^^^^ meta.impl.rust meta.path.rust
+//               ^^^^^^^^^^^^ meta.impl.rust meta.path.rust
 //                       ^^^^ meta.impl.rust support.type.rust
 //                            ^^^ meta.impl.rust keyword.other.rust
 //                                ^^ meta.impl.rust meta.generic.rust entity.name.impl.rust
@@ -139,3 +139,8 @@ trait Bar: for<'a> Foo<&'a ()> {}
 //             ^^ meta.where meta.generic storage.modifier.lifetime
 //                     ^ meta.where meta.generic keyword.operator
 //                      ^^ meta.where meta.generic storage.modifier.lifetime
+
+trait t {}
+//    ^ meta.trait entity.name.trait
+
+// <- - meta

--- a/Rust/tests/syntax_test_types.rs
+++ b/Rust/tests/syntax_test_types.rs
@@ -14,7 +14,7 @@ type FnPointer = fn(i32) -> i32;
 type GenFnPointer = Bar<fn(i32) -> i32>;
 // <- storage.type.type
 //   ^^^^^^^^^^^^ entity.name.type
-//                  ^^^^^^^^^^^^^^^^^^^ meta.generic
+//                     ^^^^^^^^^^^^^^^^ meta.generic
 //                      ^^ storage.type.function
 //                        ^^^^^ meta.group
 //                         ^^^ storage.type
@@ -25,7 +25,7 @@ type GenFnPointer = Bar<fn(i32) -> i32>;
 type GenFnPointer2 = Bar<extern "C" fn()>;
 // <- storage.type.type
 //   ^^^^^^^^^^^^^ entity.name.type
-//                   ^^^^^^^^^^^^^^^^^^^^ meta.generic
+//                      ^^^^^^^^^^^^^^^^^ meta.generic
 //                       ^^^^^^ keyword.other
 //                              ^^^ string.quoted.double
 //                                  ^^ storage.type.function
@@ -76,9 +76,10 @@ let mut mutable = 12;
 type Pair<'a> = (i32, &'a str);
 // <- storage.type.type
 //   ^^^^ entity.name.type
-//       ^ keyword.operator
+//       ^^^^ meta.generic
+//       ^ punctuation.definition.generic.begin
 //        ^^ storage.modifier.lifetime
-//          ^ keyword.operator
+//          ^ punctuation.definition.generic.end
 //            ^ keyword.operator.assignment
 //              ^^^^^^^^^^^^^^ meta.group
 //              ^ punctuation.section.group.begin
@@ -88,10 +89,11 @@ type Pair<'a> = (i32, &'a str);
 //                        ^^^ storage.type
 //                           ^ punctuation.section.group.end
 //                            ^ punctuation.terminator
+
 let p: Pair<'static> = (10, "ten");
 // <- storage.type
 //   ^ punctuation.separator
-//     ^^^^^^^^^^^^^ meta.generic
+//         ^^^^^^^^^ meta.generic
 //         ^ punctuation.definition.generic.begin
 //          ^^^^^^^ storage.modifier.lifetime
 //                 ^ punctuation.definition.generic.end
@@ -102,6 +104,7 @@ let p: Pair<'static> = (10, "ten");
 //                          ^^^^^ string.quoted.double
 //                               ^ punctuation.section.group.end
 //                                ^ punctuation.terminator
+
 fn tuple(x: (u32, u32)) {}
 //          ^^^^^^^^^^ meta.group
 //          ^ meta.group punctuation.section.group.begin
@@ -135,7 +138,7 @@ let slice: &[i32];
 // Pointer types.
 let p: *const Foo;
 //     ^^^^^^ storage.modifier
-//            ^^^ storage.type.source
+//            ^^^ storage.type
 let p: *mut u8;
 //     ^^^^ storage.modifier
 //          ^^ storage.type
@@ -151,25 +154,25 @@ let p_imm: *const u32 = &i as *const u32;
 //                                   ^^^ storage.type
 
 type Snail = Vec<SnailNum>;
-//           ^^^^^^^^^^^^^ meta.generic.rust
 //           ^^^ support.type.rust
+//              ^^^^^^^^^^ meta.generic.rust
 //              ^ punctuation.definition.generic.begin.rust
 //               ^^^^^^^^ storage.type.rust
 //                       ^ punctuation.definition.generic.end.rust
 
 type ExampleRawPointer = HashMap<*const i32, Option<i32>, BuildHasherDefault<FnvHasher>>;
-//                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.generic.rust
+//                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.generic.rust
 //                               ^^^^^^ storage.modifier
 //                                      ^^^ meta.generic storage.type
 //                                         ^ punctuation.separator.rust
-//                                           ^^^^^^^^^^^ meta.generic.rust meta.generic.rust
 //                                           ^^^^^^ support.type.rust
+//                                                 ^^^^^ meta.generic.rust meta.generic.rust
 //                                                 ^ punctuation.definition.generic.begin.rust
 //                                                  ^^^ storage.type.rust
 //                                                     ^ punctuation.definition.generic.end.rust
 //                                                      ^ punctuation.separator.rust
-//                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.generic.rust meta.generic.rust
 //                                                        ^^^^^^^^^^^^^^^^^^ storage.type
+//                                                                          ^^^^^^^^^^^ meta.generic.rust meta.generic.rust
 //                                                                          ^ punctuation.definition.generic.begin.rust
 //                                                                           ^^^^^^^^^ storage.type.rust
 //                                                                                    ^^ punctuation.definition.generic.end.rust
@@ -189,37 +192,44 @@ fn from_str() -> Result<Foo, !> {}
 //                           ^ storage.type.never.rust
 
 // Qualified path with type.
-// Note: This isn't actually a generics, but that gets reused for this purpose.
-type Item = <I as Iterator>::Item;
+// Note: This isn't actually a generic, but that gets reused for this purpose.
+type Item = <I as Iterator> :: Item;
 //          ^^^^^^^^^^^^^^^ meta.generic
+//          ^ punctuation.definition.generic.begin
+//           ^ storage.type
 //             ^^ keyword.operator
 //                ^^^^^^^^ support.type
-//                         ^^ punctuation.accessor
-//                           ^^^^ storage.type.source
-
+//                        ^ punctuation.definition.generic.end
+//                          ^^^^^^^ meta.path
+//                          ^^ punctuation.accessor
+//                             ^^^^ storage.type
+//                                 ^ punctuation.terminator
+//
 type Item = module::Temp;
 //          ^^^^^^^^ meta.path.rust
 //                ^^ punctuation.accessor.rust
-//                  ^^^^ storage.type.source.rust
+//                  ^^^^ storage.type.rust
 type Item = Iterator::Item;
 //          ^^^^^^^^^^ meta.path.rust
 //                  ^^ punctuation.accessor.rust
-//                    ^^^^ storage.type.source.rust
+//                    ^^^^ storage.type.rust
 
 impl Iterator for Struct {
     type Temp = i32;
     type Item = Self::Temp;
-//              ^^^^^^ meta.path.rust
+//              ^^^^^^^^^^ meta.path.rust
 //              ^^^^ storage.type.rust
 //                  ^^ punctuation.accessor.rust
-//                    ^^^^ storage.type.source.rust
+//                    ^^^^ storage.type.rust
 
     fn next(&mut self) -> Option<Self::Item>;
-//                        ^^^^^^^^^^^^^^^^^^ meta.impl.rust meta.block.rust meta.function.rust meta.function.return-type.rust meta.generic.rust
+//                        ^^^^^^^^^^^^^^^^^^ meta.function.rust meta.function.return-type.rust
 //                        ^^^^^^ support.type.rust
+//                              ^^^^^^^^^^^^ meta.generic
 //                              ^ punctuation.definition.generic.begin.rust
-//                               ^^^^^^ meta.path.rust - storage.type.rust storage.type.rust
+//                               ^^^^^^^^^^ meta.path.rust - storage.type.rust storage.type.rust
 //                               ^^^^ storage.type.rust
 //                                   ^^ punctuation.accessor.rust - storage.type.rust
 //                                     ^^^^
+//                                         ^ punctuation.definition.generic.end.rust
 }

--- a/Rust/tests/syntax_test_union.rs
+++ b/Rust/tests/syntax_test_union.rs
@@ -40,9 +40,9 @@ fn union() {}
 //                ^ meta.group punctuation.accessor.dot
 //                 ^^^^^ variable.function - storage.type.union
 //                      ^ punctuation.section.group.begin
-//                       ^^^^^^ storage.type.source
+//                       ^^^^^^ storage.type.rust
 //                             ^^ punctuation.accessor
-//                               ^^^^ storage.type.source
+//                               ^^^^ storage.type.rust
 //                                   ^ punctuation.section.group.end
 //                                    ^ punctuation.accessor.dot
 //                                     ^^^^^ variable.function - storage.type.union


### PR DESCRIPTION
See the individual commits for details.

In this PR, I have rewritten path matching in Rust to

- fix application of `support.function` scopes in function calls
  - also in annotations
- unify handling of identifiers, function calls and types, even inside paths (e.g. `f32::from(…)`)
- make `meta.path` span the entire "path", as specified in the scope naming docs
- make `meta.generic` not span the type it is being generic over
- be more resilient against whitespaces
- consistently apply `punctuation.accessor` for sub-path access

Fixes a few outstanding issues from #2305 (such as https://github.com/sublimehq/Packages/pull/2305#issuecomment-739496138, highlighting of `union` as a function name, which is a soft-keyword).

In addition, the syntax definition file has been restructured a bit by organizing related contexts in sections.