### PR TITLE
[C/C++/ObjC/ObjC++] Fix javadoc comment word wrap

### DIFF
--- a/C++/C.sublime-syntax
+++ b/C++/C.sublime-syntax
@@ -106,6 +106,9 @@ contexts:
     - match: \*/
       scope: punctuation.definition.comment.end.c
       pop: true
+    - match: ^\s*(\*)(?!\**/)
+      captures:
+        1: punctuation.definition.comment.c
 
   line-comments:
     - match: ^(//) =\s*(.*?)\s*=\s*$\n?

--- a/C++/syntax_test_c.c
+++ b/C++/syntax_test_c.c
@@ -427,7 +427,7 @@ struct X
 
 /*
     *
-/*  ^ comment.block.c - punctuation */
+/*  ^ comment.block.c punctuation.definition.comment.c */
 
 /////////////////////////////////////////////
 // Preprocessor branches starting blocks


### PR DESCRIPTION
This was broken by e4e5273d8ca764ebcd79b2ecfbed592036944265