### PR TITLE
[JavaScript] Fix block comment punctuation

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -151,6 +151,9 @@ contexts:
     - meta_include_prototype: false
     - meta_scope: comment.block.js
     - include: block-comment-end
+    - match: ^\s*(\*)(?!/)
+      captures:
+        1: punctuation.definition.comment.js
 
   jsdoc-comment-body:
     - meta_include_prototype: false

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -28,6 +28,12 @@
 //^^^ comment.block.js
 //   ^ - comment
 
+    /*
+     * comment
+//   ^ comment.block.js punctuation.definition.comment.js
+//    ^^^^^^^^^ comment.block.js - punctuation
+     */
+
     /**/ /***/
 // ^ - comment
 //  ^^^^ comment.block.empty.js punctuation.definition.comment.js


### PR DESCRIPTION
This commit adds scoping for leading asterisks in (normal) block comments so ST's word_wrap command can add them to each wrapped line, if present in the first one.

Notes:

This change aligns JavaScript with Java and C/C++.

Related with #3855