### PR TITLE
[TypeScript] Keyword types can't be generic

### DIFF
--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -834,7 +834,9 @@ contexts:
       push:
         - match: '{{identifier_name}}'
           scope: support.class.js
-          set: ts-type-expression-end-no-line-terminator
+          set:
+            - ts-type-expression-end-no-line-terminator
+            - ts-optional-generic-type-arguments
 
     - match: extends{{identifier_break}}
       scope: keyword.operator.type.extends.js
@@ -1063,9 +1065,13 @@ contexts:
   ts-type-basic:
     - match: '{{identifier_name}}'
       scope: support.class.js
-      set:
-        - include: ts-generic-type-arguments
-        - include: else-pop
+      set: ts-optional-generic-type-arguments
+
+  ts-optional-generic-type-arguments:
+    - match: $
+      pop: 1
+    - include: ts-generic-type-arguments
+    - include: else-pop
 
   ts-type-template-string:
     - match: '`'

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -886,8 +886,6 @@ contexts:
             - ts-type-expression-end-no-line-terminator
             - ts-type-expression-begin
 
-    - include: ts-generic-type-arguments
-
     - include: else-pop
 
   ts-generic-type-arguments:
@@ -1034,6 +1032,12 @@ contexts:
     - match: 'boolean{{identifier_break}}'
       scope: 'support.type.primitive.boolean.js'
       pop: 1
+    - match: 'true{{identifier_break}}'
+      scope: 'support.type.primitive.boolean.true.js'
+      pop: 1
+    - match: 'false{{identifier_break}}'
+      scope: 'support.type.primitive.boolean.false.js'
+      pop: 1
     - match: 'number{{identifier_break}}'
       scope: 'support.type.primitive.number.js'
       pop: 1
@@ -1059,7 +1063,9 @@ contexts:
   ts-type-basic:
     - match: '{{identifier_name}}'
       scope: support.class.js
-      pop: 1
+      set:
+        - include: ts-generic-type-arguments
+        - include: else-pop
 
   ts-type-template-string:
     - match: '`'

--- a/JavaScript/tests/syntax_test_tsx.tsx
+++ b/JavaScript/tests/syntax_test_tsx.tsx
@@ -125,6 +125,15 @@ let x : T.U<V>;
 //         ^^^ meta.generic
 //          ^ support.class
 
+let x : T.U
+//      ^^^ meta.type
+//      ^ support.class
+//       ^ punctuation.accessor
+//        ^ support.class
+
+<V />;
+// <- meta.jsx - meta.type
+
 // This is invalid TSX as the TypeScript type assertion is parsed as a JSX tag
 let strLength: number = (<string>someValue).length; // </string> );
 //                       ^^^^^^^^ meta.tag - meta.assertion

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -1327,6 +1327,38 @@ let x: import ( "foo" ) . Bar ;
 //                      ^ punctuation.accessor
 //                        ^^^ support.class
 
+let x: T.U;
+//    ^^^^ meta.type
+//     ^ support.class
+//      ^ punctuation.accessor
+//       ^ support.class
+//        ^ punctuation.terminator.statement
+
+let x: T.U[];
+//    ^^^^ meta.type
+//     ^ support.class
+//      ^ punctuation.accessor
+//       ^ support.class
+//        ^^ storage.modifier.array
+//          ^ punctuation.terminator.statement
+
+let x: T.U<V>[];
+//    ^^^^ meta.type
+//     ^ support.class
+//      ^ punctuation.accessor
+//       ^ support.class
+//        ^^^ meta.generic
+//           ^^ storage.modifier.array
+//             ^ punctuation.terminator.statement
+
+let x: T.U
+//    ^^^^ meta.type
+//     ^ support.class
+//      ^ punctuation.accessor
+//       ^ support.class
+[];
+//<- meta.sequence - meta.type
+
     foo < bar > ();
 //  ^^^ variable.function
 //      ^^^^^^^ meta.generic

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -803,6 +803,10 @@ let x: unknown;
 
 let x: boolean;
 //     ^^^^^^^ support.type.primitive.boolean
+let x: true;
+//     ^^^^ support.type.primitive.boolean.true
+let x: false;
+//     ^^^^^ support.type.primitive.boolean.false
 let x: number;
 //     ^^^^^^ support.type.primitive.number
 let x: string;
@@ -1509,3 +1513,11 @@ type T = Foo | ... 100 more ... | Bar;
 //                              ^ keyword.operator.type.union
 //                                ^^^ support.class
 //                                   ^ punctuation.terminator.statement.empty
+
+    x as number < 3;
+//  ^ variable.other.readwrite
+//    ^^ keyword.operator.type
+//       ^^^^^^ meta.type support.type.primitive.number
+//              ^ keyword.operator.comparison
+//                ^ meta.number.integer.decimal constant.numeric.value
+//                 ^ punctuation.terminator.statement


### PR DESCRIPTION
Fix #3862.

Originally, type arguments were part of the regular type expression structure, so the syntax would try to highlight type arguments after any type. But actually, only ordinary named types can get them. In the linked issue, this was causing problems with `as`-style type assertions — when followed by a `<`, the type expression was eating it and trying to parse type arguments, even when the preceding type does not accept them.

According to the spec — I'm kidding, we all know the drill by now, actually after a bunch of futzing around in AST Explorer — this should work correctly in all cases I can think of.

In order for this to work in all cases, it's necessary to ensure that all specially keyworded types are accounted for, so this PR also adds the `true` and `false` singleton types.