### PR TITLE
[Batch File] Tweak comment collapsing

### DIFF
--- a/Batch File/Comments.tmPreferences
+++ b/Batch File/Comments.tmPreferences
@@ -15,9 +15,33 @@
 			</dict>
 			<dict>
 				<key>name</key>
+				<string>TM_COMMENT_CASE_INSENSITIVE</string>
+				<key>value</key>
+				<string>yes</string>
+			</dict>
+			<dict>
+				<key>name</key>
 				<string>TM_COMMENT_START_2</string>
 				<key>value</key>
+				<string>@rem </string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_CASE_INSENSITIVE_2</string>
+				<key>value</key>
+				<string>yes</string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START_3</string>
+				<key>value</key>
 				<string>:: </string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START_4</string>
+				<key>value</key>
+				<string>::: </string>
 			</dict>
 		</array>
 	</dict>


### PR DESCRIPTION
This commit introduces two changes:

 - `@rem` (silenced `rem`) and `:::` (safe equivalent of `::`) have been added
 - `rem` and its silent equivalent `@rem` now use `TM_COMMENT_CASE_INSENSITIVE` introduced in Sublime Text 4153, which allows collapsing comments casefold