### PR TITLE
[Go] fix backtick strings inside function calls

### DIFF
--- a/Go/Embeddings/Go (Embedded Backtick String).sublime-syntax
+++ b/Go/Embeddings/Go (Embedded Backtick String).sublime-syntax
@@ -17,7 +17,7 @@ contexts:
     - match: '{{newline}}'
       scope: comment.line.double-slash.go
       set:
-        - match-any
+        - match-any-root
         - consume-comments-at-beginning-of-line
 
   consume-comments-at-beginning-of-line:
@@ -26,21 +26,6 @@ contexts:
     - match: ^(?!\s*/[/*])
       pop: true
 
-  match-any:
-    - meta_prepend: true
+  match-any-root:
     - include: pop-on-eol
-
-  match-parens:
-    - meta_prepend: true
-    - match: (?=\))
-      pop: true
-
-  match-brackets:
-    - meta_prepend: true
-    - match: (?=\])
-      pop: true
-
-  match-braces:
-    - meta_prepend: true
-    - match: (?=\})
-      pop: true
+    - include: match-any

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -916,6 +916,8 @@ contexts:
       pop: true
     - match: '{{predeclared_type}}'
       scope: support.type.go
+    - match: (?=;)
+      pop: 1
     - include: match-any
 
   match-keyword-chan:

--- a/Go/tests/syntax_test_go.go
+++ b/Go/tests/syntax_test_go.go
@@ -4961,7 +4961,7 @@ by accident, but if necessary, such support could be sacrificed.
 
     break
 //  ^^^^^ keyword.control.flow.break.go
-    case
+    case ;
 //  ^^^^ keyword.control.conditional.case.go
     continue
 //  ^^^^^^^^ keyword.control.flow.continue.go

--- a/Go/tests/syntax_test_go.go
+++ b/Go/tests/syntax_test_go.go
@@ -5847,3 +5847,13 @@ func lang_embedding() {
     //                                               ^^^^^^^^^^^ meta.interpolation.go
     //                                                             ^ meta.string.go string.quoted.backtick.go punctuation.definition.string.end.go
 }
+
+// language=sql
+some_func_call(
+    args_on_next_line, `
+        SELECT min(a) 
+        FROM b
+        WHERE c = @p1`, "some value",
+    // ^^^^^^^^^^^^^^ meta.string.go meta.embedded.go source.sql.embedded.go
+)
+// <- punctuation.section.parens.end.go - invalid


### PR DESCRIPTION
Previously the closing paren would be erroneously scoped as illegal