### PR TITLE
[JSON] Fix comment punctuation scopes

### DIFF
--- a/JSON/JSON.sublime-syntax
+++ b/JSON/JSON.sublime-syntax
@@ -63,27 +63,52 @@ contexts:
           scope: invalid.illegal.expected-sequence-separator.json
 
   comments:
-    - match: /\*\*(?!/)
-      scope: punctuation.definition.comment.json
-      push:
-        - meta_scope: comment.block.documentation.json
-        - meta_include_prototype: false
-        - match: \*/
-          pop: 1
-        - match: ^\s*(\*)(?!/)
-          captures:
-            1: punctuation.definition.comment.json
+    - include: block-comments
+    - include: line-comments
+
+  block-comments:
+    # empty block comments
+    - match: /\*\*+/
+      scope: comment.block.empty.json punctuation.definition.comment.json
+    # documentation block comments
+    - match: /\*\*+
+      scope: punctuation.definition.comment.begin.json
+      push: block-comment-documentation-body
+    # normal block comments
     - match: /\*
-      scope: punctuation.definition.comment.json
-      push:
-        - meta_scope: comment.block.json
-        - meta_include_prototype: false
-        - match: \*/
-          pop: 1
-    - match: (//).*$\n?
-      scope: comment.line.double-slash.js
+      scope: punctuation.definition.comment.begin.json
+      push: block-comment-body
+
+  block-comment-documentation-body:
+    - meta_include_prototype: false
+    - meta_scope: comment.block.documentation.json
+    - match: \*+/
+      scope: punctuation.definition.comment.end.json
+      pop: 1
+    - match: ^\s*(\*)(?![*/])
       captures:
         1: punctuation.definition.comment.json
+
+  block-comment-body:
+    - meta_include_prototype: false
+    - meta_scope: comment.block.json
+    - match: \*/
+      scope: punctuation.definition.comment.end.json
+      pop: 1
+    - match: ^\s*(\*)(?![*/])
+      captures:
+        1: punctuation.definition.comment.json
+
+  line-comments:
+    - match: //
+      scope: punctuation.definition.comment.json
+      push: line-comment-body
+
+  line-comment-body:
+    - meta_include_prototype: false
+    - meta_scope: comment.line.double-slash.json
+    - match: $\n?
+      pop: 1
 
   constant:
     - match: \b(?:false|true)\b

--- a/JSON/syntax_test_json.json
+++ b/JSON/syntax_test_json.json
@@ -1,5 +1,32 @@
 // SYNTAX TEST "Packages/JSON/JSON.sublime-syntax"
 
+    /* comment */
+//  ^^^^^^^^^^^^^ comment.block.json
+//  ^^ punctuation.definition.comment.begin.json
+//             ^^ punctuation.definition.comment.end.json
+
+  /**
+      *
+  //  ^ comment.block.documentation.json punctuation.definition.comment.json
+  */
+// <- comment.block.documentation.json
+//^^ comment.block.documentation.json punctuation.definition.comment.end.json
+
+/**/
+// <- comment.block.empty.json punctuation.definition.comment.json
+//^^ comment.block.empty.json punctuation.definition.comment.json
+
+/********/
+// <- comment.block.empty.json punctuation.definition.comment.json
+//^^^^^^^^ comment.block.empty.json punctuation.definition.comment.json
+
+/**************
+// <- comment.block.documentation.json punctuation.definition.comment.begin.json
+//^^^^^^^^^^^^^ comment.block.documentation.json punctuation.definition.comment.begin.json
+**************/
+// <- comment.block.documentation.json punctuation.definition.comment.end.json
+//^^^^^^^^^^^^^ comment.block.documentation.json punctuation.definition.comment.end.json
+
 {
 // <- meta.mapping.json punctuation.section.mapping.begin.json
   "bool": false,
@@ -32,7 +59,7 @@
   "array": [ /**/ ],
 //         ^^^^^^^^ meta.mapping.value.json meta.sequence.json
 //         ^   punctuation.section.sequence.begin.json
-//           ^^^^ comment.block.json
+//           ^^^^ comment.block.empty.json punctuation.definition.comment.json
 //                ^ punctuation.section.sequence.end.json
 
   "dict": {"foo": },
@@ -52,13 +79,15 @@
     "foo": "bar"
     // comment
 // ^ - invalid
-//  ^^^^^^^^^^ comment.line.double-slash.js
+//  ^^^^^^^^^^ comment.line.double-slash.json
     ,
 //  ^ punctuation.separator.sequence.json
     "foo": "bar"
     /* comment */
 // ^ - invalid
 //  ^^^^^^^^^^^^^ comment.block.json
+//  ^^ punctuation.definition.comment.begin.json
+//             ^^ punctuation.definition.comment.end.json
   },
 //^ punctuation.section.mapping.end.json
 // ^ punctuation.separator.sequence.json
@@ -96,7 +125,7 @@
 // <- - string
 
 /**/: "test",
-// ^ meta.mapping.json comment.block.json
+// ^ meta.mapping.json comment.block.empty.json
 //  ^ punctuation.separator.key-value.json - comment
 //    ^^^^^^ meta.mapping.value.json string.quoted.double.json
 
@@ -116,8 +145,4 @@
   "ke//y": "value"
 //^^^^^^^ meta.mapping.key.json string.quoted.double.json - comment
 
-/**
-    *
-//  ^ meta.mapping.json comment.block.documentation.json punctuation.definition.comment.json
-*/
 }


### PR DESCRIPTION
This commit ...

1. fixes missing closing `punctuation.definition` scopes
2. renames a `.js` final scope to `.json`
3. adjusts leading asterisk scoping according to #3855 and #3856.
4. refactors comment related contexts to use only named contexts.


reported at: https://discord.com/channels/280102180189634562/280157121897562114/1175037871011418222