### PR TITLE
[Python] Adjust fold rules

### DIFF
--- a/Python/Fold.tmPreferences
+++ b/Python/Fold.tmPreferences
@@ -14,48 +14,80 @@
                 <string>comment.block.documentation punctuation.definition.comment.begin</string>
                 <key>end</key>
                 <string>comment.block.documentation punctuation.definition.comment.end</string>
+                <key>excludeTrailingNewlines</key>
+                <true/>
+            </dict>
+            <dict>
+                <key>begin</key>
+                <string>string.quoted.double.block punctuation.definition.string.begin</string>
+                <key>end</key>
+                <string>string.quoted.double.block punctuation.definition.string.end</string>
+                <key>excludeTrailingNewlines</key>
+                <true/>
+            </dict>
+            <dict>
+                <key>begin</key>
+                <string>string.quoted.single.block punctuation.definition.string.begin</string>
+                <key>end</key>
+                <string>string.quoted.single.block punctuation.definition.string.end</string>
+                <key>excludeTrailingNewlines</key>
+                <true/>
             </dict>
             <dict>
                 <key>begin</key>
                 <string>punctuation.section.arguments.begin</string>
                 <key>end</key>
                 <string>punctuation.section.arguments.end</string>
+                <key>excludeTrailingNewlines</key>
+                <false/>
             </dict>
             <dict>
                 <key>begin</key>
                 <string>punctuation.section.parameters.begin</string>
                 <key>end</key>
                 <string>punctuation.section.parameters.end</string>
+                <key>excludeTrailingNewlines</key>
+                <true/>
             </dict>
             <dict>
                 <key>begin</key>
                 <string>punctuation.section.sequence.begin</string>
                 <key>end</key>
                 <string>punctuation.section.sequence.end</string>
+                <key>excludeTrailingNewlines</key>
+                <false/>
             </dict>
             <dict>
                 <key>begin</key>
                 <string>punctuation.section.group.begin</string>
                 <key>end</key>
                 <string>punctuation.section.group.end</string>
+                <key>excludeTrailingNewlines</key>
+                <false/>
             </dict>
             <dict>
                 <key>begin</key>
                 <string>punctuation.section.mapping.begin</string>
                 <key>end</key>
                 <string>punctuation.section.mapping.end</string>
+                <key>excludeTrailingNewlines</key>
+                <false/>
             </dict>
             <dict>
                 <key>begin</key>
                 <string>punctuation.section.set.begin</string>
                 <key>end</key>
                 <string>punctuation.section.set.end</string>
+                <key>excludeTrailingNewlines</key>
+                <false/>
             </dict>
             <dict>
                 <key>begin</key>
                 <string>punctuation.section.brackets.begin</string>
                 <key>end</key>
                 <string>punctuation.section.brackets.end</string>
+                <key>excludeTrailingNewlines</key>
+                <false/>
             </dict>
         </array>
     </dict>


### PR DESCRIPTION
This commit ...

1. includes trailing whitespace into most fold regions. As a result closing brackets don't stay at a separate line anymore.

   Exception: function parameters ; as folding multi-line parameters should work independently from folding code blocks (by indentation).

2. add fold rules for triple quoted block strings.

### Examples

| what | before | after
|---   |---     |---
| decorators | ![grafik](https://github.com/sublimehq/Packages/assets/16542113/40a5a58c-81ae-4337-acaa-6cd6e24e52e9) | ![grafik](https://github.com/sublimehq/Packages/assets/16542113/77b739ca-d950-43fa-8119-d7f8253a395f) 
| function calls | ![grafik](https://github.com/sublimehq/Packages/assets/16542113/10ee3e39-180d-4d9a-9429-33a15beef10f) | ![grafik](https://github.com/sublimehq/Packages/assets/16542113/43533b15-9519-4388-ba4b-45dcd11d7e21)
| dicts | ![grafik](https://github.com/sublimehq/Packages/assets/16542113/cdbd62b1-d35d-4558-83a3-0468e5cc11a6) | ![grafik](https://github.com/sublimehq/Packages/assets/16542113/714d73f2-2158-4c0d-b076-f57ffe5ae8c7)
| lists | ![grafik](https://github.com/sublimehq/Packages/assets/16542113/ba3aa752-5e4b-4b29-8bb5-ea1511888ffd) | ![grafik](https://github.com/sublimehq/Packages/assets/16542113/03f1a17a-3eaf-44c9-b314-fb20832b7ec7)



