### PR TITLE
[JSON] Add support for inheritance

### DIFF
--- a/ASP/Embeddings/JSON (for ASP).sublime-syntax
+++ b/ASP/Embeddings/JSON (for ASP).sublime-syntax
@@ -5,25 +5,21 @@
 #
 # It powers VBScript highlighting within ASP tags in embedded CSS.
 #
-#   <style>
+#   <script type="application/json">
 #     <%! ... %>
 #     <%= ... %>
 #     <%  ... %>
-#   </style>
+#   </script>
 #
 # The primary task is to add `asp-tags` context to CSS's
 # prototype to match all the <% %> tags.
 ###############################################################################
 
-scope: source.css.embedded.asp
+scope: source.json.embedded.asp
 version: 2
 hidden: true
 
-extends: Packages/CSS/CSS.sublime-syntax
-
-variables:
-
-    ident_start: (?:{{nmstart}}|<%)
+extends: Packages/JSON/JSON.sublime-syntax
 
 contexts:
 
@@ -31,6 +27,6 @@ contexts:
     - meta_prepend: true
     - include: HTML (ASP).sublime-syntax#asp-tags
 
-  string-content:
+  string-prototype:
     - meta_prepend: true
     - include: HTML (ASP).sublime-syntax#asp-interpolations

--- a/ASP/HTML (ASP).sublime-syntax
+++ b/ASP/HTML (ASP).sublime-syntax
@@ -177,6 +177,33 @@ contexts:
         3: source.js.embedded.html
         4: comment.block.html punctuation.definition.comment.end.html
 
+  script-json-content:
+    - meta_include_prototype: false
+    - match: \s*((<!\[)(CDATA)(\[))
+      captures:
+        1: meta.tag.sgml.cdata.html
+        2: punctuation.definition.tag.begin.html
+        3: keyword.declaration.cdata.html
+        4: punctuation.definition.tag.begin.html
+      pop: 1  # make sure to match only once
+      embed: scope:source.json.embedded.asp
+      embed_scope: meta.tag.sgml.cdata.html source.json.embedded.html
+      escape: \]\]>
+      escape_captures:
+        0: meta.tag.sgml.cdata.html punctuation.definition.tag.end.html
+    - match: '{{script_content_begin}}'
+      captures:
+        1: comment.block.html punctuation.definition.comment.begin.html
+      pop: 1  # make sure to match only once
+      embed: scope:source.json.embedded.asp
+      embed_scope: source.json.embedded.html
+      escape: '{{script_content_end}}'
+      escape_captures:
+        1: source.json.embedded.html
+        2: comment.block.html punctuation.definition.comment.end.html
+        3: source.json.embedded.html
+        4: comment.block.html punctuation.definition.comment.end.html
+
   script-vbscript:
     - meta_scope: meta.tag.script.begin.html
     - include: script-common

--- a/ASP/syntax_test_asp.asp
+++ b/ASP/syntax_test_asp.asp
@@ -168,6 +168,28 @@
     </script>
     ' ^^^^^^^ meta.tag - source
 
+    <script type="application/ld+json">
+        {
+            <% key %>: <%.Site.Color%>,
+        |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.json.embedded.html
+        |   ^^^^^^^^^ meta.mapping.json meta.interpolation.asp
+        |            ^^ meta.mapping.json - meta.interpolation
+        |              ^^^^^^^^^^^^^^^ meta.mapping.value.json meta.interpolation.asp
+        |                             ^ meta.mapping.json - meta.interpolation
+
+            "<% key %>": "<%.Site.Color%>",
+        |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.json.embedded.html
+        |   ^ meta.mapping.key.json string.quoted.double.json punctuation.definition.string.begin.json
+        |    ^^^^^^^^^ meta.mapping.key.json meta.interpolation.asp - string
+        |             ^ meta.mapping.key.json string.quoted.double.json punctuation.definition.string.end.json
+        |              ^^ meta.mapping.json - meta.interpolation
+        |                ^ meta.mapping.value.json meta.string.json string.quoted.double.json punctuation.definition.string.begin.json
+        |                 ^^^^^^^^^^^^^^^ meta.mapping.value.json meta.interpolation.asp - string
+        |                                ^ meta.mapping.value.json meta.string.json string.quoted.double.json punctuation.definition.string.end.json
+        |                                 ^ meta.mapping.json - meta.interpolation
+        }
+    </script>
+
     <style>
 
 ' <- source.css.embedded.html

--- a/Go/Embeddings/HTML (for Go Embedded Backtick Strings).sublime-syntax
+++ b/Go/Embeddings/HTML (for Go Embedded Backtick Strings).sublime-syntax
@@ -33,6 +33,21 @@ contexts:
         3: source.js.embedded.html
         4: comment.block.html punctuation.definition.comment.end.html
 
+  script-json-content:
+    - meta_include_prototype: false
+    - match: '{{script_content_begin}}'
+      captures:
+        1: comment.block.html punctuation.definition.comment.begin.html
+      pop: 1  # make sure to match only once
+      embed: scope:source.json.go-embedded-backtick-string
+      embed_scope: source.json.embedded.html
+      escape: '{{script_content_end}}'
+      escape_captures:
+        1: source.json.embedded.html
+        2: comment.block.html punctuation.definition.comment.end.html
+        3: source.json.embedded.html
+        4: comment.block.html punctuation.definition.comment.end.html
+
   style-css-content:
     - meta_include_prototype: false
     - match: '{{style_content_begin}}'

--- a/Go/Embeddings/JSON (for Go Embedded Backtick Strings).sublime-syntax
+++ b/Go/Embeddings/JSON (for Go Embedded Backtick Strings).sublime-syntax
@@ -14,6 +14,6 @@ contexts:
     - meta_prepend: true
     - include: scope:source.go#match-raw-text-content
 
-  inside-string:
+  string-prototype:
     - meta_prepend: true
     - include: scope:source.go#match-raw-string-content

--- a/Go/HTML (Go).sublime-syntax
+++ b/Go/HTML (Go).sublime-syntax
@@ -37,6 +37,21 @@ contexts:
         3: source.js.embedded.html
         4: comment.block.html punctuation.definition.comment.end.html
 
+  script-json-content:
+    - meta_include_prototype: false
+    - match: '{{script_content_begin}}'
+      captures:
+        1: comment.block.html punctuation.definition.comment.begin.html
+      pop: 1  # make sure to match only once
+      embed: scope:source.json.go
+      embed_scope: source.json.embedded.html
+      escape: '{{script_content_end}}'
+      escape_captures:
+        1: source.json.embedded.html
+        2: comment.block.html punctuation.definition.comment.end.html
+        3: source.json.embedded.html
+        4: comment.block.html punctuation.definition.comment.end.html
+
   style-css-content:
     - meta_include_prototype: false
     - match: '{{style_content_begin}}'

--- a/Go/JSON (Go).sublime-syntax
+++ b/Go/JSON (Go).sublime-syntax
@@ -1,0 +1,18 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/syntax.html
+name: JSON (Go)
+scope: source.json.go
+version: 2
+
+extends: Packages/JSON/JSON.sublime-syntax
+
+contexts:
+
+  prototype:
+    - meta_prepend: true
+    - include: scope:source.go#match-text-templates
+
+  string-prototype:
+    - meta_prepend: true
+    - include: scope:source.go#match-string-templates

--- a/Go/tests/syntax_test_template.html
+++ b/Go/tests/syntax_test_template.html
@@ -28,6 +28,28 @@
         | <- source.js.embedded.html meta.mapping.js punctuation.section.mapping.end.js
     </script>
 
+    <script type="application/ld+json">
+        {
+            {{ key }}: {{.Site.Color}},
+        |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.json.embedded.html
+        |   ^^^^^^^^^ meta.mapping.json meta.interpolation.go
+        |            ^^ meta.mapping.json - meta.interpolation
+        |              ^^^^^^^^^^^^^^^ meta.mapping.value.json meta.interpolation.go
+        |                             ^ meta.mapping.json - meta.interpolation
+
+            "{{ key }}": "{{.Site.Color}}",
+        |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.json.embedded.html
+        |   ^ meta.mapping.key.json string.quoted.double.json punctuation.definition.string.begin.json
+        |    ^^^^^^^^^ meta.mapping.key.json meta.interpolation.go - string
+        |             ^ meta.mapping.key.json string.quoted.double.json punctuation.definition.string.end.json
+        |              ^^ meta.mapping.json - meta.interpolation
+        |                ^ meta.mapping.value.json meta.string.json string.quoted.double.json punctuation.definition.string.begin.json
+        |                 ^^^^^^^^^^^^^^^ meta.mapping.value.json meta.interpolation.go - string
+        |                                ^ meta.mapping.value.json meta.string.json string.quoted.double.json punctuation.definition.string.end.json
+        |                                 ^ meta.mapping.json - meta.interpolation
+        }
+    </script>
+
     <style>
         .class {
            color: {{ .Site.Color }};

--- a/JSON/JSON.sublime-syntax
+++ b/JSON/JSON.sublime-syntax
@@ -39,28 +39,17 @@ contexts:
     - include: comments
 
   main:
-    - include: value
+    - include: values
 
-  value:
-    - include: constant
-    - include: number
-    - include: string
-    - include: array
-    - include: object
+  values:
+    - include: constants
+    - include: floats
+    - include: integers
+    - include: strings
+    - include: arrays
+    - include: objects
 
-  array:
-    - match: \[
-      scope: punctuation.section.sequence.begin.json
-      push:
-        - meta_scope: meta.sequence.json
-        - match: \]
-          scope: punctuation.section.sequence.end.json
-          pop: 1
-        - include: value
-        - match: ','
-          scope: punctuation.separator.sequence.json
-        - match: '[^\s\]]'
-          scope: invalid.illegal.expected-sequence-separator.json
+###[ COMMENTS ]################################################################
 
   comments:
     - include: block-comments
@@ -110,83 +99,124 @@ contexts:
     - match: $\n?
       pop: 1
 
-  constant:
+###[ ARRAYS ]##################################################################
+
+  arrays:
+    - match: \[
+      scope: punctuation.section.sequence.begin.json
+      push: array-body
+
+  array-body:
+    - meta_scope: meta.sequence.json
+    - match: \]
+      scope: punctuation.section.sequence.end.json
+      pop: 1
+    - match: ','
+      scope: punctuation.separator.sequence.json
+    - include: values
+    - match: \S
+      scope: invalid.illegal.expected-sequence-separator.json
+
+###[ OBJECTS ]#################################################################
+
+  objects:
+    - match: \{
+      scope: punctuation.section.mapping.begin.json
+      push: object-body
+
+  object-body:
+    - meta_scope: meta.mapping.json
+    - match: \}
+      scope: punctuation.section.mapping.end.json
+      pop: 1
+    - match: \"
+      scope: punctuation.definition.string.begin.json
+      push: object-key-body
+    - match: ':'
+      scope: punctuation.separator.key-value.json
+      push: expect-object-value
+    - match: \S
+      scope: invalid.illegal.expected-mapping-key.json
+
+  object-key-body:
+    - clear_scopes: 1
+    - meta_include_prototype: false
+    - meta_scope: meta.mapping.key.json string.quoted.double.json
+    - include: double-quoted-string-body
+
+  expect-object-value:
+    - meta_include_prototype: false
+    - include: comments
+    - match: ',|\s?(?=\})'
+      scope: invalid.illegal.expected-mapping-value.json
+      pop: 1
+    - match: (?=\S)
+      set: object-value-body
+
+  object-value-body:
+    - clear_scopes: 1
+    - meta_scope: meta.mapping.value.json
+    - include: values
+    - match: ''
+      set: object-value-end
+
+  object-value-end:
+    - meta_include_prototype: false
+    - include: comments
+    - match: (?=\s*\})
+      pop: 1
+    - match: ','
+      scope: punctuation.separator.sequence.json
+      pop: 1
+    - match: \s(?!/[/*])(?=[^\s,])|[^\s,]
+      scope: invalid.illegal.expected-mapping-separator.json
+      pop: 1
+
+###[ LITERALS ]################################################################
+
+  constants:
     - match: \b(?:false|true)\b
       scope: constant.language.boolean.json
     - match: \bnull\b
       scope: constant.language.null.json
 
-  number:
-    # handles integer and decimal numbers
+  floats:
     - match: (-?)((?:0|[1-9]\d*)(?:(?:(\.)\d+)(?:[eE][-+]?\d+)?|(?:[eE][-+]?\d+)))
       scope: meta.number.float.decimal.json
       captures:
         1: keyword.operator.arithmetic.json
         2: constant.numeric.value.json
         3: punctuation.separator.decimal.json
+
+  integers:
     - match: (-?)(0|[1-9]\d*)
       scope: meta.number.integer.decimal.json
       captures:
         1: keyword.operator.arithmetic.json
         2: constant.numeric.value.json
 
-  object:
-    # a JSON object
-    - match: \{
-      scope: punctuation.section.mapping.begin.json
-      push:
-        - meta_scope: meta.mapping.json
-        - match: \}
-          scope: punctuation.section.mapping.end.json
-          pop: 1
-        - match: \"
-          scope: punctuation.definition.string.begin.json
-          push:
-            - clear_scopes: 1
-            - meta_scope: meta.mapping.key.json string.quoted.double.json
-            - meta_include_prototype: false
-            - include: inside-string
-        - match: ':'
-          scope: punctuation.separator.key-value.json
-          push:
-            - match: ',|\s?(?=\})'
-              scope: invalid.illegal.expected-mapping-value.json
-              pop: 1
-            - match: (?=\S)
-              set:
-                - clear_scopes: 1
-                - meta_scope: meta.mapping.value.json
-                - include: value
-                - match: ''
-                  set:
-                    - match: ','
-                      scope: punctuation.separator.sequence.json
-                      pop: 1
-                    - match: \s*(?=\})
-                      pop: 1
-                    - match: \s(?!/[/*])(?=[^\s,])|[^\s,]
-                      scope: invalid.illegal.expected-mapping-separator.json
-                      pop: 1
-        - match: '[^\s\}]'
-          scope: invalid.illegal.expected-mapping-key.json
-
-  string:
+  strings:
     - match: \"
       scope: punctuation.definition.string.begin.json
-      push: inside-string
+      push: double-quoted-string-body
 
-  inside-string:
-    - meta_scope: string.quoted.double.json
+  double-quoted-string-body:
     - meta_include_prototype: false
+    - meta_scope: meta.string.json string.quoted.double.json
     - match: \"
       scope: punctuation.definition.string.end.json
       pop: 1
-    - include: string-escape
     - match: \n
       scope: invalid.illegal.unclosed-string.json
       pop: 1
+    - include: string-prototype
+    - include: string-escapes
 
-  string-escape:
+  # for use by inheriting syntaxes to easily inject string interpolation
+  # in any kind of quoted or unquoted string
+  string-prototype: []
+
+  string-escapes:
     - match: |-
         (?x:                # turn on extended mode
           \\                # a literal backslash

--- a/JSON/syntax_test_json.json
+++ b/JSON/syntax_test_json.json
@@ -62,6 +62,9 @@
 //           ^^^^ comment.block.empty.json punctuation.definition.comment.json
 //                ^ punctuation.section.sequence.end.json
 
+  "dict": {"foo":,},
+//               ^ invalid.illegal.expected-mapping-value.json
+//                ^ punctuation.section.mapping.end.json
   "dict": {"foo": },
 //               ^ invalid.illegal.expected-mapping-value.json
 //                ^ punctuation.section.mapping.end.json

--- a/Java/Embeddings/JSON (for JSP).sublime-syntax
+++ b/Java/Embeddings/JSON (for JSP).sublime-syntax
@@ -1,0 +1,32 @@
+%YAML 1.2
+---
+###############################################################################
+# This intermediate syntax is used by `HTML (JSP).sublime-syntax`
+#
+# It powers Java highlighting within JSP tags in embedded CSS.
+#
+#   <script type="application/json">
+#     <%! ... %>
+#     <%= ... %>
+#     <%  ... %>
+#   </script>
+#
+# The primary task is to add `jsp-embedded` context to CSS's prototype
+# to highlight all the <% %> tags.
+###############################################################################
+
+scope: source.json.embedded.jsp
+version: 2
+hidden: true
+
+extends: Packages/JSON/JSON.sublime-syntax
+
+contexts:
+
+  prototype:
+    - meta_prepend: true
+    - include: Packages/Java/HTML (JSP).sublime-syntax#jsp-embedded
+
+  string-prototype:
+    - meta_prepend: true
+    - include: Packages/Java/HTML (JSP).sublime-syntax#jsp-interpolations

--- a/Java/HTML (JSP).sublime-syntax
+++ b/Java/HTML (JSP).sublime-syntax
@@ -80,6 +80,33 @@ contexts:
         3: source.js.embedded.html
         4: comment.block.html punctuation.definition.comment.end.html
 
+  script-json-content:
+    - meta_include_prototype: false
+    - match: \s*((<!\[)(CDATA)(\[))
+      captures:
+        1: meta.tag.sgml.cdata.html
+        2: punctuation.definition.tag.begin.html
+        3: keyword.declaration.cdata.html
+        4: punctuation.definition.tag.begin.html
+      pop: 1  # make sure to match only once
+      embed: scope:source.json.embedded.jsp
+      embed_scope: meta.tag.sgml.cdata.html source.json.embedded.html
+      escape: \]\]>
+      escape_captures:
+        0: meta.tag.sgml.cdata.html punctuation.definition.tag.end.html
+    - match: '{{script_content_begin}}'
+      captures:
+        1: comment.block.html punctuation.definition.comment.begin.html
+      pop: 1  # make sure to match only once
+      embed: scope:source.json.embedded.jsp
+      embed_scope: source.json.embedded.html
+      escape: '{{script_content_end}}'
+      escape_captures:
+        1: source.json.embedded.html
+        2: comment.block.html punctuation.definition.comment.end.html
+        3: source.json.embedded.html
+        4: comment.block.html punctuation.definition.comment.end.html
+
   style-css-content:
     - meta_include_prototype: false
     - match: \s*((<!\[)(CDATA)(\[))

--- a/Java/tests/syntax_test_jsp.jsp
+++ b/Java/tests/syntax_test_jsp.jsp
@@ -143,6 +143,28 @@
     //     ^ - meta.tag - punctuation - source
     </script>
 
+    <script type="application/ld+json">
+        {
+            <%=key%>: <%=siteColor%>,
+        |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.json.embedded.html
+        |   ^^^^^^^^ meta.mapping.json meta.interpolation.jsp
+        |           ^^ meta.mapping.json - meta.interpolation
+        |             ^^^^^^^^^^^^^^ meta.mapping.value.json meta.interpolation.jsp
+        |                           ^ meta.mapping.json - meta.interpolation
+
+            "<%=key%>": "<%=siteColor%>",
+        |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.json.embedded.html
+        |   ^ meta.mapping.key.json string.quoted.double.json punctuation.definition.string.begin.json
+        |    ^^^^^^^^ meta.mapping.key.json meta.interpolation.jsp - string
+        |            ^ meta.mapping.key.json string.quoted.double.json punctuation.definition.string.end.json
+        |             ^^ meta.mapping.json - meta.interpolation
+        |               ^ meta.mapping.value.json meta.string.json string.quoted.double.json punctuation.definition.string.begin.json
+        |                ^^^^^^^^^^^^^^ meta.mapping.value.json meta.interpolation.jsp - string
+        |                              ^ meta.mapping.value.json meta.string.json string.quoted.double.json punctuation.definition.string.end.json
+        |                               ^ meta.mapping.json - meta.interpolation
+        }
+    </script>
+
     <script type="text/html">
         <![CDATA[
     // ^ - meta.tag - punctuation - source

--- a/PHP/JSON (PHP).sublime-syntax
+++ b/PHP/JSON (PHP).sublime-syntax
@@ -1,0 +1,47 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/syntax.html
+name: JSON (PHP)
+scope: source.json.php
+version: 2
+
+extends: Packages/JSON/JSON.sublime-syntax
+
+file_extensions:
+  - json.php
+
+contexts:
+
+  prototype:
+    - meta_prepend: true
+    - include: php-embedded
+
+  string-prototype:
+    - meta_prepend: true
+    - include: php-interpolations
+
+  php-interpolations:
+    - meta_include_prototype: false
+    - match: (?=<\?)
+      push: php-interpolation-body
+
+  php-interpolation-body:
+    - clear_scopes: 1
+    - meta_include_prototype: false
+    - include: php-embedded
+    - match: ''
+      pop: 1
+
+  php-embedded:
+    - meta_include_prototype: false
+    - match: <\?(?i:(?!php)ph?)
+      scope: meta.embedded.php punctuation.section.embedded.begin.php
+    - match: <\?(?i:php\b|=)?
+      scope: meta.embedded.php punctuation.section.embedded.begin.php
+      embed: Packages/PHP/PHP Source.sublime-syntax
+      embed_scope: meta.embedded.php source.php.embedded.css
+      escape: (\?>)(\s*\n)?
+      escape_captures:
+        0: meta.embedded.php
+        1: punctuation.section.embedded.end.php
+        2: meta.html-newline-after-php.php

--- a/PHP/PHP.sublime-syntax
+++ b/PHP/PHP.sublime-syntax
@@ -97,6 +97,33 @@ contexts:
         3: source.js.embedded.html
         4: comment.block.html punctuation.definition.comment.end.html
 
+  script-json-content:
+    - meta_include_prototype: false
+    - match: \s*((<!\[)(CDATA)(\[))
+      captures:
+        1: meta.tag.sgml.cdata.html
+        2: punctuation.definition.tag.begin.html
+        3: keyword.declaration.cdata.html
+        4: punctuation.definition.tag.begin.html
+      pop: 1  # make sure to match only once
+      embed: scope:source.json.php
+      embed_scope: meta.tag.sgml.cdata.html source.json.embedded.html
+      escape: \]\]>
+      escape_captures:
+        0: meta.tag.sgml.cdata.html punctuation.definition.tag.end.html
+    - match: '{{script_content_begin}}'
+      captures:
+        1: comment.block.html punctuation.definition.comment.begin.html
+      pop: 1  # make sure to match only once
+      embed: scope:source.json.php
+      embed_scope: source.json.embedded.html
+      escape: '{{script_content_end}}'
+      escape_captures:
+        1: source.json.embedded.html
+        2: comment.block.html punctuation.definition.comment.end.html
+        3: source.json.embedded.html
+        4: comment.block.html punctuation.definition.comment.end.html
+
   style-css-content:
     - meta_include_prototype: false
     - match: \s*((<!\[)(CDATA)(\[))

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -5907,6 +5907,28 @@ function embedHtml() {
 //  ^^ punctuation.section.embedded.end.php - source.php
 </script>
 
+ <script type="application/ld+json">
+     {
+         <? $key ?>: <? $SiteColor ?>,
+     |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.json.embedded.html
+     |   ^^^^^^^^^^ meta.mapping.json meta.interpolation.php
+     |             ^^ meta.mapping.json - meta.interpolation
+     |               ^^^^^^^^^^^^^^^^ meta.mapping.value.json meta.interpolation.php
+     |                               ^ meta.mapping.json - meta.interpolation
+
+         "<? $key ?>": "<? $SiteColor ?>",
+     |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.json.embedded.html
+     |   ^ meta.mapping.key.json string.quoted.double.json punctuation.definition.string.begin.json
+     |    ^^^^^^^^^^ meta.mapping.key.json meta.interpolation.php - string
+     |              ^ meta.mapping.key.json string.quoted.double.json punctuation.definition.string.end.json
+     |               ^^ meta.mapping.json - meta.interpolation
+     |                 ^ meta.mapping.value.json meta.string.json string.quoted.double.json punctuation.definition.string.begin.json
+     |                  ^^^^^^^^^^^^^^^^ meta.mapping.value.json meta.interpolation.php - string
+     |                                  ^ meta.mapping.value.json meta.string.json string.quoted.double.json punctuation.definition.string.end.json
+     |                                   ^ meta.mapping.json - meta.interpolation
+     }
+ </script>
+
 <style>
 h1 {
     font-family: Arial;

--- a/Rails/Embeddings/JSON (for HAML).sublime-syntax
+++ b/Rails/Embeddings/JSON (for HAML).sublime-syntax
@@ -1,0 +1,18 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/syntax.html
+scope: source.json.embedded.haml
+version: 2
+hidden: true
+
+extends: Packages/JSON/JSON.sublime-syntax
+
+contexts:
+
+  prototype:
+    - meta_prepend: true
+    - include: HAML.sublime-syntax#interpolations
+
+  string-prototype:
+    - meta_prepend: true
+    - include: HAML.sublime-syntax#string-interpolations

--- a/Rails/HAML.sublime-syntax
+++ b/Rails/HAML.sublime-syntax
@@ -169,6 +169,7 @@ contexts:
     - include: filters-css
     - include: filters-erb
     - include: filters-javascript
+    - include: filters-json
     - include: filters-markdown
     - include: filters-ruby
     - include: filters-plain
@@ -207,6 +208,18 @@ contexts:
       embed_scope:
         meta.filter.haml meta.embedded.haml
         source.js.embedded.haml
+      escape: '{{filter_escapes}}'
+
+  filters-json:
+    - match: ^(\s*)((:)(json)$\n?)
+      captures:
+        2: meta.filter.definition.haml
+        3: punctuation.definition.filter.haml
+        4: constant.other.language-name.javascript.haml
+      embed: scope:source.json.embedded.haml
+      embed_scope:
+        meta.filter.haml meta.embedded.haml
+        source.json.embedded.haml
       escape: '{{filter_escapes}}'
 
   filters-markdown:

--- a/Rails/HTML (Rails).sublime-syntax
+++ b/Rails/HTML (Rails).sublime-syntax
@@ -39,6 +39,21 @@ contexts:
         3: source.js.embedded.html
         4: comment.block.html punctuation.definition.comment.end.html
 
+  script-json-content:
+    - meta_include_prototype: false
+    - match: '{{script_content_begin}}'
+      captures:
+        1: comment.block.html punctuation.definition.comment.begin.html
+      pop: 1  # make sure to match only once
+      embed: scope:source.json.rails
+      embed_scope: source.json.embedded.html
+      escape: '{{script_content_end}}'
+      escape_captures:
+        1: source.json.embedded.html
+        2: comment.block.html punctuation.definition.comment.end.html
+        3: source.json.embedded.html
+        4: comment.block.html punctuation.definition.comment.end.html
+
   style-css-content:
     - meta_include_prototype: false
     - match: '{{style_content_begin}}'

--- a/Rails/JSON (Rails).sublime-syntax
+++ b/Rails/JSON (Rails).sublime-syntax
@@ -1,0 +1,21 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/syntax.html
+name: JSON (Rails)
+scope: source.json.rails
+version: 2
+
+extends: Packages/JSON/JSON.sublime-syntax
+
+file_extensions:
+  - json.erb
+
+contexts:
+
+  prototype:
+    - meta_prepend: true
+    - include: HTML (Rails).sublime-syntax#rails-embedded
+
+  string-prototype:
+    - meta_prepend: true
+    - include: HTML (Rails).sublime-syntax#rails-interpolations

--- a/Rails/tests/syntax_test_rails.haml
+++ b/Rails/tests/syntax_test_rails.haml
@@ -426,6 +426,27 @@
     / <- meta.function.js keyword.declaration.function.js
     /^^^^^^^^^^^^^^^^ meta.filter.haml meta.embedded.haml source.js.embedded.haml
 
+:json
+    {
+        #{ @key }: #{ @SiteColor },
+    /  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.filter.haml meta.embedded.haml source.json.embedded.haml
+    /   ^^^^^^^^^ meta.mapping.json meta.interpolation.haml
+    /            ^^ meta.mapping.json - meta.interpolation
+    /              ^^^^^^^^^^^^^^^ meta.mapping.value.json meta.interpolation.haml
+    /                             ^ meta.mapping.json - meta.interpolation
+
+        "#{ @key }": "#{ @SiteColor }",
+    /  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.filter.haml meta.embedded.haml source.json.embedded.haml
+    /   ^ meta.mapping.key.json string.quoted.double.json punctuation.definition.string.begin.json
+    /    ^^^^^^^^^ meta.mapping.key.json meta.interpolation.haml - string
+    /             ^ meta.mapping.key.json string.quoted.double.json punctuation.definition.string.end.json
+    /              ^^ meta.mapping.json - meta.interpolation
+    /                ^ meta.mapping.value.json meta.string.json string.quoted.double.json punctuation.definition.string.begin.json
+    /                 ^^^^^^^^^^^^^^^ meta.mapping.value.json meta.interpolation.haml - string
+    /                                ^ meta.mapping.value.json meta.string.json string.quoted.double.json punctuation.definition.string.end.json
+    /                                 ^ meta.mapping.json - meta.interpolation
+    }
+
 :markdown
 / <- meta.filter.definition.haml punctuation.definition.filter.haml
 /^^^^^^^^ meta.filter.definition.haml constant.other.language-name.markdown.haml

--- a/Rails/tests/syntax_test_rails.html.erb
+++ b/Rails/tests/syntax_test_rails.html.erb
@@ -51,6 +51,27 @@
   </script>
 # ^^^^^^^^^ meta.tag - source
 
+  <script type="application/ld+json">
+      {
+          <% key %>: <%.Site.Color%>,
+      |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.json.embedded.html
+      |   ^^^^^^^^^ meta.mapping.json meta.interpolation.rails
+      |            ^^ meta.mapping.json - meta.interpolation
+      |              ^^^^^^^^^^^^^^^ meta.mapping.value.json meta.interpolation.rails
+      |                             ^ meta.mapping.json - meta.interpolation
+
+          "<% key %>": "<%.Site.Color%>",
+      |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.json.embedded.html
+      |   ^ meta.mapping.key.json string.quoted.double.json punctuation.definition.string.begin.json
+      |    ^^^^^^^^^ meta.mapping.key.json meta.interpolation.rails - string
+      |             ^ meta.mapping.key.json string.quoted.double.json punctuation.definition.string.end.json
+      |              ^^ meta.mapping.json - meta.interpolation
+      |                ^ meta.mapping.value.json meta.string.json string.quoted.double.json punctuation.definition.string.begin.json
+      |                 ^^^^^^^^^^^^^^^ meta.mapping.value.json meta.interpolation.rails - string
+      |                                ^ meta.mapping.value.json meta.string.json string.quoted.double.json punctuation.definition.string.end.json
+      |                                 ^ meta.mapping.json - meta.interpolation
+      }
+  </script>
 
   <p>Normal HTML</p>
 # ^^^ meta.tag


### PR DESCRIPTION
This PR...

1. renames contexts to express popping/non-popping behavior via singular/plural.
2. adds named contexts for nearly everything, so it can be addressed by inherit syntaxes.

... while keeping behavior and highlighting as simple and fast as it is without bloating the package.

required for https://github.com/SublimeText/Liquid/issues/10

The new syntax is inherit in ASP, JSP, PHP, ERB and HAML to support JSON highlighting in templates.

Without this PR syntax highlighting errors occur, within `<script type="application/json">` tags due to lack of interpolation support of JSON syntax, which is already embedded in HTML.sublime-syntax.