### PR TITLE
[PHP] Fix indentation rules

### DIFF
--- a/PHP/Indentation Rules.tmPreferences
+++ b/PHP/Indentation Rules.tmPreferences
@@ -19,7 +19,7 @@
 			    \s* [}\])]                                                                    # optionally followed by whitespace, followed by a closing: curly brace, square bracket or paren
 			|                                                                                 # OR
 			    \s* (<\?(php)?\s+)?                                                           # an optional PHP open tag
-			    (else(\s*if)?\b.*:\s*($|//|/\*|\?>)|(end(if|for(each)?|switch|while))\b)             # followed by an keyword that ends a control flow block
+			    (else(\s*if)?\b.*:\s*($|//|/\*|\?>)|(end(if|for(each)?|switch|while))\b)   	  # followed by an keyword that ends a control flow block
 			)
 		]]></string>
 
@@ -46,7 +46,7 @@
 			| # OR
 			^\s* (<\?(php)?\s+)?                                                                # the beginning of the line followed by any amount of whitespace and an optional PHP open tag
 			(   (?:
-			        (?:else\s*)?if\s*\g<balanced_paren>|else                                       # PHP "if" related statements
+			        (?:else\s*)?if\s*\g<balanced_paren>|else                                    # PHP "if" related statements
 			    )\s*:(?!.*\bendif\b)                                                            # followed by a colon, not followed by an "endif" anywhere on the line
 			    |
 			    (?<php_control_word>foreach|for|switch|while)\s*\g<balanced_paren>              # PHP control keywords, followed by balanced parens

--- a/PHP/Indentation Rules.tmPreferences
+++ b/PHP/Indentation Rules.tmPreferences
@@ -54,9 +54,6 @@
 			)
 		]]></string>
 
-		<key>indentNextLinePattern</key>
-		<string><![CDATA[^(?!.*(#|//|\*/|<\?))(?!.*[};:]\s*(//|/\*.*\*/\s*$)).*[^\s;:{}]\s*$|<\?php.+?\b(if|else(?:if)?|for(?:each)?|while)\b.*:(?!.*end\1)]]></string>
-
 		<key>bracketIndentNextLinePattern</key>
 		<string>(?x)
 		^ \s* \b(if|while|else|elseif|foreach)\b [^;]* $

--- a/PHP/Indentation Rules.tmPreferences
+++ b/PHP/Indentation Rules.tmPreferences
@@ -46,7 +46,7 @@
 			| # OR
 			^\s* (<\?(php)?\s+)?                                                                # the beginning of the line followed by any amount of whitespace and an optional PHP open tag
 			(   (?:
-			        (?:else)?if\s*\g<balanced_paren>|else                                       # PHP "if" related statements
+			        (?:else\s*)?if\s*\g<balanced_paren>|else                                       # PHP "if" related statements
 			    )\s*:(?!.*\bendif\b)                                                            # followed by a colon, not followed by an "endif" anywhere on the line
 			    |
 			    (?<php_control_word>foreach|for|switch|while)\s*\g<balanced_paren>              # PHP control keywords, followed by balanced parens

--- a/PHP/tests/syntax_test_indentation.php
+++ b/PHP/tests/syntax_test_indentation.php
@@ -5,6 +5,8 @@ https://github.com/sublimehq/Packages/issues/1924
     asdfadf
 <?php elseif(false): ?>
     asdf
+<?php else if(true):?>
+    asdf
 <?php else: ?>
     qwfpg
 <?php endif;?>


### PR DESCRIPTION
This PR...

1. fixes indentation after `else if ():` as follow-up for #1932
2. removes unsupported `indentNextLinePattern` rule
3. tweaks comment positions

revealed while trying to re-produce https://forum.sublimetext.com/t/php-syntax-html-in-if-else-reindent-problem/70376/2