### PR TITLE
[Rust] Add C-string literals

### DIFF
--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -1269,6 +1269,8 @@ contexts:
     - include: raw-byte-string
     - include: string
     - include: raw-string
+    - include: c-string
+    - include: raw-c-string
 
   chars:
     - include: char
@@ -1383,6 +1385,35 @@ contexts:
 
   raw-string:
     - match: (r)((#*)")
+      captures:
+        1: storage.type.string.rust
+        2: punctuation.definition.string.begin.rust
+      push:
+        - meta_include_prototype: false
+        - meta_scope: string.quoted.double.raw.rust
+        - match: '"\3'
+          scope: punctuation.definition.string.end.rust
+          pop: true
+
+  c-string:
+    - match: '(c)(")'
+      captures:
+        1: storage.type.string.rust
+        2: punctuation.definition.string.begin.rust
+      push:
+        - meta_include_prototype: false
+        - meta_scope: string.quoted.double.rust
+        - match: '"'
+          scope: punctuation.definition.string.end.rust
+          pop: true
+        - match: '{{escaped_byte}}'
+          scope: constant.character.escape.rust
+        - match: '(\\)$'
+          scope: punctuation.separator.continuation.line.rust
+        - include: escaped-char
+
+  raw-c-string:
+    - match: (cr)((#*)")
       captures:
         1: storage.type.string.rust
         2: punctuation.definition.string.begin.rust

--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -1319,8 +1319,7 @@ contexts:
           pop: true
         - match: '{{escaped_byte}}'
           scope: constant.character.escape.rust
-        - match: '(\\)$'
-          scope: punctuation.separator.continuation.line.rust
+        - include: line-continuation
         - match: '\\.'
           scope: invalid.illegal.character.escape.rust
 
@@ -1335,6 +1334,10 @@ contexts:
         - match: '"\2'
           scope: punctuation.definition.string.end.rust
           pop: true
+
+  line-continuation:
+    - match: '\\$'
+      scope: punctuation.separator.continuation.line.rust
 
   escaped-char:
     - match: '{{escaped_char}}'
@@ -1380,8 +1383,7 @@ contexts:
           scope: punctuation.definition.string.end.rust
           pop: true
         - include: escaped-char
-        - match: '(\\)$'
-          scope: punctuation.separator.continuation.line.rust
+        - include: line-continuation
 
   raw-string:
     - match: (r)((#*)")
@@ -1408,8 +1410,7 @@ contexts:
           pop: true
         - match: '{{escaped_byte}}'
           scope: constant.character.escape.rust
-        - match: '(\\)$'
-          scope: punctuation.separator.continuation.line.rust
+        - include: line-continuation
         - include: escaped-char
 
   raw-c-string:
@@ -1435,8 +1436,7 @@ contexts:
           pop: true
         - include: escaped-char
         - include: format-escapes
-        - match: '(\\)$'
-          scope: punctuation.separator.continuation.line.rust
+        - include: line-continuation
 
   format-raw-string:
     - match: (r)(#*)"

--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -19,7 +19,6 @@ variables:
   identifier: '(?:(?:(?:r\#)?{{non_raw_ident}})\b)'
   camel_ident: '\b_*[A-Z][a-zA-Z0-9_]*[a-z][a-zA-Z0-9_]*\b'
   lifetime: '''(?:_|{{non_raw_ident}})(?!\'')\b'
-  escaped_byte: '\\([nrt0\"''\\]|x\h{2})'
   escaped_char: '\\([nrt0\"''\\]|x[0-7]\h|u\{(?:\h_*){1,6}\})'
   int_suffixes: '[iu](?:8|16|32|64|128|size)'
   float_suffixes: 'f(32|64)'
@@ -1291,8 +1290,7 @@ contexts:
         # not valid syntax.
         - match: '\n'
           pop: true
-        - match: '{{escaped_byte}}'
-          scope: constant.character.escape.rust
+        - include: escaped-byte
           set: byte-tail
         - match: ''
           set: byte-tail
@@ -1317,8 +1315,7 @@ contexts:
         - match: '"'
           scope: punctuation.definition.string.end.rust
           pop: true
-        - match: '{{escaped_byte}}'
-          scope: constant.character.escape.rust
+        - include: escaped-byte
         - include: line-continuation
         - match: '\\.'
           scope: invalid.illegal.character.escape.rust
@@ -1338,6 +1335,10 @@ contexts:
   line-continuation:
     - match: '\\$'
       scope: punctuation.separator.continuation.line.rust
+
+  escaped-byte:
+    - match: '\\([nrt0\"''\\]|x\h{2})'
+      scope: constant.character.escape.rust
 
   escaped-char:
     - match: '{{escaped_char}}'
@@ -1408,8 +1409,7 @@ contexts:
         - match: '"'
           scope: punctuation.definition.string.end.rust
           pop: true
-        - match: '{{escaped_byte}}'
-          scope: constant.character.escape.rust
+        - include: escaped-byte
         - include: line-continuation
         - include: escaped-char
 

--- a/Rust/tests/syntax_test_literals.rs
+++ b/Rust/tests/syntax_test_literals.rs
@@ -166,6 +166,46 @@ let s_uni_esc_under3 = "\u{10__FFFF}";
 let s_uni_esc_extra = "\u{1234567}";
 //                     ^^^^^^^^^^^ string.quoted.double invalid.illegal.character.escape
 
+let cstr_empty = c"";
+//               ^ string.quoted.double storage.type.string
+//               ^^^ string.quoted.double
+//                ^ punctuation.definition.string.begin
+//                 ^ punctuation.definition.string.end
+//                  ^ punctuation.terminator
+let cstr_unicode = c"æ";
+//                 ^ string.quoted.double storage.type.string
+//                 ^^^^ string.quoted.double
+let cstr_byte_escape = c"\xFF\xC3\xA6";
+//                     ^ storage.type.string
+//                     ^^^^^^^^^^^^^^^ string.quoted.double
+//                       ^^^^^^^^^^^^ constant.character.escape
+let cstr_unicode_escape = c"\u{00E6}";
+//                        ^^^^^^^^^^^ string.quoted.double
+//                          ^^^^^^^^ constant.character.escape
+let cstr_continue = c"\
+    \xFF";
+//  ^^^^ string.quoted.double constant.character.escape
+
+let raw_cstr_empty = cr"";
+//                   ^^^^ string.quoted.double.raw
+//                   ^^ storage.type.string
+//                     ^ punctuation.definition.string.begin
+//                      ^ punctuation.definition.string.end
+let raw_cstr_unicode = cr"東京";
+//                     ^^^^^^ string.quoted.double.raw
+//                     ^^ storage.type.string
+let raw_cstr_hash = cr#"text with "quote" in it."#;
+//                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.raw
+//                  ^^ storage.type.string
+//                    ^^ punctuation.definition.string.begin
+//                                              ^^ punctuation.definition.string.end
+let raw_cstr_multiline = cr##"
+//                       ^^ string.quoted.double.raw storage.type.string
+//                       ^^^^^^ string.quoted.double.raw
+    This text has "multiple lines"
+    "##;
+//   ^^ string.quoted.double.raw punctuation.definition.string.end
+
 0;
 // <- constant.numeric.integer.decimal
 1_000u32;

--- a/Rust/tests/syntax_test_literals.rs
+++ b/Rust/tests/syntax_test_literals.rs
@@ -175,10 +175,16 @@ let cstr_empty = c"";
 let cstr_unicode = c"æ";
 //                 ^ string.quoted.double storage.type.string
 //                 ^^^^ string.quoted.double
-let cstr_byte_escape = c"\xFF\xC3\xA6";
+let cstr_byte_escape = c"\xFF\xC3\xA6\n\r\t\0\"\'\\";
 //                     ^ storage.type.string
-//                     ^^^^^^^^^^^^^^^ string.quoted.double
-//                       ^^^^^^^^^^^^ constant.character.escape
+//                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double
+//                       ^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.character.escape
+let cstr_byte_escape_invalid = c"\a";
+//                             ^^^^^ string.quoted.double
+//                             ^ storage.type.string
+//                              ^ punctuation.definition.string.begin
+//                               ^^ invalid.illegal.character.escape
+//                                 ^ punctuation.definition.string.end
 let cstr_unicode_escape = c"\u{00E6}";
 //                        ^^^^^^^^^^^ string.quoted.double
 //                          ^^^^^^^^ constant.character.escape
@@ -205,6 +211,9 @@ let raw_cstr_multiline = cr##"
     This text has "multiple lines"
     "##;
 //   ^^ string.quoted.double.raw punctuation.definition.string.end
+let raw_cstr_escape_ignore = cr"\n\x01\u{0123}\";
+//                           ^^^^^^^^^^^^^^^^^^^ string.quoted.double.raw
+//                              ^^^^^^^^^^^^^^^ -constant.character.escape
 
 0;
 // <- constant.numeric.integer.decimal


### PR DESCRIPTION
Rust 1.76 has added C-string literal syntax.
