### PR TITLE
[D] Add short function definition syntax

### DIFF
--- a/D/D.sublime-syntax
+++ b/D/D.sublime-syntax
@@ -916,6 +916,8 @@ contexts:
   function-definition-after-arguments:
     - meta_scope: meta.function.d
     - include: function-attribute-in
+    - match: '=>'
+      set: [expect-end-of-line, value]
     - match: '='
       scope: keyword.operator.assignment.d
       set: [meta-function, expect-end-of-line, value]
@@ -925,6 +927,8 @@ contexts:
     - match: '(?=\S)'
       set: [meta-function, function-definition-after-condition]
   function-definition-after-condition:
+    - match: '=>'
+      set: [expect-end-of-line, value]
     - match: '\bin\b'
       scope: keyword.control.conditional.d
       set:


### PR DESCRIPTION
The short function definition syntax was introduced with DMD 2.101.0 and replaces an ordinary block statement function body with a lambda-like construct (`int foo(int x) => x + 1;`).

Due to the structure of the syntax definition file, I'm unsure whether this is complete, but it appears to work fine for the cases that I've seen so far.