### PR TITLE
[Python] Fix type parameter punctuation scope

### DIFF
--- a/Python/Fold.tmPreferences
+++ b/Python/Fold.tmPreferences
@@ -17,6 +17,14 @@
             </dict>
             <dict>
                 <key>begin</key>
+                <string>punctuation.definition.generic.begin</string>
+                <key>end</key>
+                <string>punctuation.definition.generic.end</string>
+                <key>excludeTrailingNewlines</key>
+                <false/>
+            </dict>
+            <dict>
+                <key>begin</key>
                 <string>punctuation.section.arguments.begin</string>
                 <key>end</key>
                 <string>punctuation.section.arguments.end</string>

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1090,7 +1090,7 @@ contexts:
   type-parameter-list-body:
     - meta_content_scope: meta.generic.python
     - match: \]
-      scope: meta.generic.python punctuation.section.parameters.end.python
+      scope: meta.generic.python punctuation.definition.generic.end.python
       pop: 1
     - match: ','
       scope: punctuation.separator.parameters.python

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -2047,7 +2047,7 @@ def f[T: Hashable, U: (int, str), *V, **P](x: T = SOME_CONSTANT, y: U, *args: *T
 #                                   ^ punctuation.separator.parameters.python
 #                                     ^^ keyword.operator.unpacking.mapping.python
 #                                       ^ variable.parameter.type.python
-#                                        ^ punctuation.section.parameters.end.python
+#                                        ^ punctuation.definition.generic.end.python
 #                                         ^ punctuation.section.parameters.begin.python
 #                                          ^ variable.parameter.python
 #                                           ^ punctuation.separator.annotation.python
@@ -2107,7 +2107,7 @@ def f[
 #^^^^ meta.function.python meta.generic.python
 #    ^^ meta.function.parameters.python
 #       ^^^^ meta.function.return-type.python
-#   ^ punctuation.section.parameters.end.python
+#   ^ punctuation.definition.generic.end.python
 #    ^ punctuation.section.parameters.begin.python
 #     ^ punctuation.section.parameters.end.python
 #       ^^ punctuation.separator.return-type.python
@@ -2224,7 +2224,7 @@ class GenericClass[T: X, **U]:
 #                      ^ punctuation.separator.parameters.python
 #                        ^^ keyword.operator.unpacking.mapping.python
 #                          ^ variable.parameter.type.python
-#                           ^ punctuation.section.parameters.end.python
+#                           ^ punctuation.definition.generic.end.python
 #                            ^ punctuation.section.class.begin.python
 
     from typing import override
@@ -2266,7 +2266,7 @@ type Alias[T: int] = list[T]
 #          ^ variable.parameter.type.python
 #           ^ punctuation.separator.bound.python
 #             ^^^ meta.type.python support.type.python
-#                ^ punctuation.section.parameters.end.python
+#                ^ punctuation.definition.generic.end.python
 #                  ^ keyword.operator.assignment.python
 #                    ^^^^ support.type.python
 #                        ^^^ meta.brackets.python
@@ -2283,7 +2283,7 @@ type \
 #      ^ variable.parameter.type.python
 #       ^ punctuation.separator.bound.python
 #         ^^^ meta.type.python support.type.python
-#            ^ punctuation.section.parameters.end.python
+#            ^ punctuation.definition.generic.end.python
 #              ^ keyword.operator.assignment.python
 #                ^^^^ support.type.python
 #                    ^^^ meta.brackets.python
@@ -2300,7 +2300,7 @@ type \
 # ^ variable.parameter.type.python
 #  ^ punctuation.separator.bound.python
 #    ^^^ meta.type.python support.type.python
-#       ^ punctuation.section.parameters.end.python
+#       ^ punctuation.definition.generic.end.python
 #         ^ keyword.operator.assignment.python
 #           ^^^^ support.type.python
 #               ^^^ meta.brackets.python


### PR DESCRIPTION
Fixes #3886