### PR TITLE
[Python] Add SQL syntax highlighting in f-strings

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -2829,7 +2829,31 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.block.python
     - include: triple-double-quoted-string-end
+    - include: triple-double-quoted-f-string-syntax
+
+  triple-double-quoted-f-string-syntax:
+    # Single-line string, unicode or not, starting with a SQL keyword
+    - match: (?={{sql_indicator}})
+      set: triple-double-quoted-sql-f-string-body
+    # Single-line string, unicode or not
+    - match: (?=\S)
+      set: triple-double-quoted-plain-f-string-body
+
+  triple-double-quoted-plain-f-string-body:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.double.block.python
+    - include: triple-double-quoted-string-end
     - include: triple-double-quoted-f-string-content
+
+  triple-double-quoted-sql-f-string-body:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python
+    - include: triple-double-quoted-string-end
+    - match: ''
+      push: scope:source.sql
+      with_prototype:
+        - include: triple-double-quoted-string-pop
+        - include: triple-double-quoted-f-string-content
 
   triple-double-quoted-f-string-content:
     - include: string-prototype
@@ -3171,7 +3195,31 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.double.python
     - include: double-quoted-string-end
+    - include: double-quoted-f-string-syntax
+
+  double-quoted-f-string-syntax:
+    # Single-line string, unicode or not, starting with a SQL keyword
+    - match: (?={{sql_indicator}})
+      set: double-quoted-sql-f-string-body
+    # Single-line string, unicode or not
+    - match: (?=\S)
+      set: double-quoted-plain-f-string-body
+
+  double-quoted-plain-f-string-body:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.double.python
+    - include: double-quoted-string-end
     - include: double-quoted-f-string-content
+
+  double-quoted-sql-f-string-body:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python
+    - include: double-quoted-string-end
+    - match: ''
+      push: scope:source.sql
+      with_prototype:
+        - include: double-quoted-string-pop
+        - include: double-quoted-f-string-content
 
   double-quoted-f-string-content:
     - include: string-prototype
@@ -3188,7 +3236,7 @@ contexts:
 
   double-quoted-u-string-body:
     - meta_include_prototype: false
-    - meta_content_scope: meta.string.python string.quoted.double.block.python
+    - meta_content_scope: meta.string.python string.quoted.double.python
     - include: double-quoted-string-end
     - include: double-quoted-u-string-syntax
 
@@ -3509,7 +3557,31 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.single.block.python
     - include: triple-single-quoted-string-end
+    - include: triple-single-quoted-f-string-syntax
+
+  triple-single-quoted-f-string-syntax:
+    # Single-line string, unicode or not, starting with a SQL keyword
+    - match: (?={{sql_indicator}})
+      set: triple-single-quoted-sql-f-string-body
+    # Single-line string, unicode or not
+    - match: (?=\S)
+      set: triple-single-quoted-plain-f-string-body
+
+  triple-single-quoted-plain-f-string-body:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.single.block.python
+    - include: triple-single-quoted-string-end
     - include: triple-single-quoted-f-string-content
+
+  triple-single-quoted-sql-f-string-body:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python
+    - include: triple-single-quoted-string-end
+    - match: ''
+      push: scope:source.sql
+      with_prototype:
+        - include: triple-single-quoted-string-pop
+        - include: triple-single-quoted-f-string-content
 
   triple-single-quoted-f-string-content:
     - include: string-prototype
@@ -3851,7 +3923,31 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.python string.quoted.single.python
     - include: single-quoted-string-end
+    - include: single-quoted-f-string-syntax
+
+  single-quoted-f-string-syntax:
+    # Single-line string, unicode or not, starting with a SQL keyword
+    - match: (?={{sql_indicator}})
+      set: single-quoted-sql-f-string-body
+    # Single-line string, unicode or not
+    - match: (?=\S)
+      set: single-quoted-plain-f-string-body
+
+  single-quoted-plain-f-string-body:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python string.quoted.single.python
+    - include: single-quoted-string-end
     - include: single-quoted-f-string-content
+
+  single-quoted-sql-f-string-body:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.python
+    - include: single-quoted-string-end
+    - match: ''
+      push: scope:source.sql
+      with_prototype:
+        - include: single-quoted-string-pop
+        - include: single-quoted-f-string-content
 
   single-quoted-f-string-content:
     - include: string-prototype

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -3236,7 +3236,7 @@ contexts:
 
   double-quoted-u-string-body:
     - meta_include_prototype: false
-    - meta_content_scope: meta.string.python string.quoted.double.python
+    - meta_content_scope: meta.string.python string.quoted.double.block.python
     - include: double-quoted-string-end
     - include: double-quoted-u-string-syntax
 

--- a/Python/tests/syntax_test_python_strings.py
+++ b/Python/tests/syntax_test_python_strings.py
@@ -1192,6 +1192,34 @@ f"result: {value:{width}.{precision}}\n"
 #                        ^^^^^^^^^^^ meta.interpolation.python meta.interpolation.python
 #                                   ^^^ - meta.interpolation.python meta.interpolation.python
 
+f"""SELECT * FROM {table!s:r}"""
+# <- storage.type.string.python
+#^^^ meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
+#   ^^^^^^^^^^^^^^ meta.string.python source.sql
+#                 ^^^^^^^^^^^ meta.string.python meta.interpolation.python
+#                            ^^^ meta.string.python string.quoted.double.block.python punctuation.definition.string.end.python
+
+f'''SELECT * FROM {table!s:r}'''
+# <- storage.type.string.python
+#^^^ meta.string.python string.quoted.single.block.python punctuation.definition.string.begin.python
+#   ^^^^^^^^^^^^^^ meta.string.python source.sql
+#                 ^^^^^^^^^^^ meta.string.python meta.interpolation.python
+#                            ^^^ meta.string.python string.quoted.single.block.python punctuation.definition.string.end.python
+
+f"SELECT * FROM {table!s:r}"
+# <- storage.type.string.python
+#^ meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
+# ^^^^^^^^^^^^^^ meta.string.python source.sql
+#               ^^^^^^^^^^^ meta.string.python meta.interpolation.python
+#                          ^ meta.string.python string.quoted.double.python punctuation.definition.string.end.python
+
+f'SELECT * FROM {table!s:r}'
+# <- storage.type.string.python
+#^ meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
+# ^^^^^^^^^^^^^^ meta.string.python source.sql
+#               ^^^^^^^^^^^ meta.string.python meta.interpolation.python
+#                          ^ meta.string.python string.quoted.single.python punctuation.definition.string.end.python
+
 rf"{value:{width!s:d}}"
 # <- storage.type.string - meta.string - string
 #^ storage.type.string - meta.string - string


### PR DESCRIPTION
Resolves #3885

This PR proposes to add support for SQL syntax highlghting within f-strings.

I have no strong opinion about adding this. 
The change was easy, so proposing it for thosw who want it.

Note: With #3046 Python's syntax cache grows from about 3MB to 4MB with this PR merged.