### PR TITLE
[Python] Fix double quoted u-string scope

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -3188,7 +3188,7 @@ contexts:
 
   double-quoted-u-string-body:
     - meta_include_prototype: false
-    - meta_content_scope: meta.string.python string.quoted.double.block.python
+    - meta_content_scope: meta.string.python string.quoted.double.python
     - include: double-quoted-string-end
     - include: double-quoted-u-string-syntax
 

--- a/Python/tests/syntax_test_python_strings.py
+++ b/Python/tests/syntax_test_python_strings.py
@@ -36,17 +36,30 @@ conn.execute('SELECT * FROM foobar')
 #              ^ keyword.other.DML.sql
 
 conn.execute(U"SELECT * FROM foobar")
+#             ^ meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
+#              ^^^^^^^^^^^^^^^^^^^^ meta.string.python source.sql
+#                                  ^ meta.string.python string.quoted.double.python punctuation.definition.string.end.python
 #              ^ keyword.other.DML.sql
 
 conn.execute(U'SELECT * FROM foobar')
+#             ^ meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
+#              ^^^^^^^^^^^^^^^^^^^^ meta.string.python source.sql
+#                                  ^ meta.string.python string.quoted.single.python punctuation.definition.string.end.python
 #              ^ keyword.other.DML.sql
 
 # In this example, the Python string is not raw, so \t is a python escape
 conn.execute(u"SELECT * FROM foobar WHERE foo = '\t'")
+#            ^ storage.type.string.python
+#             ^ meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
+#              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.python source.sql
 #              ^ keyword.other.DML.sql
 #                                                 ^ constant.character.escape.python
+#                                                   ^ meta.string.python string.quoted.double.python punctuation.definition.string.end.python
 
 conn.execute(u'SELECT * FROM foobar')
+#             ^ meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
+#              ^^^^^^^^^^^^^^^^^^^^ meta.string.python source.sql
+#                                  ^ meta.string.python string.quoted.single.python punctuation.definition.string.end.python
 #              ^ keyword.other.DML.sql
 
 # In this example, the Python string is raw, so the \b should be a SQL escape


### PR DESCRIPTION
This PR fixes a copy&paste error, which caused `block` scope to having been found its way to normal double quoted u-strings.