### PR TITLE
[Markdown] Add GitHub Alerts syntax

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -354,6 +354,56 @@ contexts:
 
   block-quotes:
     # https://spec.commonmark.org/0.30/#block-quotes
+    - match: '[ \t]{,3}(>)[ ]?((\[)!CAUTION(\]))'
+      captures:
+        1: punctuation.definition.blockquote.markdown
+        2: markup.heading.alert.caution.markdown
+        3: punctuation.definition.heading.begin.markdown
+        4: punctuation.definition.heading.end.markdown
+      push:
+        - block-quote-caution-meta
+        - block-quote-body
+        - block-quote-punctuation-body
+    - match: '[ \t]{,3}(>)[ ]?((\[)!WARNING(\]))'
+      captures:
+        1: punctuation.definition.blockquote.markdown
+        2: markup.heading.alert.warning.markdown
+        3: punctuation.definition.heading.begin.markdown
+        4: punctuation.definition.heading.end.markdown
+      push:
+        - block-quote-warning-meta
+        - block-quote-body
+        - block-quote-punctuation-body
+    - match: '[ \t]{,3}(>)[ ]?((\[)!IMPORTANT(\]))'
+      captures:
+        1: punctuation.definition.blockquote.markdown
+        2: markup.heading.alert.important.markdown
+        3: punctuation.definition.heading.begin.markdown
+        4: punctuation.definition.heading.end.markdown
+      push:
+        - block-quote-important-meta
+        - block-quote-body
+        - block-quote-punctuation-body
+    - match: '[ \t]{,3}(>)[ ]?((\[)!NOTE(\]))'
+      captures:
+        1: punctuation.definition.blockquote.markdown
+        2: markup.heading.alert.note.markdown
+        3: punctuation.definition.heading.begin.markdown
+        4: punctuation.definition.heading.end.markdown
+      push:
+        - block-quote-note-meta
+        - block-quote-body
+        - block-quote-punctuation-body
+    - match: '[ \t]{,3}(>)[ ]?((\[)!TIP(\]))'
+      captures:
+        1: punctuation.definition.blockquote.markdown
+        2: markup.heading.alert.tip.markdown
+        3: punctuation.definition.heading.begin.markdown
+        4: punctuation.definition.heading.end.markdown
+      push:
+        - block-quote-tip-meta
+        - block-quote-body
+        - block-quote-punctuation-body
     - match: '[ \t]{,3}(>)[ ]?'
       captures:
         1: punctuation.definition.blockquote.markdown
@@ -361,6 +411,31 @@ contexts:
         - block-quote-meta
         - block-quote-body
         - block-quote-punctuation-body
+
+  block-quote-caution-meta:
+    - meta_include_prototype: false
+    - meta_scope: markup.quote.alert.caution.markdown
+    - include: immediately-pop
+
+  block-quote-warning-meta:
+    - meta_include_prototype: false
+    - meta_scope: markup.quote.alert.warning.markdown
+    - include: immediately-pop
+
+  block-quote-important-meta:
+    - meta_include_prototype: false
+    - meta_scope: markup.quote.alert.important.markdown
+    - include: immediately-pop
+
+  block-quote-note-meta:
+    - meta_include_prototype: false
+    - meta_scope: markup.quote.alert.note.markdown
+    - include: immediately-pop
+
+  block-quote-tip-meta:
+    - meta_include_prototype: false
+    - meta_scope: markup.quote.alert.tip.markdown
+    - include: immediately-pop
 
   block-quote-meta:
     - meta_include_prototype: false
@@ -709,6 +784,56 @@ contexts:
         4: markup.list.numbered.markdown
 
   list-block-quotes:
+    - match: '[ \t]{,3}(>)[ ]?((\[)!CAUTION(\]))'
+      captures:
+        1: punctuation.definition.blockquote.markdown
+        2: markup.heading.alert.caution.markdown
+        3: punctuation.definition.heading.begin.markdown
+        4: punctuation.definition.heading.end.markdown
+      push:
+        - block-quote-caution-meta
+        - list-block-quote-body
+        - block-quote-punctuation-body
+    - match: '[ \t]{,3}(>)[ ]?((\[)!WARNING(\]))'
+      captures:
+        1: punctuation.definition.blockquote.markdown
+        2: markup.heading.alert.warning.markdown
+        3: punctuation.definition.heading.begin.markdown
+        4: punctuation.definition.heading.end.markdown
+      push:
+        - block-quote-warning-meta
+        - list-block-quote-body
+        - block-quote-punctuation-body
+    - match: '[ \t]{,3}(>)[ ]?((\[)!IMPORTANT(\]))'
+      captures:
+        1: punctuation.definition.blockquote.markdown
+        2: markup.heading.alert.important.markdown
+        3: punctuation.definition.heading.begin.markdown
+        4: punctuation.definition.heading.end.markdown
+      push:
+        - block-quote-important-meta
+        - list-block-quote-body
+        - block-quote-punctuation-body
+    - match: '[ \t]{,3}(>)[ ]?((\[)!NOTE(\]))'
+      captures:
+        1: punctuation.definition.blockquote.markdown
+        2: markup.heading.alert.note.markdown
+        3: punctuation.definition.heading.begin.markdown
+        4: punctuation.definition.heading.end.markdown
+      push:
+        - block-quote-note-meta
+        - list-block-quote-body
+        - block-quote-punctuation-body
+    - match: '[ \t]{,3}(>)[ ]?((\[)!TIP(\]))'
+      captures:
+        1: punctuation.definition.blockquote.markdown
+        2: markup.heading.alert.tip.markdown
+        3: punctuation.definition.heading.begin.markdown
+        4: punctuation.definition.heading.end.markdown
+      push:
+        - block-quote-tip-meta
+        - list-block-quote-body
+        - block-quote-punctuation-body
     - match: '[ \t]*(>)[ ]?'
       captures:
         1: punctuation.definition.blockquote.markdown

--- a/Markdown/Symbol List - Heading.tmPreferences
+++ b/Markdown/Symbol List - Heading.tmPreferences
@@ -2,7 +2,7 @@
 <plist version="1.0">
 <dict>
 	<key>scope</key>
-	<string>text.html.markdown markup.heading - meta.whitespace.newline.markdown</string>
+	<string>text.html.markdown markup.heading - markup.quote - meta.whitespace.newline.markdown</string>
 	<key>settings</key>
 	<dict>
 		<key>showInSymbolList</key>

--- a/Markdown/tests/syntax_test_markdown.md
+++ b/Markdown/tests/syntax_test_markdown.md
@@ -8193,6 +8193,155 @@ This is a [[wiki link]].
 |                    ^^ punctuation.definition.link.end.markdown
 
 
+# TEST: GITHUB ALERTS #########################################################
+
+> [!CAUTION]
+| <- markup.quote.alert.caution.markdown punctuation.definition.blockquote.markdown
+|^^^^^^^^^^^^ markup.quote.alert.caution.markdown
+| ^^^^^^^^^^ markup.heading.alert.caution.markdown
+| ^ punctuation.definition.heading.begin.markdown
+|          ^ punctuation.definition.heading.end.markdown
+
+> [!CAUTION]
+> 
+> Text
+| <- markup.quote.alert.caution.markdown punctuation.definition.blockquote.markdown
+|^ markup.quote.alert.caution.markdown - markup.paragraph
+| ^^^^^ markup.quote.alert.caution.markdown markup.paragraph.markdown
+
+> [!WARNING]
+| <- markup.quote.alert.warning.markdown punctuation.definition.blockquote.markdown
+|^^^^^^^^^^^^ markup.quote.alert.warning.markdown
+| ^^^^^^^^^^ markup.heading.alert.warning.markdown
+| ^ punctuation.definition.heading.begin.markdown
+|          ^ punctuation.definition.heading.end.markdown
+
+> [!WARNING]
+> 
+> Text
+| <- markup.quote.alert.warning.markdown punctuation.definition.blockquote.markdown
+|^ markup.quote.alert.warning.markdown - markup.paragraph
+| ^^^^^ markup.quote.alert.warning.markdown markup.paragraph.markdown
+
+> [!IMPORTANT]
+| <- markup.quote.alert.important.markdown punctuation.definition.blockquote.markdown
+|^^^^^^^^^^^^^^ markup.quote.alert.important.markdown
+| ^^^^^^^^^^^^ markup.heading.alert.important.markdown
+| ^ punctuation.definition.heading.begin.markdown
+|            ^ punctuation.definition.heading.end.markdown
+
+> [!IMPORTANT]
+> 
+> Text
+| <- markup.quote.alert.important.markdown punctuation.definition.blockquote.markdown
+|^ markup.quote.alert.important.markdown - markup.paragraph
+| ^^^^^ markup.quote.alert.important.markdown markup.paragraph.markdown
+
+> [!NOTE]
+| <- markup.quote.alert.note.markdown punctuation.definition.blockquote.markdown
+|^^^^^^^^^ markup.quote.alert.note.markdown
+| ^^^^^^^ markup.heading.alert.note.markdown
+| ^ punctuation.definition.heading.begin.markdown
+|       ^ punctuation.definition.heading.end.markdown
+
+> [!NOTE]
+> 
+> Text
+| <- markup.quote.alert.note.markdown punctuation.definition.blockquote.markdown
+|^ markup.quote.alert.note.markdown - markup.paragraph
+| ^^^^^ markup.quote.alert.note.markdown markup.paragraph.markdown
+
+> [!TIP]
+| <- markup.quote.alert.tip.markdown punctuation.definition.blockquote.markdown
+|^^^^^^^^ markup.quote.alert.tip.markdown
+| ^^^^^^ markup.heading.alert.tip.markdown
+| ^ punctuation.definition.heading.begin.markdown
+|      ^ punctuation.definition.heading.end.markdown
+
+> [!TIP]
+> 
+> Text
+| <- markup.quote.alert.tip.markdown punctuation.definition.blockquote.markdown
+|^ markup.quote.alert.tip.markdown - markup.paragraph
+| ^^^^^ markup.quote.alert.tip.markdown markup.paragraph.markdown
+
+   
+1. list item   
+   > [!CAUTION]
+   | <- markup.quote.alert.caution.markdown punctuation.definition.blockquote.markdown
+   |^^^^^^^^^^^^ markup.quote.alert.caution.markdown
+   | ^^^^^^^^^^ markup.heading.alert.caution.markdown
+   | ^ punctuation.definition.heading.begin.markdown
+   |          ^ punctuation.definition.heading.end.markdown
+
+   > [!CAUTION]
+   > 
+   > Text
+   | <- markup.quote.alert.caution.markdown punctuation.definition.blockquote.markdown
+   |^ markup.quote.alert.caution.markdown - markup.paragraph
+   | ^^^^^ markup.quote.alert.caution.markdown markup.paragraph.markdown
+
+1. list item   
+   > [!WARNING]
+   | <- markup.quote.alert.warning.markdown punctuation.definition.blockquote.markdown
+   |^^^^^^^^^^^^ markup.quote.alert.warning.markdown
+   | ^^^^^^^^^^ markup.heading.alert.warning.markdown
+   | ^ punctuation.definition.heading.begin.markdown
+   |          ^ punctuation.definition.heading.end.markdown
+
+   > [!WARNING]
+   > 
+   > Text
+   | <- markup.quote.alert.warning.markdown punctuation.definition.blockquote.markdown
+   |^ markup.quote.alert.warning.markdown - markup.paragraph
+   | ^^^^^ markup.quote.alert.warning.markdown markup.paragraph.markdown
+
+1. list item   
+   > [!IMPORTANT]
+   | <- markup.quote.alert.important.markdown punctuation.definition.blockquote.markdown
+   |^^^^^^^^^^^^^^ markup.quote.alert.important.markdown
+   | ^^^^^^^^^^^^ markup.heading.alert.important.markdown
+   | ^ punctuation.definition.heading.begin.markdown
+   |            ^ punctuation.definition.heading.end.markdown
+
+   > [!IMPORTANT]
+   > 
+   > Text
+   | <- markup.quote.alert.important.markdown punctuation.definition.blockquote.markdown
+   |^ markup.quote.alert.important.markdown - markup.paragraph
+   | ^^^^^ markup.quote.alert.important.markdown markup.paragraph.markdown
+
+1. list item   
+   > [!NOTE]
+   | <- markup.quote.alert.note.markdown punctuation.definition.blockquote.markdown
+   |^^^^^^^^^ markup.quote.alert.note.markdown
+   | ^^^^^^^ markup.heading.alert.note.markdown
+   | ^ punctuation.definition.heading.begin.markdown
+   |       ^ punctuation.definition.heading.end.markdown
+
+   > [!NOTE]
+   > 
+   > Text
+   | <- markup.quote.alert.note.markdown punctuation.definition.blockquote.markdown
+   |^ markup.quote.alert.note.markdown - markup.paragraph
+   | ^^^^^ markup.quote.alert.note.markdown markup.paragraph.markdown
+   
+1. list item   
+   > [!TIP]
+   | <- markup.quote.alert.tip.markdown punctuation.definition.blockquote.markdown
+   |^^^^^^^^ markup.quote.alert.tip.markdown
+   | ^^^^^^ markup.heading.alert.tip.markdown
+   | ^ punctuation.definition.heading.begin.markdown
+   |      ^ punctuation.definition.heading.end.markdown
+
+   > [!TIP]
+   > 
+   > Text
+   | <- markup.quote.alert.tip.markdown punctuation.definition.blockquote.markdown
+   |^ markup.quote.alert.tip.markdown - markup.paragraph
+   | ^^^^^ markup.quote.alert.tip.markdown markup.paragraph.markdown
+
+
 # TEST: MATHJAX BLOCKS MARKUP #################################################
 
   $$


### PR DESCRIPTION
Resolves #3891

This PR proposes to add support for syntax highlighting of GitHub alerts as proposed by #3891.

This PR uses dedicated scopes `markup.heading.alert` and `markup.quote.alert` to avoid unwanted negative impacts on highlighting in conjunction with legacy color schemes. Dedicated highlighting requires to opt-in via new color scheme rules. Otherwise those blocks keep highlighting as normal block quotes except `[!...]` marker being highlighted as normal heading.
