### PR TITLE
[TypeScript] Non-null assertion is not an accessor

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -96,7 +96,7 @@ variables:
       =>
     )
 
-  function_call_after_lookahead: (?=\s*(?:{{dot_accessor}}\s*)?\()
+  function_call_after_lookahead: (?=\s*(?:\?\.\s*)?\()
 
   function_assignment_lookahead: |-
     (?x:(?=
@@ -1970,7 +1970,7 @@ contexts:
 
   function-call-arguments:
     - meta_content_scope: meta.function-call.js
-    - match: '{{dot_accessor}}'
+    - match: '\?\.'
       scope: punctuation.accessor.js
     - match: \(
       scope: punctuation.section.group.begin.js
@@ -1992,7 +1992,7 @@ contexts:
         - include: expression-list
 
   property-access:
-    - match: ({{dot_accessor}})?(\[)
+    - match: (\?\.)?(\[)
       captures:
         1: punctuation.accessor.js
         2: punctuation.section.brackets.begin.js

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -18,7 +18,6 @@ first_line_match: |-
 variables:
   shebang_lang: \bts-node(?:-script)?\b
 
-  dot_accessor: (?:[?!]?\.)
   possible_arrow_function_begin: (?:\(|{{identifier_start}}|<)
 
   function_call_after_lookahead: >-
@@ -30,7 +29,8 @@ variables:
         >
         \s*
       )?
-      (?:{{dot_accessor}}\s*)?
+      (?: \! \s* )*
+      (?: \?\. \s*)?
       \(
     ))
 
@@ -692,6 +692,12 @@ contexts:
         - method-declaration-prefix
         - class-element-modifiers
 
+  left-expression-end:
+    - meta_prepend: true
+    - match: '{{function_call_after_lookahead}}'
+      push: function-call-arguments
+    - include: ts-non-null-assertion
+
   expression-end:
     - meta_prepend: true
     - include: ts-type-assertion
@@ -700,6 +706,7 @@ contexts:
   decorator-expression-end:
     - meta_prepend: true
     - include: ts-function-type-arguments-or-less-than
+    - include: ts-non-null-assertion
 
   ts-function-type-arguments-or-less-than:
     - match: (?=<(?![<=]))
@@ -756,10 +763,11 @@ contexts:
         - parenthesized-expression
     - include: else-pop
 
-  ts-type-assertion:
-    - match: '!(?![.=])'
+  ts-non-null-assertion:
+    - match: '!(?!=)'
       scope: keyword.operator.type.js
 
+  ts-type-assertion:
     - match: as{{identifier_break}}
       scope: keyword.operator.type.js
       push:
@@ -1192,3 +1200,7 @@ contexts:
           pop: 1
         - match: (?=\S)
           fail: ts-object-literal-element-modifier
+
+  function-call-arguments:
+    - meta_prepend: true
+    - include: ts-non-null-assertion

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -783,7 +783,8 @@ x as const;
 //   ^^^^^ storage.modifier.const
 
     foo!.bar;
-//     ^^ punctuation.accessor
+//     ^ keyword.operator.type - punctuation.accessor
+//      ^ punctuation.accessor
 
     x ! ;
 //  ^ variable.other.readwrite
@@ -1553,3 +1554,8 @@ type T = Foo | ... 100 more ... | Bar;
 //              ^ keyword.operator.comparison
 //                ^ meta.number.integer.decimal constant.numeric.value
 //                 ^ punctuation.terminator.statement
+
+    foo!!()
+//  ^^^^^^^ meta.function-call
+//     ^^ keyword.operator.type
+//       ^^ meta.function-call.arguments


### PR DESCRIPTION
Fix #3890.

I figured out what I was thinking. I added the `!` postfix operator to `dot_accessor` because it kept things like function call detection working without further alteration. This PR tweaks a few contexts to make everything work without wrongly marking the `!` in `!.` as an accessor.

I also changed a few contexts to use literal `?.` instead of the `dot_accessor` variable when just a dot wouldn't be valid anyway. And I moved the `!` postfix operator to `left-expression-end`. I have to imagine that having it in `expression-end` instead might have caused some subtle bugs, but I'm not sufficiently motivated to track those down (if indeed they ever existed).