### PR TITLE
[C#] fix using top level statements when using a type instead of "var"

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -240,7 +240,11 @@ contexts:
       captures:
         1: keyword.control.using.cs
       push: var_declaration
-    - match: \b(using)\s+(?={{name}}\s*=\s*)
+    - match: \b(using)\s+(?={{name}}\s+{{name}}\s*=)
+      captures:
+        1: keyword.control.using.cs
+      push: var_declaration
+    - match: \b(using)\s+(?={{name}}\s*=)
       captures:
         1: keyword.control.import.cs
       push: using_namespace

--- a/C#/tests/syntax_test_C#9.cs
+++ b/C#/tests/syntax_test_C#9.cs
@@ -422,3 +422,21 @@ public class MyClass { public record MyRecord <T> (int nums) { public const int 
 ///                                                                             ^^^^ variable.other.member
 ///                                                                                       ^ punctuation.section.block.end
 ///                                                                                         ^ punctuation.section.block.end
+
+using ServiceProvider sp = services.BuildServiceProvider();
+/// ^ keyword.control.using
+///   ^^^^^^^^^^^^^^^ support.type
+///                   ^^ variable.other
+///                      ^ keyword.operator.assignment
+///                        ^^^^^^^^ variable.other
+///                                ^ punctuation.accessor.dot
+///                                 ^^^^^^^^^^^^^^^^^^^^^^ meta.function-call
+///                                 ^^^^^^^^^^^^^^^^^^^^ variable.function
+///                                                     ^ punctuation.section.group.begin - invalid
+///                                                      ^ punctuation.section.group.end - invalid
+using IDisposable sub = pageContentObservable.Subscribe(Console.WriteLine);
+/// ^ keyword.control.using
+///   ^^^^^^^^^^^ support.type
+///               ^^^ variable.other
+///                   ^ keyword.operator.assignment
+///                     ^^^^^^^^^^^^^^^^^^^^^ variable.other


### PR DESCRIPTION
Fixes #3909 