### PR TITLE
[Rust] Use `keyword.declaration` scope

### DIFF
--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -200,7 +200,7 @@ contexts:
 
     - match: '\b(macro_rules!)\s+({{identifier}})\b'
       captures:
-        1: support.function.rust
+        1: keyword.declaration.macro.rust
         2: entity.name.macro.rust
       push: macro-block
 

--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -176,20 +176,20 @@ contexts:
 
     - match: '\b(const)\s+({{identifier}})'
       captures:
-        1: keyword.declaration.rust
+        1: keyword.declaration.variable.constant.rust
         2: entity.name.constant.rust
       push: declaration-after-identifier
 
     - match: '\b(static)\s+(?:(mut)\s+)?({{identifier}})'
       captures:
-        1: keyword.declaration.rust
+        1: keyword.declaration.variable.static.rust
         2: storage.modifier.rust
         3: entity.name.constant.rust
       push: declaration-after-identifier
 
     - match: \b(let)\s+(?:(mut)\s+)?
       captures:
-        1: keyword.declaration.rust
+        1: keyword.declaration.variable.rust
         2: storage.modifier.rust
       push: declaration-identifier
 
@@ -1739,15 +1739,20 @@ contexts:
       scope: storage.modifier.rust
 
   keywords:
-    # All keywords.  Note in `statements` some of these are superseded by more
+    # All keywords.  Note in `statements` most of these are superseded by more
     # specific rules.
     - include: bool
 
-    - match: \b(let|static)\b
-      scope: keyword.declaration.rust
+    - match: \blet\b
+      scope: keyword.declaration.variable.rust
+
+    - match: \bstatic\b
+      scope: keyword.declaration.variable.static.rust
 
     - match: \bconst\b
-      scope: storage.type.rust
+      # The storage keyword seems more likely to not have been matched earlier.
+      scope: storage.modifier.rust
+      # scope: keyword.declaration.variable.constant.rust
 
     - match: \bfn\b
       scope: keyword.declaration.function.rust

--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -44,8 +44,7 @@ contexts:
 
     - include: visibility
 
-    - match: ';'
-      scope: punctuation.terminator.rust
+    - include: terminators
 
     - match: '(''(?:{{non_raw_ident}}))\s*(:)'
       captures:
@@ -112,13 +111,11 @@ contexts:
   modules:
     - match: '\b(mod)\s+({{identifier}})\b'
       captures:
-        1: storage.type.module.rust
+        1: keyword.declaration.module.rust
         2: entity.name.module.rust
       push:
         - meta_scope: meta.module.rust
-        - match: ';'
-          scope: punctuation.terminator.rust
-          pop: true
+        - include: terminator
         - include: module-block
 
   module-block:
@@ -133,32 +130,24 @@ contexts:
 
     - match: '\b(fn)\s+(?={{identifier}})'
       captures:
-        1: storage.type.function.rust
+        1: keyword.declaration.function.rust
       push: fn-definition
 
     - match: '\bstruct\b'
-      scope: storage.type.struct.rust
+      scope: keyword.declaration.struct.rust
       push: struct-identifier
 
     - match: '\bunion\b(?!\s*\()'
-      scope: storage.type.union.rust
+      scope: keyword.declaration.union.rust
       push: union-identifier
 
-    - match: '\b(type)\s+({{identifier}})\b'
-      captures:
-        1: storage.type.type.rust
-        2: entity.name.type.rust
-      push:
-        - match: (?=<)
-          push: generic-angles
-        - match: '=(?!=)'
-          scope: keyword.operator.assignment.rust
-          set: type-declaration-body
-        - include: else-pop
+    - match: '\btype\b'
+      scope: keyword.declaration.type.rust
+      push: type-declaration-identifier
 
     - match: '\b(trait)\s+({{identifier}})\b'
       captures:
-        1: storage.type.trait.rust
+        1: keyword.declaration.trait.rust
         2: entity.name.trait.rust
       push:
         - meta_scope: meta.trait.rust
@@ -171,11 +160,11 @@ contexts:
         - include: trait-block
 
     - match: '\bimpl\b'
-      scope: storage.type.impl.rust
+      scope: keyword.declaration.impl.rust
       push: impl-definition
 
     - match: '\benum\b'
-      scope: storage.type.enum.rust
+      scope: keyword.declaration.enum.rust
       push: enum-identifier
 
     - include: raw-pointer
@@ -187,20 +176,20 @@ contexts:
 
     - match: '\b(const)\s+({{identifier}})'
       captures:
-        1: storage.type.rust
+        1: keyword.declaration.rust
         2: entity.name.constant.rust
       push: declaration-after-identifier
 
     - match: '\b(static)\s+(?:(mut)\s+)?({{identifier}})'
       captures:
-        1: storage.type.rust
+        1: keyword.declaration.rust
         2: storage.modifier.rust
         3: entity.name.constant.rust
       push: declaration-after-identifier
 
     - match: \b(let)\s+(?:(mut)\s+)?
       captures:
-        1: storage.type.rust
+        1: keyword.declaration.rust
         2: storage.modifier.rust
       push: declaration-identifier
 
@@ -495,10 +484,6 @@ contexts:
     - include: block-body
 
   ##[ TYPES ]#################################################################
-
-  type-declaration-body:
-    - include: types
-    - include: else-pop
 
   types-relaxed:
     # only the most obvious type constructs (for fallback matching)
@@ -866,6 +851,31 @@ contexts:
     - meta_scope: meta.union.rust meta.block.rust
     - include: struct-classic-body
 
+  ##[ TYPE DECLARATIONS ]#####################################################
+
+  type-declaration-identifier:
+    - meta_scope: meta.type-declaration.rust
+    - include: comments
+    - include: type-declaration-wheres  # deprecated
+    - match: '{{identifier}}'
+      scope: entity.name.type.rust
+    - match: '(?=<)'
+      push: generic-angles
+    - match: '=(?!=)'
+      scope: keyword.operator.assignment.rust
+      set: type-declaration-body
+    - include: else-pop
+
+  type-declaration-body:
+    - meta_content_scope: meta.type-declaration.rust
+    - include: type-declaration-wheres
+    - include: types
+    - include: else-pop
+
+  type-declaration-wheres:
+    - match: '(?=\bwhere\b)'
+      push: impl-where
+
   ##[ ENUMS ]#################################################################
 
   enum-identifier:
@@ -1109,9 +1119,7 @@ contexts:
 
   macro-semi-sep:
     - include: comments
-    - match: ';'
-      scope: punctuation.terminator.rust
-      pop: true
+    - include: terminator
     - match: '(?=[})\]])'
       pop: true
     - match: '\S'
@@ -1171,7 +1179,7 @@ contexts:
   impl-where:
     - meta_scope: meta.where.rust
     - include: comments
-    - match: '(?=(\{|;))'
+    - match: '(?=(\{|;|=))'
       pop: true
     - match: \bwhere\b
       scope: keyword.other.rust
@@ -1735,35 +1743,41 @@ contexts:
     # specific rules.
     - include: bool
 
-    - match: \b(let|const|static)\b
+    - match: \b(let|static)\b
+      scope: keyword.declaration.rust
+
+    - match: \bconst\b
       scope: storage.type.rust
 
     - match: \bfn\b
-      scope: storage.type.function.rust
+      scope: keyword.declaration.function.rust
 
     - match: \bmod\b
-      scope: storage.type.module.rust
+      scope: keyword.declaration.module.rust
 
     - match: \bstruct\b
-      scope: storage.type.struct.rust
+      scope: keyword.declaration.struct.rust
 
     - match: \bimpl\b
-      scope: storage.type.impl.rust
+      scope: keyword.declaration.impl.rust
 
     - match: \benum\b
-      scope: storage.type.enum.rust
+      scope: keyword.declaration.enum.rust
 
     - match: \btype\b
-      scope: storage.type.type.rust
+      scope: keyword.declaration.type.rust
 
     - match: \btrait\b
-      scope: storage.type.trait.rust
+      scope: keyword.declaration.trait.rust
 
     - match: \b(mut|pub|unsafe|move|ref)\b
       scope: storage.modifier.rust
 
-    - match: \b(crate|extern|use|where)\b
+    - match: \b(crate|extern|where)\b
       scope: keyword.other.rust
+
+    - match: \buse\b
+      scope: keyword.declaration.import.rust
 
     - match: \b(async|await|else|for|if|loop|match|try|while|yield)\b
       scope: keyword.control.rust
@@ -1788,6 +1802,15 @@ contexts:
   reserved-keywords:
     - match: \b(virtual|become|priv|typeof|unsized|do|abstract|final|override|macro|for)\b
       scope: invalid.illegal.rust
+
+  terminators:
+    - match: ';'
+      scope: punctuation.terminator.rust
+
+  terminator:
+    - match: ';'
+      scope: punctuation.terminator.rust
+      pop: true
 
   else-pop:
     - match: (?=\S)

--- a/Rust/tests/syntax_test_attributes.rs
+++ b/Rust/tests/syntax_test_attributes.rs
@@ -38,7 +38,8 @@
 // Test highlighting/scope with struct field attributes
 // https://github.com/rust-lang/sublime-rust/issues/120
 pub struct Claim {
-//  ^^^^^^^^ meta.struct
+//  ^^^^^^^^^^^^^^^ meta.struct.rust
+//  ^^^^^^ keyword.declaration.struct.rust
     pub claim_id: String,
 //  ^^^ storage.modifier
     pub patient_id: String,
@@ -74,6 +75,7 @@ enum E {
 
 // Generic parameters.
 unsafe impl<#[may_dangle] T: ?Sized> Drop for Box<T> { }
+//     ^^^^ keyword.declaration.impl
 //          ^^^^^^^^^^^^^ meta.annotation
 //         ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.impl meta.generic
 
@@ -120,7 +122,7 @@ unsafe impl<#[may_dangle] T: ?Sized> Drop for Box<T> { }
         true,
 //      ^^^^ constant.language
         struct,
-//      ^^^^^^ storage.type.struct
+//      ^^^^^^ keyword.declaration.struct
         1 + 1,
 //      ^ constant.numeric.integer.decimal
 //        ^ keyword.operator.arithmetic

--- a/Rust/tests/syntax_test_control_flow.rs
+++ b/Rust/tests/syntax_test_control_flow.rs
@@ -71,7 +71,7 @@ if n < 0 {
 // <- meta.block punctuation.section.block.end
 
 if let BasicStruct(i) = j {
-// ^^^ storage.type
+// ^^^ keyword.declaration
 //                    ^ keyword.operator.assignment
 //                        ^ meta.block punctuation.section.block.begin
     println!("Basic value: {}", i);
@@ -80,7 +80,7 @@ if let BasicStruct(i) = j {
 
 while let BasicStruct(k) = j {
 //^^^ keyword.control
-//    ^^^ storage.type
+//    ^^^ keyword.declaration
 //                       ^ keyword.operator.assignment
 //                           ^ meta.block punctuation.section.block.begin
     println!("Constructed example: {}", j)

--- a/Rust/tests/syntax_test_control_flow.rs
+++ b/Rust/tests/syntax_test_control_flow.rs
@@ -71,7 +71,7 @@ if n < 0 {
 // <- meta.block punctuation.section.block.end
 
 if let BasicStruct(i) = j {
-// ^^^ keyword.declaration
+// ^^^ keyword.declaration.variable.rust
 //                    ^ keyword.operator.assignment
 //                        ^ meta.block punctuation.section.block.begin
     println!("Basic value: {}", i);
@@ -80,7 +80,7 @@ if let BasicStruct(i) = j {
 
 while let BasicStruct(k) = j {
 //^^^ keyword.control
-//    ^^^ keyword.declaration
+//    ^^^ keyword.declaration.variable.rust
 //                       ^ keyword.operator.assignment
 //                           ^ meta.block punctuation.section.block.begin
     println!("Constructed example: {}", j)

--- a/Rust/tests/syntax_test_enum.rs
+++ b/Rust/tests/syntax_test_enum.rs
@@ -1,7 +1,7 @@
 // SYNTAX TEST "Packages/Rust/Rust.sublime-syntax"
 
 enum OperatingSystem
-// <- storage.type.enum
+// <- keyword.declaration.enum
 // ^^^^^^^^^^^^^^^^^ meta.enum
 //   ^^^^^^^^^^^^^^^ entity.name.enum
 {

--- a/Rust/tests/syntax_test_expr.rs
+++ b/Rust/tests/syntax_test_expr.rs
@@ -3,6 +3,9 @@
 // specific categories.
 
 let big_n =
+// <- keyword.declaration
+ // <- keyword.declaration
+//^ keyword.declaration
 //        ^ keyword.operator.assignment
     if n < 10 && n > -10 {
 //       ^ keyword.operator.comparison

--- a/Rust/tests/syntax_test_expr.rs
+++ b/Rust/tests/syntax_test_expr.rs
@@ -3,9 +3,9 @@
 // specific categories.
 
 let big_n =
-// <- keyword.declaration
- // <- keyword.declaration
-//^ keyword.declaration
+// <- keyword.declaration.variable.rust
+ // <- keyword.declaration.variable.rust
+//^ keyword.declaration.variable.rust
 //        ^ keyword.operator.assignment
     if n < 10 && n > -10 {
 //       ^ keyword.operator.comparison

--- a/Rust/tests/syntax_test_functions.rs
+++ b/Rust/tests/syntax_test_functions.rs
@@ -1,7 +1,7 @@
 // SYNTAX TEST "Packages/Rust/Rust.sublime-syntax"
 
 fn my_func(x: i32)
-// <- storage.type.function
+// <- keyword.declaration.function
 // ^^^^^^^ entity.name.function
 //        ^^^^^^^^ meta.function.parameters
 //        ^ punctuation.section.parameters.begin
@@ -15,7 +15,7 @@ fn my_func(x: i32)
 // <-  meta.function meta.block punctuation.section.block.end
 
 fn foo<A>(i: u32, b: i64) -> u32 {
-// <- storage.type.function
+// <- keyword.declaration.function
 // ^^^ entity.name.function
 //    ^ punctuation.definition.generic.begin
 //      ^ punctuation.definition.generic.end
@@ -47,7 +47,7 @@ fn my_other_func(e: OperatingSystem) -> &'a Type {
 
 pub fn pub_function() -> bool
 // <- storage.modifier
-//  ^^ storage.type.function
+//  ^^ keyword.declaration.function
 //     ^^^^^^^^^^^^ entity.name.function
 {
 // <- meta.function
@@ -61,7 +61,7 @@ pub unsafe extern "C" fn __sync_synchronize() { }
 //         ^^^^^^ keyword.other
 //                ^^^ string.quoted.double
 //                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
-//                    ^^ storage.type.function
+//                    ^^ keyword.declaration.function
 //                       ^^^^^^^^^^^^^^^^^^ entity.name.function
 //                                         ^ meta.function.parameters punctuation.section.parameters.begin
 //                                          ^ meta.function.parameters punctuation.section.parameters.end
@@ -117,20 +117,20 @@ fn f(self,
 
 const fn f() {}
 // <- storage.modifier
-//    ^^ meta.function storage.type.function
+//    ^^ meta.function keyword.declaration.function
 //       ^ meta.function entity.name.function
 
 const unsafe fn f() {}
 // <- storage.modifier
 //    ^^^^^^ storage.modifier
-//           ^^ meta.function storage.type.function
+//           ^^ meta.function keyword.declaration.function
 //              ^ meta.function entity.name.function
 
 const extern "C" fn f() {}
 // <- storage.modifier
 //    ^^^^^^ keyword.other
 //           ^^^ string.quoted.double
-//               ^^ meta.function storage.type.function
+//               ^^ meta.function keyword.declaration.function
 //                  ^ meta.function entity.name.function
 
 fn foo(&'a self) {}

--- a/Rust/tests/syntax_test_generics.rs
+++ b/Rust/tests/syntax_test_generics.rs
@@ -97,7 +97,7 @@ struct A<T>(T) where T: AsRef<str>;
 //             ^^^^^ meta.struct meta.where keyword.other
 pub struct A<T>(T)
 //  ^^^^^^^^^^ meta.struct
-//  ^^^^^^ meta.struct storage.type
+//  ^^^^^^ meta.struct keyword.declaration
 where
 //^^^ meta.struct meta.where keyword.other
     T: AsRef<str>;
@@ -342,7 +342,7 @@ fn f(a: for<'a, 'b> fn() -> String) {}
 
 // Function in type path with return type.
 fn factory() -> Box<Fn(i32) -> i32> {
-// <- storage.type.function
+// <- keyword.declaration.function
 // ^^^^^^^ entity.name.function
 //                 ^^^^^^^^^^^^^^^^ meta.generic
 //                  ^^ support.type

--- a/Rust/tests/syntax_test_literals.rs
+++ b/Rust/tests/syntax_test_literals.rs
@@ -1,11 +1,11 @@
 // SYNTAX TEST "Packages/Rust/Rust.sublime-syntax"
 
 let c = 'c';
-// <- storage.type
+// <- keyword.declaration
 //    ^ keyword.operator.assignment
 //      ^^^ string.quoted.single
 let b = b'c';
-// <- storage.type
+// <- keyword.declaration
 //    ^ keyword.operator.assignment
 //      ^ storage.type
 //       ^^^ string.quoted.single
@@ -13,7 +13,7 @@ let ch = '∞';
 //       ^^^ string.quoted.single
 
 let s = "This is a string \x01_\u{007F}_\"_\'_\\_\r_\n_\t_\0";
-// <- storage.type
+// <- keyword.declaration
 //    ^ keyword.operator.assignment
 //      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double
 //                        ^^^^ constant.character.escape
@@ -26,7 +26,7 @@ let s = "This is a string \x01_\u{007F}_\"_\'_\\_\r_\n_\t_\0";
 //                                                     ^^ constant.character.escape
 //                                                        ^^ constant.character.escape
 let r = r##"This is a raw string, no escapes! \x00 \0 \n"##;
-// <- storage.type
+// <- keyword.declaration
 //    ^ keyword.operator.assignment
 //      ^ storage.type
 //       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.raw - constant.character.escape
@@ -46,7 +46,7 @@ println!("Continuation in format \
 ");
 
 let bytes = b"This won't escape unicode \u{0123}, but will do \x01_\"_\'_\\_\r_\n_\t_\0";
-// <- storage.type
+// <- keyword.declaration
 //        ^ keyword.operator.assignment
 //          ^ storage.type
 //           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double
@@ -60,7 +60,7 @@ let bytes = b"This won't escape unicode \u{0123}, but will do \x01_\"_\'_\\_\r_\
 //                                                                                   ^^ constant.character.escape
 
 let raw_bytes = br#"This won't escape anything either \x01 \""#;
-// <- storage.type
+// <- keyword.declaration
 //            ^ keyword.operator.assignment
 //              ^^ storage.type
 //                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double - constant.character.escape

--- a/Rust/tests/syntax_test_literals.rs
+++ b/Rust/tests/syntax_test_literals.rs
@@ -1,11 +1,11 @@
 // SYNTAX TEST "Packages/Rust/Rust.sublime-syntax"
 
 let c = 'c';
-// <- keyword.declaration
+// <- keyword.declaration.variable.rust
 //    ^ keyword.operator.assignment
 //      ^^^ string.quoted.single
 let b = b'c';
-// <- keyword.declaration
+// <- keyword.declaration.variable.rust
 //    ^ keyword.operator.assignment
 //      ^ storage.type
 //       ^^^ string.quoted.single
@@ -13,7 +13,7 @@ let ch = '∞';
 //       ^^^ string.quoted.single
 
 let s = "This is a string \x01_\u{007F}_\"_\'_\\_\r_\n_\t_\0";
-// <- keyword.declaration
+// <- keyword.declaration.variable.rust
 //    ^ keyword.operator.assignment
 //      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double
 //                        ^^^^ constant.character.escape
@@ -26,7 +26,7 @@ let s = "This is a string \x01_\u{007F}_\"_\'_\\_\r_\n_\t_\0";
 //                                                     ^^ constant.character.escape
 //                                                        ^^ constant.character.escape
 let r = r##"This is a raw string, no escapes! \x00 \0 \n"##;
-// <- keyword.declaration
+// <- keyword.declaration.variable.rust
 //    ^ keyword.operator.assignment
 //      ^ storage.type
 //       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.raw - constant.character.escape
@@ -46,7 +46,7 @@ println!("Continuation in format \
 ");
 
 let bytes = b"This won't escape unicode \u{0123}, but will do \x01_\"_\'_\\_\r_\n_\t_\0";
-// <- keyword.declaration
+// <- keyword.declaration.variable.rust
 //        ^ keyword.operator.assignment
 //          ^ storage.type
 //           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double
@@ -60,7 +60,7 @@ let bytes = b"This won't escape unicode \u{0123}, but will do \x01_\"_\'_\\_\r_\
 //                                                                                   ^^ constant.character.escape
 
 let raw_bytes = br#"This won't escape anything either \x01 \""#;
-// <- keyword.declaration
+// <- keyword.declaration.variable.rust
 //            ^ keyword.operator.assignment
 //              ^^ storage.type
 //                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double - constant.character.escape

--- a/Rust/tests/syntax_test_macros.rs
+++ b/Rust/tests/syntax_test_macros.rs
@@ -135,7 +135,7 @@ macro_rules! brackets_square [
 /*******************************************************************/
 // Matchers and transcribers can use any bracket type.
 macro_rules! brackets {
-//^^^^^^^^^^ meta.macro support.function
+//^^^^^^^^^^ meta.macro keyword.declaration.macro
 //           ^^^^^^^^ meta.macro entity.name.macro
 //                    ^ meta.macro punctuation.section.block.begin
     ($i:ident) => ($i);

--- a/Rust/tests/syntax_test_macros.rs
+++ b/Rust/tests/syntax_test_macros.rs
@@ -189,6 +189,8 @@ macro_rules! brackets {
 macro_rules! forward_ref_binop [
 //                             ^ meta.macro punctuation.section.block.begin
     (impl $imp:ident, $method:ident for $t:ty, $u:ty) => {
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.macro meta.macro.matchers
+//   ^^^^ keyword.declaration.impl
 //        ^^^^ variable.parameter
 //             ^^^^^ storage.type
 //                    ^^^^^^^ variable.parameter
@@ -200,7 +202,7 @@ macro_rules! forward_ref_binop [
 //                                                    ^^ keyword.operator
 //                                                       ^ meta.macro meta.macro.transcribers punctuation.section.block.begin
         impl<'a, 'b> $imp<&'a $u> for &'b $t {
-//      ^^^^ storage.type.impl
+//      ^^^^ keyword.declaration.impl
 //          ^^^^^^^^ meta.generic
 //           ^^ storage.modifier.lifetime
 //               ^^ storage.modifier.lifetime
@@ -222,7 +224,7 @@ macro_rules! forward_ref_binop [
             #[inline]
 //          ^^^^^^^^^ meta.annotation
             fn $method(self, other: &'a $u) -> <$t as $imp<$u>>::Output {
-//          ^^ storage.type.function
+//          ^^ keyword.declaration.function
 //             ^^^^^^^ variable.other
 //                     ^^^^ variable.language
 //                                  ^ keyword.operator
@@ -378,7 +380,7 @@ macro_rules! designators {
 //                                        ^^^^^ storage.modifier.lifetime
 //                                              ^^^ string.quoted.single
 //                                                  ^ keyword.operator
-//                                                    ^^^^^^ storage.type.struct
+//                                                    ^^^^^^ keyword.declaration.struct
 //                                                               ^ punctuation.section.block.end
 //                                                                 ^^ meta.macro keyword.operator
 //                                                                    ^^ meta.macro meta.macro.transcribers

--- a/Rust/tests/syntax_test_modules.rs
+++ b/Rust/tests/syntax_test_modules.rs
@@ -16,7 +16,7 @@ extern crate std as ruststd;
 //                         ^ punctuation.terminator
 
 mod bar;
-// <- meta.module storage.type.module
+// <- meta.module keyword.declaration.module
 //^^^^^^ meta.module
 //  ^^^ entity.name.module
 //     ^ punctuation.terminator
@@ -24,7 +24,7 @@ mod bar;
 pub mod my_mod {
 //  ^^^^^^^^^^^^ meta.module
 // <- storage.modifier
-//  ^^^ storage.type.module
+//  ^^^ keyword.declaration.module
 //      ^^^^^^ entity.name.module
 //             ^ meta.block punctuation.section.block.begin
 }
@@ -32,7 +32,7 @@ pub mod my_mod {
 
 pub use self::trafile::*;
 // <- storage.modifier
-//  ^^^ keyword.other
+//  ^^^ keyword.declaration
 //      ^^^^ variable.language
 //      ^^^^^^^^^^^^^^^ meta.path
 //                   ^^ punctuation.accessor
@@ -40,7 +40,7 @@ pub use self::trafile::*;
 //                      ^ punctuation.terminator
 
 use std::fmt;
-// <- keyword.other
+// <- keyword.declaration
 //  ^^^^^^^^ meta.path
 //     ^^ punctuation.accessor
 //          ^ punctuation.terminator
@@ -65,7 +65,7 @@ use foo::{Baz, QUX, quux};
 //                       ^ punctuation.terminator
 
 use std::{
-// <- keyword.other
+// <- keyword.declaration
 //  ^^^^^ meta.path
 //       ^ meta.block punctuation.section.block.begin
     fs::{self, read_dir},

--- a/Rust/tests/syntax_test_struct.rs
+++ b/Rust/tests/syntax_test_struct.rs
@@ -2,8 +2,8 @@
 
 struct BasicStruct(i32);
 // ^^^^^^^^^^^^^^^^^^^^ meta.struct
-// <- storage.type.struct
-//^^^^ storage.type.struct
+// <- keyword.declaration.struct
+//^^^^ keyword.declaration.struct
 //     ^^^^^^^^^^^ entity.name.struct
 //                ^ punctuation.section.group.begin
 //                 ^^^ storage.type
@@ -11,8 +11,8 @@ struct BasicStruct(i32);
 
 struct PrintableStruct(Box<i32>);
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.struct
-// <- storage.type.struct
-//^^^^ storage.type.struct
+// <- keyword.declaration.struct
+//^^^^ keyword.declaration.struct
 //     ^^^^^^^^^^^^^^^ entity.name.struct
 //                    ^ punctuation.section.group.begin
 //                     ^^^ support.type
@@ -55,7 +55,7 @@ impl Point
 {
 // <- meta.impl meta.block punctuation.section.block.begin
     fn new(x: i32, y: i32) -> Point
-    // <- storage.type.function
+    // <- keyword.declaration.function
     // ^^^ entity.name.function
     {
     // <- meta.function meta.block

--- a/Rust/tests/syntax_test_traits.rs
+++ b/Rust/tests/syntax_test_traits.rs
@@ -41,8 +41,8 @@ impl<'a, T: MyTrait + OtherTrait> PrintInOption for T where
 impl fmt::Display for PrintableStruct {
 // <- meta.impl
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.impl
-// <- storage.type.impl
-//^^ storage.type.impl
+// <- keyword.declaration.impl
+//^^ keyword.declaration.impl
 //   ^^^^^ meta.path
 //      ^^ punctuation.accessor
 //                ^^^ keyword.other
@@ -51,7 +51,7 @@ impl fmt::Display for PrintableStruct {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.impl
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
-//  ^^ storage.type.function
+//  ^^ keyword.declaration.function
 //     ^^^ entity.name.function
 //        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.parameters
 //        ^ punctuation.section.parameters.begin

--- a/Rust/tests/syntax_test_types.rs
+++ b/Rust/tests/syntax_test_types.rs
@@ -1,9 +1,11 @@
 // SYNTAX TEST "Packages/Rust/Rust.sublime-syntax"
 // This file is for misc type definitions that don't fit in other more
 // specific categories.
+//
+// https://doc.rust-lang.org/reference/items/type-aliases.html
 
 type FnPointer = fn(i32) -> i32;
-// <- storage.type.type
+// <- keyword.declaration.type
 //   ^^^^^^^^^ entity.name.type
 //               ^^ storage.type.function
 //                 ^^^^^ meta.group
@@ -12,7 +14,7 @@ type FnPointer = fn(i32) -> i32;
 //                          ^^^ storage.type
 
 type GenFnPointer = Bar<fn(i32) -> i32>;
-// <- storage.type.type
+// <- keyword.declaration.type
 //   ^^^^^^^^^^^^ entity.name.type
 //                     ^^^^^^^^^^^^^^^^ meta.generic
 //                      ^^ storage.type.function
@@ -23,7 +25,7 @@ type GenFnPointer = Bar<fn(i32) -> i32>;
 //                                     ^ - meta.generic
 
 type GenFnPointer2 = Bar<extern "C" fn()>;
-// <- storage.type.type
+// <- keyword.declaration.type
 //   ^^^^^^^^^^^^^ entity.name.type
 //                      ^^^^^^^^^^^^^^^^^ meta.generic
 //                       ^^^^^^ keyword.other
@@ -32,14 +34,14 @@ type GenFnPointer2 = Bar<extern "C" fn()>;
 //                                       ^ - meta.generic
 
 const ZERO: u64 = 0;
-// <- storage.type
+// <- keyword.declaration
 //    ^^^^ entity.name.constant
 //        ^ punctuation.separator
 //          ^^^ storage.type
 //              ^ keyword.operator.assignment
 //                ^ constant.numeric.integer.decimal
 static NAME: &'static str = "John";
-// <- storage.type
+// <- keyword.declaration
 //     ^^^^ entity.name.constant
 //           ^ keyword.operator
 //            ^^^^^^^ storage.modifier.lifetime
@@ -47,14 +49,14 @@ static NAME: &'static str = "John";
 //                        ^ keyword.operator.assignment
 //                          ^^^^^^ string.quoted.double
 static mut BRAVO: u32 = 0;
-// <- storage.type
+// <- keyword.declaration
 //     ^^^ storage.modifier
 //         ^^^^^ entity.name.constant
 
 // Function type in a box return type.
 // fixes https://github.com/rust-lang/sublime-rust/issues/144
 fn factory() -> Box<Fn(i32) -> i32> {
-// <- storage.type.function
+// <- keyword.declaration.function
 // ^^^^^^^ entity.name.function
 //                  ^^^^^^^^^^^^^^ meta.generic
 //                      ^^ storage.type
@@ -63,6 +65,7 @@ fn factory() -> Box<Fn(i32) -> i32> {
 }
 
 let x: __m128i = __m128i::from_bits(f32x4::from_bits(m32x4::new(true, true, true, true)));
+// <- keyword.declaration
 //     ^^^^^^^ storage.type
 //               ^^^^^^^ storage.type
 //                                  ^^^^^ meta.group storage.type
@@ -74,7 +77,7 @@ let mut mutable = 12;
 
 // Tuple types.
 type Pair<'a> = (i32, &'a str);
-// <- storage.type.type
+// <- keyword.declaration.type
 //   ^^^^ entity.name.type
 //       ^^^^ meta.generic
 //       ^ punctuation.definition.generic.begin
@@ -91,7 +94,7 @@ type Pair<'a> = (i32, &'a str);
 //                            ^ punctuation.terminator
 
 let p: Pair<'static> = (10, "ten");
-// <- storage.type
+// <- keyword.declaration
 //   ^ punctuation.separator
 //         ^^^^^^^^^ meta.generic
 //         ^ punctuation.definition.generic.begin
@@ -233,3 +236,39 @@ impl Iterator for Struct {
 //                                     ^^^^
 //                                         ^ punctuation.definition.generic.end.rust
 }
+
+// Generics
+type TypeAlias<T> where T: Foo = Bar<T>; // deprecated
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type-declaration.rust
+//   ^^^^^^^^^ entity.name.type.rust
+//            ^^^ meta.generic.rust
+//            ^ punctuation.definition.generic.begin.rust
+//             ^ storage.type.rust
+//              ^ punctuation.definition.generic.end.rust
+//                ^^^^^^^^^^^^ meta.type-declaration meta.where
+//                ^^^^^ keyword.other
+//                      ^ storage.type
+//                       ^ punctuation.separator
+//                         ^^^ storage.type
+//                             ^ keyword.operator.assignment - meta.type-declaration meta.type-declaration
+//                                  ^^^ meta.generic
+//                                     ^ punctuation.terminator
+
+type TypeAlias<T> = /**/ Bar<T> /**/ where /**/ T: Foo; // preferred
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.type-declaration.rust
+//   ^^^^^^^^^ entity.name.type.rust
+//            ^^^ meta.generic.rust
+//            ^ punctuation.definition.generic.begin.rust
+//             ^ storage.type.rust
+//              ^ punctuation.definition.generic.end.rust
+//                ^ keyword.operator.assignment.rust - meta.type-declaration meta.type-declaration
+//                  ^^^^ comment.block.rust
+//                          ^^^ meta.generic.rust
+//                              ^^^^ comment.block.rust
+//                                   ^^^^^^^^^^^^ meta.where.rust
+//                                   ^^^^^ keyword.other.rust
+//                                         ^^^^ comment.block.rust
+//                                              ^ storage.type.rust
+//                                               ^ punctuation.separator.rust
+//                                                 ^^^ storage.type.rust
+//                                                    ^ punctuation.terminator.rust

--- a/Rust/tests/syntax_test_types.rs
+++ b/Rust/tests/syntax_test_types.rs
@@ -34,14 +34,14 @@ type GenFnPointer2 = Bar<extern "C" fn()>;
 //                                       ^ - meta.generic
 
 const ZERO: u64 = 0;
-// <- keyword.declaration
+// <- keyword.declaration.variable.constant.rust
 //    ^^^^ entity.name.constant
 //        ^ punctuation.separator
 //          ^^^ storage.type
 //              ^ keyword.operator.assignment
 //                ^ constant.numeric.integer.decimal
 static NAME: &'static str = "John";
-// <- keyword.declaration
+// <- keyword.declaration.variable.static.rust
 //     ^^^^ entity.name.constant
 //           ^ keyword.operator
 //            ^^^^^^^ storage.modifier.lifetime
@@ -49,7 +49,7 @@ static NAME: &'static str = "John";
 //                        ^ keyword.operator.assignment
 //                          ^^^^^^ string.quoted.double
 static mut BRAVO: u32 = 0;
-// <- keyword.declaration
+// <- keyword.declaration.variable.static.rust
 //     ^^^ storage.modifier
 //         ^^^^^ entity.name.constant
 
@@ -65,7 +65,7 @@ fn factory() -> Box<Fn(i32) -> i32> {
 }
 
 let x: __m128i = __m128i::from_bits(f32x4::from_bits(m32x4::new(true, true, true, true)));
-// <- keyword.declaration
+// <- keyword.declaration.variable.rust
 //     ^^^^^^^ storage.type
 //               ^^^^^^^ storage.type
 //                                  ^^^^^ meta.group storage.type
@@ -94,7 +94,7 @@ type Pair<'a> = (i32, &'a str);
 //                            ^ punctuation.terminator
 
 let p: Pair<'static> = (10, "ten");
-// <- keyword.declaration
+// <- keyword.declaration.variable.rust
 //   ^ punctuation.separator
 //         ^^^^^^^^^ meta.generic
 //         ^ punctuation.definition.generic.begin

--- a/Rust/tests/syntax_test_union.rs
+++ b/Rust/tests/syntax_test_union.rs
@@ -1,7 +1,7 @@
 // SYNTAX TEST "Packages/Rust/Rust.sublime-syntax"
 
 union Union {
-//^^^ meta.union storage.type.union
+//^^^ meta.union keyword.declaration.union
 //^^^^^^^^^^^ meta.union
 //    ^^^^^ entity.name.union
 //          ^ meta.block punctuation.section.block.begin
@@ -15,7 +15,7 @@ union Union {
 pub union Foo<'a, Y: Baz>
 // <- storage.modifier
 //  ^^^^^^^^^^^^^^^^^^^^^ meta.union
-//  ^^^^^ meta.union storage.type.union
+//  ^^^^^ meta.union keyword.declaration.union
 //        ^^^ meta.union meta.generic entity.name.union
 //           ^ meta.union meta.generic meta.generic punctuation.definition.generic.begin
 //            ^^ meta.union meta.generic meta.generic storage.modifier.lifetime

--- a/Rust/tests/syntax_test_visibility.rs
+++ b/Rust/tests/syntax_test_visibility.rs
@@ -36,13 +36,13 @@ pub ( in self ) enum E {A,B}
 pub ( in super ) const CONST: i32 = 1;
 //    ^^ keyword.other
 //       ^^^^^ keyword.other
-//               ^^^^^ keyword.declaration
+//               ^^^^^ keyword.declaration.variable.constant.rust
 pub ( in super::super ) static STATIC: i32 = 1;
 //    ^^ keyword.other
 //       ^^^^^ keyword.other
 //            ^^ meta.path
 //              ^^^^^ keyword.other
-//                      ^^^^^^ keyword.declaration
+//                      ^^^^^^ keyword.declaration.variable.static.rust
 
 struct S {
     pub f1: i32,

--- a/Rust/tests/syntax_test_visibility.rs
+++ b/Rust/tests/syntax_test_visibility.rs
@@ -19,7 +19,7 @@ pub ( in foo :: bar ) type T = i32;
 //           ^^ meta.path
 //              ^^^ meta.path
 //                  ^ punctuation.section.group.end
-//                    ^^^^ storage.type.type
+//                    ^^^^ keyword.declaration.type
 pub ( in ::foo ) fn f() {}
 //       ^^^^^ meta.path
 //               ^^^^^^^^^ meta.function
@@ -28,7 +28,7 @@ pub ( self ) mod m {}
 //           ^^^^^^^^ meta.module
 pub ( super ) use a::b;
 //    ^^^^^ keyword.other
-//            ^^^ keyword.other
+//            ^^^ keyword.declaration.import
 pub ( in self ) enum E {A,B}
 //    ^^ keyword.other
 //       ^^^^ keyword.other
@@ -36,13 +36,13 @@ pub ( in self ) enum E {A,B}
 pub ( in super ) const CONST: i32 = 1;
 //    ^^ keyword.other
 //       ^^^^^ keyword.other
-//               ^^^^^ storage.type
+//               ^^^^^ keyword.declaration
 pub ( in super::super ) static STATIC: i32 = 1;
 //    ^^ keyword.other
 //       ^^^^^ keyword.other
 //            ^^ meta.path
 //              ^^^^^ keyword.other
-//                      ^^^^^^ storage.type
+//                      ^^^^^^ keyword.declaration
 
 struct S {
     pub f1: i32,


### PR DESCRIPTION
Following the example of Java, we're replacing the `storage.type` scope
with `keyword.declaration` without keeping the `storage.type` for
compatibility. Also, like in Java, the `use` keyword gets a
`keyword.declaration.import` scope to signal that it is introducing
names into the current namespace.

`type` aliases have slightly been refactored to properly match `where`
clauses. (I did a bit of work twice here because I forgot to `git pull`
before and included the remainder …)

Closes #3640.