### PR TITLE
[XML] Add .drawio extension

### DIFF
--- a/XML/XML.sublime-syntax
+++ b/XML/XML.sublime-syntax
@@ -77,6 +77,7 @@ hidden_file_extensions:
   - vcxproj
   - dae
   - props
+  - drawio
   - targets
 
 first_line_match: |-


### PR DESCRIPTION
https://draw.io is a famous open-sourced flow chart maker. And its own file format is XML with `.drawio` as the filename extension.