### PR TITLE
[Diff] Scope trailing spaces

### DIFF
--- a/Diff/Diff.sublime-settings
+++ b/Diff/Diff.sublime-settings
@@ -1,5 +1,4 @@
 {
-    "draw_white_space": ["trailing_all"],
     "trim_trailing_white_space_on_save": "none",
     "translate_tabs_to_spaces": false,
 }

--- a/Diff/Diff.sublime-settings
+++ b/Diff/Diff.sublime-settings
@@ -1,4 +1,5 @@
 {
+    "draw_white_space": ["trailing_all"],
     "trim_trailing_white_space_on_save": "none",
     "translate_tabs_to_spaces": false,
 }

--- a/Diff/Diff.sublime-syntax
+++ b/Diff/Diff.sublime-syntax
@@ -51,20 +51,23 @@ contexts:
         2: punctuation.definition.to-file.diff
         3: punctuation.definition.to-file.diff
         4: punctuation.definition.to-file.diff
-    - match: ^(((>)( .*)?)|((\+).*))$\n?
+    - match: ^(?:(>)(?:\ .*?)?|(\+).*?)(\s*?)$\n?
       scope: markup.inserted.diff
       captures:
-        3: punctuation.definition.inserted.diff
-        6: punctuation.definition.inserted.diff
-    - match: ^(!).*$\n?
+        1: punctuation.definition.inserted.diff
+        2: punctuation.definition.inserted.diff
+        3: meta.whitespace.trailing.diff
+    - match: ^(!).*?(\s*?)$\n?
       scope: markup.changed.diff
       captures:
         1: punctuation.definition.changed.diff
-    - match: ^(((<)( .*)?)|((-).*))$\n?
+        2: meta.whitespace.trailing.diff
+    - match: ^(?:(<)(?:\ .*?)?|(-).*?)(\s*?)$\n?
       scope: markup.deleted.diff
       captures:
-        3: punctuation.definition.deleted.diff
-        6: punctuation.definition.deleted.diff
+        1: punctuation.definition.deleted.diff
+        2: punctuation.definition.deleted.diff
+        3: meta.whitespace.trailing.diff
     - match: ^Index(:) (.+)$\n?
       scope: meta.diff.index meta.index.diff
       captures:

--- a/Diff/syntax_test_diff.diff
+++ b/Diff/syntax_test_diff.diff
@@ -70,27 +70,32 @@
 Plain Text
 #^^^^^^^^^ source.diff
 
-+ Addition
-# <-       punctuation.definition.inserted.diff
-# ^^^^^^^^ markup.inserted.diff
++ Addition  
+# <- markup.inserted.diff punctuation.definition.inserted.diff
+# ^^^^^^^^ markup.inserted.diff - meta.whitespace
+#         ^^ markup.inserted.diff meta.whitespace.trailing.diff
 
-> Addition
-# <-       punctuation.definition.inserted.diff
-# ^^^^^^^^ markup.inserted.diff
+> Addition  
+# <- markup.inserted.diff punctuation.definition.inserted.diff
+# ^^^^^^^^ markup.inserted.diff - meta.whitespace
+#         ^^ markup.inserted.diff meta.whitespace.trailing.diff
 
-- Deletion
-# <-       punctuation.definition.deleted.diff
-# ^^^^^^^^ markup.deleted.diff
+- Deletion  
+# <- markup.deleted.diff punctuation.definition.deleted.diff
+# ^^^^^^^^ markup.deleted.diff - meta.whitespace
+#         ^^ markup.deleted.diff meta.whitespace.trailing.diff
 
-< Deletion
-# <-       punctuation.definition.deleted.diff
-# ^^^^^^^^ markup.deleted.diff
+< Deletion  
+# <- markup.deleted.diff punctuation.definition.deleted.diff
+# ^^^^^^^^ markup.deleted.diff - meta.whitespace
+#         ^^ markup.deleted.diff meta.whitespace.trailing.diff
 
-! Modified
-# <-       punctuation.definition.changed.diff
-# ^^^^^^^^ markup.changed.diff
+! Modified  
+# <- markup.changed.diff punctuation.definition.changed.diff
+# ^^^^^^^^ markup.changed.diff - meta.whitespace
+#         ^^ markup.changed.diff meta.whitespace.trailing.diff
 
 Index: value
 #^^^^^^^^^^^ meta.diff.index meta.index.diff
-#    ^       punctuation.separator.key-value.diff
+#    ^ punctuation.separator.key-value.diff
 #      ^^^^^ meta.toc-list.file-name.diff


### PR DESCRIPTION
Resolves #1304

This PR...

1. ~~sets syntax specific setting `"draw_white_space": ["trailing_all"]` so trailing spaces are rendered by default.~~
2. scopes trailing spaces `meta.whitespace.trailing` in inserted/removed/modified lines, so color schemes can address them and possibly apply background color.

### Example:

![grafik](https://github.com/sublimehq/Packages/assets/16542113/3783372f-1bb9-49fa-9197-764a45ebbd80)


#### Color Scheme Rules

```jsonc
{
	"scope": "markup.changed.diff meta.whitespace",
	"background": "color(var(orange) alpha(0.15))",
},
{
	"scope": "markup.deleted.diff meta.whitespace",
	"background": "color(var(red2) alpha(0.15))",
},
{
	"scope": "markup.inserted.diff meta.whitespace",
	"background": "color(var(green2) alpha(0.15))",
},
```
