### PR TITLE
[Sublime] Add Syntax Test Results syntax

### DIFF
--- a/Sublime/Sublime Syntax Test Results.sublime-syntax
+++ b/Sublime/Sublime Syntax Test Results.sublime-syntax
@@ -66,7 +66,10 @@ contexts:
 
   expected-scope-body:
     - meta_scope: meta.scope.expected.sublime.syntax-test-results
-    - include: selector-body
+    - match: \]
+      scope: punctuation.section.scope.end.sublime.syntax-test-results
+      pop: 1
+    - include: scope-selectors
 
   found-scope:
     - match: \[
@@ -77,13 +80,26 @@ contexts:
 
   found-scope-body:
     - meta_scope: meta.scope.found.sublime.syntax-test-results
-    - include: selector-body
-
-  selector-body:
     - match: \]
       scope: punctuation.section.scope.end.sublime.syntax-test-results
+      pop: 1
+    - include: scope-selectors
+
+  scope-selectors:
+    - meta_scope: meta.group.scope-selector
+    - match: \(
+      scope: punctuation.section.group.begin.scope-selector
+      push: scope-selectors
+    - match: \)
+      scope: punctuation.section.group.end.scope-selector
       pop: 1
     - match: '{{scope_segment}}'
       scope: string.unquoted.scope-segment.scope-selector
     - match: \.
       scope: punctuation.separator.scope-segments.scope-selector
+    - match: '-'
+      scope: keyword.operator.without.scope-selector
+    - match: '&'
+      scope: keyword.operator.with.scope-selector
+    - match: '[,|]'
+      scope: keyword.operator.or.scope-selector

--- a/Sublime/Sublime Syntax Test Results.sublime-syntax
+++ b/Sublime/Sublime Syntax Test Results.sublime-syntax
@@ -11,6 +11,9 @@ variables:
 
 contexts:
   main:
+    # comments
+    - match: ^\#.+\n?
+      scope: comment.line.double-dash.syntax-test-results
     # summaries
     - match: ^(\[)Finished(\])
       scope: meta.summary.finished.sublime.syntax-test-results markup.info.finished.sublime.syntax-test-results
@@ -33,7 +36,7 @@ contexts:
         3: meta.assertions.count.sublime.syntax-test-results meta.number.integer.decimal.sublime.syntax-test-results constant.numeric.value.sublime.syntax-test-results
         4: meta.test-files.count.sublime.syntax-test-results meta.number.integer.decimal.sublime.syntax-test-results constant.numeric.value.sublime.syntax-test-results
     # failures
-    - match: ^
+    - match: ^(?=\S)
       push:
         - found-scope
         - expected-scope

--- a/Sublime/Sublime Syntax Test Results.sublime-syntax
+++ b/Sublime/Sublime Syntax Test Results.sublime-syntax
@@ -1,0 +1,86 @@
+%YAML 1.2
+---
+# https://www.sublimetext.com/docs/syntax.html
+name: Sublime Syntax Test Results
+scope: text.sublime.syntax-test-results
+version: 2
+hidden: true
+
+variables:
+  scope_segment: \w+(?:[\w-]*\+*) # \+* is for the non standard scope.c++ scopes
+
+contexts:
+  main:
+    # summaries
+    - match: ^(\[)Finished(\])
+      scope: meta.summary.finished.sublime.syntax-test-results markup.info.finished.sublime.syntax-test-results
+      captures:
+        1: punctuation.definition.markup.begin.sublime.syntax-test-results
+        2: punctuation.definition.markup.end.sublime.syntax-test-results
+    - match: ^(FAILED)(:) (\d+) of (\d+) assertions in (\d+) files failed
+      scope: meta.summary.failure.sublime.syntax-test-results
+      captures:
+        1: markup.error.failed.sublime.syntax-test-results
+        2: punctuation.separator.other.sublime.syntax-test-results
+        3: meta.assertions.failed.sublime.syntax-test-results meta.number.integer.decimal.sublime.syntax-test-results constant.numeric.value.sublime.syntax-test-results
+        4: meta.assertions.count.sublime.syntax-test-results meta.number.integer.decimal.sublime.syntax-test-results constant.numeric.value.sublime.syntax-test-results
+        5: meta.test-files.count.sublime.syntax-test-results meta.number.integer.decimal.sublime.syntax-test-results constant.numeric.value.sublime.syntax-test-results
+    - match: ^(Success)(:) (\d+) assertions in (\d+) files passed
+      scope: meta.summary.success.sublime.syntax-test-results
+      captures:
+        1: markup.info.success.sublime.syntax-test-results
+        2: punctuation.separator.other.sublime.syntax-test-results
+        3: meta.assertions.count.sublime.syntax-test-results meta.number.integer.decimal.sublime.syntax-test-results constant.numeric.value.sublime.syntax-test-results
+        4: meta.test-files.count.sublime.syntax-test-results meta.number.integer.decimal.sublime.syntax-test-results constant.numeric.value.sublime.syntax-test-results
+    # failures
+    - match: ^
+      push:
+        - found-scope
+        - expected-scope
+        - location
+
+  location:
+    - meta_content_scope: meta.path.filename.sublime.syntax-test-results entity.name.filename.sublime.syntax-test-results
+    - match: (:)(\d+)(:)(\d+)(:)
+      captures:
+        1: meta.path.row.sublime.syntax-test-results punctuation.separator.row.sublime.syntax-test-results
+        2: meta.path.row.sublime.syntax-test-results meta.number.integer.decimal.sublime.syntax-test-results constant.numeric.value.sublime.syntax-test-results
+        3: meta.path.column.sublime.syntax-test-results punctuation.separator.column.sublime.syntax-test-results
+        4: meta.path.column.sublime.syntax-test-results meta.number.integer.decimal.sublime.syntax-test-results constant.numeric.value.sublime.syntax-test-results
+        5: punctuation.separator.other.sublime.syntax-test-results
+      pop: 1
+    - match: /
+      scope: punctuation.separator.path.sublime.syntax-test-results
+    - match: $
+      pop: 1
+
+  expected-scope:
+    - match: \[
+      scope: punctuation.section.scope.begin.sublime.syntax-test-results
+      set: expected-scope-body
+    - match: (?=\S)
+      pop: 1
+
+  expected-scope-body:
+    - meta_scope: meta.scope.expected.sublime.syntax-test-results
+    - include: selector-body
+
+  found-scope:
+    - match: \[
+      scope: punctuation.section.scope.begin.sublime.syntax-test-results
+      set: found-scope-body
+    - match: $
+      pop: 1
+
+  found-scope-body:
+    - meta_scope: meta.scope.found.sublime.syntax-test-results
+    - include: selector-body
+
+  selector-body:
+    - match: \]
+      scope: punctuation.section.scope.end.sublime.syntax-test-results
+      pop: 1
+    - match: '{{scope_segment}}'
+      scope: string.unquoted.scope-segment.scope-selector
+    - match: \.
+      scope: punctuation.separator.scope-segments.scope-selector

--- a/Sublime/tests/syntax_test_results.sublime-syntax-test-results
+++ b/Sublime/tests/syntax_test_results.sublime-syntax-test-results
@@ -1,0 +1,53 @@
+# SYNTAX TEST "Sublime Syntax Test Results.sublime-syntax"
+
+Packages/Sublime/tests/syntax_test_results.sublime-syntax-test-results:14:2: [markup.info.failed] does not match scope [text meta.summary.success markup.info.success]
+# <- meta.path.filename entity.name.filename
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.path.filename entity.name.filename
+#                                                                     ^^^ meta.path.row
+#                                                                        ^^ meta.path.column
+#                                                                          ^ punctuation.separator.other
+#                                                                            ^^^^^^^^^^^^^^^^^^^^ meta.scope.expected
+#                                                                            ^ punctuation.section.scope.begin
+#                                                                             ^^^^^^ string.unquoted.scope-segment.scope-selector
+#                                                                                   ^ punctuation.separator.scope-segments.scope-selector
+#                                                                                    ^^^^ string.unquoted.scope-segment.scope-selector
+#                                                                                        ^ punctuation.separator.scope-segments.scope-selector
+#                                                                                         ^^^^^^ string.unquoted.scope-segment.scope-selector
+#                                                                                               ^ punctuation.section.scope.end
+#                                                                                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.scope.found
+#                                                                                                                      ^ punctuation.section.scope.begin
+#                                                                                                                       ^^^^ string.unquoted.scope-segment.scope-selector
+#                                                                                                                            ^^^^ string.unquoted.scope-segment.scope-selector
+#                                                                                                                                ^ punctuation.separator.scope-segments.scope-selector
+#                                                                                                                                 ^^^^^^^ string.unquoted.scope-segment.scope-selector
+#                                                                                                                                        ^ punctuation.separator.scope-segments.scope-selector
+#                                                                                                                                         ^^^^^^^ string.unquoted.scope-segment.scope-selector
+#                                                                                                                                                 ^^^^^^ string.unquoted.scope-segment.scope-selector
+#                                                                                                                                                       ^ punctuation.separator.scope-segments.scope-selector
+#                                                                                                                                                        ^^^^ string.unquoted.scope-segment.scope-selector
+#                                                                                                                                                            ^ punctuation.separator.scope-segments.scope-selector
+#                                                                                                                                                             ^^^^^^^ string.unquoted.scope-segment.scope-selector
+#                                                                                                                                                                    ^ punctuation.section.scope.end
+
+FAILED: 6 of 62 assertions in 1 files failed
+# <- meta.summary.failure markup.error.failed
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.summary.failure
+#^^^^^ markup.error.failed
+#     ^ punctuation.separator.other
+#       ^ meta.assertions.failed meta.number.integer.decimal constant.numeric.value
+#            ^^ meta.assertions.count meta.number.integer.decimal constant.numeric.value
+#                             ^ meta.test-files.count meta.number.integer.decimal constant.numeric.value
+
+Success: 12 assertions in 1 files passed
+# <- meta.summary.success markup.info.success
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.summary.success
+#^^^^^^ markup.info.success
+#      ^ punctuation.separator.other
+#        ^^ meta.assertions.count meta.number.integer.decimal constant.numeric.value
+#                         ^ meta.test-files.count meta.number.integer.decimal constant.numeric.value
+
+[Finished]
+# <- meta.summary.finished markup.info.finished punctuation.definition.markup.begin
+#^^^^^^^^^ meta.summary.finished markup.info.finished
+#        ^ punctuation.definition.markup.end
+#         ^ - meta - markup

--- a/Sublime/tests/syntax_test_results.sublime-syntax-test-results
+++ b/Sublime/tests/syntax_test_results.sublime-syntax-test-results
@@ -1,4 +1,4 @@
-# SYNTAX TEST "Sublime Syntax Test Results.sublime-syntax"
+# SYNTAX TEST "Packages/Sublime/Sublime Syntax Test Results.sublime-syntax"
 
 Packages/Sublime/tests/syntax_test_results.sublime-syntax-test-results:14:2: [markup.info.failed] does not match scope [text meta.summary.success markup.info.success]
 # <- meta.path.filename entity.name.filename
@@ -28,6 +28,30 @@ Packages/Sublime/tests/syntax_test_results.sublime-syntax-test-results:14:2: [ma
 #                                                                                                                                                            ^ punctuation.separator.scope-segments.scope-selector
 #                                                                                                                                                             ^^^^^^^ string.unquoted.scope-segment.scope-selector
 #                                                                                                                                                                    ^ punctuation.section.scope.end
+
+Packages/syntax_test_results:14:2: [(meta.assertion & markup.info.failed) - punctuation, meta.assertion | meta.info] does not match scope [text meta.summary.success markup.info.success]
+#                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group.scope-selector
+#                                   ^ punctuation.section.group.begin.scope-selector
+#                                    ^^^^ string.unquoted.scope-segment.scope-selector
+#                                        ^ punctuation.separator.scope-segments.scope-selector
+#                                         ^^^^^^^^^ string.unquoted.scope-segment.scope-selector
+#                                                   ^ keyword.operator.with.scope-selector
+#                                                     ^^^^^^ string.unquoted.scope-segment.scope-selector
+#                                                           ^ punctuation.separator.scope-segments.scope-selector
+#                                                            ^^^^ string.unquoted.scope-segment.scope-selector
+#                                                                ^ punctuation.separator.scope-segments.scope-selector
+#                                                                 ^^^^^^ string.unquoted.scope-segment.scope-selector
+#                                                                       ^ punctuation.section.group.end.scope-selector
+#                                                                         ^ keyword.operator.without.scope-selector
+#                                                                           ^^^^^^^^^^^ string.unquoted.scope-segment.scope-selector
+#                                                                                      ^ keyword.operator.or.scope-selector
+#                                                                                        ^^^^ string.unquoted.scope-segment.scope-selector
+#                                                                                            ^ punctuation.separator.scope-segments.scope-selector
+#                                                                                             ^^^^^^^^^ string.unquoted.scope-segment.scope-selector
+#                                                                                                       ^ keyword.operator.or.scope-selector
+#                                                                                                         ^^^^ string.unquoted.scope-segment.scope-selector
+#                                                                                                             ^ punctuation.separator.scope-segments.scope-selector
+#                                                                                                              ^^^^ string.unquoted.scope-segment.scope-selector
 
 FAILED: 6 of 62 assertions in 1 files failed
 # <- meta.summary.failure markup.error.failed


### PR DESCRIPTION
This PR proposes to add a _Sublime_ package with _Sublime Syntax Test Results_ syntax definition for highlighting syntax test result outputs with regards to https://github.com/sublimehq/sublime_text/issues/3022.

Thoughts:

1. A package named "Sublime" does not yet exist on package control.
2. The package name is generic enough to potentially take more Sublime Text related syntax files.

Maybe more suitable alternative package names are appriciated.


Syntax definition is designed to highlight ST's default syntax test result output - despite the proposal in https://github.com/sublimehq/sublime_text/issues/3022, which addresses a reformatted output.

![grafik](https://github.com/sublimehq/Packages/assets/16542113/fba4bbf7-36f5-44d5-ab74-08993161b578)
