### PR TITLE
[Python] Add todo highlighting

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -364,6 +364,12 @@ contexts:
 ###[ COMMENTS ]###############################################################
 
   comments:
+    - match: '(# ?)(TODO|ToDo|Todo|todo)\b(.*)'
+      captures:
+        1: comment
+        2: string.todo
+        3: string.todo
+
     # Special Sphinx comment syntax to denote documentation
     # https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#directive-autoattribute
     - match: '#:'

--- a/Python/tests/syntax_test_python_strings.py
+++ b/Python/tests/syntax_test_python_strings.py
@@ -1656,3 +1656,11 @@ f'''{
 }'''
 # <- meta.string.python meta.interpolation.python punctuation.section.interpolation.end.python
 #^^^ meta.string.python string.quoted.single.block.python punctuation.definition.string.end.python
+
+## Todo: some task
+#^ comment
+#  ^^^^^^^^^^^^^^^ string.todo
+
+##ToDo: some task
+#^ comment
+# ^^^^^^^^^^^^^^^ string.todo


### PR DESCRIPTION
This PR suggests adding support for highlighting "todo" syntax inside comments. 

E.g. in one of color schemes:
![todo_highlight](https://github.com/sublimehq/Packages/assets/59206490/7b498dba-e29d-4a93-aa19-8f019f573bcf)

Currently, no packages have this functionality. Existing packages only allow for background color changes, not text color. It could be worthwhile to create a package with this feature. However, this would require modifications to the syntax file (or creation of alternative syntax file), which makes it more fitting to include in the default Python syntax.

I used string.todo to allow users to select alternative colors for this namespace. Using comment.todo might be a better option, but it will not highlight todos. This is because all existing themes do not use it, meaning it will remain as a regular comment.