### PR TITLE
[Diff] Add context menu id

### DIFF
--- a/Diff/Context.sublime-menu
+++ b/Diff/Context.sublime-menu
@@ -1,4 +1,4 @@
 [
-	{ "caption": "-" },
+	{ "caption": "-", "id": "diff" },
 	{ "caption": "Show Unsaved Changes…", "command": "diff_changes" }
 ]


### PR DESCRIPTION
This commit adds `id: diff` to context menu to group it with default items from Default/Context.sublime-menu.