### PR TITLE
[PHP] Fix function calls with array identifiers

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -1626,7 +1626,7 @@ contexts:
         - function-call-identifier
         - unqualified-function-name
     # Function invocation with function name as variable
-    - match: ((\$+){{identifier}})\s*(?=\()
+    - match: ((\$+){{identifier}})\s*(?=(?:\[.*?\]\s*)?\()
       scope: meta.function-call.identifier.php
       captures:
         1: variable.other.php
@@ -1634,6 +1634,7 @@ contexts:
       push:
         - maybe-item-access
         - function-call-arguments
+        - maybe-item-access
 
   qualified-path-meta:
     - meta_include_prototype: false
@@ -1665,6 +1666,7 @@ contexts:
 
   function-call-arguments:
     - meta_include_prototype: false
+    - meta_content_scope: meta.function-call.identifier.php
     - match: (\()\s*(\.\.\.)\s*(\))
       scope: meta.function-call.arguments.php meta.group.php
       captures:

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -2033,6 +2033,26 @@ $array = array_reduce(
 );
 // <- punctuation.section.group.end
 
+$array['callback'](first: 'first', second: 'second');
+// <- meta.function-call.identifier.php variable.other.php punctuation.definition.variable.php
+//^^^^ meta.function-call.identifier.php - meta.item-access
+//    ^^^^^^^^^^^^ meta.function-call.identifier.php meta.item-access.php
+//                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.php meta.group.php
+//^^^^ variable.other.php
+//    ^ punctuation.section.brackets.begin.php
+//     ^^^^^^^^^^ meta.string.php string.quoted.single.php
+//               ^ punctuation.section.brackets.end.php
+//                ^ punctuation.section.group.begin.php
+//                 ^^^^^ variable.parameter.named.php
+//                      ^ keyword.operator.assignment.php
+//                        ^^^^^^^ meta.string.php string.quoted.single.php
+//                               ^ punctuation.separator.sequence.php
+//                                 ^^^^^^ variable.parameter.named.php
+//                                       ^ keyword.operator.assignment.php
+//                                         ^^^^^^^^ meta.string.php string.quoted.single.php
+//                                                 ^ punctuation.section.group.end.php
+//                                                  ^ punctuation.terminator.statement.php
+
 nested( static function ( {  } );
 //    ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.php meta.group.php
 //             ^^^^^^^^^ meta.function.php


### PR DESCRIPTION
Fixes #3936

This commit fixes function calls not being scoped as such, if identifier is an array variable.