### PR TITLE
[CSS] Add :global() and :local() pseudo-classes

### DIFF
--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -90,6 +90,9 @@ variables:
 
   keyframe_selector_begin: (?=\b(?i:from|to){{break}}|\.?[\d,%])
 
+  pseudo_classes_with_selector_args: |-
+    (?xi: global | local | matches | is | where | not | has | host(?:-context)?)
+
   # Combinators
   # https://drafts.csswg.org/selectors-4/#combinators
   combinators: (?:>{1,3}|[~+]|\|{2})
@@ -1401,7 +1404,7 @@ contexts:
   # Functional Pseudo Classes with selector list
   pseudo-class-function-with-selector-args:
     # global(), local() - CSS Modules, Less, Astro
-    - match: (?i:global|local|matches|is|where|not|has|host(?:-context)?)(?=\()
+    - match: '{{pseudo_classes_with_selector_args}}(?=\()'
       scope: meta.function-call.identifier.css entity.other.pseudo-class.css
       set:
         - pseudo-class-selector-arguments-list-body

--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -1400,7 +1400,8 @@ contexts:
 
   # Functional Pseudo Classes with selector list
   pseudo-class-function-with-selector-args:
-    - match: (?i:matches|is|where|not|has|host(?:-context)?)(?=\()
+    # global(), local() - CSS Modules, Less, Astro
+    - match: (?i:global|local|matches|is|where|not|has|host(?:-context)?)(?=\()
       scope: meta.function-call.identifier.css entity.other.pseudo-class.css
       set:
         - pseudo-class-selector-arguments-list-body

--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -93,6 +93,18 @@ variables:
   pseudo_classes_with_selector_args: |-
     (?xi: global | local | matches | is | where | not | has | host(?:-context)?)
 
+  pseudo_classes_with_anb_args: |-
+    (?xi:
+    # https://drafts.csswg.org/selectors-4/#table-pseudos
+      nth-last-col
+    | nth-col
+    # https://drafts.csswg.org/selectors-4/#typed-child-index
+    | nth-last-child
+    | nth-child
+    | nth-last-of-type
+    | nth-of-type
+    )
+
   # Combinators
   # https://drafts.csswg.org/selectors-4/#combinators
   combinators: (?:>{1,3}|[~+]|\|{2})
@@ -1364,17 +1376,7 @@ contexts:
   # Functional Pseudo Classes with `An+B` param
   # An+B Notation: https://drafts.csswg.org/css-syntax/#anb
   pseudo-class-function-with-anb-args:
-    - match: |-
-        (?xi:
-        # https://drafts.csswg.org/selectors-4/#table-pseudos
-          nth-last-col
-        | nth-col
-        # https://drafts.csswg.org/selectors-4/#typed-child-index
-        | nth-last-child
-        | nth-child
-        | nth-last-of-type
-        | nth-of-type
-        )(?=\()
+    - match: '{{pseudo_classes_with_anb_args}}(?=\()'
       scope: meta.function-call.identifier.css entity.other.pseudo-class.css
       set:
         - pseudo-class-anb-arguments-list-body


### PR DESCRIPTION
This commit adds `:global(selector)` and `:local(selector)` pseudo-class support. The former is used by CSS Modules, Less and Astro framework. The ladder is used by CSS Modules only, but is added for completeness.

It is no default CSS feature, but appears to be specific enough to not cause any conflicts.

Adding it to core CSS would avoid the need to extend CSS for Astro, just for this single reason.

Vue.js also uses `:global` (see: https://vuejs.org/api/sfc-css-features.html#global-selectors).