### PR TITLE
[YAML] Add CITATION.cff file extension

### DIFF
--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -43,6 +43,8 @@ file_extensions:
   - yaml
   - yml
   - sublime-syntax
+
+hidden_file_extensions:
   - CITATION.cff
 
 first_line_match: ^%YAML( ?1.\d+)? # Technically the number is required, but we'll be a bit loose here

--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -43,6 +43,7 @@ file_extensions:
   - yaml
   - yml
   - sublime-syntax
+  - CITATION.cff
 
 first_line_match: ^%YAML( ?1.\d+)? # Technically the number is required, but we'll be a bit loose here
 


### PR DESCRIPTION
https://citation-file-format.github.io/

Also see https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md which states that the file must be named exactly `CITATION.cff` and that it is YAML.