### PR TITLE
[Python] Fix raw-string termination

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -4051,8 +4051,8 @@ contexts:
 
   escaped-raw-quotes:
     # consume escaped quotes in raw-strings to preven them terminating strings
+    # but don't scope them as escapes as they are treated literal
     - match: \\[\\'"]
-      scope: constant.character.escape.python
 
   escaped-string-braces:
     - match: \{\{|\}\}

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -4051,7 +4051,7 @@ contexts:
 
   escaped-raw-quotes:
     # consume escaped quotes in raw-strings to preven them terminating strings
-    - match: \\['"]
+    - match: \\[\\'"]
       scope: constant.character.escape.python
 
   escaped-string-braces:

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -16,7 +16,7 @@ ur"""Raw docstring \""""
 # <- storage.type.string.python - comment
 # ^^^ comment.block.documentation.python punctuation.definition.comment.begin.python
 #    ^^^^^^^^^^^^^^^^ comment.block.documentation.summary.python
-#                  ^^ constant.character.escape.python
+#                  ^^ - constant.character.escape
 #                    ^^^ comment.block.documentation.python punctuation.definition.comment.end.python
 
 R"""
@@ -92,7 +92,7 @@ ur'''Raw docstring \''''
 # <- storage.type.string.python - comment
 # ^^^ comment.block.documentation.python punctuation.definition.comment.begin.python
 #    ^^^^^^^^^^^^^^^^ comment.block.documentation.summary.python
-#                  ^^ constant.character.escape.python
+#                  ^^ - constant.character.escape
 #                    ^^^ comment.block.documentation.python punctuation.definition.comment.end.python
 
 R'''

--- a/Python/tests/syntax_test_python_strings.py
+++ b/Python/tests/syntax_test_python_strings.py
@@ -278,35 +278,35 @@ sql = 'SELECT * FROM foo -- bar baz'
 
 r'''\''''
 #^^^^^^^^ comment.block.documentation
-#   ^^ constant.character.escape.python
+#   ^^ - constant.character.escape
 
 r"""\""""
 #^^^^^^^^ comment.block.documentation
-#   ^^ constant.character.escape.python
+#   ^^ - constant.character.escape
 
 R'''\''''
 #^^^^^^^^ comment.block.documentation
-#   ^^ constant.character.escape.python
+#   ^^ - constant.character.escape
 
 R"""\""""
 #^^^^^^^^ comment.block.documentation
-#   ^^ constant.character.escape.python
+#   ^^ - constant.character.escape
 
 r'''\\'''
 #^^^^^^^^ comment.block.documentation
-#   ^^ constant.character.escape.python
+#   ^^ - constant.character.escape
 
 r"""\\"""
 #^^^^^^^^ comment.block.documentation
-#   ^^ constant.character.escape.python
+#   ^^ - constant.character.escape
 
 R'''\\'''
 #^^^^^^^^ comment.block.documentation
-#   ^^ constant.character.escape.python
+#   ^^ - constant.character.escape
 
 R"""\\"""
 #^^^^^^^^ comment.block.documentation
-#   ^^ constant.character.escape.python
+#   ^^ - constant.character.escape
 
 raw = r'foo\'' + r'foo\"' + r'foo\\'
 #      ^^^^^^^ meta.string.python string.quoted.single.python
@@ -391,85 +391,85 @@ raw = rf"foo\"" + rf"foo\'" + rf"foo\\"
 raw = R'foo\'' + R'foo\"' + R'foo\\'
 #      ^^^^^^^ meta.string.python string.quoted.single.python
 #      ^ punctuation.definition.string.begin.python
-#          ^^ constant.character.escape.python
+#          ^^ - constant.character.escape
 #            ^ punctuation.definition.string.end.python
 #                 ^^^^^^^ meta.string.python string.quoted.single.python
 #                 ^ punctuation.definition.string.begin.python
-#                     ^^ constant.character.escape.python
+#                     ^^ - constant.character.escape
 #                       ^ punctuation.definition.string.end.python
 #                            ^^^^^^^ meta.string.python string.quoted.single.python
 #                            ^ punctuation.definition.string.begin.python
-#                                ^^ constant.character.escape.python
+#                                ^^ - constant.character.escape
 #                                  ^ punctuation.definition.string.end.python
 
 raw = R"foo\"" + R"foo\'" + R"foo\\"
 #      ^^^^^^^ meta.string.python string.quoted.double.python
 #      ^ punctuation.definition.string.begin.python
-#          ^^ constant.character.escape.python
+#          ^^ - constant.character.escape
 #            ^ punctuation.definition.string.end.python
 #                 ^^^^^^^ meta.string.python string.quoted.double.python
 #                 ^ punctuation.definition.string.begin.python
-#                     ^^ constant.character.escape.python
+#                     ^^ - constant.character.escape
 #                       ^ punctuation.definition.string.end.python
 #                            ^^^^^^^ meta.string.python string.quoted.double.python
 #                            ^ punctuation.definition.string.begin.python
-#                                ^^ constant.character.escape.python
+#                                ^^ - constant.character.escape
 #                                  ^ punctuation.definition.string.end.python
 
 raw = RB'foo\'' + RB'foo\"' + RB'foo\\'
 #       ^^^^^^^ meta.string.python string.quoted.single.python
 #       ^ punctuation.definition.string.begin.python
-#           ^^ constant.character.escape.python
+#           ^^ - constant.character.escape
 #             ^ punctuation.definition.string.end.python
 #                   ^^^^^^^ meta.string.python string.quoted.single.python
 #                   ^ punctuation.definition.string.begin.python
-#                       ^^ constant.character.escape.python
+#                       ^^ - constant.character.escape
 #                         ^ punctuation.definition.string.end.python
 #                               ^^^^^^^ meta.string.python string.quoted.single.python
 #                               ^ punctuation.definition.string.begin.python
-#                                   ^^ constant.character.escape.python
+#                                   ^^ - constant.character.escape
 #                                     ^ punctuation.definition.string.end.python
 
 raw = RB"foo\"" + RB"foo\'" + RB"foo\\"
 #       ^^^^^^^ meta.string.python string.quoted.double.python
 #       ^ punctuation.definition.string.begin.python
-#           ^^ constant.character.escape.python
+#           ^^ - constant.character.escape
 #             ^ punctuation.definition.string.end.python
 #                   ^^^^^^^ meta.string.python string.quoted.double.python
 #                   ^ punctuation.definition.string.begin.python
-#                       ^^ constant.character.escape.python
+#                       ^^ - constant.character.escape
 #                         ^ punctuation.definition.string.end.python
 #                               ^^^^^^^ meta.string.python string.quoted.double.python
 #                               ^ punctuation.definition.string.begin.python
-#                                   ^^ constant.character.escape.python
+#                                   ^^ - constant.character.escape
 #                                     ^ punctuation.definition.string.end.python
 
 raw = RF'foo\'' + RF'foo\"' + RF'foo\\'
 #       ^^^^^^^ meta.string.python string.quoted.single.python
 #       ^ punctuation.definition.string.begin.python
-#           ^^ constant.character.escape.python
+#           ^^ - constant.character.escape
 #             ^ punctuation.definition.string.end.python
 #                   ^^^^^^^ meta.string.python string.quoted.single.python
 #                   ^ punctuation.definition.string.begin.python
-#                       ^^ constant.character.escape.python
+#                       ^^ - constant.character.escape
 #                         ^ punctuation.definition.string.end.python
 #                               ^^^^^^^ meta.string.python string.quoted.single.python
 #                               ^ punctuation.definition.string.begin.python
-#                                   ^^ constant.character.escape.python
+#                                   ^^ - constant.character.escape
 #                                     ^ punctuation.definition.string.end.python
 
 raw = RF"foo\"" + RF"foo\'" + RF"foo\\"
 #       ^^^^^^^ meta.string.python string.quoted.double.python
 #       ^ punctuation.definition.string.begin.python
-#           ^^ constant.character.escape.python
+#           ^^ - constant.character.escape
 #             ^ punctuation.definition.string.end.python
 #                   ^^^^^^^ meta.string.python string.quoted.double.python
 #                   ^ punctuation.definition.string.begin.python
-#                       ^^ constant.character.escape.python
+#                       ^^ - constant.character.escape
 #                         ^ punctuation.definition.string.end.python
 #                               ^^^^^^^ meta.string.python string.quoted.double.python
 #                               ^ punctuation.definition.string.begin.python
-#                                   ^^ constant.character.escape.python
+#                                   ^^ - constant.character.escape
 #                                     ^ punctuation.definition.string.end.python
 
 raw = r'''foo\'''' + r'''foo\"''' + r'''foo\\'''
@@ -559,85 +559,85 @@ raw = rf"""foo\"""" + rf"""foo\'""" + rf"""foo\\"""
 raw = R'''foo\'''' + R'''foo\"''' + R'''foo\\'''
 #      ^^^^^^^^^^^ meta.string.python string.quoted.single.block.python
 #      ^ punctuation.definition.string.begin.python
-#            ^^ constant.character.escape.python
+#            ^^ - constant.character.escape
 #              ^^^ punctuation.definition.string.end.python
 #                     ^^^^^^^^^^^ meta.string.python string.quoted.single.block.python
 #                     ^^^ punctuation.definition.string.begin.python
-#                           ^^ constant.character.escape.python
+#                           ^^ - constant.character.escape
 #                             ^^^ punctuation.definition.string.end.python
 #                                    ^^^^^^^^^^^ meta.string.python string.quoted.single.block.python
 #                                    ^^^ punctuation.definition.string.begin.python
-#                                          ^^ constant.character.escape.python
+#                                          ^^ - constant.character.escape
 #                                            ^^^ punctuation.definition.string.end.python
 
 raw = R"""foo\"""" + R"""foo\'""" + R"""foo\\"""
 #      ^^^^^^^^^^^ meta.string.python string.quoted.double.block.python
 #      ^ punctuation.definition.string.begin.python
-#            ^^ constant.character.escape.python
+#            ^^ - constant.character.escape
 #              ^^^ punctuation.definition.string.end.python
 #                     ^^^^^^^^^^^ meta.string.python string.quoted.double.block.python
 #                     ^^^ punctuation.definition.string.begin.python
-#                           ^^ constant.character.escape.python
+#                           ^^ - constant.character.escape
 #                             ^^^ punctuation.definition.string.end.python
 #                                    ^^^^^^^^^^^ meta.string.python string.quoted.double.block.python
 #                                    ^^^ punctuation.definition.string.begin.python
-#                                          ^^ constant.character.escape.python
+#                                          ^^ - constant.character.escape
 #                                            ^^^ punctuation.definition.string.end.python
 
 raw = RB'''foo\'''' + RB'''foo\"''' + RB'''foo\\'''
 #       ^^^^^^^^^^^ meta.string.python string.quoted.single.block.python
 #       ^ punctuation.definition.string.begin.python
-#             ^^ constant.character.escape.python
+#             ^^ - constant.character.escape
 #               ^^^ punctuation.definition.string.end.python
 #                       ^^^^^^^^^^^ meta.string.python string.quoted.single.block.python
 #                       ^^^ punctuation.definition.string.begin.python
-#                             ^^ constant.character.escape.python
+#                             ^^ - constant.character.escape
 #                               ^^^ punctuation.definition.string.end.python
 #                                       ^^^^^^^^^^^ meta.string.python string.quoted.single.block.python
 #                                       ^^^ punctuation.definition.string.begin.python
-#                                             ^^ constant.character.escape.python
+#                                             ^^ - constant.character.escape
 #                                               ^^^ punctuation.definition.string.end.python
 
 raw = RB"""foo\"""" + RB"""foo\'""" + RB"""foo\\"""
 #       ^^^^^^^^^^^ meta.string.python string.quoted.double.block.python
 #       ^ punctuation.definition.string.begin.python
-#             ^^ constant.character.escape.python
+#             ^^ - constant.character.escape
 #               ^^^ punctuation.definition.string.end.python
 #                       ^^^^^^^^^^^ meta.string.python string.quoted.double.block.python
 #                       ^^^ punctuation.definition.string.begin.python
-#                             ^^ constant.character.escape.python
+#                             ^^ - constant.character.escape
 #                               ^^^ punctuation.definition.string.end.python
 #                                       ^^^^^^^^^^^ meta.string.python string.quoted.double.block.python
 #                                       ^^^ punctuation.definition.string.begin.python
-#                                             ^^ constant.character.escape.python
+#                                             ^^ - constant.character.escape
 #                                               ^^^ punctuation.definition.string.end.python
 
 raw = RF'''foo\'''' + RF'''foo\"''' + RF'''foo\\'''
 #       ^^^^^^^^^^^ meta.string.python string.quoted.single.block.python
 #       ^ punctuation.definition.string.begin.python
-#             ^^ constant.character.escape.python
+#             ^^ - constant.character.escape
 #               ^^^ punctuation.definition.string.end.python
 #                       ^^^^^^^^^^^ meta.string.python string.quoted.single.block.python
 #                       ^^^ punctuation.definition.string.begin.python
-#                             ^^ constant.character.escape.python
+#                             ^^ - constant.character.escape
 #                               ^^^ punctuation.definition.string.end.python
 #                                       ^^^^^^^^^^^ meta.string.python string.quoted.single.block.python
 #                                       ^^^ punctuation.definition.string.begin.python
-#                                             ^^ constant.character.escape.python
+#                                             ^^ - constant.character.escape
 #                                               ^^^ punctuation.definition.string.end.python
 
 raw = RF"""foo\"""" + RF"""foo\'""" + RF"""foo\\"""
 #       ^^^^^^^^^^^ meta.string.python string.quoted.double.block.python
 #       ^ punctuation.definition.string.begin.python
-#             ^^ constant.character.escape.python
+#             ^^ - constant.character.escape
 #               ^^^ punctuation.definition.string.end.python
 #                       ^^^^^^^^^^^ meta.string.python string.quoted.double.block.python
 #                       ^^^ punctuation.definition.string.begin.python
-#                             ^^ constant.character.escape.python
+#                             ^^ - constant.character.escape
 #                               ^^^ punctuation.definition.string.end.python
 #                                       ^^^^^^^^^^^ meta.string.python string.quoted.double.block.python
 #                                       ^^^ punctuation.definition.string.begin.python
-#                                             ^^ constant.character.escape.python
+#                                             ^^ - constant.character.escape
 #                                               ^^^ punctuation.definition.string.end.python
 
 ###################################################

--- a/Python/tests/syntax_test_python_strings.py
+++ b/Python/tests/syntax_test_python_strings.py
@@ -292,7 +292,23 @@ R"""\""""
 #^^^^^^^^ comment.block.documentation
 #   ^^ constant.character.escape.python
 
-raw = r'foo\'' + r'foo\"'
+r'''\\'''
+#^^^^^^^^ comment.block.documentation
+#   ^^ constant.character.escape.python
+
+r"""\\"""
+#^^^^^^^^ comment.block.documentation
+#   ^^ constant.character.escape.python
+
+R'''\\'''
+#^^^^^^^^ comment.block.documentation
+#   ^^ constant.character.escape.python
+
+R"""\\"""
+#^^^^^^^^ comment.block.documentation
+#   ^^ constant.character.escape.python
+
+raw = r'foo\'' + r'foo\"' + r'foo\\'
 #      ^^^^^^^ meta.string.python string.quoted.single.python
 #      ^ punctuation.definition.string.begin.python
 #          ^^ constant.character.escape
@@ -301,8 +317,12 @@ raw = r'foo\'' + r'foo\"'
 #                 ^ punctuation.definition.string.begin.python
 #                     ^^ constant.character.escape
 #                       ^ punctuation.definition.string.end.python
+#                            ^^^^^^^ meta.string.python string.quoted.single.python
+#                            ^ punctuation.definition.string.begin.python
+#                                ^^ constant.character.escape
+#                                  ^ punctuation.definition.string.end.python
 
-raw = r"foo\"" + r"foo\'"
+raw = r"foo\"" + r"foo\'" + r"foo\\"
 #      ^^^^^^^ meta.string.python string.quoted.double.python
 #      ^ punctuation.definition.string.begin.python
 #          ^^ constant.character.escape
@@ -311,8 +331,12 @@ raw = r"foo\"" + r"foo\'"
 #                 ^ punctuation.definition.string.begin.python
 #                     ^^ constant.character.escape
 #                       ^ punctuation.definition.string.end.python
+#                            ^^^^^^^ meta.string.python string.quoted.double.python
+#                            ^ punctuation.definition.string.begin.python
+#                                ^^ constant.character.escape
+#                                  ^ punctuation.definition.string.end.python
 
-raw = rb'foo\'' + rb'foo\"'
+raw = rb'foo\'' + rb'foo\"' + rb'foo\\'
 #       ^^^^^^^ meta.string.python string.quoted.single.python
 #       ^ punctuation.definition.string.begin.python
 #           ^^ constant.character.escape
@@ -321,8 +345,12 @@ raw = rb'foo\'' + rb'foo\"'
 #                   ^ punctuation.definition.string.begin.python
 #                       ^^ constant.character.escape
 #                         ^ punctuation.definition.string.end.python
+#                               ^^^^^^^ meta.string.python string.quoted.single.python
+#                               ^ punctuation.definition.string.begin.python
+#                                   ^^ constant.character.escape
+#                                     ^ punctuation.definition.string.end.python
 
-raw = rb"foo\"" + rb"foo\'"
+raw = rb"foo\"" + rb"foo\'" + rb"foo\\"
 #       ^^^^^^^ meta.string.python string.quoted.double.python
 #       ^ punctuation.definition.string.begin.python
 #           ^^ constant.character.escape
@@ -332,7 +360,7 @@ raw = rb"foo\"" + rb"foo\'"
 #                       ^^ constant.character.escape
 #                         ^ punctuation.definition.string.end.python
 
-raw = rf'foo\'' + rf'foo\"'
+raw = rf'foo\'' + rf'foo\"' + rf'foo\\'
 #       ^^^^^^^ meta.string.python string.quoted.single.python
 #       ^ punctuation.definition.string.begin.python
 #           ^^ constant.character.escape
@@ -341,8 +369,12 @@ raw = rf'foo\'' + rf'foo\"'
 #                   ^ punctuation.definition.string.begin.python
 #                       ^^ constant.character.escape
 #                         ^ punctuation.definition.string.end.python
+#                               ^^^^^^^ meta.string.python string.quoted.single.python
+#                               ^ punctuation.definition.string.begin.python
+#                                   ^^ constant.character.escape
+#                                     ^ punctuation.definition.string.end.python
 
-raw = rf"foo\"" + rf"foo\'"
+raw = rf"foo\"" + rf"foo\'" + rf"foo\\"
 #       ^^^^^^^ meta.string.python string.quoted.double.python
 #       ^ punctuation.definition.string.begin.python
 #           ^^ constant.character.escape
@@ -351,8 +383,12 @@ raw = rf"foo\"" + rf"foo\'"
 #                   ^ punctuation.definition.string.begin.python
 #                       ^^ constant.character.escape
 #                         ^ punctuation.definition.string.end.python
+#                               ^^^^^^^ meta.string.python string.quoted.double.python
+#                               ^ punctuation.definition.string.begin.python
+#                                   ^^ constant.character.escape
+#                                     ^ punctuation.definition.string.end.python
 
-raw = R'foo\'' + R'foo\"'
+raw = R'foo\'' + R'foo\"' + R'foo\\'
 #      ^^^^^^^ meta.string.python string.quoted.single.python
 #      ^ punctuation.definition.string.begin.python
 #          ^^ constant.character.escape.python
@@ -361,8 +397,12 @@ raw = R'foo\'' + R'foo\"'
 #                 ^ punctuation.definition.string.begin.python
 #                     ^^ constant.character.escape.python
 #                       ^ punctuation.definition.string.end.python
+#                            ^^^^^^^ meta.string.python string.quoted.single.python
+#                            ^ punctuation.definition.string.begin.python
+#                                ^^ constant.character.escape.python
+#                                  ^ punctuation.definition.string.end.python
 
-raw = R"foo\"" + R"foo\'"
+raw = R"foo\"" + R"foo\'" + R"foo\\"
 #      ^^^^^^^ meta.string.python string.quoted.double.python
 #      ^ punctuation.definition.string.begin.python
 #          ^^ constant.character.escape.python
@@ -371,8 +411,12 @@ raw = R"foo\"" + R"foo\'"
 #                 ^ punctuation.definition.string.begin.python
 #                     ^^ constant.character.escape.python
 #                       ^ punctuation.definition.string.end.python
+#                            ^^^^^^^ meta.string.python string.quoted.double.python
+#                            ^ punctuation.definition.string.begin.python
+#                                ^^ constant.character.escape.python
+#                                  ^ punctuation.definition.string.end.python
 
-raw = RB'foo\'' + RB'foo\"'
+raw = RB'foo\'' + RB'foo\"' + RB'foo\\'
 #       ^^^^^^^ meta.string.python string.quoted.single.python
 #       ^ punctuation.definition.string.begin.python
 #           ^^ constant.character.escape.python
@@ -381,8 +425,12 @@ raw = RB'foo\'' + RB'foo\"'
 #                   ^ punctuation.definition.string.begin.python
 #                       ^^ constant.character.escape.python
 #                         ^ punctuation.definition.string.end.python
+#                               ^^^^^^^ meta.string.python string.quoted.single.python
+#                               ^ punctuation.definition.string.begin.python
+#                                   ^^ constant.character.escape.python
+#                                     ^ punctuation.definition.string.end.python
 
-raw = RB"foo\"" + RB"foo\'"
+raw = RB"foo\"" + RB"foo\'" + RB"foo\\"
 #       ^^^^^^^ meta.string.python string.quoted.double.python
 #       ^ punctuation.definition.string.begin.python
 #           ^^ constant.character.escape.python
@@ -391,8 +439,12 @@ raw = RB"foo\"" + RB"foo\'"
 #                   ^ punctuation.definition.string.begin.python
 #                       ^^ constant.character.escape.python
 #                         ^ punctuation.definition.string.end.python
+#                               ^^^^^^^ meta.string.python string.quoted.double.python
+#                               ^ punctuation.definition.string.begin.python
+#                                   ^^ constant.character.escape.python
+#                                     ^ punctuation.definition.string.end.python
 
-raw = RF'foo\'' + RF'foo\"'
+raw = RF'foo\'' + RF'foo\"' + RF'foo\\'
 #       ^^^^^^^ meta.string.python string.quoted.single.python
 #       ^ punctuation.definition.string.begin.python
 #           ^^ constant.character.escape.python
@@ -401,8 +453,12 @@ raw = RF'foo\'' + RF'foo\"'
 #                   ^ punctuation.definition.string.begin.python
 #                       ^^ constant.character.escape.python
 #                         ^ punctuation.definition.string.end.python
+#                               ^^^^^^^ meta.string.python string.quoted.single.python
+#                               ^ punctuation.definition.string.begin.python
+#                                   ^^ constant.character.escape.python
+#                                     ^ punctuation.definition.string.end.python
 
-raw = RF"foo\"" + RF"foo\'"
+raw = RF"foo\"" + RF"foo\'" + RF"foo\\"
 #       ^^^^^^^ meta.string.python string.quoted.double.python
 #       ^ punctuation.definition.string.begin.python
 #           ^^ constant.character.escape.python
@@ -411,8 +467,12 @@ raw = RF"foo\"" + RF"foo\'"
 #                   ^ punctuation.definition.string.begin.python
 #                       ^^ constant.character.escape.python
 #                         ^ punctuation.definition.string.end.python
+#                               ^^^^^^^ meta.string.python string.quoted.double.python
+#                               ^ punctuation.definition.string.begin.python
+#                                   ^^ constant.character.escape.python
+#                                     ^ punctuation.definition.string.end.python
 
-raw = r'''foo\'''' + r'''foo\"'''
+raw = r'''foo\'''' + r'''foo\"''' + r'''foo\\'''
 #      ^^^^^^^^^^^ meta.string.python string.quoted.single.block.python
 #      ^ punctuation.definition.string.begin.python
 #            ^^ constant.character.escape
@@ -421,8 +481,12 @@ raw = r'''foo\'''' + r'''foo\"'''
 #                     ^^^ punctuation.definition.string.begin.python
 #                           ^^ constant.character.escape
 #                             ^^^ punctuation.definition.string.end.python
+#                                    ^^^^^^^^^^^ meta.string.python string.quoted.single.block.python
+#                                    ^^^ punctuation.definition.string.begin.python
+#                                          ^^ constant.character.escape
+#                                            ^^^ punctuation.definition.string.end.python
 
-raw = r"""foo\"""" + r"""foo\'"""
+raw = r"""foo\"""" + r"""foo\'""" + r"""foo\\"""
 #      ^^^^^^^^^^^ meta.string.python string.quoted.double.block.python
 #      ^ punctuation.definition.string.begin.python
 #            ^^ constant.character.escape
@@ -431,8 +495,12 @@ raw = r"""foo\"""" + r"""foo\'"""
 #                     ^^^ punctuation.definition.string.begin.python
 #                           ^^ constant.character.escape
 #                             ^^^ punctuation.definition.string.end.python
+#                                    ^^^^^^^^^^^ meta.string.python string.quoted.double.block.python
+#                                    ^^^ punctuation.definition.string.begin.python
+#                                          ^^ constant.character.escape
+#                                            ^^^ punctuation.definition.string.end.python
 
-raw = rb'''foo\'''' + rb'''foo\"'''
+raw = rb'''foo\'''' + rb'''foo\"''' + rb'''foo\\'''
 #       ^^^^^^^^^^^ meta.string.python string.quoted.single.block.python
 #       ^ punctuation.definition.string.begin.python
 #             ^^ constant.character.escape
@@ -441,8 +509,12 @@ raw = rb'''foo\'''' + rb'''foo\"'''
 #                       ^^^ punctuation.definition.string.begin.python
 #                             ^^ constant.character.escape
 #                               ^^^ punctuation.definition.string.end.python
+#                                       ^^^^^^^^^^^ meta.string.python string.quoted.single.block.python
+#                                       ^^^ punctuation.definition.string.begin.python
+#                                             ^^ constant.character.escape
+#                                               ^^^ punctuation.definition.string.end.python
 
-raw = rb"""foo\"""" + rb"""foo\'"""
+raw = rb"""foo\"""" + rb"""foo\'""" + rb"""foo\\"""
 #       ^^^^^^^^^^^ meta.string.python string.quoted.double.block.python
 #       ^ punctuation.definition.string.begin.python
 #             ^^ constant.character.escape
@@ -451,8 +523,12 @@ raw = rb"""foo\"""" + rb"""foo\'"""
 #                       ^^^ punctuation.definition.string.begin.python
 #                             ^^ constant.character.escape
 #                               ^^^ punctuation.definition.string.end.python
+#                                       ^^^^^^^^^^^ meta.string.python string.quoted.double.block.python
+#                                       ^^^ punctuation.definition.string.begin.python
+#                                             ^^ constant.character.escape
+#                                               ^^^ punctuation.definition.string.end.python
 
-raw = rf'''foo\'''' + rf'''foo\"'''
+raw = rf'''foo\'''' + rf'''foo\"''' + rf'''foo\\'''
 #       ^^^^^^^^^^^ meta.string.python string.quoted.single.block.python
 #       ^ punctuation.definition.string.begin.python
 #             ^^ constant.character.escape
@@ -461,8 +537,12 @@ raw = rf'''foo\'''' + rf'''foo\"'''
 #                       ^^^ punctuation.definition.string.begin.python
 #                             ^^ constant.character.escape
 #                               ^^^ punctuation.definition.string.end.python
+#                                       ^^^^^^^^^^^ meta.string.python string.quoted.single.block.python
+#                                       ^^^ punctuation.definition.string.begin.python
+#                                             ^^ constant.character.escape
+#                                               ^^^ punctuation.definition.string.end.python
 
-raw = rf"""foo\"""" + rf"""foo\'"""
+raw = rf"""foo\"""" + rf"""foo\'""" + rf"""foo\\"""
 #       ^^^^^^^^^^^ meta.string.python string.quoted.double.block.python
 #       ^ punctuation.definition.string.begin.python
 #             ^^ constant.character.escape
@@ -471,8 +551,12 @@ raw = rf"""foo\"""" + rf"""foo\'"""
 #                       ^^^ punctuation.definition.string.begin.python
 #                             ^^ constant.character.escape
 #                               ^^^ punctuation.definition.string.end.python
+#                                       ^^^^^^^^^^^ meta.string.python string.quoted.double.block.python
+#                                       ^^^ punctuation.definition.string.begin.python
+#                                             ^^ constant.character.escape
+#                                               ^^^ punctuation.definition.string.end.python
 
-raw = R'''foo\'''' + R'''foo\"'''
+raw = R'''foo\'''' + R'''foo\"''' + R'''foo\\'''
 #      ^^^^^^^^^^^ meta.string.python string.quoted.single.block.python
 #      ^ punctuation.definition.string.begin.python
 #            ^^ constant.character.escape.python
@@ -481,8 +565,12 @@ raw = R'''foo\'''' + R'''foo\"'''
 #                     ^^^ punctuation.definition.string.begin.python
 #                           ^^ constant.character.escape.python
 #                             ^^^ punctuation.definition.string.end.python
+#                                    ^^^^^^^^^^^ meta.string.python string.quoted.single.block.python
+#                                    ^^^ punctuation.definition.string.begin.python
+#                                          ^^ constant.character.escape.python
+#                                            ^^^ punctuation.definition.string.end.python
 
-raw = R"""foo\"""" + R"""foo\'"""
+raw = R"""foo\"""" + R"""foo\'""" + R"""foo\\"""
 #      ^^^^^^^^^^^ meta.string.python string.quoted.double.block.python
 #      ^ punctuation.definition.string.begin.python
 #            ^^ constant.character.escape.python
@@ -491,8 +579,12 @@ raw = R"""foo\"""" + R"""foo\'"""
 #                     ^^^ punctuation.definition.string.begin.python
 #                           ^^ constant.character.escape.python
 #                             ^^^ punctuation.definition.string.end.python
+#                                    ^^^^^^^^^^^ meta.string.python string.quoted.double.block.python
+#                                    ^^^ punctuation.definition.string.begin.python
+#                                          ^^ constant.character.escape.python
+#                                            ^^^ punctuation.definition.string.end.python
 
-raw = RB'''foo\'''' + RB'''foo\"'''
+raw = RB'''foo\'''' + RB'''foo\"''' + RB'''foo\\'''
 #       ^^^^^^^^^^^ meta.string.python string.quoted.single.block.python
 #       ^ punctuation.definition.string.begin.python
 #             ^^ constant.character.escape.python
@@ -501,8 +593,12 @@ raw = RB'''foo\'''' + RB'''foo\"'''
 #                       ^^^ punctuation.definition.string.begin.python
 #                             ^^ constant.character.escape.python
 #                               ^^^ punctuation.definition.string.end.python
+#                                       ^^^^^^^^^^^ meta.string.python string.quoted.single.block.python
+#                                       ^^^ punctuation.definition.string.begin.python
+#                                             ^^ constant.character.escape.python
+#                                               ^^^ punctuation.definition.string.end.python
 
-raw = RB"""foo\"""" + RB"""foo\'"""
+raw = RB"""foo\"""" + RB"""foo\'""" + RB"""foo\\"""
 #       ^^^^^^^^^^^ meta.string.python string.quoted.double.block.python
 #       ^ punctuation.definition.string.begin.python
 #             ^^ constant.character.escape.python
@@ -511,8 +607,12 @@ raw = RB"""foo\"""" + RB"""foo\'"""
 #                       ^^^ punctuation.definition.string.begin.python
 #                             ^^ constant.character.escape.python
 #                               ^^^ punctuation.definition.string.end.python
+#                                       ^^^^^^^^^^^ meta.string.python string.quoted.double.block.python
+#                                       ^^^ punctuation.definition.string.begin.python
+#                                             ^^ constant.character.escape.python
+#                                               ^^^ punctuation.definition.string.end.python
 
-raw = RF'''foo\'''' + RF'''foo\"'''
+raw = RF'''foo\'''' + RF'''foo\"''' + RF'''foo\\'''
 #       ^^^^^^^^^^^ meta.string.python string.quoted.single.block.python
 #       ^ punctuation.definition.string.begin.python
 #             ^^ constant.character.escape.python
@@ -521,8 +621,12 @@ raw = RF'''foo\'''' + RF'''foo\"'''
 #                       ^^^ punctuation.definition.string.begin.python
 #                             ^^ constant.character.escape.python
 #                               ^^^ punctuation.definition.string.end.python
+#                                       ^^^^^^^^^^^ meta.string.python string.quoted.single.block.python
+#                                       ^^^ punctuation.definition.string.begin.python
+#                                             ^^ constant.character.escape.python
+#                                               ^^^ punctuation.definition.string.end.python
 
-raw = RF"""foo\"""" + RF"""foo\'"""
+raw = RF"""foo\"""" + RF"""foo\'""" + RF"""foo\\"""
 #       ^^^^^^^^^^^ meta.string.python string.quoted.double.block.python
 #       ^ punctuation.definition.string.begin.python
 #             ^^ constant.character.escape.python
@@ -531,6 +635,10 @@ raw = RF"""foo\"""" + RF"""foo\'"""
 #                       ^^^ punctuation.definition.string.begin.python
 #                             ^^ constant.character.escape.python
 #                               ^^^ punctuation.definition.string.end.python
+#                                       ^^^^^^^^^^^ meta.string.python string.quoted.double.block.python
+#                                       ^^^ punctuation.definition.string.begin.python
+#                                             ^^ constant.character.escape.python
+#                                               ^^^ punctuation.definition.string.end.python
 
 ###################################################
 # There are many variations of making a byte string


### PR DESCRIPTION
Fixes #3954


This PR...

1. extends escape pattern of raw strings by `\\` to prevent unwanted consuming of `\"` in `\\"`.
2. drops scoping `\\`, `\"` or `\'` with `constant.character.escape` in raw strings as those tokens are treated literal - printed as is.

   They remain scoped escapes in regexp strings though as scoping of embedded
syntax applies.