### PR TITLE
[D] Add highlighting for recognised __traits/pragmas

### DIFF
--- a/D/D.sublime-syntax
+++ b/D/D.sublime-syntax
@@ -65,6 +65,9 @@ variables:
   language_variable: 'this|super'
   reserved: '{{keyword}}|{{basic_type}}|{{language_constant}}|{{language_variable}}'
 
+  traits: 'isAbstractClass|isArithmetic|isAssociativeArray|isFinalClass|isPOD|isNested|isFuture|isDeprecated|isFloating|isIntegral|isScalar|isStaticArray|isUnsigned|isDisabled|isVirtualFunction|isVirtualMethod|isAbstractFunction|isFinalFunction|isStaticFunction|isOverrideFunction|isTemplate|isRef|isOut|isLazy|isReturnOnStack|isCopyable|isZeroInit|isModule|isPackage|hasMember|hasCopyConstructor|hasPostblit|identifier|getAliasThis|getAttributes|getFunctionAttributes|getFunctionVariadicStyle|getLinkage|getLocation|getMember|getOverloads|getParameterStorageClasses|getPointerBitmap|getCppNamespaces|getVisibility|getProtection|getTargetInfo|getVirtualFunctions|getVirtualMethods|getUnitTests|parent|child|classInstanceSize|classInstanceAlignment|getVirtualIndex|allMembers|derivedMembers|isSame|compiles|toType|initSymbol|parameters'
+  pragmas: 'crt_constructor|crt_destructor|inline|lib|linkerDirective|mangle|msg|printf|scanf|startaddress|LDC_alloca|LDC_allow_inline|LDC_extern_weak|LDC_global_crt_ctor|LDC_global_crt_dtor|LDC_inline_ir|LDC_intrinsic|LDC_never_inline|LDC_no_moduleinfo|LDC_no_typeinfo|LDC_va_start|LDC_va_arg|LDC_va_end|LDC_va_copy'
+
   operator_overloads: 'opNeg|opCom|opPostInc|opPostDec|opCast|opAdd|opSub|opSub_r|opMul|opDiv|opDiv_r|opMod|opMod_r|opAnd|opOr|opXor|opShl|opShl_r|opShr|opShr_r|opUShr|opUShr_r|opCat|opCat_r|opEquals|opEquals|opCmp|opCmp|opCmp|opCmp|opAddAssign|opSubAssign|opMulAssign|opDivAssign|opModAssign|opAndAssign|opOrAssign|opXorAssign|opShlAssign|opShrAssign|opUShrAssign|opCatAssign|opIndex|opIndexAssign|opCall|opSlice|opSliceAssign|opPos|opAdd_r|opMul_r|opAnd_r|opOr_r|opXor_r'
 
   block_statement_loohahead: '(?={)'
@@ -697,16 +700,20 @@ contexts:
       scope: punctuation.section.parens.end.d
       pop: true
   pragma-attribute:
+    - match: '\b({{pragmas}})\b'
+      scope: variable.function.d constant.other.d
+      set: pragma-in
     - match: '\b({{name}})\b'
       scope: variable.function.d
-      set:
-        - match: '\)'
-          scope: punctuation.section.parens.end.d
-          pop: true
-        - match: ','
-          scope: punctuation.separator.sequence.d
-          set: [pragma-attribute-after, value-list]
-        - include: not-whitespace-illegal-pop
+      set: pragma-in
+    - include: not-whitespace-illegal-pop
+  pragma-in:
+    - match: '\)'
+      scope: punctuation.section.parens.end.d
+      pop: true
+    - match: ','
+      scope: punctuation.separator.sequence.d
+      set: [pragma-attribute-after, value-list]
     - include: not-whitespace-illegal-pop
   pragma-attribute-after:
     - match: '\)'
@@ -1191,12 +1198,16 @@ contexts:
         - match: '\('
           scope: punctuation.section.parens.begin.d
           set:
-            - match: '\b{{name}}\b'
-              scope: variable.function.d
+            - match: '\b({{traits}})\b'
+              scope: variable.function.d constant.other.d
               set:
                 - match: ','
                   scope: punctuation.separator.sequence.d
                   set: [value-parens-after, value-list]
+                - match: '\)'
+                  scope: punctuation.section.parens.end.d
+                  pop: true
+            - include: not-whitespace-illegal-pop
     - match: '\b(function|delegate)\b'
       scope: meta.function.d keyword.other.d
       set:

--- a/D/D.sublime-syntax
+++ b/D/D.sublime-syntax
@@ -701,7 +701,7 @@ contexts:
       pop: true
   pragma-attribute:
     - match: '\b({{pragmas}})\b'
-      scope: variable.function.d constant.other.d
+      scope: constant.other.d
       set: pragma-in
     - match: '\b({{name}})\b'
       scope: variable.function.d
@@ -1199,7 +1199,7 @@ contexts:
           scope: punctuation.section.parens.begin.d
           set:
             - match: '\b({{traits}})\b'
-              scope: variable.function.d constant.other.d
+              scope: constant.other.d
               set:
                 - match: ','
                   scope: punctuation.separator.sequence.d

--- a/D/tests/syntax_test_d.d
+++ b/D/tests/syntax_test_d.d
@@ -508,11 +508,11 @@ extern(1)
   pragma(inline) pragma(mangle, "main"):
 //^^^^^^ keyword.other.pragma.d
 //      ^ punctuation.section.parens.begin.d
-//       ^^^^^^ variable.function.d
+//       ^^^^^^ constant.other.d
 //             ^ punctuation.section.parens.end.d
 //               ^^^^^^ keyword.other.pragma.d
 //                     ^ punctuation.section.parens.begin.d
-//                      ^^^^^^ variable.function.d constant.other.d
+//                      ^^^^^^ constant.other.d
 //                              ^^^^^^ string.quoted.double.d
 //                                    ^ punctuation.section.parens.end.d
   private:
@@ -2920,7 +2920,7 @@ extern(1)
 //                 ^ punctuation.section.parens.begin.d
 //                  ^^^^^^^^ keyword.other.d
 //                          ^ punctuation.section.parens.begin.d
-//                           ^^^^^^^^^ variable.function.d constant.other.d
+//                           ^^^^^^^^^ constant.other.d
 //                                    ^ punctuation.separator.sequence.d
 //                                      ^^^^ variable.language.d
 //                                          ^ punctuation.separator.sequence.d

--- a/D/tests/syntax_test_d.d
+++ b/D/tests/syntax_test_d.d
@@ -505,6 +505,16 @@ extern(1)
 //                 ^^^^ variable.function.d
 //                       ^^^^ storage.type.d
 //                           ^ punctuation.section.parens.end.d
+  pragma(inline) pragma(mangle, "main"):
+//^^^^^^ keyword.other.pragma.d
+//      ^ punctuation.section.parens.begin.d
+//       ^^^^^^ variable.function.d
+//             ^ punctuation.section.parens.end.d
+//               ^^^^^^ keyword.other.pragma.d
+//                     ^ punctuation.section.parens.begin.d
+//                      ^^^^^^ variable.function.d constant.other.d
+//                              ^^^^^^ string.quoted.double.d
+//                                    ^ punctuation.section.parens.end.d
   private:
 //^^^^^^^ storage.modifier.access-control.d
 //       ^ punctuation.separator.d
@@ -2897,10 +2907,10 @@ extern(1)
   __traits(foo, a);
 //^^^^^^^^ keyword.other.d
 //        ^ punctuation.section.parens.begin.d
-//         ^^^ variable.function.d
+//         ^^^ invalid.illegal.d
 //            ^ punctuation.separator.sequence.d
 //              ^ meta.path.d variable.other.d
-//               ^ punctuation.section.parens.end.d
+//               ^ invalid.illegal.d
 //                ^ punctuation.terminator.d
   values ~= toValue(__traits(getMember, this, primaryKey));
 //^^^^^^ meta.path.d variable.other.d
@@ -2910,7 +2920,7 @@ extern(1)
 //                 ^ punctuation.section.parens.begin.d
 //                  ^^^^^^^^ keyword.other.d
 //                          ^ punctuation.section.parens.begin.d
-//                           ^^^^^^^^^ variable.function.d
+//                           ^^^^^^^^^ variable.function.d constant.other.d
 //                                    ^ punctuation.separator.sequence.d
 //                                      ^^^^ variable.language.d
 //                                          ^ punctuation.separator.sequence.d


### PR DESCRIPTION
Changes:
- Valid `__traits` are highlighted with `constant.other.d`.
- Invalid `__traits` now trigger `invalid.illegal.d`, because they cause compile errors.
- Highlight known pragmas with `constant.other.d`. Invalid pragmas are not *meant* to cause compile errors in D (currently they do, but it's being fixed), so they do NOT trigger `invalid.illegal.d`.