### PR TITLE
[D] Make `in` a word operator

### DIFF
--- a/D/D.sublime-syntax
+++ b/D/D.sublime-syntax
@@ -1423,7 +1423,10 @@ contexts:
     - match: '(<<|>>>|>>|\||\^|&)'
       scope: keyword.operator.bitwise.d
       set: value
-    - match: '(==|!=|\bis\b|!is\b|<=|<|>=|>|\bin\b|!in\b)'
+    - match: '(\bis\b|!is\b|\bin\b|!in\b)'
+      scope: keyword.operator.word.d keyword.operator.comparison.d
+      set: value
+    - match: '(==|!=|<=|<|>=|>)'
       scope: keyword.operator.comparison.d
       set: value
     - match: '='

--- a/D/D.sublime-syntax
+++ b/D/D.sublime-syntax
@@ -1424,7 +1424,7 @@ contexts:
       scope: keyword.operator.bitwise.d
       set: value
     - match: '(\bis\b|!is\b|\bin\b|!in\b)'
-      scope: keyword.operator.word.d keyword.operator.comparison.d
+      scope: keyword.operator.word.d
       set: value
     - match: '(==|!=|<=|<|>=|>)'
       scope: keyword.operator.comparison.d

--- a/D/tests/syntax_test_d.d
+++ b/D/tests/syntax_test_d.d
@@ -3181,11 +3181,19 @@ extern(1)
 //                     ^ variable.other.d
 //                      ^ punctuation.terminator.d
 
+  assert(foo is bar);
+//^^^^^^ keyword.other.assert.d
+//      ^ punctuation.section.parens.begin.d
+//       ^^^ meta.path.d variable.other.d
+//           ^^ keyword.operator.word.d keyword.operator.comparison.d
+//              ^^^ meta.path.d variable.other.d
+//                 ^ punctuation.section.parens.end.d
+//                  ^ punctuation.terminator.d
   assert(foo !is bar);
 //^^^^^^ keyword.other.assert.d
 //      ^ punctuation.section.parens.begin.d
 //       ^^^ meta.path.d variable.other.d
-//           ^^^ keyword.operator.comparison.d
+//           ^^^ keyword.operator.word.d keyword.operator.comparison.d
 //               ^^^ meta.path.d variable.other.d
 //                  ^ punctuation.section.parens.end.d
 //                   ^ punctuation.terminator.d

--- a/D/tests/syntax_test_d.d
+++ b/D/tests/syntax_test_d.d
@@ -1948,7 +1948,7 @@ extern(1)
 //^^ keyword.control.conditional.d
 //   ^ punctuation.section.parens.begin.d
 //    ^ variable.other.d
-//      ^^ keyword.operator.comparison.d
+//      ^^ keyword.operator.word.d
 //         ^ variable.other.d
 //          ^ punctuation.section.parens.end.d
 //            ^^ meta.block.d
@@ -1959,7 +1959,7 @@ extern(1)
 //^^ keyword.control.conditional.d
 //   ^ punctuation.section.parens.begin.d
 //    ^ variable.other.d
-//       ^^ keyword.operator.comparison.d
+//      ^^^ keyword.operator.word.d
 //          ^ variable.other.d
 //           ^ punctuation.section.parens.end.d
 //             ^^ meta.block.d
@@ -2924,7 +2924,7 @@ extern(1)
 //     ^ meta.number.integer.decimal.d
 //       ^^ keyword.operator.logical.d
 //          ^^^ string.quoted.double.d
-//              ^^^ keyword.operator.comparison.d
+//              ^^^ keyword.operator.word.d
 //                  ^ punctuation.section.brackets.begin.d
 //                   ^ meta.number.integer.decimal.d
 //                    ^ punctuation.section.brackets.end.d
@@ -3185,7 +3185,7 @@ extern(1)
 //^^^^^^ keyword.other.assert.d
 //      ^ punctuation.section.parens.begin.d
 //       ^^^ meta.path.d variable.other.d
-//           ^^ keyword.operator.word.d keyword.operator.comparison.d
+//           ^^ keyword.operator.word.d
 //              ^^^ meta.path.d variable.other.d
 //                 ^ punctuation.section.parens.end.d
 //                  ^ punctuation.terminator.d
@@ -3193,7 +3193,7 @@ extern(1)
 //^^^^^^ keyword.other.assert.d
 //      ^ punctuation.section.parens.begin.d
 //       ^^^ meta.path.d variable.other.d
-//           ^^^ keyword.operator.word.d keyword.operator.comparison.d
+//           ^^^ keyword.operator.word.d
 //               ^^^ meta.path.d variable.other.d
 //                  ^ punctuation.section.parens.end.d
 //                   ^ punctuation.terminator.d


### PR DESCRIPTION
Changes:
- Marked `in` as a word operator so that it can be highlighted as-such.