### PR TITLE
[D] Separate built-in type-aliases from built-in types

### DIFF
--- a/D/D.sublime-syntax
+++ b/D/D.sublime-syntax
@@ -61,7 +61,7 @@ variables:
 
   keyword: 'else|enum|export|extern|debug|default|delegate|delete|deprecated|do|body|break|case|cast|catch|class|const|continue|abstract|alias|align|asm|assert|auto|final|finally|for|foreach|foreach_reverse|function|goto|if|immutable|import|in|inout|interface|invariant|is|lazy|macro|mixin|module|new|nothrow|out|override|package|pragma|private|protected|public|pure|ref|return|scope|shared|static|struct|switch|synchronized|template|throw|try|typeid|typeof|union|unittest|version|while|with|__gshared|__traits|__vector|__parameters'
   basic_type: 'bool|byte|cdouble|cent|cfloat|char|creal|dchar|double|float|idouble|ifloat|int|ireal|long|real|short|ubyte|ucent|uint|ulong|ushort|void|wchar'
-  builtin_type_alias: 'string|dstring|wstring|size_t|ptrdiff_t'
+  builtin_type_alias: 'string|dstring|wstring|size_t|ptrdiff_t|noreturn'
   language_constant: 'null|true|false|__FILE__|__FILE_FULL_PATH__|__MODULE__|__LINE__|__FUNCTION__|__PRETTY_FUNCTION__|__DATE__|__EOF__|__TIME__|__TIMESTAMP__|__VENDOR__|__VERSION__|__ctfe'
   language_variable: 'this|super'
   reserved: '{{keyword}}|{{basic_type}}|{{language_constant}}|{{language_variable}}'
@@ -1241,11 +1241,11 @@ contexts:
     - match: '\$'
       scope: variable.language.d
       set: value-after
-    - match: '\b({{builtin_type_alias}})\b'
-      scope: storage.type.d support.type.builtin-alias.d
-      set: value-after
     - match: '\b({{basic_type}})\b'
       scope: storage.type.d
+      set: value-after
+    - match: '\b({{builtin_type_alias}})\b'
+      scope: support.type.builtin-alias.d
       set: value-after
     - match: '\b({{name}})\s*(=>)'
       captures:

--- a/D/D.sublime-syntax
+++ b/D/D.sublime-syntax
@@ -1242,7 +1242,7 @@ contexts:
       scope: variable.language.d
       set: value-after
     - match: '\b({{builtin_type_alias}})\b'
-      scope: support.type.d
+      scope: storage.type.d support.type.builtin-alias.d
       set: value-after
     - match: '\b({{basic_type}})\b'
       scope: storage.type.d

--- a/D/D.sublime-syntax
+++ b/D/D.sublime-syntax
@@ -1241,6 +1241,9 @@ contexts:
     - match: '\$'
       scope: variable.language.d
       set: value-after
+    - match: '\b({{builtin_type_alias}})\b'
+      scope: support.type.d
+      set: value-after
     - match: '\b({{basic_type}})\b'
       scope: storage.type.d
       set: value-after

--- a/D/D.sublime-syntax
+++ b/D/D.sublime-syntax
@@ -2239,18 +2239,18 @@ contexts:
       scope: meta.function-call.template.d meta.path.d variable.function.d
       pop: true
     - match: '\b{{builtin_type_alias}}\b'
-      scope: meta.path.d storage.type.d support.type.builtin-alias.d
+      scope: meta.path.d support.type.builtin-alias.d
       set: type-identifier-after
     - match: '\b{{name}}\b'
       scope: meta.path.d storage.type.d
       set: type-identifier-after
     - include: not-whitespace-illegal-pop
   type-identifier-after:
-      - match: \.
-        scope: meta.path.d punctuation.accessor.dot.d
-        set: type-identifier
-      - match: '(?=\S)'
-        pop: true
+    - match: \.
+      scope: meta.path.d punctuation.accessor.dot.d
+      set: type-identifier
+    - match: '(?=\S)'
+      pop: true
   type-identifier-ref:
     - match: \.
       scope: meta.path.d punctuation.accessor.dot.d

--- a/D/D.sublime-syntax
+++ b/D/D.sublime-syntax
@@ -60,7 +60,8 @@ variables:
   construction_lookahead: '(?=~?\s*this\s*\()'
 
   keyword: 'else|enum|export|extern|debug|default|delegate|delete|deprecated|do|body|break|case|cast|catch|class|const|continue|abstract|alias|align|asm|assert|auto|final|finally|for|foreach|foreach_reverse|function|goto|if|immutable|import|in|inout|interface|invariant|is|lazy|macro|mixin|module|new|nothrow|out|override|package|pragma|private|protected|public|pure|ref|return|scope|shared|static|struct|switch|synchronized|template|throw|try|typeid|typeof|union|unittest|version|while|with|__gshared|__traits|__vector|__parameters'
-  basic_type: 'bool|byte|cdouble|cent|cfloat|char|creal|dchar|double|float|idouble|ifloat|int|ireal|long|real|short|ubyte|ucent|uint|ulong|ushort|void|wchar|string|dstring|wstring|size_t|ptrdiff_t'
+  basic_type: 'bool|byte|cdouble|cent|cfloat|char|creal|dchar|double|float|idouble|ifloat|int|ireal|long|real|short|ubyte|ucent|uint|ulong|ushort|void|wchar'
+  builtin_type_alias: 'string|dstring|wstring|size_t|ptrdiff_t'
   language_constant: 'null|true|false|__FILE__|__FILE_FULL_PATH__|__MODULE__|__LINE__|__FUNCTION__|__PRETTY_FUNCTION__|__DATE__|__EOF__|__TIME__|__TIMESTAMP__|__VENDOR__|__VERSION__|__ctfe'
   language_variable: 'this|super'
   reserved: '{{keyword}}|{{basic_type}}|{{language_constant}}|{{language_variable}}'
@@ -2234,15 +2235,19 @@ contexts:
     - match: '\b{{name}}\b(?=\s*!)'
       scope: meta.function-call.template.d meta.path.d variable.function.d
       pop: true
+    - match: '\b{{builtin_type_alias}}\b'
+      scope: meta.path.d storage.type.d support.type.builtin-alias.d
+      set: type-identifier-after
     - match: '\b{{name}}\b'
       scope: meta.path.d storage.type.d
-      set:
-        - match: \.
-          scope: meta.path.d punctuation.accessor.dot.d
-          set: type-identifier
-        - match: '(?=\S)'
-          pop: true
+      set: type-identifier-after
     - include: not-whitespace-illegal-pop
+  type-identifier-after:
+      - match: \.
+        scope: meta.path.d punctuation.accessor.dot.d
+        set: type-identifier
+      - match: '(?=\S)'
+        pop: true
   type-identifier-ref:
     - match: \.
       scope: meta.path.d punctuation.accessor.dot.d

--- a/D/tests/syntax_test_d.d
+++ b/D/tests/syntax_test_d.d
@@ -547,7 +547,7 @@ extern(1)
 //                                         ^ meta.path.d variable.other.d
 //                                          ^ punctuation.terminator.d
   string foo = import("foo.txt");
-//^^^^^^ storage.type.d
+//^^^^^^ storage.type.d support.type.builtin-alias.d
 //       ^^^ variable.other.d
 //           ^ keyword.operator.assignment.d
 //             ^^^^^^ keyword.control.import.d
@@ -915,7 +915,7 @@ extern(1)
 //^^^^^ keyword.declaration.union.d
 //      ^^^^ entity.name.union.d
 //          ^ punctuation.section.group.begin.d
-//           ^^^^^^ storage.type.d
+//           ^^^^^^ storage.type.d support.type.builtin-alias.d
 //                  ^ variable.parameter.d
 //                   ^ punctuation.separator.sequence.d
 //                     ^ variable.parameter.d
@@ -1494,7 +1494,7 @@ extern(1)
 //           ^ keyword.operator.comparison.d
 //             ^^^ storage.type.d
 //                ^ punctuation.separator.sequence.d
-//                  ^^^^^^ storage.type.d
+//                  ^^^^^^ storage.type.d support.type.builtin-alias.d
 //                         ^ variable.parameter.d
 //                           ^ keyword.operator.comparison.d
 //                             ^^^ string.quoted.double.d
@@ -1769,7 +1769,7 @@ extern(1)
   //^^^^^^^^ keyword.declaration.template.d
   //         ^ entity.name.template.d
   //          ^ punctuation.section.group.begin.d
-  //           ^^^^^^ storage.type.d
+  //           ^^^^^^ storage.type.d support.type.builtin-alias.d
   //                  ^ variable.parameter.d
   //                   ^ punctuation.section.group.end.d
   //                     ^ punctuation.section.block.begin.d
@@ -2034,7 +2034,7 @@ extern(1)
   for (size_t i; !val.empty; val.popFront(), ++i) {}
 //^^^ keyword.control.loop.d
 //    ^ punctuation.section.parens.begin.d
-//     ^^^^^^ storage.type.d
+//     ^^^^^^ storage.type.d support.type.builtin-alias.d
 //            ^ variable.other.d
 //             ^ punctuation.terminator.d
 //               ^ keyword.operator.logical.d
@@ -2864,7 +2864,7 @@ extern(1)
 //         ^^^ storage.type.d
 //             ^ variable.parameter.d
 //              ^ punctuation.separator.sequence.d
-//                ^^^^^^ storage.type.d
+//                ^^^^^^ storage.type.d support.type.builtin-alias.d
 //                       ^ variable.parameter.d
 //                        ^ punctuation.section.group.end.d
 //                          ^^^^^^^^^^^ meta.function.d
@@ -2875,7 +2875,7 @@ extern(1)
   function size_t(foo a) {};
 //^^^^^^^^^^^^^^^ meta.function.d
 //^^^^^^^^ keyword.other.d
-//         ^^^^^^ storage.type.d
+//         ^^^^^^ storage.type.d support.type.builtin-alias.d
 //               ^^^^^^^ meta.function.parameters.d
 //               ^ punctuation.section.group.begin.d
 //                ^^^ storage.type.d
@@ -3041,7 +3041,7 @@ extern(1)
 //     ^^^^^^^^^^^ meta.function.d entity.name.function.d
 //                ^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.parameters.d
 //                ^ punctuation.section.group.begin.d
-//                 ^^^^^^ storage.type.d
+//                 ^^^^^^ storage.type.d support.type.builtin-alias.d
 //                        ^ variable.parameter.d
 //                         ^ punctuation.separator.sequence.d
 //                           ^ variable.parameter.d

--- a/D/tests/syntax_test_d.d
+++ b/D/tests/syntax_test_d.d
@@ -547,7 +547,7 @@ extern(1)
 //                                         ^ meta.path.d variable.other.d
 //                                          ^ punctuation.terminator.d
   string foo = import("foo.txt");
-//^^^^^^ storage.type.d support.type.builtin-alias.d
+//^^^^^^ support.type.builtin-alias.d
 //       ^^^ variable.other.d
 //           ^ keyword.operator.assignment.d
 //             ^^^^^^ keyword.control.import.d
@@ -580,7 +580,7 @@ extern(1)
 //            ^^^^^ storage.modifier.d
 //                  ^^^ storage.type.d
 //                     ^ punctuation.section.brackets.begin.d
-//                      ^^^^^^ storage.type.d support.type.builtin-alias.d
+//                      ^^^^^^ support.type.builtin-alias.d
 //                            ^ punctuation.section.brackets.end.d
 //                             ^ punctuation.separator.sequence.d
 //                               ^^^ entity.name.type.d
@@ -599,7 +599,7 @@ extern(1)
 //      ^^^^^ storage.modifier.d
 //            ^^^ storage.type.d
 //               ^ punctuation.section.brackets.begin.d
-//                ^^^^^^ storage.type.d
+//                ^^^^^^ support.type.builtin-alias.d
 //                      ^ punctuation.section.brackets.end.d
 //                        ^^^^^^^^^ entity.name.type.d
 //                                 ^ punctuation.separator.sequence.d
@@ -649,7 +649,7 @@ extern(1)
   foo[string] b = 123;
 //^^^ storage.type.d
 //   ^ punctuation.section.brackets.begin.d
-//    ^^^^^^ storage.type.d
+//    ^^^^^^ support.type.builtin-alias.d
 //          ^ punctuation.section.brackets.end.d
 //            ^ variable.other.d
 //              ^ keyword.operator.assignment.d
@@ -915,7 +915,7 @@ extern(1)
 //^^^^^ keyword.declaration.union.d
 //      ^^^^ entity.name.union.d
 //          ^ punctuation.section.group.begin.d
-//           ^^^^^^ storage.type.d support.type.builtin-alias.d
+//           ^^^^^^ support.type.builtin-alias.d
 //                  ^ variable.parameter.d
 //                   ^ punctuation.separator.sequence.d
 //                     ^ variable.parameter.d
@@ -959,7 +959,7 @@ extern(1)
 //     ^ punctuation.separator.mapping.d
 //       ^^^ storage.type.d
 //          ^ punctuation.section.brackets.begin.d
-//           ^^^^^^ storage.type.d
+//           ^^^^^^ support.type.builtin-alias.d
 //                 ^ punctuation.section.brackets.end.d
 //                   ^ punctuation.section.block.begin.d
 //                     ^^^^ entity.name.constant.d
@@ -1241,7 +1241,7 @@ extern(1)
   int[string] foo() {}
 //^^^ storage.type.d
 //   ^ punctuation.section.brackets.begin.d
-//    ^^^^^^ storage.type.d
+//    ^^^^^^ support.type.builtin-alias.d
 //          ^ punctuation.section.brackets.end.d
 //            ^^^ meta.function.d entity.name.function.d
 //               ^^ meta.function.parameters.d
@@ -1344,7 +1344,7 @@ extern(1)
 //       ^ variable.parameter.d
 //        ^^^ keyword.operator.variadic.d
 //           ^ punctuation.separator.sequence.d
-//             ^^^^^^ storage.type.d
+//             ^^^^^^ support.type.builtin-alias.d
 //                   ^ punctuation.section.brackets.begin.d
 //                    ^ punctuation.section.brackets.end.d
 //                      ^ variable.parameter.d
@@ -1462,7 +1462,7 @@ extern(1)
   const(string) foo(T)(ref const(int) a, auto ref T b) {}
 //^^^^^ storage.modifier.d
 //     ^ punctuation.section.group.begin.d
-//      ^^^^^^ storage.type.d
+//      ^^^^^^ support.type.builtin-alias.d
 //            ^ punctuation.section.group.end.d
 //              ^^^ meta.function.d entity.name.function.d
 //                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.parameters.d
@@ -1494,7 +1494,7 @@ extern(1)
 //           ^ keyword.operator.comparison.d
 //             ^^^ storage.type.d
 //                ^ punctuation.separator.sequence.d
-//                  ^^^^^^ storage.type.d support.type.builtin-alias.d
+//                  ^^^^^^ support.type.builtin-alias.d
 //                         ^ variable.parameter.d
 //                           ^ keyword.operator.comparison.d
 //                             ^^^ string.quoted.double.d
@@ -1769,7 +1769,7 @@ extern(1)
   //^^^^^^^^ keyword.declaration.template.d
   //         ^ entity.name.template.d
   //          ^ punctuation.section.group.begin.d
-  //           ^^^^^^ storage.type.d support.type.builtin-alias.d
+  //           ^^^^^^ support.type.builtin-alias.d
   //                  ^ variable.parameter.d
   //                   ^ punctuation.section.group.end.d
   //                     ^ punctuation.section.block.begin.d
@@ -2034,7 +2034,7 @@ extern(1)
   for (size_t i; !val.empty; val.popFront(), ++i) {}
 //^^^ keyword.control.loop.d
 //    ^ punctuation.section.parens.begin.d
-//     ^^^^^^ storage.type.d support.type.builtin-alias.d
+//     ^^^^^^ support.type.builtin-alias.d
 //            ^ variable.other.d
 //             ^ punctuation.terminator.d
 //               ^ keyword.operator.logical.d
@@ -2251,7 +2251,7 @@ extern(1)
 //             ^ punctuation.separator.sequence.d
 //               ^^^^^ string.quoted.double.d
 //                    ^ punctuation.section.parens.end.d
-//                      ^^^^^^ storage.type.d
+//                      ^^^^^^ support.type.builtin-alias.d
 //                            ^ punctuation.section.brackets.begin.d
 //                             ^^ meta.number.integer.decimal.d
 //                               ^ punctuation.section.brackets.end.d
@@ -2282,7 +2282,7 @@ extern(1)
 //        ^ punctuation.separator.sequence.d
 //          ^ meta.number.integer.decimal.d
 //           ^ punctuation.section.parens.end.d
-//             ^^^^^^ storage.type.d
+//             ^^^^^^ support.type.builtin-alias.d
 //                   ^ punctuation.section.brackets.begin.d
 //                    ^^ meta.number.integer.decimal.d
 //                      ^ punctuation.section.brackets.end.d
@@ -2499,7 +2499,7 @@ extern(1)
 //                    ^ punctuation.terminator.d
 
   string[] f = [
-//^^^^^^ storage.type.d
+//^^^^^^ support.type.builtin-alias.d
 //      ^ punctuation.section.brackets.begin.d
 //       ^ punctuation.section.brackets.end.d
 //         ^ variable.other.d
@@ -2864,7 +2864,7 @@ extern(1)
 //         ^^^ storage.type.d
 //             ^ variable.parameter.d
 //              ^ punctuation.separator.sequence.d
-//                ^^^^^^ storage.type.d support.type.builtin-alias.d
+//                ^^^^^^ support.type.builtin-alias.d
 //                       ^ variable.parameter.d
 //                        ^ punctuation.section.group.end.d
 //                          ^^^^^^^^^^^ meta.function.d
@@ -2875,7 +2875,7 @@ extern(1)
   function size_t(foo a) {};
 //^^^^^^^^^^^^^^^ meta.function.d
 //^^^^^^^^ keyword.other.d
-//         ^^^^^^ storage.type.d support.type.builtin-alias.d
+//         ^^^^^^ support.type.builtin-alias.d
 //               ^^^^^^^ meta.function.parameters.d
 //               ^ punctuation.section.group.begin.d
 //                ^^^ storage.type.d
@@ -3041,7 +3041,7 @@ extern(1)
 //     ^^^^^^^^^^^ meta.function.d entity.name.function.d
 //                ^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.parameters.d
 //                ^ punctuation.section.group.begin.d
-//                 ^^^^^^ storage.type.d support.type.builtin-alias.d
+//                 ^^^^^^ support.type.builtin-alias.d
 //                        ^ variable.parameter.d
 //                         ^ punctuation.separator.sequence.d
 //                           ^ variable.parameter.d

--- a/D/tests/syntax_test_d.d
+++ b/D/tests/syntax_test_d.d
@@ -580,7 +580,7 @@ extern(1)
 //            ^^^^^ storage.modifier.d
 //                  ^^^ storage.type.d
 //                     ^ punctuation.section.brackets.begin.d
-//                      ^^^^^^ storage.type.d
+//                      ^^^^^^ storage.type.d support.type.builtin-alias.d
 //                            ^ punctuation.section.brackets.end.d
 //                             ^ punctuation.separator.sequence.d
 //                               ^^^ entity.name.type.d

--- a/D/tests/syntax_test_old.d
+++ b/D/tests/syntax_test_old.d
@@ -46,7 +46,7 @@ template testTemplate(X)
     {
         enum test = true;
         string g = "test";
-        // ^ storage.type
+        // ^ support.type.builtin-alias.d
     }
     else
         enum test = false;


### PR DESCRIPTION
Changes:
- Separated built-in type-aliases (e.g. `size_t`, `string`) from built-in types (e.g. `int`, `float`) so that their identifiers aren't treated as reserved (they aren't, e.g. you can make your own `string`), and so that they can be highlighted separately.