### PR TITLE
[D] Add shortened function definition (#3894)

### DIFF
--- a/D/D.sublime-syntax
+++ b/D/D.sublime-syntax
@@ -916,7 +916,7 @@ contexts:
   function-definition-after-arguments:
     - meta_scope: meta.function.d
     - include: function-attribute-in
-    - match: '='
+    - match: '=(?!>)'
       scope: keyword.operator.assignment.d
       set: [meta-function, expect-end-of-line, value]
     - match: '\bif\b'
@@ -939,6 +939,9 @@ contexts:
     - match: '\b(do|body)\b'
       scope: keyword.other.d
       set: block-statement
+    - match: '=>'
+      scope: keyword.declaration.function.d
+      set: [meta-function, expect-end-of-line, value]
     - match: '{{block_statement_loohahead}}'
       set: block-statement
     - include: expect-end-of-line

--- a/D/tests/syntax_test_d.d
+++ b/D/tests/syntax_test_d.d
@@ -1250,6 +1250,32 @@ extern(1)
 //                  ^^ meta.function.d meta.block.d
 //                  ^ punctuation.section.block.begin.d
 //                   ^ punctuation.section.block.end.d
+  int boo() => 5;
+//^^^ storage.type.d
+//    ^^^ meta.function.d entity.name.function.d
+//       ^^ meta.function.parameters.d
+//       ^ punctuation.section.group.begin.d
+//        ^ punctuation.section.group.end.d
+//          ^^ meta.function.d keyword.declaration.function.d
+//             ^ meta.number.integer.decimal.d
+//              ^ meta.function.d punctuation.terminator.d
+  int par(T)() if(true) => 7;
+//^^^ storage.type.d
+//    ^^^ meta.function.d entity.name.function.d
+//       ^^^^^ meta.function.parameters.d
+//       ^ punctuation.section.group.begin.d
+//        ^ variable.parameter.d
+//         ^ punctuation.section.group.end.d
+//          ^ punctuation.section.group.begin.d
+//           ^ punctuation.section.group.end.d
+//             ^^^^^^^^^^^^^ meta.function.d
+//             ^^ keyword.control.conditional.d
+//               ^ punctuation.section.parens.begin.d
+//                ^^^^ constant.language.d
+//                    ^ punctuation.section.parens.end.d
+//                      ^^ meta.function.d keyword.declaration.function.d
+//                         ^ meta.number.integer.decimal.d
+//                          ^ meta.function.d punctuation.terminator.d
     void bar();
   //^^^^ storage.type.d
   //     ^^^ meta.function.d entity.name.function.d


### PR DESCRIPTION
Fixes #3894.
Changes:
- Support shortened function definition syntax (e.g. `int main() => 0;`) in all its forms:
  - plain functions;
  - functions with one-line pre/postconditions;
  - template functions with template constraints.