### PR TITLE
[Markdown] Fix backticks and code-spans in table cells

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -126,6 +126,12 @@ variables:
     | (?! \s*\-\s+ | \s+\|){{table_cell}}\|(?!\s+$)
     )
 
+  table_codespan_content: |-
+    (?x:
+      [^`|]             # first or only char must not be a backtick or pipe.
+      (?:[^|]*[^`|])?   # none must be a pipe, the last additionally must not be a backtick
+    )
+
   fenced_code_block_start: |-
     (?x:
       ([ \t]*)
@@ -2376,11 +2382,39 @@ contexts:
     - include: markups
 
   table-cell-code-spans:
-    - match: (`+)[^`|]+(\1)
+    # code-spans quoted with up to 6 backticks are supported
+    # to avoid usage of slower Oniguruma features
+    - match: (`{6}){{table_codespan_content}}(`{6})(?!`)
       scope: markup.raw.inline.markdown
       captures:
         1: punctuation.definition.raw.begin.markdown
         2: punctuation.definition.raw.end.markdown
+    - match: (`{5}){{table_codespan_content}}(`{5})(?!`)
+      scope: markup.raw.inline.markdown
+      captures:
+        1: punctuation.definition.raw.begin.markdown
+        2: punctuation.definition.raw.end.markdown
+    - match: (`{4}){{table_codespan_content}}(`{4})(?!`)
+      scope: markup.raw.inline.markdown
+      captures:
+        1: punctuation.definition.raw.begin.markdown
+        2: punctuation.definition.raw.end.markdown
+    - match: (`{3}){{table_codespan_content}}(`{3})(?!`)
+      scope: markup.raw.inline.markdown
+      captures:
+        1: punctuation.definition.raw.begin.markdown
+        2: punctuation.definition.raw.end.markdown
+    - match: (`{2}){{table_codespan_content}}(`{2})(?!`)
+      scope: markup.raw.inline.markdown
+      captures:
+        1: punctuation.definition.raw.begin.markdown
+        2: punctuation.definition.raw.end.markdown
+    - match: (`{1}){{table_codespan_content}}(`{1})(?!`)
+      scope: markup.raw.inline.markdown
+      captures:
+        1: punctuation.definition.raw.begin.markdown
+        2: punctuation.definition.raw.end.markdown
+    - match: \`+  # consume remainers
 
   table-cell-emphasis:
     - include: emphasis

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -2366,13 +2366,21 @@ contexts:
   table-cell-content:
     - match: (?={{balanced_emphasis}})
       push: table-cell-emphasis
-    - match: (?!{{backticks}})`+
-      scope: invalid.deprecated.unescaped-backticks.markdown
+    - include: table-cell-code-spans
     - include: table-cell-separators
     - include: images
-    - include: literals
+    - include: critics
+    - include: math-inline
+    - include: escapes
     - include: links
     - include: markups
+
+  table-cell-code-spans:
+    - match: (`+)[^`|]+(\1)
+      scope: markup.raw.inline.markdown
+      captures:
+        1: punctuation.definition.raw.begin.markdown
+        2: punctuation.definition.raw.end.markdown
 
   table-cell-emphasis:
     - include: emphasis

--- a/Markdown/tests/syntax_test_markdown.md
+++ b/Markdown/tests/syntax_test_markdown.md
@@ -3178,8 +3178,9 @@ bar | baz
 | f\|oo  |
 | ------ |
 | b `|` az |
-|   ^^^ meta.table markup.raw.inline - meta.table.header-separator
-|          ^ meta.table punctuation.separator.table-cell
+|^^^^^^^^^^^ meta.table.markdown-gfm - markup.raw
+|    ^ punctuation.separator.table-cell.markdown
+|          ^ punctuation.separator.table-cell.markdown
 | b **|** im |
 | <- meta.table punctuation.separator.table-cell
 |   ^^^^^ meta.table markup.bold - punctuation.separator.table-cell
@@ -3248,8 +3249,17 @@ not a table |
 |      ^ punctuation.separator.table-cell
 |           ^ punctuation.separator.table-cell
 |`test | me |
-|^ invalid.deprecated.unescaped-backticks
+|^^^^^^^^^^^^^ meta.table.markdown-gfm - markup.raw
 |      ^ punctuation.separator.table-cell
+| ` ` | ` me ` |
+| <- meta.table.markdown-gfm punctuation.separator.table-cell.markdown
+| ^^^ meta.table.markdown-gfm markup.raw.inline.markdown
+| ^ punctuation.definition.raw.begin.markdown
+|   ^ punctuation.definition.raw.end.markdown
+|     ^ punctuation.separator.table-cell
+|       ^^^^^^ markup.raw.inline.markdown
+|       ^ punctuation.definition.raw.begin.markdown
+|            ^ punctuation.definition.raw.end.markdown
 
 | table | followed by
 paragraph

--- a/Markdown/tests/syntax_test_markdown.md
+++ b/Markdown/tests/syntax_test_markdown.md
@@ -3195,6 +3195,46 @@ test
 > bar
 | <- markup.quote punctuation.definition.blockquote - meta.table
 
+| c1  |  c2    | c3      | c4     | c5          | c6       | c7
+| --- | ---    | ---     | ---    | ---         | ---      | ---
+| ` ` | ` me ` | `` ` `` | ` `` ` | ``foo`bar`` | ```foo`` | ``foo```
+| <- meta.table.markdown-gfm punctuation.separator.table-cell.markdown
+| ^^^ meta.table.markdown-gfm markup.raw.inline.markdown
+| ^ punctuation.definition.raw.begin.markdown
+|   ^ punctuation.definition.raw.end.markdown
+|     ^ punctuation.separator.table-cell
+|       ^^^^^^ markup.raw.inline.markdown
+|       ^ punctuation.definition.raw.begin.markdown
+|            ^ punctuation.definition.raw.end.markdown
+|                ^^^^^^^ markup.raw.inline.markdown
+|                ^^ punctuation.definition.raw.begin.markdown
+|                  ^^^ - punctuation
+|                     ^^ punctuation.definition.raw.end.markdown
+|                        ^ punctuation.separator.table-cell
+|                          ^^^^^^ markup.raw.inline.markdown
+|                          ^ punctuation.definition.raw.begin.markdown
+|                           ^^^^ - punctuation
+|                               ^ punctuation.definition.raw.end.markdown
+|                                 ^ punctuation.separator.table-cell
+|                                   ^^^^^^^^^^^ markup.raw.inline.markdown
+|                                   ^^ punctuation.definition.raw.begin.markdown
+|                                     ^^^^^^^ - punctuation
+|                                            ^^ punctuation.definition.raw.end.markdown
+|                                               ^ punctuation.separator.table-cell
+|                                                 ^^^^^^^^ - markup.raw
+
+| c1             |  c2                 |
+| ---            | ---                 |
+| ```` ``` ````  | `````` ````` `````` |
+| ^^^^^^^^^^^^^ markup.raw.inline.markdown
+| ^^^^ punctuation.definition.raw.begin.markdown
+|     ^^^^^ - punctuation
+|          ^^^^ punctuation.definition.raw.end.markdown
+|                  ^^^^^^^^^^^^^^^^^^^ markup.raw.inline.markdown
+|                  ^^^^^^ punctuation.definition.raw.begin.markdown
+|                        ^^^^^^^ - punctuation
+|                               ^^^^^^ punctuation.definition.raw.end.markdown
+
 `|` this `|` example `|` is not a table `|`
 | ^ punctuation.definition.raw.end - meta.table
 | nor is this | because it is not at block level, it immediately follows a paragraph |
@@ -3251,15 +3291,6 @@ not a table |
 |`test | me |
 |^^^^^^^^^^^^^ meta.table.markdown-gfm - markup.raw
 |      ^ punctuation.separator.table-cell
-| ` ` | ` me ` |
-| <- meta.table.markdown-gfm punctuation.separator.table-cell.markdown
-| ^^^ meta.table.markdown-gfm markup.raw.inline.markdown
-| ^ punctuation.definition.raw.begin.markdown
-|   ^ punctuation.definition.raw.end.markdown
-|     ^ punctuation.separator.table-cell
-|       ^^^^^^ markup.raw.inline.markdown
-|       ^ punctuation.definition.raw.begin.markdown
-|            ^ punctuation.definition.raw.end.markdown
 
 | table | followed by
 paragraph


### PR DESCRIPTION
Fixes #3968

This commit...

1. removes `invalid.deprecated` scope from single backticks in table cells
2. fixes code spans treatment in tables. Codespans require balanced backticks in a single line not containing a `|` cell separator are found.