### PR TITLE
[D] Update keywords, attributes, and operator overloads

### DIFF
--- a/D/D.sublime-syntax
+++ b/D/D.sublime-syntax
@@ -59,13 +59,13 @@ variables:
 
   construction_lookahead: '(?=~?\s*this\s*\()'
 
-  keyword: 'else|enum|export|extern|debug|default|delegate|delete|deprecated|do|body|break|case|cast|catch|class|const|continue|abstract|alias|align|asm|assert|auto|final|finally|for|foreach|foreach_reverse|function|goto|if|immutable|import|in|inout|interface|invariant|is|lazy|macro|mixin|module|new|nothrow|out|override|package|pragma|private|protected|public|pure|ref|return|scope|shared|static|struct|switch|synchronized|template|throw|try|typeid|typeof|union|unittest|version|while|with|__gshared|__traits|__vector|__parameters'
+  keyword: 'else|enum|export|extern|debug|default|delegate|delete|deprecated|do|break|case|cast|catch|class|const|continue|abstract|alias|align|asm|assert|auto|final|finally|for|foreach|foreach_reverse|function|goto|if|immutable|import|in|inout|interface|invariant|is|lazy|macro|mixin|module|new|nothrow|out|override|package|pragma|private|protected|public|pure|ref|return|scope|shared|static|struct|switch|synchronized|template|throw|try|typeid|typeof|union|unittest|version|while|with|__gshared|__traits|__vector|__parameters'
   basic_type: 'bool|byte|cdouble|cent|cfloat|char|creal|dchar|double|float|idouble|ifloat|int|ireal|long|real|short|ubyte|ucent|uint|ulong|ushort|void|wchar|string|dstring|wstring|size_t|ptrdiff_t'
   language_constant: 'null|true|false|__FILE__|__FILE_FULL_PATH__|__MODULE__|__LINE__|__FUNCTION__|__PRETTY_FUNCTION__|__DATE__|__EOF__|__TIME__|__TIMESTAMP__|__VENDOR__|__VERSION__|__ctfe'
   language_variable: 'this|super'
   reserved: '{{keyword}}|{{basic_type}}|{{language_constant}}|{{language_variable}}'
 
-  operator_overloads: 'opNeg|opCom|opPostInc|opPostDec|opCast|opAdd|opSub|opSub_r|opMul|opDiv|opDiv_r|opMod|opMod_r|opAnd|opOr|opXor|opShl|opShl_r|opShr|opShr_r|opUShr|opUShr_r|opCat|opCat_r|opEquals|opEquals|opCmp|opCmp|opCmp|opCmp|opAddAssign|opSubAssign|opMulAssign|opDivAssign|opModAssign|opAndAssign|opOrAssign|opXorAssign|opShlAssign|opShrAssign|opUShrAssign|opCatAssign|opIndex|opIndexAssign|opCall|opSlice|opSliceAssign|opPos|opAdd_r|opMul_r|opAnd_r|opOr_r|opXor_r'
+  operator_overloads: 'opAssign|opBinary|opBinaryRight|opCall|opCast|opCmp|opDispatch|opDollar|opEquals|opIndex|opIndexAssign|opIndexOpAssign|opOpAssign|opSlice|opSliceAssign|opUnary'
 
   block_statement_loohahead: '(?={)'
 
@@ -936,7 +936,7 @@ contexts:
     - match: '\bout\b'
       scope: keyword.control.conditional.d
       push: function-out-contract
-    - match: '\b(do|body)\b'
+    - match: '\b(do)\b'
       scope: keyword.other.d
       set: block-statement
     - match: '{{block_statement_loohahead}}'

--- a/D/D.sublime-syntax
+++ b/D/D.sublime-syntax
@@ -936,7 +936,7 @@ contexts:
     - match: '\bout\b'
       scope: keyword.control.conditional.d
       push: function-out-contract
-    - match: '\b(do)\b'
+    - match: '\b(do|body)\b'
       scope: keyword.other.d
       set: block-statement
     - match: '{{block_statement_loohahead}}'

--- a/D/D.sublime-syntax
+++ b/D/D.sublime-syntax
@@ -52,7 +52,7 @@ variables:
   type_qualifier_lookahead: '(?=\b({{type_qualifier}})\b)'
   attribute_lookahead: '(?=@|\b({{attributes}}|extern|align|deprecated|pragma|private|protected|public|export|package)\b)'
   attributes: 'static|abstract|final|override|synchronized|scope|__gshared|nothrow|pure|ref|return|auto'
-  at_attributes: 'disable|nogc|property|safe|system|trusted'
+  at_attributes: 'disable|live|mustuse|nogc|property|safe|system|trusted'
   function_attribute_lookahead: '{{attribute_lookahead}}|{{type_qualifier_lookahead}}'
   parameter_attribute_lookahead: '(?=\b({{parameter_attribute}})\b)'
   parameter_attribute: 'in|lazy|out|alias'

--- a/D/D.sublime-syntax
+++ b/D/D.sublime-syntax
@@ -52,7 +52,7 @@ variables:
   type_qualifier_lookahead: '(?=\b({{type_qualifier}})\b)'
   attribute_lookahead: '(?=@|\b({{attributes}}|extern|align|deprecated|pragma|private|protected|public|export|package)\b)'
   attributes: 'static|abstract|final|override|synchronized|scope|__gshared|nothrow|pure|ref|return|auto'
-  at_attributes: 'disable|live|mustuse|nogc|property|safe|system|trusted'
+  at_attributes: 'disable|gnuAbiTag|live|mustuse|nogc|optional|property|safe|selector|standalone|system|trusted|weak'
   function_attribute_lookahead: '{{attribute_lookahead}}|{{type_qualifier_lookahead}}'
   parameter_attribute_lookahead: '(?=\b({{parameter_attribute}})\b)'
   parameter_attribute: 'in|lazy|out|alias'

--- a/D/tests/syntax_test_d.d
+++ b/D/tests/syntax_test_d.d
@@ -1632,9 +1632,9 @@ extern(1)
   //      ^ punctuation.terminator.d
   }
 //^ meta.function.d meta.block.d punctuation.section.block.end.d
-  body {
-//^^^^ keyword.other.d
-//     ^ punctuation.section.block.begin.d
+  do {
+//^^ keyword.other.d
+//   ^ punctuation.section.block.begin.d
   }
   void f()
 //^^^^ storage.type.d

--- a/D/tests/syntax_test_old.d
+++ b/D/tests/syntax_test_old.d
@@ -100,9 +100,9 @@ void main(char[][] args)
         //                       ^ meta.block - keyword.type
         assert(result.allocated > 0);
     }
-    body {
-    // ^ meta.block keyword.other
-    //   ^ meta.block meta.block
+    do {
+  //^^ meta.block keyword.other
+  //   ^ meta.block meta.block
         specs* s = new specs;
          s.count = args.length;
          s.allocated = typeof(args).sizeof;

--- a/D/tests/syntax_test_old.d
+++ b/D/tests/syntax_test_old.d
@@ -100,9 +100,9 @@ void main(char[][] args)
         //                       ^ meta.block - keyword.type
         assert(result.allocated > 0);
     }
-    do {
-  //^^ meta.block keyword.other
-  //   ^ meta.block meta.block
+    body {
+    // ^ meta.block keyword.other
+    //   ^ meta.block meta.block
         specs* s = new specs;
          s.count = args.length;
          s.allocated = typeof(args).sizeof;


### PR DESCRIPTION
Changes:
- Removed `body` from `keywords` and as an alternative to `do` in function contracts because it is no longer a keyword, and no longer acts as an alternative to `do` in function contracts.
- Added the missing [`@gnuAbiTag`](https://dlang.org/phobos/core_attribute.html#.gnuAbiTag), [`@live`](https://dlang.org/spec/ob.html#live), [`@mustuse`](https://dlang.org/spec/attribute.html#mustuse-attribute), [`@optional`](https://dlang.org/spec/objc_interface.html#optional-attribute), [`@standalone`](https://dlang.org/changelog/2.107.0.html#dmd.standalone-attribute), and [`@weak`](https://dlang.org/phobos/core_attribute.html#.weak) attributes to `at_attributes`.
- Removed [D1 operator overloads](https://digitalmars.com/d/1.0/operatoroverloading.html) from `operator_overloads` because they have [not been supported](https://dlang.org/spec/operatoroverloading.html#old-style) for a very long time now.
- Added [missing operator overloads](https://dlang.org/spec/operatoroverloading.html) to `operator_overloads`.