### PR TITLE
[D] Fix shortened function definitions

### DIFF
--- a/D/D.sublime-syntax
+++ b/D/D.sublime-syntax
@@ -909,21 +909,20 @@ contexts:
     - match: '(?=\()'
       set: [function-definition-before-after-arguments, function-argument-definition-list]
     - match: '(?=\S)'
-      set: function-definition-after-arguments
+      set: [meta-function, function-definition-after-arguments]
   function-definition-before-after-arguments:
     - match: ''
-      set: function-definition-after-arguments
+      set: [meta-function, function-definition-after-arguments]
   function-definition-after-arguments:
-    - meta_scope: meta.function.d
     - include: function-attribute-in
     - match: '=(?!>)'
       scope: keyword.operator.assignment.d
-      set: [meta-function, expect-end-of-line, value]
+      set: [expect-end-of-line, value]
     - match: '\bif\b'
       scope: keyword.control.conditional.d
-      set: [meta-function, function-definition-after-condition, condition]
+      set: [function-definition-after-condition, condition]
     - match: '(?=\S)'
-      set: [meta-function, function-definition-after-condition]
+      set: [function-definition-after-condition]
   function-definition-after-condition:
     - match: '\bin\b'
       scope: keyword.control.conditional.d
@@ -941,7 +940,7 @@ contexts:
       set: block-statement
     - match: '=>'
       scope: keyword.declaration.function.d
-      set: [meta-function, expect-end-of-line, value]
+      set: [expect-end-of-line, value]
     - match: '{{block_statement_loohahead}}'
       set: block-statement
     - include: expect-end-of-line
@@ -1853,17 +1852,19 @@ contexts:
       push: construction
   construction:
     # Post-blit constructor
-    - match: '\b(this)\s*(\()\s*(this)\s*(\))'
+    - match: '\b((this)\s*)((\()\s*(this)\s*(\)))'
       captures:
-        1: meta.function.d entity.name.function.post-blit.d
-        2: meta.function.parameters.d punctuation.section.group.begin.d
-        3: meta.function.parameters.d variable.language.d
-        4: meta.function.parameters.d punctuation.section.group.end.d
-      set: function-definition-after-arguments
+        1: meta.function.d
+        2: entity.name.function.post-blit.d
+        3: meta.function.parameters.d
+        4: punctuation.section.group.begin.d
+        5: variable.language.d
+        6: punctuation.section.group.end.d
+      set: function-definition-before-after-arguments
     - match: '\b(this)\s*(?=\(|$)'
+      scope: meta.function.d
       captures:
-        1: meta.function.d entity.name.function.constructor.d
-        2: punctuation.section.group.begin.d
+        1: entity.name.function.constructor.d
       set: constructor-argument-list
     - match: '~\s*this'
       scope: meta.function.d entity.name.function.destructor.d
@@ -1872,7 +1873,6 @@ contexts:
   # This could either be function/template parameters or arguments. Assume
   # arguments and switch to parameters when possible
   constructor-argument-list:
-    - meta_scope: meta.function.parameters.d
     - match: '\('
       scope: punctuation.section.group.begin.d
       set:
@@ -1881,12 +1881,12 @@ contexts:
           scope: punctuation.section.group.end.d
           set: function-definition-after-first-argument-list
         - match: '{{parameter_attribute_lookahead}}'
-          set: [function-definition-after-first-argument-list, meta-function-parameters, function-argument-definition-list-content]
+          set: [function-definition-after-first-argument-list, function-argument-definition-list-content]
         - match: '(?=\S)'
           set: [constructor-argument-list-after-value, value]
     - include: not-whitespace-illegal-pop
   constructor-argument-list-after-value:
-    - meta_scope: meta.function.parameters.d
+    - meta_content_scope: meta.function.parameters.d
     - match: ','
       scope: punctuation.separator.sequence.d
       set: [constructor-argument-list-after-value, value]
@@ -1897,12 +1897,12 @@ contexts:
       set: [function-definition-after-first-argument-list, meta-function-parameters, function-argument, function-argument-or-type]
   destructor-arguments:
     - match: '\('
-      scope: meta.function.parameters.d punctuation.section.group.begin.d
+      scope: punctuation.section.group.begin.d
       set:
         - meta_scope: meta.function.parameters.d
         - match: '\)'
           scope: punctuation.section.group.end.d
-          set: function-definition-after-arguments
+          set: function-definition-before-after-arguments
         - include: not-whitespace-illegal-pop
     - include: not-whitespace-illegal-pop
 

--- a/D/D.sublime-syntax
+++ b/D/D.sublime-syntax
@@ -916,7 +916,7 @@ contexts:
   function-definition-after-arguments:
     - meta_scope: meta.function.d
     - include: function-attribute-in
-    - match: '='
+    - match: '=(?!>)'
       scope: keyword.operator.assignment.d
       set: [meta-function, expect-end-of-line, value]
     - match: '\bif\b'
@@ -939,6 +939,9 @@ contexts:
     - match: '\b(do|body)\b'
       scope: keyword.other.d
       set: block-statement
+    - match: '=>'
+      scope: keyword.declaration.function.d
+      set: [meta-function, expect-end-of-line, value]
     - match: '{{block_statement_loohahead}}'
       set: block-statement
     - include: expect-end-of-line

--- a/D/tests/syntax_test_d.d
+++ b/D/tests/syntax_test_d.d
@@ -1250,6 +1250,32 @@ extern(1)
 //                  ^^ meta.function.d meta.block.d
 //                  ^ punctuation.section.block.begin.d
 //                   ^ punctuation.section.block.end.d
+  int boo() => 5;
+//^^^ storage.type.d
+//    ^^^ meta.function.d entity.name.function.d
+//       ^^ meta.function.parameters.d
+//       ^ punctuation.section.group.begin.d
+//        ^ punctuation.section.group.end.d
+//          ^^ meta.function.d keyword.declaration.function.d
+//             ^ meta.number.integer.decimal.d
+//              ^ meta.function.d punctuation.terminator.d
+  int par(T)() if(true) => 7;
+//^^^ storage.type.d
+//    ^^^ meta.function.d entity.name.function.d
+//       ^^^^^ meta.function.parameters.d
+//       ^ punctuation.section.group.begin.d
+//        ^ variable.parameter.d
+//         ^ punctuation.section.group.end.d
+//          ^ punctuation.section.group.begin.d
+//           ^ punctuation.section.group.end.d
+//             ^^^^^^^^^^^^^ meta.function.d
+//             ^^ keyword.control.conditional.d
+//               ^ punctuation.section.parens.begin.d
+//                ^^^^ constant.language.d
+//                    ^ punctuation.section.parens.end.d
+//                      ^^ meta.function.d keyword.declaration.function.d
+//                         ^ meta.number.integer.decimal.d
+//                          ^ meta.function.d punctuation.terminator.d
     void bar();
   //^^^^ storage.type.d
   //     ^^^ meta.function.d entity.name.function.d

--- a/D/tests/syntax_test_d.d
+++ b/D/tests/syntax_test_d.d
@@ -1252,6 +1252,7 @@ extern(1)
 //                   ^ punctuation.section.block.end.d
 
   int boo() => 5;
+//^^^^^^^^^^^^^^^ - meta.function meta.function
 //^^^ storage.type.d
 //    ^^^ meta.function.d entity.name.function.d
 //       ^^ meta.function.parameters.d
@@ -1262,6 +1263,7 @@ extern(1)
 //              ^ meta.function.d punctuation.terminator.d
 
   int par(T)() if(true) => 7;
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.function meta.function
 //^^^ storage.type.d
 //    ^^^ meta.function.d entity.name.function.d
 //       ^^^^^ meta.function.parameters.d
@@ -1281,6 +1283,7 @@ extern(1)
 
   // shortened function with InContractExpression
   int par(int T) in(T) => 7;
+//^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.function meta.function
 //^^^ storage.type.d
 //    ^^^ meta.function.d entity.name.function.d
 //       ^^^^^^^ meta.function.parameters.d
@@ -1295,6 +1298,7 @@ extern(1)
 
   // shortened function with OutContractExpression
   int par(int T) out(;) => 7;
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.function meta.function
 //^^^ storage.type.d
 //    ^^^ meta.function.d entity.name.function.d
 //       ^^^^^^^ meta.function.parameters.d
@@ -1309,6 +1313,7 @@ extern(1)
 
   // shortened function with OutContractExpression
   int par(int T) out(; arg) => 7;
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.function meta.function
 //^^^ storage.type.d
 //    ^^^ meta.function.d entity.name.function.d
 //       ^^^^^^^ meta.function.parameters.d
@@ -1324,6 +1329,7 @@ extern(1)
 
   // No shortened function due to OutStatement `out(...)`
   int par(int T) out(T) => 7;
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.function meta.function
 //^^^ storage.type.d
 //    ^^^ meta.function.d entity.name.function.d
 //       ^^^^^^^ meta.function.parameters.d
@@ -1344,6 +1350,7 @@ extern(1)
 //         ^ punctuation.section.group.end.d
 //          ^ meta.function.d punctuation.terminator.d
   int[] map(int[] array, ) {
+//^^^^^^^^^^^^^^^^^^^^^^^^ - meta.function meta.function
 //^^^ storage.type.d
 //   ^ punctuation.section.brackets.begin.d
 //    ^ punctuation.section.brackets.end.d
@@ -1363,6 +1370,7 @@ extern(1)
 }
 // <- meta.function.d meta.block.d punctuation.section.block.end.d
   T[] map(T, void fn)(T[] array) {
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.function meta.function
 //^ storage.type.d
 // ^ punctuation.section.brackets.begin.d
 //  ^ punctuation.section.brackets.end.d
@@ -1713,6 +1721,7 @@ extern(1)
 //           ^ punctuation.terminator.d
 
   this(int foo) {
+//^^^^^^^^^^^^^^^ - meta.function meta.function
 //^^^^ meta.function.d entity.name.function.constructor.d
 //    ^^^^^^^^^ meta.function.parameters.d
 //    ^ punctuation.section.group.begin.d
@@ -1723,6 +1732,7 @@ extern(1)
   }
 //^ meta.function.d meta.block.d punctuation.section.block.end.d
   ~this() @disable;
+//^^^^^^^^^^^^^^^^^ - meta.function meta.function
 //^^^^^ meta.function.d entity.name.function.destructor.d
 //     ^^ meta.function.parameters.d
 //     ^ punctuation.section.group.begin.d
@@ -1731,15 +1741,17 @@ extern(1)
 //        ^^^^^^^^ storage.modifier.d
 //                ^ punctuation.terminator.d
   this(this) {}
-//^^^^ meta.function.d entity.name.function.post-blit.d
-//    ^^^^^^ meta.function.d meta.function.parameters.d
+//^^^^^^^^^^^^^ meta.function - meta.function meta.function
+//^^^^ entity.name.function.post-blit.d
+//    ^^^^^^ meta.function.parameters.d
 //    ^ punctuation.section.group.begin.d
 //     ^^^^ variable.language.d
 //         ^ punctuation.section.group.end.d
-//           ^^ meta.function.d meta.block.d
+//           ^^ meta.block.d
 //           ^ punctuation.section.block.begin.d
 //            ^ punctuation.section.block.end.d
   this(1, 2, 3);
+//^^^^^^^^^^^^^^ - meta.function meta.function
 //^^^^ meta.function.d entity.name.function.constructor.d
 //    ^^^^^^^^^ meta.function.parameters.d
 //    ^ punctuation.section.group.begin.d
@@ -1751,6 +1763,7 @@ extern(1)
 //            ^ punctuation.section.group.end.d
 //             ^ meta.function.d punctuation.terminator.d
   this(T)(T foo);
+//^^^^^^^^^^^^^^^ - meta.function meta.function
 //^^^^ meta.function.d entity.name.function.constructor.d
 //    ^^^^^^^^^^ meta.function.parameters.d
 //    ^ punctuation.section.group.begin.d
@@ -1762,8 +1775,9 @@ extern(1)
 //             ^ punctuation.section.group.end.d
 //              ^ meta.function.d punctuation.terminator.d
   this(in ref foo t) {}
+//^^^^^^^^^^^^^^^^^^^^^ - meta.function meta.function
 //^^^^ meta.function.d entity.name.function.constructor.d
-//    ^^^^^^^^^^^^^^ meta.function.parameters.d meta.function.parameters.d
+//    ^^^^^^^^^^^^^^ meta.function.parameters.d
 //    ^ punctuation.section.group.begin.d
 //     ^^ storage.modifier.d
 //        ^^^ storage.modifier.d

--- a/D/tests/syntax_test_d.d
+++ b/D/tests/syntax_test_d.d
@@ -1250,6 +1250,7 @@ extern(1)
 //                  ^^ meta.function.d meta.block.d
 //                  ^ punctuation.section.block.begin.d
 //                   ^ punctuation.section.block.end.d
+
   int boo() => 5;
 //^^^ storage.type.d
 //    ^^^ meta.function.d entity.name.function.d
@@ -1259,6 +1260,7 @@ extern(1)
 //          ^^ meta.function.d keyword.declaration.function.d
 //             ^ meta.number.integer.decimal.d
 //              ^ meta.function.d punctuation.terminator.d
+
   int par(T)() if(true) => 7;
 //^^^ storage.type.d
 //    ^^^ meta.function.d entity.name.function.d
@@ -1276,53 +1278,111 @@ extern(1)
 //                      ^^ meta.function.d keyword.declaration.function.d
 //                         ^ meta.number.integer.decimal.d
 //                          ^ meta.function.d punctuation.terminator.d
-    void bar();
-  //^^^^ storage.type.d
-  //     ^^^ meta.function.d entity.name.function.d
-  //        ^^ meta.function.parameters.d
-  //        ^ punctuation.section.group.begin.d
-  //         ^ punctuation.section.group.end.d
-  //          ^ meta.function.d punctuation.terminator.d
-    int[] map(int[] array, ) {
-  //^^^ storage.type.d
-  //   ^ punctuation.section.brackets.begin.d
-  //    ^ punctuation.section.brackets.end.d
-  //      ^^^ meta.function.d entity.name.function.d
-  //         ^^^^^^^^^^^^^^^ meta.function.parameters.d
-  //         ^ punctuation.section.group.begin.d
-  //          ^^^ storage.type.d
-  //             ^ punctuation.section.brackets.begin.d
-  //              ^ punctuation.section.brackets.end.d
-  //                ^^^^^ variable.parameter.d
-  //                     ^ punctuation.separator.sequence.d
-  //                       ^
-  //                         ^ meta.function.d meta.block.d punctuation.section.block.begin.d
-      foo();
-    //^^^^^^^ meta.function.d meta.block.d
-    //^^^ variable.function.d
-    }
-  //^ meta.function.d meta.block.d punctuation.section.block.end.d
-    T[] map(T, void fn)(T[] array) {
-  //^ storage.type.d
-  // ^ punctuation.section.brackets.begin.d
-  //  ^ punctuation.section.brackets.end.d
-  //    ^^^ meta.function.d entity.name.function.d
-  //       ^^^^^^^^^^^^^^^^^^^^^^^ meta.function.parameters.d
-  //       ^ punctuation.section.group.begin.d
-  //        ^ variable.parameter.d
-  //         ^ punctuation.separator.sequence.d
-  //           ^^^^ storage.type.d
-  //                ^^ variable.parameter.d
-  //                  ^ punctuation.section.group.end.d
-  //                   ^ punctuation.section.group.begin.d
-  //                    ^ storage.type.d
-  //                     ^ punctuation.section.brackets.begin.d
-  //                      ^ punctuation.section.brackets.end.d
-  //                        ^^^^^ variable.parameter.d
-  //                             ^ punctuation.section.group.end.d
-  //                               ^ meta.function.d meta.block.d punctuation.section.block.begin.d
-    }
-  //^ meta.function.d meta.block.d punctuation.section.block.end.d
+
+  // shortened function with InContractExpression
+  int par(int T) in(T) => 7;
+//^^^ storage.type.d
+//    ^^^ meta.function.d entity.name.function.d
+//       ^^^^^^^ meta.function.parameters.d
+//               ^^^^^^^^^^^ meta.function.d
+//               ^^ keyword.control.conditional.d
+//                 ^ punctuation.section.parens.begin.d
+//                  ^ variable.other.d
+//                   ^ punctuation.section.parens.end.d
+//                     ^^ keyword.declaration.function.d
+//                        ^ constant.numeric.value.d
+//                         ^ punctuation.terminator.d
+
+  // shortened function with OutContractExpression
+  int par(int T) out(;) => 7;
+//^^^ storage.type.d
+//    ^^^ meta.function.d entity.name.function.d
+//       ^^^^^^^ meta.function.parameters.d
+//               ^^^^^^^^^^^^ meta.function.d
+//               ^^^ keyword.control.conditional.d
+//                  ^ punctuation.section.parens.begin.d
+//                   ^ punctuation.separator.sequence.d
+//                    ^ punctuation.section.parens.end.d
+//                      ^^ keyword.declaration.function.d
+//                         ^ constant.numeric.value.d
+//                          ^ punctuation.terminator.d
+
+  // shortened function with OutContractExpression
+  int par(int T) out(; arg) => 7;
+//^^^ storage.type.d
+//    ^^^ meta.function.d entity.name.function.d
+//       ^^^^^^^ meta.function.parameters.d
+//               ^^^^^^^^^^^^^^^^ meta.function.d
+//               ^^^ keyword.control.conditional.d
+//                  ^ punctuation.section.parens.begin.d
+//                   ^ punctuation.separator.sequence.d
+//                     ^^^ variable.other.d
+//                        ^ punctuation.section.parens.end.d
+//                          ^^ keyword.declaration.function.d
+//                             ^ constant.numeric.value.d
+//                              ^ punctuation.terminator.d
+
+  // No shortened function due to OutStatement `out(...)`
+  int par(int T) out(T) => 7;
+//^^^ storage.type.d
+//    ^^^ meta.function.d entity.name.function.d
+//       ^^^^^^^ meta.function.parameters.d
+//               ^^^^^^^^^ meta.function.d
+//               ^^^ keyword.control.conditional.d
+//                  ^ punctuation.section.parens.begin.d
+//                   ^ variable.parameter.d
+//                    ^ punctuation.section.parens.end.d
+//                      ^^ invalid.illegal.d
+//                         ^ constant.numeric.value.d
+//                          ^ punctuation.terminator.d
+
+  void bar();
+//^^^^ storage.type.d
+//     ^^^ meta.function.d entity.name.function.d
+//        ^^ meta.function.parameters.d
+//        ^ punctuation.section.group.begin.d
+//         ^ punctuation.section.group.end.d
+//          ^ meta.function.d punctuation.terminator.d
+  int[] map(int[] array, ) {
+//^^^ storage.type.d
+//   ^ punctuation.section.brackets.begin.d
+//    ^ punctuation.section.brackets.end.d
+//      ^^^ meta.function.d entity.name.function.d
+//         ^^^^^^^^^^^^^^^ meta.function.parameters.d
+//         ^ punctuation.section.group.begin.d
+//          ^^^ storage.type.d
+//             ^ punctuation.section.brackets.begin.d
+//              ^ punctuation.section.brackets.end.d
+//                ^^^^^ variable.parameter.d
+//                     ^ punctuation.separator.sequence.d
+//                       ^
+//                         ^ meta.function.d meta.block.d punctuation.section.block.begin.d
+  foo();
+//^^^^^^^ meta.function.d meta.block.d
+//^^^ variable.function.d
+}
+// <- meta.function.d meta.block.d punctuation.section.block.end.d
+  T[] map(T, void fn)(T[] array) {
+//^ storage.type.d
+// ^ punctuation.section.brackets.begin.d
+//  ^ punctuation.section.brackets.end.d
+//    ^^^ meta.function.d entity.name.function.d
+//       ^^^^^^^^^^^^^^^^^^^^^^^ meta.function.parameters.d
+//       ^ punctuation.section.group.begin.d
+//        ^ variable.parameter.d
+//         ^ punctuation.separator.sequence.d
+//           ^^^^ storage.type.d
+//                ^^ variable.parameter.d
+//                  ^ punctuation.section.group.end.d
+//                   ^ punctuation.section.group.begin.d
+//                    ^ storage.type.d
+//                     ^ punctuation.section.brackets.begin.d
+//                      ^ punctuation.section.brackets.end.d
+//                        ^^^^^ variable.parameter.d
+//                             ^ punctuation.section.group.end.d
+//                               ^ meta.function.d meta.block.d punctuation.section.block.begin.d
+}
+// <- meta.function.d meta.block.d punctuation.section.block.end.d
   VeryLongTypeNameThatWillForceALineWrapWith80WidthLines
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ variable.other.d
   veryLongFunctionNameToHelpWithTheLineWrappingThing


### PR DESCRIPTION
Fixes #3894 

This PR...

1. Recovers valuable fixes from closed PR #3966 
2. adds further tests to ensure correct scoping of shortened functions including `InOutContractExpressions`
3. fixes various overlapping meta.function scopes found on the way going.