### PR TITLE
[Markdown] Make table_codespan_content non-greedy

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -129,7 +129,7 @@ variables:
   table_codespan_content: |-
     (?x:
       [^`|]             # first or only char must not be a backtick or pipe.
-      (?:[^|]*[^`|])?   # none must be a pipe, the last additionally must not be a backtick
+      (?:[^|]*?[^`|])?   # none must be a pipe, the last additionally must not be a backtick
     )
 
   fenced_code_block_start: |-

--- a/Markdown/tests/syntax_test_markdown.md
+++ b/Markdown/tests/syntax_test_markdown.md
@@ -3234,6 +3234,14 @@ test
 |                  ^^^^^^ punctuation.definition.raw.begin.markdown
 |                        ^^^^^^^ - punctuation
 |                               ^^^^^^ punctuation.definition.raw.end.markdown
+| table with | `multiple` code `spans`) |
+| <- punctuation.separator.table-cell
+|            ^ punctuation.separator.table-cell
+|              ^^^^^^^^^^ markup.raw.inline
+|                        ^^^^^^ - markup.raw.inline
+|                              ^^^^^^^ markup.raw.inline
+
+
 
 `|` this `|` example `|` is not a table `|`
 | ^ punctuation.definition.raw.end - meta.table


### PR DESCRIPTION
Otherwise it misses the end of a code span if there are multiple in a single cell.