### PR TITLE
[HTML] Add variable for custom tag start character

### DIFF
--- a/ASP/HTML (ASP).sublime-syntax
+++ b/ASP/HTML (ASP).sublime-syntax
@@ -22,6 +22,8 @@ variables:
   vbscript_mime_type: |-
     (?xi: (?: (?:application|text) / )? vbscript )
 
+  tag_name_start: (?:[A-Za-z]|<%)
+
 contexts:
 
 ###[ HTML TAGS ]##############################################################

--- a/ASP/syntax_test_asp.asp
+++ b/ASP/syntax_test_asp.asp
@@ -1382,6 +1382,43 @@ test = "hello%>
 '                  ^^^ punctuation.section.embedded.begin.asp
 '                               ^^ punctuation.section.embedded.end.asp
 
+  <my-<%=tag%> <%=attr%>=<%=value%>/>
+' ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.other.html
+' ^ meta.tag.other.html punctuation.definition.tag.begin.html
+'  ^^^ entity.name.tag.other.html - meta.interpolation
+'     ^^^^^^^^ entity.name.tag.other.html meta.embedded.asp
+'     ^^^ punctuation.section.embedded.begin.asp 
+'        ^^^ variable.other.asp
+'           ^^ punctuation.section.embedded.end.asp
+'              ^^^^^^^^^ meta.attribute-with-value.html entity.other.attribute-name.html meta.embedded.asp
+'              ^^^ punctuation.section.embedded.begin.asp 
+'                 ^^^^ variable.other.asp
+'                     ^^ punctuation.section.embedded.end.asp
+'                       ^ meta.attribute-with-value.html punctuation.separator.key-value.html
+'                        ^^^^^^^^^^ meta.attribute-with-value.html meta.string.html meta.embedded.asp
+'                        ^^^ punctuation.section.embedded.begin.asp 
+'                           ^^^^^ variable.other.asp
+'                                ^^ punctuation.section.embedded.end.asp
+'                                  ^^ punctuation.definition.tag.end.html
+
+  <<%=tag%> <%=attr%>=<%=value%>/>
+' ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.other.html
+' ^ meta.tag.other.html punctuation.definition.tag.begin.html
+'  ^^^^^^^^ entity.name.tag.other.html meta.embedded.asp
+'  ^^^ punctuation.section.embedded.begin.asp 
+'     ^^^ variable.other.asp
+'        ^^ punctuation.section.embedded.end.asp
+'           ^^^^^^^^^ meta.attribute-with-value.html entity.other.attribute-name.html meta.embedded.asp
+'           ^^^ punctuation.section.embedded.begin.asp 
+'              ^^^^ variable.other.asp
+'                  ^^ punctuation.section.embedded.end.asp
+'                    ^ meta.attribute-with-value.html punctuation.separator.key-value.html
+'                     ^^^^^^^^^^ meta.attribute-with-value.html meta.string.html meta.embedded.asp
+'                     ^^^ punctuation.section.embedded.begin.asp 
+'                        ^^^^^ variable.other.asp
+'                             ^^ punctuation.section.embedded.end.asp
+'                               ^^ punctuation.definition.tag.end.html
+
  </body>
 '^^^^^^^ meta.tag.structure.any.html
 <script type="text/javascript">

--- a/Go/CSS (Go).sublime-syntax
+++ b/Go/CSS (Go).sublime-syntax
@@ -11,6 +11,10 @@ file_extensions:
   - gocss
   - go.css
 
+variables:
+
+    ident_start: (?:{{nmstart}}|{{)
+
 contexts:
 
   prototype:

--- a/Go/Embeddings/CSS (for Go Embedded Backtick Strings).sublime-syntax
+++ b/Go/Embeddings/CSS (for Go Embedded Backtick Strings).sublime-syntax
@@ -8,6 +8,10 @@ hidden: true
 
 extends: Packages/CSS/CSS.sublime-syntax
 
+variables:
+
+    ident_start: (?:{{nmstart}}|{{)
+
 contexts:
 
   prototype:

--- a/Go/Embeddings/HTML (for Go Embedded Backtick Strings).sublime-syntax
+++ b/Go/Embeddings/HTML (for Go Embedded Backtick Strings).sublime-syntax
@@ -8,6 +8,10 @@ hidden: true
 
 extends: Packages/HTML/HTML.sublime-syntax
 
+variables:
+
+  tag_name_start: (?:[A-Za-z]|{{)
+
 contexts:
 
   prototype:

--- a/Go/HTML (Go).sublime-syntax
+++ b/Go/HTML (Go).sublime-syntax
@@ -12,6 +12,10 @@ file_extensions:
   - go.html
   - tmpl
 
+variables:
+
+  tag_name_start: (?:[A-Za-z]|{{)
+
 contexts:
 
   prototype:

--- a/Go/tests/syntax_test_template.html
+++ b/Go/tests/syntax_test_template.html
@@ -91,6 +91,49 @@
 |                     ^^ punctuation.section.interpolation.begin.go - source.go.template
 |                       ^^^^^^^^^^^ source.go.template
 |                                  ^^ punctuation.section.interpolation.end.go - source.go.template
+
+    <my-{{.tag}} {{.attr}}={{.value}}/>
+|   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.other.html
+|   ^ meta.tag.other.html punctuation.definition.tag.begin.html
+|    ^^^ entity.name.tag.other.html - meta.interpolation
+|       ^^^^^^^ entity.name.tag.other.html meta.interpolation.go
+|       ^^ punctuation.section.interpolation.begin.go
+|         ^ punctuation.accessor.dot.go
+|          ^^^ variable.other.member.go
+|             ^^ punctuation.section.interpolation.end.go
+|                ^^^^^^^^ meta.attribute-with-value.html entity.other.attribute-name.html meta.interpolation.go
+|                ^^ punctuation.section.interpolation.begin.go
+|                  ^ punctuation.accessor.dot.go
+|                   ^^^^ variable.other.member.go
+|                       ^^ punctuation.section.interpolation.end.go
+|                         ^ meta.attribute-with-value.html punctuation.separator.key-value.html
+|                          ^^^^^^^^^ meta.attribute-with-value.html meta.string.html meta.interpolation.go
+|                          ^^ punctuation.section.interpolation.begin.go
+|                            ^ punctuation.accessor.dot.go
+|                             ^^^^^ variable.other.member.go
+|                                  ^^ punctuation.section.interpolation.end.go
+|                                    ^^ punctuation.definition.tag.end.html
+
+    <{{.tag}} {{.attr}}={{.value}}/>
+|   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.other.html
+|   ^ meta.tag.other.html punctuation.definition.tag.begin.html
+|    ^^^^^^^ entity.name.tag.other.html meta.interpolation.go
+|    ^^ punctuation.section.interpolation.begin.go
+|      ^ punctuation.accessor.dot.go
+|       ^^^ variable.other.member.go
+|          ^^ punctuation.section.interpolation.end.go
+|             ^^^^^^^^ meta.attribute-with-value.html entity.other.attribute-name.html meta.interpolation.go
+|             ^^ punctuation.section.interpolation.begin.go
+|               ^ punctuation.accessor.dot.go
+|                ^^^^ variable.other.member.go
+|                    ^^ punctuation.section.interpolation.end.go
+|                      ^ meta.attribute-with-value.html punctuation.separator.key-value.html
+|                       ^^^^^^^^^ meta.attribute-with-value.html meta.string.html meta.interpolation.go
+|                       ^^ punctuation.section.interpolation.begin.go
+|                         ^ punctuation.accessor.dot.go
+|                          ^^^^^ variable.other.member.go
+|                               ^^ punctuation.section.interpolation.end.go
+|                                 ^^ punctuation.definition.tag.end.html
 </html>
 
 <!-- Page Templates -->

--- a/HTML/HTML (Plain).sublime-syntax
+++ b/HTML/HTML (Plain).sublime-syntax
@@ -60,6 +60,24 @@
 #          pop: 1
 #        - ...
 #
+#  2 TAG NAME INTERPOLATION
+#
+#    Default HTML tags start with a case insensitive latter a..z.
+#
+#    If a template language supports interpolation within HTML tag names,
+#    it must also ensure a tag being identified as such, if its name starts
+#    with a template tag by overriding the `tag_name_start` variable.
+#
+#    Example:
+#
+#      variables:
+#        # make `{{` a valid tag name start char
+#        tag_name_start: (?:[A-Za-z]|{{)
+#
+#    Enables correct scoping of:
+#
+#        <{{tag_name}} ... >
+#
 ###############################################################################
 # https://www.sublimetext.com/docs/syntax.html
 # https://html.spec.whatwg.org/multipage/syntax.html
@@ -88,7 +106,7 @@ variables:
   tag_name_break_char: '[{{ascii_space}}/<>]'
   tag_name_break: (?={{tag_name_break_char}})
   tag_name_char: '[^{{tag_name_break_char}}]'
-  tag_name_start: '[A-Za-z]'
+  tag_name_start: '[A-Za-z]'  # Override it for proper tag name interpolation.
   tag_name: '{{tag_name_start}}{{tag_name_char}}*'
 
 ###############################################################################

--- a/HTML/HTML (Plain).sublime-syntax
+++ b/HTML/HTML (Plain).sublime-syntax
@@ -88,7 +88,8 @@ variables:
   tag_name_break_char: '[{{ascii_space}}/<>]'
   tag_name_break: (?={{tag_name_break_char}})
   tag_name_char: '[^{{tag_name_break_char}}]'
-  tag_name: '[A-Za-z]{{tag_name_char}}*'
+  tag_name_start: '[A-Za-z]'
+  tag_name: '{{tag_name_start}}{{tag_name_char}}*'
 
 ###############################################################################
 

--- a/HTML/HTML (Plain).sublime-syntax
+++ b/HTML/HTML (Plain).sublime-syntax
@@ -62,7 +62,7 @@
 #
 #  2 TAG NAME INTERPOLATION
 #
-#    Default HTML tags start with a case insensitive latter a..z.
+#    Default HTML tags start with a case-insensitive latter a..z.
 #
 #    If a template language supports interpolation within HTML tag names,
 #    it must also ensure a tag being identified as such, if its name starts
@@ -71,7 +71,7 @@
 #    Example:
 #
 #      variables:
-#        # make `{{` a valid tag name start char
+#        # make `{{` a valid tag name start sequence
 #        tag_name_start: (?:[A-Za-z]|{{)
 #
 #    Enables correct scoping of:

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -264,7 +264,7 @@ contexts:
 ###[ OTHER TAG ]##############################################################
 
   tag-other:
-    - match: </?(?=[A-Za-z])
+    - match: </?(?={{tag_name_start}})
       scope: punctuation.definition.tag.begin.html
       push:
         - tag-other-content

--- a/Haskell/Embeddings/HTML (for HSX).sublime-syntax
+++ b/Haskell/Embeddings/HTML (for HSX).sublime-syntax
@@ -12,6 +12,10 @@ hidden: true
 
 extends: Packages/HTML/HTML.sublime-syntax
 
+variables:
+
+  tag_name_start: (?:[A-Za-z{])
+
 contexts:
 
   prototype:

--- a/Haskell/tests/syntax_test_haskell.hs
+++ b/Haskell/tests/syntax_test_haskell.hs
@@ -3172,6 +3172,44 @@ main = do
 --                   ^^^^^^^^^^^^^^^^^^^^ meta.interpolation.haskell source.haskell.embedded.html
 --                                       ^ meta.interpolation.haskell punctuation.section.interpolation.end.haskell
 --                                        ^ string.quoted.double.html punctuation.definition.string.end.html
+
+        <my-{tag} {attr}={value}/>
+--      ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.other.html
+--      ^ meta.tag.other.html punctuation.definition.tag.begin.html
+--       ^^^ entity.name.tag.other.html - meta.interpolation
+--          ^^^^^ entity.name.tag.other.html meta.interpolation.haskell
+--          ^ punctuation.section.interpolation.begin.haskell
+--           ^^^ variable.other.haskell
+--              ^ punctuation.section.interpolation.end.haskell
+--                ^^^^^^ meta.attribute-with-value.html entity.other.attribute-name.html meta.interpolation.haskell
+--                ^ punctuation.section.interpolation.begin.haskell
+--                 ^^^^ variable.other.haskell
+--                     ^ punctuation.section.interpolation.end.haskell
+--                      ^ meta.attribute-with-value.html punctuation.separator.key-value.html
+--                       ^^^^^^^ meta.attribute-with-value.html meta.string.html meta.interpolation.haskell
+--                       ^ punctuation.section.interpolation.begin.haskell
+--                        ^^^^^ variable.other.haskell
+--                             ^ punctuation.section.interpolation.end.haskell
+--                              ^^ punctuation.definition.tag.end.html
+
+        <{tag} {attr}={value}/>
+--      ^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.other.html
+--      ^ meta.tag.other.html punctuation.definition.tag.begin.html
+--       ^^^^^ entity.name.tag.other.html meta.interpolation.haskell
+--       ^ punctuation.section.interpolation.begin.haskell
+--        ^^^ variable.other.haskell
+--           ^ punctuation.section.interpolation.end.haskell
+--             ^^^^^^ meta.attribute-with-value.html entity.other.attribute-name.html meta.interpolation.haskell
+--             ^ punctuation.section.interpolation.begin.haskell
+--              ^^^^ variable.other.haskell
+--                  ^ punctuation.section.interpolation.end.haskell
+--                   ^ meta.attribute-with-value.html punctuation.separator.key-value.html
+--                    ^^^^^^^ meta.attribute-with-value.html meta.string.html meta.interpolation.haskell
+--                    ^ punctuation.section.interpolation.begin.haskell
+--                     ^^^^^ variable.other.haskell
+--                          ^ punctuation.section.interpolation.end.haskell
+--                           ^^ punctuation.definition.tag.end.html
+
     |]
 -- ^ meta.quoted.quasi.haskell text.html.embedded.haskell
 --  ^^ meta.quoted.quasi.haskell punctuation.section.quoted.end.haskell - text.html

--- a/Java/HTML (JSP).sublime-syntax
+++ b/Java/HTML (JSP).sublime-syntax
@@ -32,6 +32,8 @@ variables:
   dec_digit: '\d'
   dec_exponent: '[eE][-+]?{{dec_digit}}*'
 
+  tag_name_start: (?:[A-Za-z]|<%|\${)
+
 contexts:
 
   prototype:

--- a/Java/tests/syntax_test_jsp.jsp
+++ b/Java/tests/syntax_test_jsp.jsp
@@ -222,6 +222,80 @@
 //                             ^^^^^^^ meta.tag.sgml.cdata.html meta.string.html meta.interpolation.jsp meta.embedded.expression.jstl - string
 //                                    ^^^^^^^^^^^^^^^ meta.tag.sgml.cdata.html meta.string.html string.unquoted.cdata.html - meta.interpolation
 
+    <my-<%=tag%> <%=attr%>=<%=value%>/>
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.other.html
+//  ^ meta.tag.other.html punctuation.definition.tag.begin.html
+//   ^^^ entity.name.tag.other.html - meta.interpolation
+//      ^^^^^^^^ entity.name.tag.other.html meta.embedded.expression.jsp
+//      ^^^ punctuation.section.embedded.begin.jsp
+//         ^^^ variable.other.java
+//            ^^ punctuation.section.embedded.end.jsp
+//               ^^^^^^^^^ meta.attribute-with-value.html entity.other.attribute-name.html meta.embedded.expression.jsp
+//               ^^^ punctuation.section.embedded.begin.jsp
+//                  ^^^^ variable.other.java
+//                      ^^ punctuation.section.embedded.end.jsp
+//                        ^ meta.attribute-with-value.html punctuation.separator.key-value.html
+//                         ^^^^^^^^^^ meta.attribute-with-value.html meta.string.html meta.embedded.expression.jsp
+//                         ^^^ punctuation.section.embedded.begin.jsp
+//                            ^^^^^ variable.other.java
+//                                 ^^ punctuation.section.embedded.end.jsp
+//                                   ^^ punctuation.definition.tag.end.html
+
+    <<%=tag%> <%=attr%>=<%=value%>/>
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.other.html
+//  ^ meta.tag.other.html punctuation.definition.tag.begin.html
+//   ^^^^^^^^ entity.name.tag.other.html meta.embedded.expression.jsp
+//   ^^^ punctuation.section.embedded.begin.jsp
+//      ^^^ variable.other.java
+//         ^^ punctuation.section.embedded.end.jsp
+//            ^^^^^^^^^ meta.attribute-with-value.html entity.other.attribute-name.html meta.embedded.expression.jsp
+//            ^^^ punctuation.section.embedded.begin.jsp
+//               ^^^^ variable.other.java
+//                   ^^ punctuation.section.embedded.end.jsp
+//                     ^ meta.attribute-with-value.html punctuation.separator.key-value.html
+//                      ^^^^^^^^^^ meta.attribute-with-value.html meta.string.html meta.embedded.expression.jsp
+//                      ^^^ punctuation.section.embedded.begin.jsp
+//                         ^^^^^ variable.other.java
+//                              ^^ punctuation.section.embedded.end.jsp
+//                                ^^ punctuation.definition.tag.end.html
+
+    <my-${tag} ${attr}=${value}/>
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.other.html
+//  ^ meta.tag.other.html punctuation.definition.tag.begin.html
+//   ^^^ entity.name.tag.other.html - meta.interpolation
+//      ^^^^^^ entity.name.tag.other.html meta.embedded.expression.jstl
+//      ^^ punctuation.section.embedded.begin.jstl
+//        ^^^ variable.other.jstl
+//           ^ punctuation.section.embedded.end.jstl
+//             ^^^^^^^ meta.attribute-with-value.html entity.other.attribute-name.html meta.embedded.expression.jstl
+//             ^^ punctuation.section.embedded.begin.jstl
+//               ^^^^ variable.other.jstl
+//                   ^ punctuation.section.embedded.end.jstl
+//                    ^ meta.attribute-with-value.html punctuation.separator.key-value.html
+//                     ^^^^^^^^ meta.attribute-with-value.html meta.string.html meta.interpolation.jsp meta.embedded.expression.jstl
+//                     ^^ punctuation.section.embedded.begin.jstl
+//                       ^^^^^ variable.other.jstl
+//                            ^ punctuation.section.embedded.end.jstl
+//                             ^^ punctuation.definition.tag.end.html
+
+    <${tag} ${attr}=${value}/>
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.other.html
+//  ^ meta.tag.other.html punctuation.definition.tag.begin.html
+//   ^^^^^^ entity.name.tag.other.html meta.embedded.expression.jstl
+//   ^^ punctuation.section.embedded.begin.jstl
+//     ^^^ variable.other.jstl
+//        ^ punctuation.section.embedded.end.jstl
+//          ^^^^^^^ meta.attribute-with-value.html entity.other.attribute-name.html meta.embedded.expression.jstl
+//          ^^ punctuation.section.embedded.begin.jstl
+//            ^^^^ variable.other.jstl
+//                ^ punctuation.section.embedded.end.jstl
+//                 ^ meta.attribute-with-value.html punctuation.separator.key-value.html
+//                  ^^^^^^^^ meta.attribute-with-value.html meta.string.html meta.interpolation.jsp meta.embedded.expression.jstl
+//                  ^^ punctuation.section.embedded.begin.jstl
+//                    ^^^^^ variable.other.jstl
+//                         ^ punctuation.section.embedded.end.jstl
+//                          ^^ punctuation.definition.tag.end.html
+
     <%-- This is a comment --%>
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.jsp
 

--- a/PHP/Embeddings/HTML (for PHP Interpolated).sublime-syntax
+++ b/PHP/Embeddings/HTML (for PHP Interpolated).sublime-syntax
@@ -6,6 +6,10 @@ hidden: true
 
 extends: Packages/HTML/HTML.sublime-syntax
 
+variables:
+
+  tag_name_start: (?:[A-Za-z]|<\?)
+
 contexts:
 
   prototype:

--- a/PHP/PHP.sublime-syntax
+++ b/PHP/PHP.sublime-syntax
@@ -24,6 +24,10 @@ first_line_match: |-
   | ^ \s* <\?php\b                          # php tag
   )
 
+variables:
+
+  tag_name_start: (?:[A-Za-z]|<\?)
+
 ##############################################################################
 
 contexts:

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -6096,6 +6096,42 @@ h1 {
 //                 ^^^^^^^^^^ meta.tag.sgml.cdata.html meta.string.html meta.embedded.php - string
 //                           ^^^^^^^^^^^^^^^ meta.tag.sgml.cdata.html meta.string.html string.unquoted.cdata.html
 
+  <<?php $tag ?> <?php $attr ?>=<?php $value ?> />
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ text.html.php meta.tag.other.html
+//^ punctuation.definition.tag.begin.html
+// ^^^^^^^^^^^^^ entity.name.tag.other.html meta.embedded.php
+// ^^^^^ punctuation.section.embedded.begin.php
+//       ^^^^ variable.other.php
+//            ^^ punctuation.section.embedded.end.php
+//               ^^^^^^^^^^^^^^ meta.attribute-with-value.html entity.other.attribute-name.html meta.embedded.php
+//               ^^^^^ punctuation.section.embedded.begin.php
+//                     ^^^^^ variable.other.php
+//                           ^^ punctuation.section.embedded.end.php
+//                             ^ meta.attribute-with-value.html punctuation.separator.key-value.html
+//                              ^^^^^^^^^^^^^^^ meta.attribute-with-value.html meta.string.html meta.embedded.php
+//                              ^^^^^ punctuation.section.embedded.begin.php
+//                                    ^^^^^^ variable.other.php
+//                                           ^^ punctuation.section.embedded.end.php
+//                                              ^^ punctuation.definition.tag.end.html
+
+  <<? $tag ?> <? $attr ?>=<? $value ?> />
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ text.html.php meta.tag.other.html
+//^ punctuation.definition.tag.begin.html
+// ^^^^^^^^^^ entity.name.tag.other.html meta.embedded.php
+// ^^ punctuation.section.embedded.begin.php
+//    ^^^^ variable.other.php
+//         ^^ punctuation.section.embedded.end.php
+//            ^^^^^^^^^^^ meta.attribute-with-value.html entity.other.attribute-name.html meta.embedded.php
+//            ^^ punctuation.section.embedded.begin.php
+//               ^^^^^ variable.other.php
+//                     ^^ punctuation.section.embedded.end.php
+//                       ^ meta.attribute-with-value.html punctuation.separator.key-value.html
+//                        ^^^^^^^^^^^^ meta.attribute-with-value.html meta.string.html meta.embedded.php
+//                        ^^ punctuation.section.embedded.begin.php
+//                           ^^^^^^ variable.other.php
+//                                  ^^ punctuation.section.embedded.end.php
+//                                     ^^ punctuation.definition.tag.end.html
+
   <?phpzzzz
 //^^ punctuation.section.embedded.begin.php
 //  ^^^^^^^ constant.other.php

--- a/Rails/HTML (Rails).sublime-syntax
+++ b/Rails/HTML (Rails).sublime-syntax
@@ -12,6 +12,10 @@ file_extensions:
   - erb
   - html.erb
 
+variables:
+
+  tag_name_start: (?:[A-Za-z]|<%)
+
 contexts:
 
 ###[ CUSTOM HTML ]############################################################

--- a/Rails/tests/syntax_test_rails.html.erb
+++ b/Rails/tests/syntax_test_rails.html.erb
@@ -181,3 +181,40 @@
 #        ^^^^^^^^^^ meta.tag.sgml.cdata.html meta.string.html string.unquoted.cdata.html
 #                  ^^^^^^^^^^^ meta.tag.sgml.cdata.html meta.string.html meta.interpolation.rails meta.embedded.rails - string
 #                             ^^^^^^^^^^^^^^^ meta.tag.sgml.cdata.html meta.string.html string.unquoted.cdata.html
+
+  <my-<%=$tag%> <%=$attr%>=<%=$value%>/>
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.other.html
+# ^ meta.tag.other.html punctuation.definition.tag.begin.html
+#  ^^^ entity.name.tag.other.html - meta.interpolation
+#     ^^^^^^^^^ entity.name.tag.other.html meta.embedded.rails
+#     ^^^ punctuation.section.embedded.begin.rails
+#        ^^^^ variable.other.readwrite.global.ruby
+#            ^^ punctuation.section.embedded.end.rails
+#               ^^^^^^^^^^ meta.attribute-with-value.html entity.other.attribute-name.html meta.embedded.rails
+#               ^^^ punctuation.section.embedded.begin.rails
+#                  ^^^^^ variable.other.readwrite.global.ruby
+#                       ^^ punctuation.section.embedded.end.rails
+#                         ^ meta.attribute-with-value.html punctuation.separator.key-value.html
+#                          ^^^^^^^^^^^ meta.attribute-with-value.html meta.string.html meta.embedded.rails
+#                          ^^^ punctuation.section.embedded.begin.rails
+#                             ^^^^^^ variable.other.readwrite.global.ruby
+#                                   ^^ punctuation.section.embedded.end.rails
+#                                     ^^ punctuation.definition.tag.end.html
+
+  <<%=$tag%> <%=$attr%>=<%=$value%>/>
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.other.html
+# ^ meta.tag.other.html punctuation.definition.tag.begin.html
+#  ^^^^^^^^ entity.name.tag.other.html meta.embedded.rails
+#  ^^^ punctuation.section.embedded.begin.rails
+#     ^^^^ variable.other.readwrite.global.ruby
+#         ^^ punctuation.section.embedded.end.rails
+#            ^^^^^^^^^^ meta.attribute-with-value.html entity.other.attribute-name.html meta.embedded.rails
+#            ^^^ punctuation.section.embedded.begin.rails
+#               ^^^^^ variable.other.readwrite.global.ruby
+#                    ^^ punctuation.section.embedded.end.rails
+#                      ^ meta.attribute-with-value.html punctuation.separator.key-value.html
+#                       ^^^^^^^^^^^ meta.attribute-with-value.html meta.string.html meta.embedded.rails
+#                       ^^^ punctuation.section.embedded.begin.rails
+#                          ^^^^^^ variable.other.readwrite.global.ruby
+#                                ^^ punctuation.section.embedded.end.rails
+#                                  ^^ punctuation.definition.tag.end.html


### PR DESCRIPTION
This commit adds a `tag_name_start` variable to represent a custom tag's first character across syntax definitions instead of hard-coding `[A-Za-z]`.

It enables template syntaxes to override such tags' names easier, if they begin with a template interpolation.

Example:

    <{{tag_name}} ...>

To scope `{{tag_name}}` entity.name.tag, a template syntax has needed to extend the `tag-other` context before this commit with something like:

    tag-other:
      - meta_prepend: true
      - match: </?(?={{) 
        scope: punctuation.definition.tag.begin.html 
        push:
          - tag-other-content
          - tag-other-name

even though `{{ ... }}` tags are already part of the `prototype` context.

With this commit it is enough to override the `tag_name_start` to add the template begin punctuation in order to achieve the same outcome.

    variables:
      tag_name_start: (?:[A-Za-z]|{{)

> [!NOTE]
>
> The new variable is added to all template syntaxes such as ASP, ERB, JSP and PHP in order to enable support for tag names, beginning with template interpolation.