### PR TITLE
[CSS] Remove completion restrictions

### DIFF
--- a/CSS/CSS.sublime-settings
+++ b/CSS/CSS.sublime-settings
@@ -4,7 +4,7 @@
 
     // Controls what scopes default completions will be provided in.
     // Can be a list of strings which are joined before matching.
-    "default_completions_selector": "source.css - meta.selector.css",
+    "default_completions_selector": "source.css",
 
     // Default separators except `-`
     "word_separators": "./\\()\"':,.;<>~!@#$%^&*|+=[]{}`~?",

--- a/CSS/css_completions.py
+++ b/CSS/css_completions.py
@@ -80,14 +80,11 @@ class CSSCompletions(sublime_plugin.EventListener):
             items = self.complete_function_argument(view, prefix, pt)
         elif view.match_selector(pt - 1, "meta.property-value.css, punctuation.separator.key-value"):
             items = self.complete_property_value(view, prefix, pt)
-        elif view.match_selector(pt - 1, "meta.property-name.css, meta.property-list.css - meta.selector"):
-            items = self.complete_property_name(view, prefix, pt)
         else:
-            # TODO: provide selectors, at-rules
-            items = None
+            items = self.complete_property_name(view, prefix, pt)
 
         if items:
-            return sublime.CompletionList(items, sublime.INHIBIT_WORD_COMPLETIONS)
+            return sublime.CompletionList(items)
         return None
 
     def complete_property_name(self, view, prefix, pt):


### PR DESCRIPTION
Suggest properties also within `meta.selector` as this is the most likely scope in front of nested selectors, if a property is not yet terminated by semi-colon.

As completions are much more likely, do no longer suppress word completions.

Without this commit auto-completion no longer provides property-name completions in front of nested selectors.

Example:

```css
div {
  color: red;
  bo|  <- no more completions here

  h2 {
    text-decoration: none;
  }
}
```

reported at https://github.com/SublimeText/Sass/issues/107