### PR TITLE
[JavaScript] Fix comma after ternary expression

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1437,7 +1437,7 @@ contexts:
   ternary-operator-expect-colon:
     - match: ':'
       scope: keyword.operator.ternary.js
-      set: expression-no-comma
+      set: expression
     - include: else-pop
 
   postfix-operators:

--- a/JavaScript/tests/syntax_test_js_control.js
+++ b/JavaScript/tests/syntax_test_js_control.js
@@ -157,6 +157,33 @@
 //      ^^^^^^^^^^^ meta.group
 //         ^^ keyword.operator.word
 
+    for (a in b, c ? d: e, f(g())) {};
+//  ^^^^ meta.for - meta.group
+//      ^^^^^^^^^^^^^^^^^^^ meta.for meta.group - meta.function-call
+//                         ^^^^^^ meta.for meta.group meta.function-call
+//                               ^ meta.for meta.group - meta.function-call
+//                                ^ meta.for - meta.block - meta.group
+//                                 ^^ meta.for meta.block
+//  ^^^ keyword.control.loop.for
+//      ^ punctuation.section.group.begin
+//       ^ variable.other.readwrite
+//         ^^ keyword.operator.word
+//            ^ variable.other.readwrite
+//             ^ keyword.operator.comma
+//               ^ variable.other.readwrite
+//                 ^ keyword.operator.ternary
+//                   ^ variable.other.readwrite
+//                    ^ keyword.operator.ternary
+//                      ^ variable.other.readwrite
+//                       ^ keyword.operator.comma
+//                         ^ variable.function
+//                          ^ punctuation.section.group.begin
+//                           ^ variable.function
+//                            ^ punctuation.section.group.begin
+//                             ^^^ punctuation.section.group.end
+//                                 ^ punctuation.section.block.begin
+//                                  ^ punctuation.section.block.end
+
     for (x of list) {}
 //  ^^^^^^^^^^^^^^^^^^ meta.for
 //  ^^^ keyword.control.loop.for


### PR DESCRIPTION
Fixes #3985

This PR sets `expression` instead of `expression-no-comma` onto stack after ternary expressions, so they can appear in the middle of sequences.