### PR TITLE
[Batch File] Fix comment scope around newlines

### DIFF
--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -161,7 +161,7 @@ contexts:
   comment-body:
     - meta_scope: comment.line.colon.dosbatch
     - include: line-continuations
-    - match: \n
+    - match: $\n?
       pop: 1
 
   ignored-tail-inner:
@@ -843,7 +843,7 @@ contexts:
     # meta_content_scope is used since rem should not be
     # highlighted as a comment, but a command
     - meta_content_scope: comment.line.rem.dosbatch
-    - match: \n
+    - match: $\n?
       scope: comment.line.rem.dosbatch
       pop: 1
 

--- a/Batch File/tests/syntax_test_batch_file.bat
+++ b/Batch File/tests/syntax_test_batch_file.bat
@@ -38,13 +38,18 @@
 :: ^^^^^^^^^^^^^^^^^ comment.line.rem.dosbatch
 
    REM ^
+
+   I'm a (com|ment)
+:: ^^^^^^^^^^^^^^^^^ comment.line.rem.dosbatch
+
+   REM ^
    I'm a (com|ment) ^
    not a comment
-:: ^^^^^^^^^^^^^ - comment
+:: ^^^^^^^^^^^^^^ - comment
 
 REM
    not a comment
-:: ^^^^^^^^^^^^^ - comment
+:: ^^^^^^^^^^^^^^ - comment
 
 REM This follows a REM command
 :: <- keyword.declaration.rem.dosbatch - comment
@@ -52,48 +57,110 @@ REM This follows a REM command
 
 REM This & and | echo "is commented out" ^
 :: <- keyword.declaration.rem.dosbatch
-::  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.command.rem.dosbatch comment.line.rem.dosbatch
+::  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.command.rem.dosbatch comment.line.rem.dosbatch
 
 REM No line ^
 continuation
 :: <- - comment
-:: ^^^^^^^^^ - comment
+:: ^^^^^^^^^^ - comment
 
    ::: Me too!
 :: ^^^ punctuation.definition.comment.dosbatch
-:: ^^^^^^^^^^^ comment.line.colon.dosbatch
+:: ^^^^^^^^^^^^ comment.line.colon.dosbatch
+
+   :::
+   Not me, though.
+:: ^^^^^^^^^^^^^^^^ - comment
 
    :: Me too!
 :: ^^ punctuation.definition.comment.dosbatch
-:: ^^^^^^^^^^ comment.line.colon.dosbatch
+:: ^^^^^^^^^^^ comment.line.colon.dosbatch
+
+   ::
+   Not me, though.
+:: ^^^^^^^^^^^^^^^^ - comment
 
    :+ Me too!
 :: ^^ punctuation.definition.comment.dosbatch
+:: ^^^^^^^^^^^ comment.line.colon.dosbatch
+
+   :+
+   Not me, though.
+:: ^^^^^^^^^^^^^^^^ - comment
 
    := Me too!
 :: ^^ punctuation.definition.comment.dosbatch
+:: ^^^^^^^^^^^ comment.line.colon.dosbatch
+
+   :=
+   Not me, though.
+:: ^^^^^^^^^^^^^^^^ - comment
 
    :, Me too!
 :: ^^ punctuation.definition.comment.dosbatch
+:: ^^^^^^^^^^^ comment.line.colon.dosbatch
+
+   :,
+   Not me, though.
+:: ^^^^^^^^^^^^^^^^ - comment
 
    :; Me too!
 :: ^^ punctuation.definition.comment.dosbatch
+:: ^^^^^^^^^^^ comment.line.colon.dosbatch
+
+   :;
+   Not me, though.
+:: ^^^^^^^^^^^^^^^^ - comment
 
    : Me too!
 :: ^^ punctuation.definition.comment.dosbatch
+:: ^^^^^^^^^^ comment.line.colon.dosbatch
+
+   :
+   Not me, though.
+:: ^^^^^^^^^^^^^^^^ - comment
+
+   :::^
+   Me too!
+:: ^^^^^^^^ comment.line.colon.dosbatch
+
+   :::^
+
+   Me too!
+:: ^^^^^^^^ comment.line.colon.dosbatch
+
+   ::: ^
+   A continued comment.^
+   Me too!
+:: ^^^^^^^^ comment.line.colon.dosbatch
 
    ::^
    Me too!
-:: ^^^^^^^ comment.line.colon.dosbatch
+:: ^^^^^^^^ comment.line.colon.dosbatch
+
+   ::^
+
+   Me too!
+:: ^^^^^^^^ comment.line.colon.dosbatch
+
+   :: ^
+   A continued comment.^
+   Me too!
+:: ^^^^^^^^ comment.line.colon.dosbatch
 
    : ^
    Me too!
-:: ^^^^^^^ comment.line.colon.dosbatch
+:: ^^^^^^^^ comment.line.colon.dosbatch
+
+   : ^
+
+   Me too!
+:: ^^^^^^^^ comment.line.colon.dosbatch
 
    : ^
    A continued comment.^
    Me too!
-:: ^^^^^^^ comment.line.colon.dosbatch
+:: ^^^^^^^^ comment.line.colon.dosbatch
 
    :> ignored content ( & | )
 :: ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.colon.dosbatch
@@ -114,30 +181,30 @@ continuation
 ECHO &&:: A comment
 ::   ^^ keyword.operator.logical.dosbatch
 ::     ^^ punctuation.definition.comment.dosbatch
-::     ^^^^^^^^^^^^ comment.line.colon.dosbatch
+::     ^^^^^^^^^^^^^ comment.line.colon.dosbatch
 
 ECHO &:: A comment
 ::   ^ keyword.operator.logical.dosbatch
 ::    ^^ punctuation.definition.comment.dosbatch
-::    ^^^^^^^^^^^^ comment.line.colon.dosbatch
+::    ^^^^^^^^^^^^^ comment.line.colon.dosbatch
 
 ECHO ||:: A comment
 ::   ^^ keyword.operator.logical.dosbatch
 ::     ^^ punctuation.definition.comment.dosbatch
-::     ^^^^^^^^^^^^ comment.line.colon.dosbatch
+::     ^^^^^^^^^^^^^ comment.line.colon.dosbatch
 
 ECHO |:: Not a comment
 ::   ^ keyword.operator.assignment.pipe.dosbatch
 ::    ^^^^^^^^^^^^^^^^ invalid.illegal.unexpected.dosbatch
 
 ECHO : Not a comment ^
-::   ^^^^^^^^^^^^^^^ - comment
+::   ^^^^^^^^^^^^^^^^^^ - comment
 ::                   ^^ punctuation.separator.continuation.line.dosbatch
 
 ECHO : Not a comment ^
 :: Me not, too
 :: <- - comment
-::^^^^^^^^^^^^  - comment
+::^^^^^^^^^^^^^ - comment
 
 :::: [ @ Operator ] :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 


### PR DESCRIPTION
Multiple colons immediately followed by a non-empty line cause said line
to be scoped as a comment:

```batchfile
::: Set some variables
:::
set WSL_UTF8=1
```