### PR TITLE
[Batch File] Fix line continuation

### DIFF
--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -2004,7 +2004,10 @@ contexts:
     # Note: Must consume \n to work.
     - match: ^\n
       set: bol-pop
-    - include: bol-pop
+    # The first caret at a continued line is escaped by the continuation caret
+    # and thus printed literal.
+    - match: ^\^?
+      pop: 1
 
   eoc-pop:
     # Note: An end of command appears in unquoted regions only!

--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -1981,6 +1981,7 @@ contexts:
 ###[ PROTOTYPES ]#############################################################
 
   bol-pop:
+    - meta_include_prototype: false
     - match: ^
       pop: 1
 
@@ -2000,6 +2001,7 @@ contexts:
       push: line-continuation-body
 
   line-continuation-body:
+    - meta_include_prototype: false
     # The first linefeed diretly following a continuation is treated literal.
     # Note: Must consume \n to work.
     - match: ^\n

--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -845,8 +845,9 @@ contexts:
     # In REM comments only the first continuation directly following
     # the first token is taken into account.
     - meta_include_prototype: false
-    - match: \^\n
-      scope: punctuation.separator.continuation.line.dosbatch
+    - match: (\^)\n
+      captures:
+        1: punctuation.separator.continuation.line.dosbatch
       set: line-continuation-body
     - match: (?={{metachar}})
       pop: 1
@@ -1993,8 +1994,9 @@ contexts:
       pop: 1
 
   line-continuations:
-    - match: \^\n
-      scope: punctuation.separator.continuation.line.dosbatch
+    - match: (\^)\n
+      captures:
+        1: punctuation.separator.continuation.line.dosbatch
       push: line-continuation-body
 
   line-continuation-body:

--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -1,6 +1,7 @@
 %YAML 1.2
 ---
 # https://www.sublimetext.com/docs/syntax.html
+# https://stackoverflow.com/questions/4094699/how-does-the-windows-command-interpreter-cmd-exe-parse-scripts/4095133#4095133
 name: Batch File
 scope: source.dosbatch
 version: 2
@@ -836,7 +837,19 @@ contexts:
     - include: cmd-arg-help
     - include: unquoted-eol-pop
     - match: (?=\S)
-      set: cmd-rem-comment-body
+      set:
+        - cmd-rem-comment-body
+        - cmd-rem-comment-begin
+
+  cmd-rem-comment-begin:
+    # In REM comments only the first continuation directly following
+    # the first token is taken into account.
+    - meta_include_prototype: false
+    - match: \^\n
+      scope: punctuation.separator.continuation.line.dosbatch
+      set: line-continuation-body
+    - match: (?={{metachar}})
+      pop: 1
 
   cmd-rem-comment-body:
     - meta_include_prototype: false
@@ -1967,8 +1980,7 @@ contexts:
 ###[ PROTOTYPES ]#############################################################
 
   bol-pop:
-    # Note: empty lines are ignored
-    - match: ^(?!$)
+    - match: ^
       pop: 1
 
   else-pop:
@@ -1983,7 +1995,14 @@ contexts:
   line-continuations:
     - match: \^\n
       scope: punctuation.separator.continuation.line.dosbatch
-      push: bol-pop
+      push: line-continuation-body
+
+  line-continuation-body:
+    # The first linefeed diretly following a continuation is treated literal.
+    # Note: Must consume \n to work.
+    - match: ^\n
+      set: bol-pop
+    - include: bol-pop
 
   eoc-pop:
     # Note: An end of command appears in unquoted regions only!

--- a/Batch File/tests/syntax_test_batch_file.bat
+++ b/Batch File/tests/syntax_test_batch_file.bat
@@ -1,7 +1,7 @@
 :: SYNTAX TEST "Packages/Batch File/Batch File.sublime-syntax"
 
 
-:::: [ Comments ] :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+:::: [ REM Comments ] :::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
    REM/? ignored
 :: ^^^^^^^^^^^^^ meta.command.rem.dosbatch
@@ -64,16 +64,22 @@ REM This & and | echo "is commented out" ^
 :: <- keyword.declaration.rem.dosbatch
 ::  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.command.rem.dosbatch comment.line.rem.dosbatch
 
+::: Test Case : single token continued at next line
+
 REM Line^
 continuation
 :: <- meta.command.rem.dosbatch comment.line.rem.dosbatch
 :: ^^^^^^^^^^ meta.command.rem.dosbatch comment.line.rem.dosbatch
+
+::: Test Case : single token continued after empty line
 
 REM Line^
 
 continuation
 :: <- meta.command.rem.dosbatch comment.line.rem.dosbatch
 :: ^^^^^^^^^^ meta.command.rem.dosbatch comment.line.rem.dosbatch
+
+::: Test Case : no more continuation after 2nd token
 
 REM Line^
 
@@ -82,6 +88,8 @@ not a comment
 :: <- - comment
 :: ^^^^^^^^^^ - comment
 
+::: Test Case : no continuation after 2nd empty line
+
 REM Line^
 
 
@@ -89,10 +97,62 @@ not a comment
 :: <- - comment
 :: ^^^^^^^ - comment
 
+::: Test Case : continuation beginning with literal caret
+
+REM Line^
+^continuation
+not a comment
+:: <- - comment
+:: ^^^^^^^^^^ - comment
+
+::: Test Case : continuation beginning escaping caret after empty line
+
+REM Line^
+
+^continuation
+not a comment
+:: <- - comment
+:: ^^^^^^^^^^ - comment
+
+::: Test Case : continuation with only litaral caret, no recursive continuation
+
+REM Line^
+^
+not a comment
+:: <- - comment
+:: ^^^^^^^^^^ - comment
+
+::: Test Case : continuation with only escaping caret after empty line, no recursive continuation
+
+REM Line^
+
+^
+not a comment
+:: <- - comment
+:: ^^^^^^^^^^ - comment
+
+::: Test Case : no line continuation after 2nd token #1
+
 REM No line ^
 continuation
 :: <- - comment
 :: ^^^^^^^^^^ - comment
+
+::: Test Case : no line continuation after 2nd token #2
+
+REM No line ^
+^
+:: <- meta.function-call.identifier.dosbatch variable.function.dosbatch punctuation.separator.continuation.line.dosbatch
+
+::: Test Case : no line continuation after 2nd token #3
+
+REM No line ^
+^
+not a comment
+:: <- - comment
+::^^^^^^^^^^^^ - comment
+
+:::: [ Label Comments ] :::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
    ::: Me too!
 :: ^^^ punctuation.definition.comment.dosbatch
@@ -164,6 +224,16 @@ continuation
    Me too!
 :: ^^^^^^^^ comment.line.colon.dosbatch
 
+   ::: ^
+   ^
+   Me too!
+:: ^^^^^^^^ comment.line.colon.dosbatch
+
+::: ^
+^
+   Not me, though.
+:: ^^^^^^^^^^^^^^^^ - comment
+
    ::^
    Me too!
 :: ^^^^^^^^ comment.line.colon.dosbatch
@@ -178,6 +248,16 @@ continuation
    Me too!
 :: ^^^^^^^^ comment.line.colon.dosbatch
 
+   :: ^
+   ^
+   Me too!
+:: ^^^^^^^^ comment.line.colon.dosbatch
+
+:: ^
+^
+   Not me, though.
+:: ^^^^^^^^^^^^^^^^ - comment
+
    : ^
    Me too!
 :: ^^^^^^^^ comment.line.colon.dosbatch
@@ -191,6 +271,16 @@ continuation
    A continued comment.^
    Me too!
 :: ^^^^^^^^ comment.line.colon.dosbatch
+
+   : ^
+   ^
+   Me too!
+:: ^^^^^^^^ comment.line.colon.dosbatch
+
+: ^
+^
+   Not me, though.
+:: ^^^^^^^^^^^^^^^^ - comment
 
    :> ignored content ( & | )
 :: ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.colon.dosbatch
@@ -2560,6 +2650,7 @@ put arg1 arg2
 :: ^^^^ meta.function-call.identifier.dosbatch support.function.builtin.dosbatch
 ::     ^^^ meta.function-call.arguments.dosbatch
 ::      ^ punctuation.separator.continuation.line.dosbatch
+::       ^ - punctuation
 
    ECHO ^
    /? ignored
@@ -2702,6 +2793,44 @@ put arg1 arg2
 ::                           ^^^ meta.string.dosbatch string.unquoted.dosbatch
 ::                              ^ - meta.command - meta.string - string
 
+   ECHO line ^
+::      ^^^^^^^ meta.command.echo.dosbatch meta.function-call.arguments.dosbatch meta.string.dosbatch string.unquoted.dosbatch
+::           ^ punctuation.separator.continuation.line.dosbatch
+::            ^ - punctuation
+
+   ECHO line ^
+   continuation
+:: <- meta.command.echo.dosbatch meta.function-call.arguments.dosbatch meta.string.dosbatch string.unquoted.dosbatch
+::^^^^^^^^^^^^^ meta.command.echo.dosbatch meta.function-call.arguments.dosbatch meta.string.dosbatch string.unquoted.dosbatch
+
+   ECHO line ^
+
+   continuation
+:: <- meta.command.echo.dosbatch meta.function-call.arguments.dosbatch meta.string.dosbatch string.unquoted.dosbatch
+::^^^^^^^^^^^^^ meta.command.echo.dosbatch meta.function-call.arguments.dosbatch meta.string.dosbatch string.unquoted.dosbatch
+
+   ECHO line ^
+   ^
+:: <- meta.command.echo.dosbatch meta.function-call.arguments.dosbatch meta.string.dosbatch string.unquoted.dosbatch
+::^^^ meta.command.echo.dosbatch meta.function-call.arguments.dosbatch meta.string.dosbatch string.unquoted.dosbatch
+:: ^ punctuation.separator.continuation.line.dosbatch
+::  ^ - punctuation
+
+   ECHO line ^
+   ^
+   continuation
+:: <- meta.command.echo.dosbatch meta.function-call.arguments.dosbatch meta.string.dosbatch string.unquoted.dosbatch
+::^^^^^^^^^^^^^ meta.command.echo.dosbatch meta.function-call.arguments.dosbatch meta.string.dosbatch string.unquoted.dosbatch
+
+ECHO line ^
+^
+:: <- meta.command.echo.dosbatch meta.function-call.arguments.dosbatch meta.string.dosbatch string.unquoted.dosbatch - punctuation
+
+ECHO line ^
+^
+no continuation
+:: <- - meta.command.echo - meta.string - string
+::^^^^^^^^^^^^^ - meta.command.echo
 
 :::: [ ECHO escaped characters ]:::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/Batch File/tests/syntax_test_batch_file.bat
+++ b/Batch File/tests/syntax_test_batch_file.bat
@@ -47,6 +47,11 @@
    not a comment
 :: ^^^^^^^^^^^^^^ - comment
 
+   REM ^
+   Line^
+   continuation after first token
+:: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.command.rem.dosbatch comment.line.rem.dosbatch
+
 REM
    not a comment
 :: ^^^^^^^^^^^^^^ - comment
@@ -58,6 +63,31 @@ REM This follows a REM command
 REM This & and | echo "is commented out" ^
 :: <- keyword.declaration.rem.dosbatch
 ::  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.command.rem.dosbatch comment.line.rem.dosbatch
+
+REM Line^
+continuation
+:: <- meta.command.rem.dosbatch comment.line.rem.dosbatch
+:: ^^^^^^^^^^ meta.command.rem.dosbatch comment.line.rem.dosbatch
+
+REM Line^
+
+continuation
+:: <- meta.command.rem.dosbatch comment.line.rem.dosbatch
+:: ^^^^^^^^^^ meta.command.rem.dosbatch comment.line.rem.dosbatch
+
+REM Line^
+
+continuation^
+not a comment
+:: <- - comment
+:: ^^^^^^^^^^ - comment
+
+REM Line^
+
+
+not a comment
+:: <- - comment
+:: ^^^^^^^ - comment
 
 REM No line ^
 continuation
@@ -480,6 +510,22 @@ ECHO : Not a comment ^
 ::     ^ - meta.function-call
 :: ^ punctuation.definition.variable.dosbatch
 :: ^^^^ variable.label.dosbatch - keyword
+
+   CALL ^
+
+   :EOF
+:: ^^^^ meta.function-call.identifier.dosbatch
+::     ^ - meta.function-call
+:: ^ punctuation.definition.variable.dosbatch
+:: ^^^^ variable.label.dosbatch - keyword
+
+   CALL ^
+
+
+   :EOF
+:: ^^^^ - meta.function-call
+:: ^ punctuation.definition.label.dosbatch
+:: ^^^^ entity.name.label.dosbatch
 
    CALL :foo 10 %1
 ::^ - meta.function-call

--- a/Batch File/tests/syntax_test_batch_file.bat
+++ b/Batch File/tests/syntax_test_batch_file.bat
@@ -229,7 +229,8 @@ ECHO |:: Not a comment
 
 ECHO : Not a comment ^
 ::   ^^^^^^^^^^^^^^^^^^ - comment
-::                   ^^ punctuation.separator.continuation.line.dosbatch
+::                   ^ punctuation.separator.continuation.line.dosbatch
+::                    ^ - punctuation
 
 ECHO : Not a comment ^
 :: Me not, too
@@ -1380,7 +1381,8 @@ is a #@$虎" strange label
 
    IF^
 :: ^^ - keyword.control.conditional
-::   ^^ punctuation.separator.continuation.line.dosbatch
+::   ^ punctuation.separator.continuation.line.dosbatch
+::    ^ - punctuation
 
    IF ^
    NOT EXIST "C:\file.log"
@@ -1935,7 +1937,8 @@ is a #@$虎" strange label
 :: ^^^^^^ meta.function-call.identifier.dosbatch variable.function.dosbatch
 ::       ^^^^^^^^^^ meta.function-call.arguments.dosbatch
    out^
-::    ^^ punctuation.separator.continuation.line.dosbatch
+::    ^ punctuation.separator.continuation.line.dosbatch
+::     ^ - punctuation
 
    out^
 put arg1 arg2
@@ -2111,7 +2114,8 @@ put arg1 arg2
 
    command arg^
 ::         ^^^^^ meta.function-call.arguments.dosbatch
-::            ^^ punctuation.separator.continuation.line.dosbatch
+::            ^ punctuation.separator.continuation.line.dosbatch
+::             ^ - punctuation
 
    command arg^
    for
@@ -3463,7 +3467,8 @@ put arg1 arg2
 ::     ^^^^ variable.other.readwrite.dosbatch
 ::         ^ keyword.operator.assignment.dosbatch
 ::          ^^^^^^ string.unquoted.dosbatch
-::              ^^ punctuation.separator.continuation.line.dosbatch
+::              ^ punctuation.separator.continuation.line.dosbatch
+::               ^ - punctuation
 
    set foo"="bar^
    baz
@@ -3492,7 +3497,8 @@ put arg1 arg2
 ::     ^^^^^ variable.other.readwrite.dosbatch
 ::          ^ keyword.operator.assignment.dosbatch
 ::           ^^^^^ string.unquoted.dosbatch
-::              ^^ punctuation.separator.continuation.line.dosbatch
+::              ^ punctuation.separator.continuation.line.dosbatch
+::               ^ - punctuation
 
    set fo"o"=bar^
    baz
@@ -3520,7 +3526,8 @@ put arg1 arg2
 ::     ^^^^ variable.other.readwrite.dosbatch
 ::          ^ keyword.operator.assignment.dosbatch
 ::           ^^^^^^^ meta.string.dosbatch string.unquoted.dosbatch
-::                ^^ punctuation.separator.continuation.line.dosbatch
+::                ^ punctuation.separator.continuation.line.dosbatch
+::                 ^ - punctuation
 
    set fo"o"="bar"^
    baz
@@ -4602,7 +4609,8 @@ put arg1 arg2
 ::        ^^^^^ variable.other.readwrite.dosbatch
 ::             ^ keyword.operator.assignment.dosbatch
 ::              ^^^^^^^^^ string.unquoted.dosbatch
-::                     ^^ punctuation.separator.continuation.line.dosbatch
+::                     ^ punctuation.separator.continuation.line.dosbatch
+::                      ^ - punctuation
 
    :: even number of quotes in l-value
    :: unquoted value


### PR DESCRIPTION
This commit applies the following rule:

If `^` appears at the end of a line, the linefeed is stripped and the next character is escaped or uses its special meaning, if any. If the next character is also a linefeed, it is treated literal.

REM command seems to be working special by line continuation working only directly after the first token.