### PR TITLE
[Batch File] Fix empty comments exceeding to next line

### DIFF
--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -48,7 +48,7 @@ variables:
   eoc: (?=\s*{{eoc_char}})
   eoc_char: '[\n|&]'
 
-  label_comment: ':+[^{{label_start}}]'
+  label_comment: ':(?::+|(?!{{label_start}}))'
   label_start: '[^{{metachar}}:+]'
 
   path_terminator_chars: '[\s,;"{{redir_or_eoc_char}}]'

--- a/Batch File/tests/syntax_test_batch_file.bat
+++ b/Batch File/tests/syntax_test_batch_file.bat
@@ -81,40 +81,40 @@ continuation
 :: ^^^^^^^^^^^^^^^^ - comment
 
    :+ Me too!
-:: ^^ punctuation.definition.comment.dosbatch
-:: ^^^^^^^^^^^ comment.line.colon.dosbatch
+:: ^ comment.line.colon.dosbatch punctuation.definition.comment.dosbatch
+::  ^^^^^^^^^^ comment.line.colon.dosbatch - punctuation
 
    :+
    Not me, though.
 :: ^^^^^^^^^^^^^^^^ - comment
 
    := Me too!
-:: ^^ punctuation.definition.comment.dosbatch
-:: ^^^^^^^^^^^ comment.line.colon.dosbatch
+:: ^ comment.line.colon.dosbatch punctuation.definition.comment.dosbatch
+::  ^^^^^^^^^^ comment.line.colon.dosbatch - punctuation
 
    :=
    Not me, though.
 :: ^^^^^^^^^^^^^^^^ - comment
 
    :, Me too!
-:: ^^ punctuation.definition.comment.dosbatch
-:: ^^^^^^^^^^^ comment.line.colon.dosbatch
+:: ^ comment.line.colon.dosbatch punctuation.definition.comment.dosbatch
+::  ^^^^^^^^^^ comment.line.colon.dosbatch - punctuation
 
    :,
    Not me, though.
 :: ^^^^^^^^^^^^^^^^ - comment
 
    :; Me too!
-:: ^^ punctuation.definition.comment.dosbatch
-:: ^^^^^^^^^^^ comment.line.colon.dosbatch
+:: ^ comment.line.colon.dosbatch punctuation.definition.comment.dosbatch
+::  ^^^^^^^^^^ comment.line.colon.dosbatch - punctuation
 
    :;
    Not me, though.
 :: ^^^^^^^^^^^^^^^^ - comment
 
    : Me too!
-:: ^^ punctuation.definition.comment.dosbatch
-:: ^^^^^^^^^^ comment.line.colon.dosbatch
+:: ^ comment.line.colon.dosbatch punctuation.definition.comment.dosbatch
+::  ^^^^^^^^^ comment.line.colon.dosbatch - punctuation
 
    :
    Not me, though.
@@ -163,20 +163,20 @@ continuation
 :: ^^^^^^^^ comment.line.colon.dosbatch
 
    :> ignored content ( & | )
-:: ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.colon.dosbatch
-:: ^^ punctuation.definition.comment.dosbatch
+:: ^ comment.line.colon.dosbatch punctuation.definition.comment.dosbatch
+::  ^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.colon.dosbatch - punctuation
 
    :< ignored content ( & | )
-:: ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.colon.dosbatch
-:: ^^ punctuation.definition.comment.dosbatch
+:: ^ comment.line.colon.dosbatch punctuation.definition.comment.dosbatch
+::  ^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.colon.dosbatch - punctuation
 
    :& ignored content ( & | )
-:: ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.colon.dosbatch
-:: ^^ punctuation.definition.comment.dosbatch
+:: ^ comment.line.colon.dosbatch punctuation.definition.comment.dosbatch
+::  ^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.colon.dosbatch - punctuation
 
    :| ignored content ( & | )
-:: ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.colon.dosbatch
-:: ^^ punctuation.definition.comment.dosbatch
+:: ^ comment.line.colon.dosbatch punctuation.definition.comment.dosbatch
+::  ^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.colon.dosbatch - punctuation
 
 ECHO &&:: A comment
 ::   ^^ keyword.operator.logical.dosbatch


### PR DESCRIPTION
This commit fixes "label comment" related patterns, to only scope leading colons `punctuation.definition.comment`.

Label comments make use of invalid labels being ignored. A label is invalid, if the first character after leading colon is a "metachar".

A label starting with `::` is already an invalid label and thus can be followed by any (meta) char to still be a "valid" comment.

The wrong pattern was the real reason for the issue addressed by PR #3992.