### PR TITLE
[Batch File] Refactor labels and label-like comments

### DIFF
--- a/Batch File/Batch File (Compound).sublime-syntax
+++ b/Batch File/Batch File (Compound).sublime-syntax
@@ -21,4 +21,4 @@ hidden: true
 extends: Packages/Batch File/Batch File.sublime-syntax
 
 variables:
-  eoc_char: '[\n|&)]'
+  eoc_char: \)\n\|&

--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -69,9 +69,6 @@ variables:
   # A label variable is therefore terminated by `+`, `:` or word break (`metachar`)
   label_variable_break: (?![^:+{{metachar}}])
 
-  path_terminator_chars: '[\s,;"{{redir_or_eoc_char}}]'
-  path_terminators: (?={{path_terminator_chars}})
-
   set_arithmetic_operators_unquoted: (?:\+|-|\*|/|%%|~)
   set_arithmetic_operators_quoted: (?:\||<<|>>|&|\^)
   set_quoted_end: \"(?![^"{{redir_or_eoc_char}}]*\")
@@ -1709,17 +1706,12 @@ contexts:
 
   path-pattern-unquoted-body:
     - meta_scope: meta.path.dosbatch meta.string.dosbatch string.unquoted.dosbatch
-    - include: path-pattern-unquoted-end
+    - include: unquoted-word-end
     - include: path-pattern-unquoted-content
 
   path-pattern-unquoted-content:
     - include: unquoted-escapes-and-interpolations
     - include: path-pattern-common
-
-  path-pattern-unquoted-end:
-    - match: '{{path_terminators}}'
-      pop: 1
-    - include: line-continuations
 
   path-pattern-common:
     - match: '[:\\/]'

--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -53,10 +53,10 @@ variables:
   arg_char: '[^{{metachar}}:]'
 
   # Command statement terminators and redirections
-  redir_or_eoc: (?=\s*{{redir_or_eoc_char}})
-  redir_or_eoc_char: '[<>{{eoc_char}}]'
-  eoc: (?=\s*{{eoc_char}})
-  eoc_char: '[\n|&]'
+  redir_or_eoc: (?=\s*[{{redir_or_eoc_char}}])
+  redir_or_eoc_char: '<>{{eoc_char}}'
+  eoc: (?=\s*[{{eoc_char}}])
+  eoc_char: \n\|&
 
   # Label definition statements
   label_comment: :[:+]+

--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -143,6 +143,7 @@ contexts:
     - include: blocks
     - include: operators
     - include: redirections
+    - include: separators
     - include: control
     - include: commands
 
@@ -283,8 +284,7 @@ contexts:
       scope: punctuation.section.group.end.dosbatch
       pop: 1
     - include: groups
-    - include: separator-semicolon
-    - include: separator-comma
+    - include: separators
     - include: redirections
     - include: cmd-args-values
 
@@ -490,7 +490,7 @@ contexts:
       scope: punctuation.section.set.end.dosbatch
       pop: 1
     - include: invalid-operators
-    - include: separator-comma
+    - include: separators
     - include: embedded
     - include: cmd-args-values
 
@@ -705,6 +705,7 @@ contexts:
   cmd-args-body:
     - include: redirections
     - include: eoc-pop
+    - include: separators
     - include: cmd-arg-help
     - include: cmd-args-options
     - include: cmd-args-values
@@ -831,8 +832,6 @@ contexts:
     - include: immediately-pop
 
   cmd-mode-args:
-    - include: redirections
-    - include: eoc-pop
     - match: (?i:COM\d+|CON|LPT\d+):?{{arg_break}}
       scope: variable.language.device.dosbatch
     # known option values
@@ -846,9 +845,7 @@ contexts:
       scope: variable.parameter.option.dosbatch
     - match: =
       scope: keyword.operator.assignment.dosbatch
-    - include: cmd-arg-help
-    - include: cmd-args-options
-    - include: cmd-args-values
+    - include: cmd-args-body
 
 ###[ COMMAND REM ]############################################################
 
@@ -1222,7 +1219,7 @@ contexts:
     - match: '!'
       scope: keyword.operator.logical.dosbatch
     - include: numbers
-    - include: separator-comma
+    - include: separators
     - include: escaped-characters
     - include: variables
     - match: '[^-+*/%~=()"''^{{metachar}}]+'
@@ -1586,11 +1583,12 @@ contexts:
       scope: keyword.operator.assignment.pipe.dosbatch
       push: maybe-illegal-comment
 
-  separator-comma:
+  separators:
+    # non-whitespace chars, which break or separate words
+    - match: =
+      scope: punctuation.separator.dosbatch
     - match: ','
       scope: punctuation.separator.comma.dosbatch
-
-  separator-semicolon:
     - match: ';'
       scope: punctuation.separator.semicolon.dosbatch
 
@@ -1975,7 +1973,7 @@ contexts:
       scope: variable.other.readwrite.dosbatch
 
   variable-substrings:
-    - include: separator-comma
+    - include: separators
     - match: ([-+]?)(0|[1-9][0-9]*)
       scope: meta.number.integer.decimal.dosbatch
       captures:

--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -23,10 +23,19 @@ first_line_match: |-
 ###############################################################################
 
 variables:
+  # Tokens are separated by token delimiters.
+  # The standard token delimiters are <space> <tab> ; , = <0x0B> <0x0C> and <0xFF>
+  # Consecutive token delimiters are treated as one - there are no empty tokens
+  # between token delimiters
+  delim_char: ' \t;,=\x0B\x0C\xFF'
+
+  # The following characters may have special meaning in this phase, depending on context:
+  # <CR> ^ ( @ & | < > <LF> <space> <tab> ; , = <0x0B> <0x0C> <0xFF>
+
   # A character that, when unquoted, separates words. A metacharacter is a
   # space, tab, newline, or one of the following characters:
   # ‘|’, ‘&’, ‘,’, ‘;’, ‘<’, or ‘>’.
-  metachar: '[\s=,;{{redir_or_eoc_char}}]'
+  metachar: '{{delim_char}}{{redir_or_eoc_char}}'
 
   # Keywords
   keyword_break: (?![^{{metachar}}(.:\\/])
@@ -49,8 +58,16 @@ variables:
   eoc: (?=\s*{{eoc_char}})
   eoc_char: '[\n|&]'
 
-  label_comment: ':+[^{{label_start}}]'
-  label_start: '[^{{metachar}}:+]'
+  # Label definition statements
+  label_comment: :[:+]+
+  label_begin: (?=[^{{delim_char}}])
+  label_break: (?![^ \t:+{{redir_or_eoc_char}}])
+
+  # Label variable
+  # If labels appear in arguments, normal word parsing is performed first with
+  # everything up a label break character being used for label lookup.
+  # A label variable is therefore terminated by `+`, `:` or word break (`metachar`)
+  label_variable_break: (?![^:+{{metachar}}])
 
   path_terminator_chars: '[\s,;"{{redir_or_eoc_char}}]'
   path_terminators: (?={{path_terminator_chars}})
@@ -121,12 +138,12 @@ variables:
 
 contexts:
   main:
-    - include: comments
     - include: statements
 
   statements:
-    - include: blocks
+    - include: comments
     - include: labels
+    - include: blocks
     - include: operators
     - include: redirections
     - include: control
@@ -186,23 +203,38 @@ contexts:
 
 ###[ LABELS ]#################################################################
 
-  maybe-label:
-    - match: \:(?={{label_start}})
-      scope: entity.name.label.dosbatch punctuation.definition.label.dosbatch
-      set: label-name
-    - include: else-pop
-
   labels:
-    - match: ^\s*(:)(?={{label_start}})
-      captures:
-        1: entity.name.label.dosbatch punctuation.definition.label.dosbatch
-      push: label-name
+    - match: ':'
+      scope: punctuation.definition.label.dosbatch
+      push: label-begin
+
+  label-begin:
+    - meta_content_scope: comment.line.ignored.dosbatch
+    - match: (?=\^\n)
+      set: label-skip
+    - match: '{{label_begin}}'
+      set: label-name
+    - include: label-tail
 
   label-name:
     - meta_content_scope: entity.name.label.dosbatch
-    - match: '{{word_break}}'
-      set: ignored-tail-outer
+    - match: \s+|{{label_break}}
+      set: label-tail
     - include: escaped-characters
+
+  label-skip:
+    - meta_include_prototype: false
+    - meta_content_scope: comment.line.ignored.dosbatch
+    - include: line-continuations
+    - include: label-tail
+
+  label-tail:
+    # neither line continuation, pipelining or quotations are supported
+    - meta_include_prototype: false
+    - meta_content_scope: comment.line.ignored.dosbatch
+    - match: $\n?
+      scope: comment.line.ignored.dosbatch
+      pop: 1
 
 ###[ BLOCKS ]#################################################################
 
@@ -241,7 +273,7 @@ contexts:
     - match: \)
       scope: punctuation.section.block.end.dosbatch
       pop: 1
-    - include: main
+    - include: statements
 
   groups:
     - match: \(
@@ -484,14 +516,16 @@ contexts:
   ctl-call-identifier:
     - meta_content_scope: meta.function-call.dosbatch
     - match: ':'
-      scope: punctuation.definition.variable.dosbatch
+      scope: variable.label.dosbatch punctuation.definition.label.dosbatch
       set: ctl-call-label
     - include: cmd-arg-help
     - include: else-pop
 
   ctl-call-label:
-    - meta_scope: meta.function-call.identifier.dosbatch variable.label.dosbatch
-    - match: '{{word_break}}'
+    - meta_scope: meta.function-call.identifier.dosbatch
+    - meta_content_scope: variable.label.dosbatch
+    - match: (?:[+:][^{{metachar}}]*)?{{word_break}}
+      scope: comment.line.ignored.dosbatch
       set:
         - cmd-args-meta
         - cmd-args-body
@@ -549,14 +583,16 @@ contexts:
         1: punctuation.definition.variable.dosbatch
         2: keyword.control.flow.return.dosbatch
       pop: 1
-    - match: (:)?(?={{label_start}})
+    - match: (:)?{{label_begin}}
       scope: punctuation.definition.label.dosbatch
       set: ctl-goto-label
 
   ctl-goto-label:
     - meta_scope: variable.label.dosbatch
+    - match: '{{label_variable_break}}'
+      set: ignored-tail-outer
     - include: line-continuations
-    - include: label-name
+    - include: escaped-characters
     - include: variables
 
 ###[ CONTROL PAUSE ]##########################################################
@@ -849,16 +885,15 @@ contexts:
       captures:
         1: punctuation.separator.continuation.line.dosbatch
       set: line-continuation-body
-    - match: (?={{metachar}})
+    - match: '{{word_break}}'
       pop: 1
 
   cmd-rem-comment-body:
     - meta_include_prototype: false
     # meta_content_scope is used since rem should not be
     # highlighted as a comment, but a command
-    - meta_content_scope: comment.line.rem.dosbatch
+    - meta_scope: comment.line.rem.dosbatch
     - match: $\n?
-      scope: comment.line.rem.dosbatch
       pop: 1
 
 ###[ COMMAND SET ]############################################################
@@ -1548,7 +1583,6 @@ contexts:
   operators:
     - match: \@
       scope: keyword.operator.at.dosbatch
-      push: maybe-label
     - match: \&\&?|\|\|
       scope: keyword.operator.logical.dosbatch
     - match: \|

--- a/Batch File/tests/syntax_test_batch_file.bat
+++ b/Batch File/tests/syntax_test_batch_file.bat
@@ -497,16 +497,19 @@ ECHO : Not a comment ^
 ::^^ - entity
 :: ^ punctuation.definition.label.dosbatch
 ::  ^^^^^^^ entity.name.label.dosbatch
+::     ^ - punctuation
 
    :foo;bar
 ::^^ - entity
 :: ^ punctuation.definition.label.dosbatch
 ::  ^^^^^^^ entity.name.label.dosbatch
+::     ^ - punctuation
 
    :foo=bar
 ::^^ - entity
 :: ^ punctuation.definition.label.dosbatch
 ::  ^^^^^^^ entity.name.label.dosbatch
+::     ^ - punctuation
 
    :foo>bar
 ::^^ - entity
@@ -867,19 +870,19 @@ ECHO : Not a comment ^
    CALL :foo,bar & :: foo > %0 , bar > %1
 ::      ^ variable.label.dosbatch punctuation.definition.label.dosbatch
 ::       ^^^ variable.label.dosbatch
-::          ^ - comment - string - variable
+::          ^ punctuation.separator.comma.dosbatch - comment - string - variable
 ::           ^^^ meta.string.dosbatch string.unquoted.dosbatch
 
    CALL :foo;bar & :: foo > %0 , bar > %1
 ::      ^ variable.label.dosbatch punctuation.definition.label.dosbatch
 ::       ^^^ variable.label.dosbatch
-::          ^ - comment - string - variable
+::          ^ punctuation.separator.semicolon.dosbatch - comment - string - variable
 ::           ^^^ meta.string.dosbatch string.unquoted.dosbatch
 
    CALL :foo=bar & :: foo > %0 , bar > %1
 ::      ^ variable.label.dosbatch punctuation.definition.label.dosbatch
 ::       ^^^ variable.label.dosbatch
-::          ^ - comment - string - variable
+::          ^ punctuation.separator.dosbatch - comment - string - variable
 ::           ^^^ meta.string.dosbatch string.unquoted.dosbatch
 
    CALL :foo>bar

--- a/Batch File/tests/syntax_test_batch_file.bat
+++ b/Batch File/tests/syntax_test_batch_file.bat
@@ -171,42 +171,18 @@ not a comment
 :: ^^^^^^^^^^^^^^^^ - comment
 
    :+ Me too!
-:: ^^ punctuation.definition.comment.dosbatch
-:: ^^^^^^^^^^^ comment.line.colon.dosbatch
+:: ^^ comment.line.colon.dosbatch punctuation.definition.comment.dosbatch
+::   ^^^^^^^^^ comment.line.colon.dosbatch - punctuation
 
    :+
    Not me, though.
 :: ^^^^^^^^^^^^^^^^ - comment
 
-   := Me too!
-:: ^^ punctuation.definition.comment.dosbatch
-:: ^^^^^^^^^^^ comment.line.colon.dosbatch
+   :+: Me too!
+:: ^^^ comment.line.colon.dosbatch punctuation.definition.comment.dosbatch
+::    ^^^^^^^^^ comment.line.colon.dosbatch - punctuation
 
-   :=
-   Not me, though.
-:: ^^^^^^^^^^^^^^^^ - comment
-
-   :, Me too!
-:: ^^ punctuation.definition.comment.dosbatch
-:: ^^^^^^^^^^^ comment.line.colon.dosbatch
-
-   :,
-   Not me, though.
-:: ^^^^^^^^^^^^^^^^ - comment
-
-   :; Me too!
-:: ^^ punctuation.definition.comment.dosbatch
-:: ^^^^^^^^^^^ comment.line.colon.dosbatch
-
-   :;
-   Not me, though.
-:: ^^^^^^^^^^^^^^^^ - comment
-
-   : Me too!
-:: ^^ punctuation.definition.comment.dosbatch
-:: ^^^^^^^^^^ comment.line.colon.dosbatch
-
-   :
+   :+:
    Not me, though.
 :: ^^^^^^^^^^^^^^^^ - comment
 
@@ -257,47 +233,6 @@ not a comment
 ^
    Not me, though.
 :: ^^^^^^^^^^^^^^^^ - comment
-
-   : ^
-   Me too!
-:: ^^^^^^^^ comment.line.colon.dosbatch
-
-   : ^
-
-   Me too!
-:: ^^^^^^^^ comment.line.colon.dosbatch
-
-   : ^
-   A continued comment.^
-   Me too!
-:: ^^^^^^^^ comment.line.colon.dosbatch
-
-   : ^
-   ^
-   Me too!
-:: ^^^^^^^^ comment.line.colon.dosbatch
-
-: ^
-^
-   Not me, though.
-:: ^^^^^^^^^^^^^^^^ - comment
-
-   :> ignored content ( & | )
-:: ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.colon.dosbatch
-:: ^^ punctuation.definition.comment.dosbatch
-
-   :< ignored content ( & | )
-:: ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.colon.dosbatch
-:: ^^ punctuation.definition.comment.dosbatch
-
-   :& ignored content ( & | )
-:: ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.colon.dosbatch
-:: ^^ punctuation.definition.comment.dosbatch
-
-   :| ignored content ( & | )
-:: ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.colon.dosbatch
-:: ^^ punctuation.definition.comment.dosbatch
-
 ECHO &&:: A comment
 ::   ^^ keyword.operator.logical.dosbatch
 ::     ^^ punctuation.definition.comment.dosbatch
@@ -338,23 +273,23 @@ ECHO : Not a comment ^
 
    @:label
 :: ^ keyword.operator.at.dosbatch
-::  ^^^^^^ entity.name.label.dosbatch
 ::  ^ punctuation.definition.label.dosbatch
+::   ^^^^^ entity.name.label.dosbatch
 
    @ :label
 :: ^ keyword.operator.at.dosbatch
-::   ^^^^^^ entity.name.label.dosbatch
 ::   ^ punctuation.definition.label.dosbatch
+::    ^^^^^ entity.name.label.dosbatch
 
    @:@@@@@
 :: ^ keyword.operator.at.dosbatch
-::  ^^^^^^ entity.name.label.dosbatch
 ::  ^ punctuation.definition.label.dosbatch
+::   ^^^^^ entity.name.label.dosbatch
 
    @ :@@@@@
 :: ^ keyword.operator.at.dosbatch
-::   ^^^^^^ entity.name.label.dosbatch
 ::   ^ punctuation.definition.label.dosbatch
+::    ^^^^^ entity.name.label.dosbatch
 
    @ECHO OFF
 :: ^ keyword.operator.at.dosbatch
@@ -407,161 +342,273 @@ ECHO : Not a comment ^
 :::: [ Labels ] :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
    :l
-::^ - entity
-:: ^ entity.name.label.dosbatch punctuation.definition.label.dosbatch
+::^^ - entity
+:: ^ punctuation.definition.label.dosbatch
 ::  ^ entity.name.label.dosbatch - punctuation
 ::   ^ - entity
 
    :(
-::^ - entity
-:: ^ entity.name.label.dosbatch punctuation.definition.label.dosbatch
+::^^ - entity
+:: ^ punctuation.definition.label.dosbatch
 ::  ^ entity.name.label.dosbatch - punctuation
 ::   ^ - entity
 
    :)
-::^ - entity
-:: ^ entity.name.label.dosbatch punctuation.definition.label.dosbatch
+::^^ - entity
+:: ^ punctuation.definition.label.dosbatch
 ::  ^ entity.name.label.dosbatch - punctuation
 ::   ^ - entity
 
    :[
-::^ - entity
-:: ^ entity.name.label.dosbatch punctuation.definition.label.dosbatch
+::^^ - entity
+:: ^ punctuation.definition.label.dosbatch
 ::  ^ entity.name.label.dosbatch - punctuation
 ::   ^ - entity
 
    :]
-::^ - entity
-:: ^ entity.name.label.dosbatch punctuation.definition.label.dosbatch
+::^^ - entity
+:: ^ punctuation.definition.label.dosbatch
 ::  ^ entity.name.label.dosbatch - punctuation
 ::   ^ - entity
 
    :{
-::^ - entity
-:: ^ entity.name.label.dosbatch punctuation.definition.label.dosbatch
+::^^ - entity
+:: ^ punctuation.definition.label.dosbatch
 ::  ^ entity.name.label.dosbatch - punctuation
 ::   ^ - entity
 
    :}
-::^ - entity
-:: ^ entity.name.label.dosbatch punctuation.definition.label.dosbatch
+::^^ - entity
+:: ^ punctuation.definition.label.dosbatch
 ::  ^ entity.name.label.dosbatch - punctuation
 ::   ^ - entity
 
    :^(
-::^ - entity
-:: ^ entity.name.label.dosbatch punctuation.definition.label.dosbatch
+::^^ - entity
+:: ^ punctuation.definition.label.dosbatch
 ::  ^^ entity.name.label.dosbatch constant.character.escape.dosbatch - punctuation
 ::    ^ - entity
 
    :^)
-::^ - entity
-:: ^ entity.name.label.dosbatch punctuation.definition.label.dosbatch
+::^^ - entity
+:: ^ punctuation.definition.label.dosbatch
 ::  ^^ entity.name.label.dosbatch constant.character.escape.dosbatch - punctuation
 ::    ^ - entity
 
    :^[
-::^ - entity
-:: ^ entity.name.label.dosbatch punctuation.definition.label.dosbatch
+::^^ - entity
+:: ^ punctuation.definition.label.dosbatch
 ::  ^^ entity.name.label.dosbatch constant.character.escape.dosbatch - punctuation
 ::    ^ - entity
 
    :^]
-::^ - entity
-:: ^ entity.name.label.dosbatch punctuation.definition.label.dosbatch
+::^^ - entity
+:: ^ punctuation.definition.label.dosbatch
 ::  ^^ entity.name.label.dosbatch constant.character.escape.dosbatch - punctuation
 ::    ^ - entity
 
    :^{
-::^ - entity
-:: ^ entity.name.label.dosbatch punctuation.definition.label.dosbatch
+::^^ - entity
+:: ^ punctuation.definition.label.dosbatch
 ::  ^^ entity.name.label.dosbatch constant.character.escape.dosbatch - punctuation
 ::    ^ - entity
 
    :^}
-::^ - entity
-:: ^ entity.name.label.dosbatch punctuation.definition.label.dosbatch
+::^^ - entity
+:: ^ punctuation.definition.label.dosbatch
 ::  ^^ entity.name.label.dosbatch constant.character.escape.dosbatch - punctuation
 ::    ^ - entity
 
    :^>
-::^ - entity
-:: ^ entity.name.label.dosbatch punctuation.definition.label.dosbatch
+::^^ - entity
+:: ^ punctuation.definition.label.dosbatch
 ::  ^^ entity.name.label.dosbatch constant.character.escape.dosbatch - punctuation
 ::    ^ - entity
 
    :^<
-::^ - entity
-:: ^ entity.name.label.dosbatch punctuation.definition.label.dosbatch
+::^^ - entity
+:: ^ punctuation.definition.label.dosbatch
 ::  ^^ entity.name.label.dosbatch constant.character.escape.dosbatch - punctuation
 ::    ^ - entity
 
    :^&
-::^ - entity
-:: ^ entity.name.label.dosbatch punctuation.definition.label.dosbatch
+::^^ - entity
+:: ^ punctuation.definition.label.dosbatch
 ::  ^^ entity.name.label.dosbatch constant.character.escape.dosbatch - punctuation
 ::    ^ - entity
 
    :^|
-::^ - entity
-:: ^ entity.name.label.dosbatch punctuation.definition.label.dosbatch
+::^^ - entity
+:: ^ punctuation.definition.label.dosbatch
 ::  ^^ entity.name.label.dosbatch constant.character.escape.dosbatch - punctuation
 ::    ^ - entity
 
    :%%
-::^ - entity
-:: ^ entity.name.label.dosbatch punctuation.definition.label.dosbatch
+::^^ - entity
+:: ^ punctuation.definition.label.dosbatch
 ::  ^^ entity.name.label.dosbatch - constant.character.escape - punctuation
 ::    ^ - entity
 
    :%
-::^ - entity
-:: ^ entity.name.label.dosbatch punctuation.definition.label.dosbatch
+::^^ - entity
+:: ^ punctuation.definition.label.dosbatch
 ::  ^ entity.name.label.dosbatch - constant.character.escape - punctuation
 ::   ^ - entity
 
    :%var% ignored content ( & echo foo
-::^ - entity
-:: ^^^^^^ entity.name.label.dosbatch
+::^^ - entity
 :: ^ punctuation.definition.label.dosbatch
+::  ^^^^^ entity.name.label.dosbatch
 ::       ^ - entity - comment
-::        ^^^^^^^^^^^^^^^^^ comment.line.ignored.dosbatch
-::                          ^ keyword.operator.logical.dosbatch
-::                            ^^^^^^^^ meta.command.echo.dosbatch
+::        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.ignored.dosbatch
 
    :!
-::^ - entity
-:: ^ entity.name.label.dosbatch punctuation.definition.label.dosbatch
+::^^ - entity
+:: ^ punctuation.definition.label.dosbatch
 ::  ^ entity.name.label.dosbatch - constant.character.escape - punctuation
 ::   ^ - entity
 
    :!var! ignored content ( | echo foo
-::^ - entity
-:: ^^^^^^ entity.name.label.dosbatch
+::^^ - entity
 :: ^ punctuation.definition.label.dosbatch
+::  ^^^^^ entity.name.label.dosbatch
 ::       ^ - entity - comment
-::        ^^^^^^^^^^^^^^^^^ comment.line.ignored.dosbatch
-::                          ^ keyword.operator.assignment.pipe.dosbatch
-::                            ^^^^^^^^ meta.command.echo.dosbatch
+::        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.ignored.dosbatch
+
+   :foo bar
+::^^ - entity
+:: ^ punctuation.definition.label.dosbatch
+::  ^^^ entity.name.label.dosbatch
+::      ^^^ comment.line.ignored.dosbatch
+
+   :foo+bar
+::^^ - entity
+:: ^ punctuation.definition.label.dosbatch
+::  ^^^ entity.name.label.dosbatch
+::     ^^^^ comment.line.ignored.dosbatch
+
+   :foo:bar
+::^^ - entity
+:: ^ punctuation.definition.label.dosbatch
+::  ^^^ entity.name.label.dosbatch
+::     ^^^^ comment.line.ignored.dosbatch
+
+   :foo,bar
+::^^ - entity
+:: ^ punctuation.definition.label.dosbatch
+::  ^^^^^^^ entity.name.label.dosbatch
+
+   :foo;bar
+::^^ - entity
+:: ^ punctuation.definition.label.dosbatch
+::  ^^^^^^^ entity.name.label.dosbatch
+
+   :foo=bar
+::^^ - entity
+:: ^ punctuation.definition.label.dosbatch
+::  ^^^^^^^ entity.name.label.dosbatch
+
+   :foo>bar
+::^^ - entity
+:: ^ punctuation.definition.label.dosbatch
+::  ^^^ entity.name.label.dosbatch
+::     ^^^^^ comment.line.ignored.dosbatch
+
+   :foo<bar
+::^^ - entity
+:: ^ punctuation.definition.label.dosbatch
+::  ^^^ entity.name.label.dosbatch
+::     ^^^^^ comment.line.ignored.dosbatch
+
+   :foo&bar
+::^^ - entity
+:: ^ punctuation.definition.label.dosbatch
+::  ^^^ entity.name.label.dosbatch
+::     ^^^^^ comment.line.ignored.dosbatch
+
+   :foo|bar
+::^^ - entity
+:: ^ punctuation.definition.label.dosbatch
+::  ^^^ entity.name.label.dosbatch
+::     ^^^^^ comment.line.ignored.dosbatch
+
+   :==foo==
+:: ^ punctuation.definition.label.dosbatch
+::  ^^ comment.line.ignored.dosbatch
+::    ^^^^^ entity.name.label.dosbatch
+
+   :== foo ==
+:: ^ punctuation.definition.label.dosbatch
+::  ^^^ comment.line.ignored.dosbatch
+::     ^^^ entity.name.label.dosbatch
+::         ^^^ comment.line.ignored.dosbatch
+
+   :== &foo ==
+:: ^ punctuation.definition.label.dosbatch
+::  ^^^^^^^^^^^ comment.line.ignored.dosbatch
+
+   :== ^
+   foo ===
+:: ^^^^^^^ comment.line.ignored.dosbatch
 
    :This is a #@$虎 strange label
-::^ - entity
+::^^ - entity
 :: ^ punctuation.definition.label.dosbatch
-:: ^^^^^ entity.name.label.dosbatch
+::  ^^^^ entity.name.label.dosbatch
 ::      ^ - entity - comment
 ::       ^^^^^^^^^^^^^^^^^^^^^^^ comment.line.ignored.dosbatch
 
    :This" is a #@$虎" strange label
-::^ - entity
-:: ^^^^^^ entity.name.label.dosbatch
+::^^ - entity
+::  ^^^^^ entity.name.label.dosbatch
 ::       ^ - entity - comment
 ::        ^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.ignored.dosbatch
 
    :"This is a #@$虎" strange label
-::^ - entity
-:: ^^^^^^ entity.name.label.dosbatch
+::^^ - entity
+::  ^^^^^ entity.name.label.dosbatch
 ::       ^ - entity - comment
 ::        ^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.ignored.dosbatch
+
+   :> ignored content ( & | )
+:: ^ punctuation.definition.label.dosbatch
+::  ^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.ignored.dosbatch - punctuation
+
+   :< ignored content ( & | )
+:: ^ punctuation.definition.label.dosbatch
+::  ^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.ignored.dosbatch - punctuation
+
+   :& ignored content ( & | )
+:: ^ punctuation.definition.label.dosbatch
+::  ^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.ignored.dosbatch - punctuation
+
+   :| ignored content ( & | )
+:: ^ punctuation.definition.label.dosbatch
+::  ^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.ignored.dosbatch - punctuation
+
+   : ^
+   Me too!
+:: ^^^^^^^ comment.line.ignored.dosbatch
+
+   : ^
+
+   Me too!
+:: ^^^^^^^ comment.line.ignored.dosbatch
+
+   : ^
+   A continued comment.^
+   Me too!
+:: ^^^^^^^ comment.line.ignored.dosbatch
+
+   : ^
+   ^
+   Me too!
+:: ^^^^^^^^ comment.line.ignored.dosbatch
+
+: ^
+^
+   Not me, though.
+:: ^^^^^^^^^^^^^^^^ - comment
 
 :::: [ Control Flow ] :::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
@@ -580,7 +627,7 @@ ECHO : Not a comment ^
 ::          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.dosbatch
 ::                                     ^ - meta.function-call
 :: ^^^^ keyword.control.flow.call.dosbatch
-::     ^ punctuation.definition.variable.dosbatch
+::     ^ punctuation.definition.label.dosbatch
 ::     ^^^^^ variable.label.dosbatch - keyword
 ::          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ - variable
 ::                     ^^ constant.character.escape.dosbatch
@@ -592,14 +639,14 @@ ECHO : Not a comment ^
 ::     ^^^^ meta.function-call.identifier.dosbatch
 ::         ^ - meta.function-call
 :: ^^^^ keyword.control.flow.call.dosbatch
-::     ^ punctuation.definition.variable.dosbatch
+::     ^ punctuation.definition.label.dosbatch
 ::     ^^^^ variable.label.dosbatch - keyword
 
    CALL ^
    :EOF
 :: ^^^^ meta.function-call.identifier.dosbatch
 ::     ^ - meta.function-call
-:: ^ punctuation.definition.variable.dosbatch
+:: ^ punctuation.definition.label.dosbatch
 :: ^^^^ variable.label.dosbatch - keyword
 
    CALL ^
@@ -607,7 +654,7 @@ ECHO : Not a comment ^
    :EOF
 :: ^^^^ meta.function-call.identifier.dosbatch
 ::     ^ - meta.function-call
-:: ^ punctuation.definition.variable.dosbatch
+:: ^ punctuation.definition.label.dosbatch
 :: ^^^^ variable.label.dosbatch - keyword
 
    CALL ^
@@ -616,7 +663,7 @@ ECHO : Not a comment ^
    :EOF
 :: ^^^^ - meta.function-call
 :: ^ punctuation.definition.label.dosbatch
-:: ^^^^ entity.name.label.dosbatch
+::  ^^^ entity.name.label.dosbatch
 
    CALL :foo 10 %1
 ::^ - meta.function-call
@@ -625,7 +672,7 @@ ECHO : Not a comment ^
 ::          ^^^^^^ meta.function-call.arguments.dosbatch
 ::                ^ - meta.function-call
 :: ^^^^ keyword.control.flow.call.dosbatch
-::      ^ punctuation.definition.variable.dosbatch
+::      ^ punctuation.definition.label.dosbatch
 ::      ^^^^ variable.label.dosbatch - keyword
 ::           ^^ meta.number.integer.decimal.dosbatch constant.numeric.value.dosbatch
 ::              ^^ variable.parameter.dosbatch
@@ -637,7 +684,7 @@ ECHO : Not a comment ^
 ::                ^^ meta.function-call.arguments.dosbatch
 ::                  ^ - meta.function-call
 :: ^^^^ keyword.control.flow.call.dosbatch
-::      ^ punctuation.definition.variable.dosbatch
+::      ^ punctuation.definition.label.dosbatch
 ::      ^^^^ variable.label.dosbatch - keyword
 ::                ^^ meta.number.integer.decimal.dosbatch constant.numeric.value.dosbatch
 
@@ -648,7 +695,7 @@ ECHO : Not a comment ^
 ::           ^^^^^^^^ meta.function-call.arguments.dosbatch
 ::                   ^ - meta.function-call
 :: ^^^^ keyword.control.flow.call.dosbatch
-::      ^ punctuation.definition.variable.dosbatch
+::      ^ punctuation.definition.label.dosbatch
 ::      ^^^^ variable.label.dosbatch - keyword
 ::           ^^^^^ meta.interpolation.dosbatch - variable.label - keyword
 ::                 ^^ meta.number.integer.decimal.dosbatch constant.numeric.value.dosbatch
@@ -660,7 +707,7 @@ ECHO : Not a comment ^
 ::        ^^^ meta.function-call.arguments.dosbatch
 ::           ^ - meta.function-call
 :: ^^^^ keyword.control.flow.call.dosbatch
-::      ^ punctuation.definition.variable.dosbatch
+::      ^ punctuation.definition.label.dosbatch
 ::      ^^ variable.label.dosbatch - keyword
 ::         ^^ meta.number.integer.decimal.dosbatch constant.numeric.value.dosbatch
 
@@ -671,7 +718,7 @@ ECHO : Not a comment ^
 ::         ^^^ meta.function-call.arguments.dosbatch
 ::            ^ - meta.function-call
 :: ^^^^ keyword.control.flow.call.dosbatch
-::      ^ punctuation.definition.variable.dosbatch
+::      ^ punctuation.definition.label.dosbatch
 ::      ^^^ variable.label.dosbatch - keyword
 ::       ^^ constant.character.escape.dosbatch
 ::          ^^ meta.number.integer.decimal.dosbatch constant.numeric.value.dosbatch
@@ -683,7 +730,7 @@ ECHO : Not a comment ^
 ::        ^^^ meta.function-call.arguments.dosbatch
 ::           ^ - meta.function-call
 :: ^^^^ keyword.control.flow.call.dosbatch
-::      ^ punctuation.definition.variable.dosbatch
+::      ^ punctuation.definition.label.dosbatch
 ::      ^^ variable.label.dosbatch - keyword
 ::         ^^ meta.number.integer.decimal.dosbatch constant.numeric.value.dosbatch
 
@@ -694,7 +741,7 @@ ECHO : Not a comment ^
 ::         ^^^ meta.function-call.arguments.dosbatch
 ::            ^ - meta.function-call
 :: ^^^^ keyword.control.flow.call.dosbatch
-::      ^ punctuation.definition.variable.dosbatch
+::      ^ punctuation.definition.label.dosbatch
 ::      ^^^ variable.label.dosbatch - keyword
 ::       ^^ constant.character.escape.dosbatch
 ::          ^^ meta.number.integer.decimal.dosbatch constant.numeric.value.dosbatch
@@ -706,7 +753,7 @@ ECHO : Not a comment ^
 ::         ^^^ meta.function-call.arguments.dosbatch
 ::            ^ - meta.function-call
 :: ^^^^ keyword.control.flow.call.dosbatch
-::      ^ punctuation.definition.variable.dosbatch
+::      ^ punctuation.definition.label.dosbatch
 ::      ^^^ variable.label.dosbatch - keyword
 ::       ^^ constant.character.escape.dosbatch
 ::          ^^ meta.number.integer.decimal.dosbatch constant.numeric.value.dosbatch
@@ -718,7 +765,7 @@ ECHO : Not a comment ^
 ::         ^^^ meta.function-call.arguments.dosbatch
 ::            ^ - meta.function-call
 :: ^^^^ keyword.control.flow.call.dosbatch
-::      ^ punctuation.definition.variable.dosbatch
+::      ^ punctuation.definition.label.dosbatch
 ::      ^^^ variable.label.dosbatch - keyword
 ::       ^^ constant.character.escape.dosbatch
 ::          ^^ meta.number.integer.decimal.dosbatch constant.numeric.value.dosbatch
@@ -730,7 +777,7 @@ ECHO : Not a comment ^
 ::         ^^^ meta.function-call.arguments.dosbatch
 ::            ^ - meta.function-call
 :: ^^^^ keyword.control.flow.call.dosbatch
-::      ^ punctuation.definition.variable.dosbatch
+::      ^ punctuation.definition.label.dosbatch
 ::      ^^^ variable.label.dosbatch - keyword
 ::       ^^ constant.character.escape.dosbatch
 ::          ^^ meta.number.integer.decimal.dosbatch constant.numeric.value.dosbatch
@@ -742,7 +789,7 @@ ECHO : Not a comment ^
 ::         ^^^ meta.function-call.arguments.dosbatch
 ::            ^ - meta.function-call
 :: ^^^^ keyword.control.flow.call.dosbatch
-::      ^ punctuation.definition.variable.dosbatch
+::      ^ punctuation.definition.label.dosbatch
 ::      ^^^ variable.label.dosbatch - keyword
 ::       ^^ constant.character.escape.dosbatch
 ::          ^^ meta.number.integer.decimal.dosbatch constant.numeric.value.dosbatch
@@ -754,7 +801,7 @@ ECHO : Not a comment ^
 ::         ^^^ meta.function-call.arguments.dosbatch
 ::            ^ - meta.function-call
 :: ^^^^ keyword.control.flow.call.dosbatch
-::      ^ punctuation.definition.variable.dosbatch
+::      ^ punctuation.definition.label.dosbatch
 ::      ^^^ variable.label.dosbatch - keyword
 ::       ^^ constant.character.escape.dosbatch
 ::          ^^ meta.number.integer.decimal.dosbatch constant.numeric.value.dosbatch
@@ -766,7 +813,7 @@ ECHO : Not a comment ^
 ::              ^^^ meta.function-call.arguments.dosbatch
 ::                 ^ - meta.function-call
 :: ^^^^ keyword.control.flow.call.dosbatch
-::      ^ variable.label.dosbatch punctuation.definition.variable.dosbatch
+::      ^ variable.label.dosbatch punctuation.definition.label.dosbatch
 ::       ^^^^^^^ variable.label.dosbatch meta.interpolation.dosbatch
 ::       ^ punctuation.section.interpolation.begin.dosbatch
 ::        ^^^^^ variable.other.readwrite.dosbatch
@@ -780,7 +827,7 @@ ECHO : Not a comment ^
 ::         ^^^ meta.function-call.arguments.dosbatch
 ::            ^ - meta.function-call
 :: ^^^^ keyword.control.flow.call.dosbatch
-::      ^ punctuation.definition.variable.dosbatch
+::      ^ punctuation.definition.label.dosbatch
 ::      ^^^ variable.label.dosbatch - keyword
 ::       ^^ constant.character.escape.dosbatch
 ::          ^^ meta.number.integer.decimal.dosbatch constant.numeric.value.dosbatch
@@ -792,12 +839,70 @@ ECHO : Not a comment ^
 ::              ^^^ meta.function-call.arguments.dosbatch
 ::                 ^ - meta.function-call
 :: ^^^^ keyword.control.flow.call.dosbatch
-::      ^ variable.label.dosbatch punctuation.definition.variable.dosbatch
+::      ^ variable.label.dosbatch punctuation.definition.label.dosbatch
 ::       ^^^^^^^ variable.label.dosbatch meta.interpolation.dosbatch
 ::       ^ punctuation.section.interpolation.begin.dosbatch
 ::        ^^^^^ variable.other.readwrite.dosbatch
 ::             ^ punctuation.section.interpolation.end.dosbatch
 ::               ^^ meta.number.integer.decimal.dosbatch constant.numeric.value.dosbatch
+
+   CALL :foo bar & :: foo > %0 , bar > %1
+::      ^ variable.label.dosbatch punctuation.definition.label.dosbatch
+::       ^^^ variable.label.dosbatch
+::          ^ - comment - string - variable
+::           ^^^ meta.string.dosbatch string.unquoted.dosbatch
+
+   CALL :foo+bar & :: foo > %0, bar ignored for label lookup, no arguments
+::      ^ variable.label.dosbatch punctuation.definition.label.dosbatch
+::       ^^^ variable.label.dosbatch
+::          ^^^^ comment.line.ignored.dosbatch
+::              ^ - comment - variable
+
+   CALL :foo:bar & :: foo > %0, bar ignored for label lookup, no arguments
+::      ^ variable.label.dosbatch punctuation.definition.label.dosbatch
+::       ^^^ variable.label.dosbatch
+::          ^^^^ comment.line.ignored.dosbatch
+::              ^ - comment - variable
+
+   CALL :foo,bar & :: foo > %0 , bar > %1
+::      ^ variable.label.dosbatch punctuation.definition.label.dosbatch
+::       ^^^ variable.label.dosbatch
+::          ^ - comment - string - variable
+::           ^^^ meta.string.dosbatch string.unquoted.dosbatch
+
+   CALL :foo;bar & :: foo > %0 , bar > %1
+::      ^ variable.label.dosbatch punctuation.definition.label.dosbatch
+::       ^^^ variable.label.dosbatch
+::          ^ - comment - string - variable
+::           ^^^ meta.string.dosbatch string.unquoted.dosbatch
+
+   CALL :foo=bar & :: foo > %0 , bar > %1
+::      ^ variable.label.dosbatch punctuation.definition.label.dosbatch
+::       ^^^ variable.label.dosbatch
+::          ^ - comment - string - variable
+::           ^^^ meta.string.dosbatch string.unquoted.dosbatch
+
+   CALL :foo>bar
+::      ^ variable.label.dosbatch punctuation.definition.label.dosbatch
+::       ^^^ variable.label.dosbatch
+::          ^^^^ meta.redirection.dosbatch
+
+   CALL :foo<bar
+::      ^ variable.label.dosbatch punctuation.definition.label.dosbatch
+::       ^^^ variable.label.dosbatch
+::          ^^^^ meta.redirection.dosbatch
+
+   CALL :foo&bar
+::      ^ variable.label.dosbatch punctuation.definition.label.dosbatch
+::       ^^^ variable.label.dosbatch
+::          ^ keyword.operator.logical.dosbatch
+::           ^^^ variable.function.dosbatch
+
+   CALL :foo|bar
+::      ^ variable.label.dosbatch punctuation.definition.label.dosbatch
+::       ^^^ variable.label.dosbatch
+::          ^ keyword.operator.assignment.pipe.dosbatch
+::           ^^^ variable.function.dosbatch
 
    CALL :foo^
 bar baz
@@ -1223,6 +1328,74 @@ bar baz
 ::           ^^ constant.character.escape.dosbatch
 ::              ^^^^^^^^^^^^^^^^^ comment.line.ignored.dosbatch
 ::                                ^ keyword.operator.assignment.pipe.dosbatch
+
+   GOTO :foo bar
+:: ^^^^^^^^^^^^^ meta.command.goto.dosbatch
+::      ^ variable.label.dosbatch punctuation.definition.label.dosbatch
+::       ^^^ variable.label.dosbatch
+::           ^^^ comment.line.ignored.dosbatch
+
+   GOTO :foo+bar
+:: ^^^^^^^^^^^^^ meta.command.goto.dosbatch
+::      ^ variable.label.dosbatch punctuation.definition.label.dosbatch
+::       ^^^ variable.label.dosbatch
+::          ^^^^ comment.line.ignored.dosbatch
+
+   GOTO :foo:bar
+:: ^^^^^^^^^^^^^ meta.command.goto.dosbatch
+::      ^ variable.label.dosbatch punctuation.definition.label.dosbatch
+::       ^^^ variable.label.dosbatch
+::          ^^^^ comment.line.ignored.dosbatch
+
+   GOTO :foo,bar
+:: ^^^^^^^^^^^^^ meta.command.goto.dosbatch
+::      ^ variable.label.dosbatch punctuation.definition.label.dosbatch
+::       ^^^ variable.label.dosbatch
+::          ^^^^ comment.line.ignored.dosbatch
+
+   GOTO :foo;bar
+:: ^^^^^^^^^^^^^ meta.command.goto.dosbatch
+::      ^ variable.label.dosbatch punctuation.definition.label.dosbatch
+::       ^^^ variable.label.dosbatch
+::          ^^^^ comment.line.ignored.dosbatch
+
+   GOTO :foo=bar
+:: ^^^^^^^^^^^^^ meta.command.goto.dosbatch
+::      ^ variable.label.dosbatch punctuation.definition.label.dosbatch
+::       ^^^ variable.label.dosbatch
+::          ^^^^ comment.line.ignored.dosbatch
+
+   GOTO :foo>bar
+:: ^^^^^^^^^ meta.command.goto.dosbatch - meta.redirection
+::          ^^^^ meta.command.goto.dosbatch meta.redirection.dosbatch
+::      ^ variable.label.dosbatch punctuation.definition.label.dosbatch
+::       ^^^ variable.label.dosbatch
+::          ^ keyword.operator.assignment.redirection.dosbatch
+::           ^^^ meta.string.dosbatch string.unquoted.dosbatch
+
+   GOTO :foo<bar
+:: ^^^^^^^^^ meta.command.goto.dosbatch - meta.redirection
+::          ^^^^ meta.command.goto.dosbatch meta.redirection.dosbatch
+::      ^ variable.label.dosbatch punctuation.definition.label.dosbatch
+::       ^^^ variable.label.dosbatch
+::          ^ keyword.operator.assignment.redirection.dosbatch
+::           ^^^ meta.string.dosbatch string.unquoted.dosbatch
+
+   GOTO :foo&bar
+:: ^^^^^^^^^ meta.command.goto.dosbatch
+::          ^^^^^ - meta.command.goto
+::      ^ variable.label.dosbatch punctuation.definition.label.dosbatch
+::       ^^^ variable.label.dosbatch
+::          ^ keyword.operator.logical.dosbatch
+::           ^^^ variable.function.dosbatch
+
+   GOTO :foo|bar
+:: ^^^^^^^^^ meta.command.goto.dosbatch
+::          ^^^^^ - meta.command.goto
+::      ^ variable.label.dosbatch punctuation.definition.label.dosbatch
+::       ^^^ variable.label.dosbatch
+::          ^ keyword.operator.assignment.pipe.dosbatch
+::           ^^^ variable.function.dosbatch
 
    GOTO:This is a #@$虎 strange label
 :: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.command.goto.dosbatch

--- a/Batch File/tests/syntax_test_batch_file.bat
+++ b/Batch File/tests/syntax_test_batch_file.bat
@@ -2456,6 +2456,7 @@ put arg1 arg2
 ::          ^^^^^^^^ meta.parameter.option.dosbatch - meta.interpolation
 ::                  ^^^^ meta.parameter.option.dosbatch meta.interpolation.dosbatch
 ::                      ^ meta.parameter.option.dosbatch - meta.interpolation
+::                       ^ - meta.parameter
 ::         ^ punctuation.definition.variable.dosbatch
 ::          ^ - punctuation
 ::                  ^ punctuation.section.interpolation.begin.dosbatch
@@ -2472,7 +2473,8 @@ put arg1 arg2
 ::                           ^ meta.parameter.value.dosbatch meta.string.dosbatch string.unquoted.dosbatch
 ::                            ^ - meta.parameter
 
-   command ..\folder2\ /type:*.txt
+   :: note: unescaped `=` breaks words and is ignored if not in assignment position
+   command ..\folder2\=/type:*.txt
 :: ^^^^^^^ meta.function-call.identifier.dosbatch variable.function.dosbatch
 ::        ^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.dosbatch
 ::                                ^ - meta.function-call
@@ -2485,6 +2487,7 @@ put arg1 arg2
 ::         ^^ constant.other.path.parent.dosbatch
 ::           ^ punctuation.separator.path.dosbatch
 ::                   ^ punctuation.separator.path.dosbatch
+::                    ^ punctuation.separator.dosbatch
 ::                     ^^^^^ variable.parameter.option.dosbatch
 ::                          ^ keyword.operator.assignment.dosbatch
 ::                           ^^^^^ string.unquoted.dosbatch


### PR DESCRIPTION
This PR applies tokenization rules from https://stackoverflow.com/questions/4094699/how-does-the-windows-command-interpreter-cmd-exe-parse-scripts/4095133#4095133 to labels and common command arguments.

As a result invalid labels are scoped "ignored" even without dedicated comment contexts and less special-casing patterns. They are however kept to maintain `comment.line` scopes for now.

Delimiter characters such as `=` are ignored, which fixes scoping of somewhat uncommon but valid labels like `:=== label ===`.

Delimiter chars are scoped `punctuation.separator` if not having any other special meaning (e.g.: `=` `keyword.operator.assignment`) depending on context.

Accuracy of various tokens - including some odds of batch - is increased to match highlighting better to interpreter's behavior.

