### PR TITLE
[Rust] Add variants for short message formats

### DIFF
--- a/Rust/Cargo.sublime-build
+++ b/Rust/Cargo.sublime-build
@@ -12,8 +12,18 @@
             "name": "Run"
         },
         {
+            "cmd": ["cargo", "run", "--message-format", "short"],
+            "file_regex": "^([^:]*):([0-9]*):([0-9]*):\\s*(.*)",
+            "name": "Run (Short)"
+        },
+        {
             "cmd": ["cargo", "test"],
             "name": "Test"
+        },
+        {
+            "cmd": ["cargo", "test", "--message-format", "short"],
+            "file_regex": "^([^:]*):([0-9]*):([0-9]*):\\s*(.*)",
+            "name": "Test (Short)"
         },
         {
             "cmd": ["cargo", "bench"],
@@ -26,6 +36,20 @@
         {
             "cmd": ["cargo", "clippy"],
             "name": "Clippy"
+        },
+        {
+            "cmd": ["cargo", "clippy", "--message-format", "short"],
+            "file_regex": "^([^:]*):([0-9]*):([0-9]*):\\s*(.*)",
+            "name": "Clippy (Short)"
+        },
+        {
+            "cmd": ["cargo", "check", "--all-targets"],
+            "name": "Check"
+        },
+        {
+            "cmd": ["cargo", "check", "--all-targets", "--message-format", "short"],
+            "file_regex": "^([^:]*):([0-9]*):([0-9]*):\\s*(.*)",
+            "name": "Check (Short)"
         },
     ]
 }


### PR DESCRIPTION
Closes #4004

I've added some variants for building, running, and checking using Rust's short message format, which gives a nicer inline error than Rust's default output.

I'm not familiar with the conventions of this codebase though around naming, preferred use of regex features etc, so if it's easier to just redo this in a more idiomatic way than it is to explain it then feel free to close :slightly_smiling_face: