### PR TITLE
[Markdown] Match code block syntax names with Linguist aliases

### DIFF
--- a/Markdown/Code Block Syntaxes.sublime-completions
+++ b/Markdown/Code Block Syntaxes.sublime-completions
@@ -18,13 +18,19 @@
 
 		// AppleScript
 		{
-			"trigger": "AppleScript",
+			"trigger": "applescript",
 			"annotation": "AppleScript",
 			"kind": ["markup", "s", "Syntax"],
 			"details": "Specifies <code>AppleScript</code> code highlighting"
 		},
 		{
 			"trigger": "osascript",
+			"annotation": "AppleScript",
+			"kind": ["markup", "s", "Syntax"],
+			"details": "Specifies <code>AppleScript</code> code highlighting"
+		},
+		{
+			"trigger": "scpt",
 			"annotation": "AppleScript",
 			"kind": ["markup", "s", "Syntax"],
 			"details": "Specifies <code>AppleScript</code> code highlighting"
@@ -39,19 +45,19 @@
 		},
 		{
 			"trigger": "cpp",
-			"annotation": "C++",
+			"annotation": "C++ source",
 			"kind": ["markup", "s", "Syntax"],
 			"details": "Specifies <code>C++</code> code highlighting"
 		},
 		{
 			"trigger": "cxx",
-			"annotation": "C++",
+			"annotation": "C++ source",
 			"kind": ["markup", "s", "Syntax"],
 			"details": "Specifies <code>C++</code> code highlighting"
 		},
 		{
 			"trigger": "c++",
-			"annotation": "C++",
+			"annotation": "C++ source",
 			"kind": ["markup", "s", "Syntax"],
 			"details": "Specifies <code>C++</code> code highlighting"
 		},
@@ -130,6 +136,12 @@
 			"details": "Specifies <code>Diff</code> code highlighting"
 		},
 		{
+			"trigger": "udiff",
+			"annotation": "Unified Diff",
+			"kind": ["markup", "s", "Syntax"],
+			"details": "Specifies <code>Diff</code> code highlighting"
+		},
+		{
 			"trigger": "patch",
 			"annotation": "Patch",
 			"kind": ["markup", "s", "Syntax"],
@@ -144,19 +156,43 @@
 			"details": "Specifies <code>DOS batch</code> code highlighting"
 		},
 		{
+			"trigger": "batch",
+			"annotation": "DOS batch",
+			"kind": ["markup", "s", "Syntax"],
+			"details": "Specifies <code>DOS batch</code> code highlighting"
+		},
+		{
+			"trigger": "batchfile",
+			"annotation": "DOS batch",
+			"kind": ["markup", "s", "Syntax"],
+			"details": "Specifies <code>DOS batch</code> code highlighting"
+		},
+		{
 			"trigger": "cmd",
 			"annotation": "DOS batch",
 			"kind": ["markup", "s", "Syntax"],
 			"details": "Specifies <code>DOS batch</code> code highlighting"
 		},
 		{
-			"trigger": "dos",
+			"trigger": "dosbatch",
+			"annotation": "DOS batch",
+			"kind": ["markup", "s", "Syntax"],
+			"details": "Specifies <code>DOS batch</code> code highlighting"
+		},
+		{
+			"trigger": "winbatch",
 			"annotation": "DOS batch",
 			"kind": ["markup", "s", "Syntax"],
 			"details": "Specifies <code>DOS batch</code> code highlighting"
 		},
 
 		// Erlang
+		{
+			"trigger": "erl",
+			"annotation": "Erlang",
+			"kind": ["markup", "s", "Syntax"],
+			"details": "Specifies <code>Erlang</code> code highlighting"
+		},
 		{
 			"trigger": "erlang",
 			"annotation": "Erlang",
@@ -186,7 +222,19 @@
 
 		// GraphViz
 		{
+			"trigger": "dot",
+			"annotation": "GraphViz",
+			"kind": ["markup", "s", "Syntax"],
+			"details": "Specifies <code>GraphViz</code> code highlighting"
+		},
+		{
 			"trigger": "graphviz",
+			"annotation": "GraphViz",
+			"kind": ["markup", "s", "Syntax"],
+			"details": "Specifies <code>GraphViz</code> code highlighting"
+		},
+		{
+			"trigger": "gv",
 			"annotation": "GraphViz",
 			"kind": ["markup", "s", "Syntax"],
 			"details": "Specifies <code>GraphViz</code> code highlighting"
@@ -199,10 +247,28 @@
 			"kind": ["markup", "s", "Syntax"],
 			"details": "Specifies <code>Haskell</code> code highlighting"
 		},
+		{
+			"trigger": "hs",
+			"annotation": "Haskell",
+			"kind": ["markup", "s", "Syntax"],
+			"details": "Specifies <code>Haskell</code> code highlighting"
+		},
+		{
+			"trigger": "hsc",
+			"annotation": "Haskell C binding",
+			"kind": ["markup", "s", "Syntax"],
+			"details": "Specifies <code>Haskell</code> code highlighting"
+		},
 
 		// HTML
 		{
 			"trigger": "html",
+			"annotation": "HTML",
+			"kind": ["markup", "s", "Syntax"],
+			"details": "Specifies <code>HTML</code> code highlighting"
+		},
+		{
+			"trigger": "xhtml",
 			"annotation": "HTML",
 			"kind": ["markup", "s", "Syntax"],
 			"details": "Specifies <code>HTML</code> code highlighting"
@@ -242,13 +308,25 @@
 			"details": "Specifies <code>JavaScript</code> code highlighting"
 		},
 		{
-			"trigger": "JSX",
+			"trigger": "node",
+			"annotation": "JavaScript",
+			"kind": ["markup", "s", "Syntax"],
+			"details": "Specifies <code>JavaScript</code> code highlighting"
+		},
+		{
+			"trigger": "jsx",
 			"annotation": "JavaScript React",
 			"kind": ["markup", "s", "Syntax"],
 			"details": "Specifies <code>JavaScript React</code> code highlighting"
 		},
 		{
 			"trigger": "ts",
+			"annotation": "TypeScript",
+			"kind": ["markup", "s", "Syntax"],
+			"details": "Specifies <code>TypeScript</code> code highlighting"
+		},
+		{
+			"trigger": "tsnode",
 			"annotation": "TypeScript",
 			"kind": ["markup", "s", "Syntax"],
 			"details": "Specifies <code>TypeScript</code> code highlighting"
@@ -308,6 +386,26 @@
 			"annotation": "Lua",
 			"kind": ["markup", "s", "Syntax"],
 			"details": "Specifies <code>Lua</code> code highlighting"
+		},
+
+		// Makefile
+		{
+			"trigger": "make",
+			"annotation": "Makefile",
+			"kind": ["markup", "s", "Syntax"],
+			"details": "Specifies <code>Makefile</code> code highlighting"
+		},
+		{
+			"trigger": "makefile",
+			"annotation": "Makefile",
+			"kind": ["markup", "s", "Syntax"],
+			"details": "Specifies <code>Makefile</code> code highlighting"
+		},
+		{
+			"trigger": "mf",
+			"annotation": "Makefile",
+			"kind": ["markup", "s", "Syntax"],
+			"details": "Specifies <code>Makefile</code> code highlighting"
 		},
 
 		// Matlab
@@ -383,10 +481,22 @@
 			"kind": ["markup", "s", "Syntax"],
 			"details": "Specifies <code>Perl 5</code> code highlighting"
 		},
+		{
+			"trigger": "perl5",
+			"annotation": "Perl 5",
+			"kind": ["markup", "s", "Syntax"],
+			"details": "Specifies <code>Perl 5</code> code highlighting"
+		},
 
 		// PHP
 		{
 			"trigger": "html+php",
+			"annotation": "PHP",
+			"kind": ["markup", "s", "Syntax"],
+			"details": "Specifies <code>HTML+PHP</code> code highlighting"
+		},
+		{
+			"trigger": "phtml",
 			"annotation": "PHP",
 			"kind": ["markup", "s", "Syntax"],
 			"details": "Specifies <code>HTML+PHP</code> code highlighting"
@@ -404,9 +514,15 @@
 			"details": "Specifies <code>PHP</code> code highlighting"
 		},
 
-		// Phyton
+		// Python
 		{
 			"trigger": "python",
+			"annotation": "Python",
+			"kind": ["markup", "s", "Syntax"],
+			"details": "Specifies <code>Python</code> code highlighting"
+		},
+		{
+			"trigger": "python3",
 			"annotation": "Python",
 			"kind": ["markup", "s", "Syntax"],
 			"details": "Specifies <code>Python</code> code highlighting"

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -1161,7 +1161,7 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          (?i:\s*(applescript|osascript))
+          (?i:\s*(applescript|osascript|scpt))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.applescript.markdown-gfm
@@ -1293,7 +1293,7 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          (?i:\s*(diff|patch))
+          (?i:\s*(u?diff|patch))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.diff.markdown-gfm
@@ -1315,7 +1315,7 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          (?i:\s*(bat|cmd|dos))
+          (?i:\s*(bat(?:ch(?:file)?)?|cmd|(?:dos|win)batch))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.dosbatch.markdown-gfm
@@ -1337,7 +1337,7 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          (?i:\s*(erlang|escript))
+          (?i:\s*(erl(?:ang)?|escript))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.erlang.markdown-gfm
@@ -1359,7 +1359,7 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          (?i:\s*(graphviz))
+          (?i:\s*(dot|graphviz|gv))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.graphviz.markdown-gfm
@@ -1403,7 +1403,7 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          (?i:\s*(haskell))
+          (?i:\s*(haskell|hsc?))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.haskell.markdown-gfm
@@ -1425,7 +1425,7 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          (?i:\s*(html\+php))
+          (?i:\s*(html\+php|phtml))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.html-php.markdown-gfm
@@ -1447,7 +1447,7 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          (?i:\s*(html))
+          (?i:\s*(x?html))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.html.markdown-gfm
@@ -1491,7 +1491,7 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          (?i:\s*(javascript|js))
+          (?i:\s*(javascript|js|node))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.javascript.markdown-gfm
@@ -1645,7 +1645,7 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          (?i:\s*(makefile))
+          (?i:\s*(make(?:file)?|mf))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.makefile.markdown-gfm
@@ -1755,7 +1755,7 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          (?i:\s*(perl))
+          (?i:\s*(perl5?))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.perl.markdown-gfm
@@ -1799,7 +1799,7 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          (?i:\s*(python|py))
+          (?i:\s*(python3?|py))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.python.markdown-gfm
@@ -2019,7 +2019,7 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          (?i:\s*(typescript|ts))
+          (?i:\s*(typescript|ts(?:node)?))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.typescript.markdown-gfm

--- a/Markdown/tests/syntax_test_markdown.md
+++ b/Markdown/tests/syntax_test_markdown.md
@@ -1842,9 +1842,9 @@ echo This is a smiley :-\) \(I have to escape the parentheses, though!\)
 |^^ meta.code-fence.definition.end.diff.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 |  ^ meta.code-fence.definition.end.diff.markdown-gfm meta.fold.code-fence.end - punctuation
 
-```Graphviz
-|^^^^^^^^^^ meta.code-fence.definition.begin - meta.fold
-|          ^ meta.code-fence.definition.begin meta.fold.code-fence.begin
+```dot
+|^^^^^ meta.code-fence.definition.begin - meta.fold
+|     ^ meta.code-fence.definition.begin meta.fold.code-fence.begin
 
 graph n {}
 | ^^^ storage.type.dot


### PR DESCRIPTION
Mainly because `batchfile` didn't work for batch files...

This commit adds most of Linguist (GH language detector - [source][1]) aliases for languages for which fenced code block contexts exist in Markdown grammar.

I've omitted a few aliases because these name separate languages with their own third-party packages (notably `cake`, `octave` and some `sh` variants).

I've left ActionScript alone as I wasn't sure whether the grammar covers as3.

[1]: https://github.com/github-linguist/linguist/blob/master/lib/linguist/languages.yml