### PR TITLE
[Mixed] Use detailed scope for true/false/null

### DIFF
--- a/ActionScript/ActionScript.sublime-syntax
+++ b/ActionScript/ActionScript.sublime-syntax
@@ -24,7 +24,13 @@ contexts:
       scope: keyword.control.actionscript.2
     - match: \b(Boolean|Number|String|Void)\b
       scope: storage.type.actionscript.2
-    - match: \b(null|undefined|true|false)\b
+    - match: \bfalse\b
+      scope: constant.language.boolean.false.actionscript.2
+    - match: \btrue\b
+      scope: constant.language.boolean.true.actionscript.2
+    - match: \bnull\b
+      scope: constant.language.null.actionscript.2
+    - match: \bundefined\b
       scope: constant.language.actionscript.2
     - match: '\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\.?[0-9]*)|(\.[0-9]+))((e|E)(\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f)?\b'
       scope: constant.numeric.actionscript.2

--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -1634,8 +1634,12 @@ contexts:
   # bools, numbers, chars, simple strings
   literals:
     # language constants
-    - match: \b(true|false|null)\b
-      scope: constant.language.cs
+    - match: \bfalse\b
+      scope: constant.language.boolean.false.cs
+    - match: \btrue\b
+      scope: constant.language.boolean.true.cs
+    - match: \bnull\b
+      scope: constant.language.null.cs
     # characters
     - match: '''\'''
       scope: invalid.illegal.lone-escape.cs

--- a/C++/C.sublime-syntax
+++ b/C++/C.sublime-syntax
@@ -211,7 +211,13 @@ contexts:
       scope: variable.other.readwrite.static.mac-classic.c
 
   constants:
-    - match: \b(__func__|NULL|true|false|TRUE|FALSE)\b
+    - match: \b(false|FALSE)\b
+      scope: constant.language.boolean.false.c
+    - match: \b(true|TRUE)\b
+      scope: constant.language.boolean.true.c
+    - match: \bNULL\b
+      scope: constant.language.null.c
+    - match: \b__func__\b
       scope: constant.language.c
     - match: \b(__FILE__|__FUNCTION__|__LINE__)\b
       scope: support.constant.c

--- a/Erlang/Erlang.sublime-syntax
+++ b/Erlang/Erlang.sublime-syntax
@@ -1386,8 +1386,10 @@ contexts:
 
   constant:
     # https://www.erlang.org/doc/reference_manual/data_types.html#boolean
-    - match: (false|true){{ident_break}}
-      scope: constant.language.boolean.erlang
+    - match: false{{ident_break}}
+      scope: constant.language.boolean.false.erlang
+    - match: true{{ident_break}}
+      scope: constant.language.boolean.true.erlang
     # https://www.erlang.org/doc/reference_manual/errors.html#exceptions
     - match: (error|exit|ok|throw){{ident_break}}
       scope: constant.language.exception.type.erlang

--- a/Erlang/syntax_test_erlang.erl
+++ b/Erlang/syntax_test_erlang.erl
@@ -33,10 +33,10 @@ atom_tests() -> .
 % Special atom tests
 
     true
-%   ^^^^ constant.language.boolean.erlang
+%   ^^^^ constant.language.boolean.true.erlang
 
     false
-%   ^^^^^ constant.language.boolean.erlang
+%   ^^^^^ constant.language.boolean.false.erlang
 
     error
 %   ^^^^^ constant.language.exception.type.erlang
@@ -473,7 +473,7 @@ list_tests() -> .
 %   ^ punctuation.section.sequence.begin.erlang
 %    ^ meta.number.integer.decimal.erlang constant.numeric.value.erlang
 %      ^^ keyword.operator.comprehension.erlang
-%         ^^^^ constant.language.boolean.erlang
+%         ^^^^ constant.language.boolean.true.erlang
 %             ^ punctuation.section.sequence.end.erlang
 
     [2 || is_integer(2)]
@@ -4137,7 +4137,7 @@ func_name ( ) when true ->
 %         ^ punctuation.section.parameters.begin.erlang
 %           ^ punctuation.section.parameters.end.erlang
 %             ^^^^ keyword.control.conditional.when.erlang
-%                  ^^^^ constant.language.boolean.erlang
+%                  ^^^^ constant.language.boolean.true.erlang
 %                       ^^ punctuation.separator.clause-head-body.erlang
     .
 %   ^ meta.function.erlang punctuation.terminator.clause.erlang
@@ -4389,7 +4389,7 @@ case_tests() ->
 %                                 ^ punctuation.separator.clauses.erlang
 %                                   ^^^ variable.other.readwrite.erlang
 %                                       ^^ keyword.operator.comparison.erlang
-%                                          ^^^^^ constant.language.boolean.erlang
+%                                          ^^^^^ constant.language.boolean.false.erlang
 %                                                ^^ punctuation.separator.clause-head-body.erlang
             print("ok");
 %          ^^^^^^^^^^^^ meta.case.erlang
@@ -4446,7 +4446,7 @@ if_tests() ->
 %                                 ^ punctuation.separator.clauses.erlang
 %                                   ^^^ variable.other.readwrite.erlang
 %                                       ^^ keyword.operator.comparison.erlang
-%                                          ^^^^^ constant.language.boolean.erlang
+%                                          ^^^^^ constant.language.boolean.false.erlang
 %                                                ^^ punctuation.separator.clause-head-body.erlang
             print("ok");
 %          ^^^^^^^^^^^^ meta.if.erlang
@@ -4496,7 +4496,7 @@ maybe_tests() ->
 %                         ^ punctuation.separator.expressions.erlang
             true = A >= 0,
 %   ^^^^^^^^^^^^^^^^^^^^^^^ meta.maybe.erlang meta.maybe.erlang
-%           ^^^^ constant.language.boolean.erlang
+%           ^^^^ constant.language.boolean.true.erlang
 %                ^ keyword.operator.assignment.erlang
 %                  ^ variable.other.readwrite.erlang
 %                    ^^ keyword.operator.comparison.erlang
@@ -5243,7 +5243,7 @@ fun_expression_tests() ->
 %              ^^^^ keyword.control.conditional.when.erlang
 %                   ^ variable.other.readwrite.erlang
 %                     ^^ keyword.operator.comparison.erlang
-%                        ^^^^ constant.language.boolean.erlang
+%                        ^^^^ constant.language.boolean.true.erlang
 %                            ^ punctuation.separator.clauses.erlang
 %                              ^^^^^^^^ support.function.erlang
 %                                      ^ punctuation.section.arguments.begin.erlang

--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -344,8 +344,12 @@ contexts:
   # would be ideal, but is beyond the scope of this syntax engine; we simply
   # expect it to be very rare.
   match-predeclared-constants:
-    - match: \b(?:true|false|nil)\b
-      scope: constant.language.go
+    - match: \bfalse\b
+      scope: constant.language.boolean.false.go
+    - match: \btrue\b
+      scope: constant.language.boolean.true.go
+    - match: \bnil\b
+      scope: constant.language.null.go
 
   # Reference: https://golang.org/ref/spec#Predeclared_identifiers
   #

--- a/Go/tests/syntax_test_go.go
+++ b/Go/tests/syntax_test_go.go
@@ -5082,9 +5082,9 @@ by accident, but if necessary, such support could be sacrificed.
 /* # Predeclared Constants */
 
     true false nil
-//  ^^^^ constant.language.go
-//       ^^^^^ constant.language.go
-//             ^^^ constant.language.go
+//  ^^^^ constant.language.boolean.true.go
+//       ^^^^^ constant.language.boolean.false.go
+//             ^^^ constant.language.null.go
 
 
 /* # Built-in Types */

--- a/Groovy/Groovy.sublime-syntax
+++ b/Groovy/Groovy.sublime-syntax
@@ -116,8 +116,12 @@ contexts:
   constants:
     - match: '\b([A-Z][A-Z0-9_]+)\b'
       scope: constant.other.groovy
-    - match: \b(true|false|null)\b
-      scope: constant.language.groovy
+    - match: \bfalse\b
+      scope: constant.language.boolean.false.groovy
+    - match: \btrue\b
+      scope: constant.language.boolean.true.groovy
+    - match: \bnull\b
+      scope: constant.language.null.groovy
   groovy:
     - include: classes
     - include: methods

--- a/JSON/JSON.sublime-syntax
+++ b/JSON/JSON.sublime-syntax
@@ -175,8 +175,10 @@ contexts:
 ###[ LITERALS ]################################################################
 
   constants:
-    - match: \b(?:false|true)\b
-      scope: constant.language.boolean.json
+    - match: \bfalse\b
+      scope: constant.language.boolean.false.json
+    - match: \btrue\b
+      scope: constant.language.boolean.true.json
     - match: \bnull\b
       scope: constant.language.null.json
 

--- a/JSON/syntax_test_json.json
+++ b/JSON/syntax_test_json.json
@@ -32,7 +32,7 @@
   "bool": false,
 //^^^^^^ meta.mapping.key.json
 //^^^^^^^^^^^^^^ - meta.mapping meta.mapping
-//        ^^^^^ constant.language.boolean.json
+//        ^^^^^ constant.language.boolean.false.json
 
   "null": null,
 //^^^^^^ meta.mapping.key.json

--- a/Java/HTML (JSP).sublime-syntax
+++ b/Java/HTML (JSP).sublime-syntax
@@ -640,14 +640,19 @@ contexts:
     - include: jstl-expressions
 
   jstl-constants:
-    - match: (?:false|true){{break}}
-      scope: constant.language.boolean.jstl
+    - match: false{{break}}
+      scope: constant.language.boolean.false.jstl
+    - match: true{{break}}
+      scope: constant.language.boolean.true.jstl
     - match: null{{break}}
       scope: constant.language.null.jstl
 
   jstl-constant:
-    - match: (?:false|true){{break}}
-      scope: constant.language.boolean.jstl
+    - match: false{{break}}
+      scope: constant.language.boolean.false.jstl
+      pop: 1
+    - match: true{{break}}
+      scope: constant.language.boolean.true.jstl
       pop: 1
     - match: null{{break}}
       scope: constant.language.null.jstl

--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -2346,16 +2346,21 @@ contexts:
 
   literal-constants:
     # https://docs.oracle.com/javase/specs/jls/se13/html/jls-3.html#jls-3.10.3
-    - match: (?:false|true){{break}}
-      scope: constant.language.boolean.java
+    - match: false{{break}}
+      scope: constant.language.boolean.false.java
+    - match: true{{break}}
+      scope: constant.language.boolean.true.java
     # https://docs.oracle.com/javase/specs/jls/se13/html/jls-3.html#jls-3.10.7
     - match: null{{break}}
       scope: constant.language.null.java
 
   literal-constant:
     # https://docs.oracle.com/javase/specs/jls/se13/html/jls-3.html#jls-3.10.3
-    - match: (?:false|true){{break}}
-      scope: constant.language.boolean.java
+    - match: false{{break}}
+      scope: constant.language.boolean.false.java
+      pop: 1
+    - match: true{{break}}
+      scope: constant.language.boolean.true.java
       pop: 1
     # https://docs.oracle.com/javase/specs/jls/se13/html/jls-3.html#jls-3.10.7
     - match: null{{break}}

--- a/Java/tests/syntax_test_java.java
+++ b/Java/tests/syntax_test_java.java
@@ -5434,7 +5434,7 @@ class IfStatementTests {
 //                                   ^ - meta.statement.conditional.if
 //                   ^ punctuation.section.block.begin.java
 //                     ^^^^^^ keyword.control.flow.return.java
-//                            ^^^^^ constant.language.boolean.java
+//                            ^^^^^ constant.language.boolean.false.java
 //                                  ^ punctuation.section.block.end.java
 
     if (foo) else
@@ -5506,7 +5506,7 @@ class IfStatementTests {
 //     ^ punctuation.section.group.begin.java
 //      ^^^ variable.function.java
 //            ^^ keyword.operator.comparison.java
-//               ^^^^ constant.language.boolean.java
+//               ^^^^ constant.language.boolean.true.java
 //                   ^ punctuation.section.group.end.java
 //                     ^^^ variable.function.java
 //                           ^^^^ keyword.control.conditional.else.java
@@ -5554,7 +5554,7 @@ class AssertStatementTests {
 // ^ - keyword
 //  ^^^^^^ keyword.control.flow.assert.java
 //        ^ - keyword - constant
-//         ^^^^ constant.language.boolean.java
+//         ^^^^ constant.language.boolean.true.java
 //             ^ punctuation.terminator.java
 
     assert :
@@ -5612,7 +5612,7 @@ class AssertStatementTests {
 //                      ^ punctuation.separator.expressions.java
 //                        ^^^ variable.other.java
 //                            ^^ keyword.operator.comparison.java
-//                               ^^^^ constant.language.boolean.java
+//                               ^^^^ constant.language.boolean.true.java
 //                                   ^ punctuation.terminator.java
 
     assert int foo=0;
@@ -6459,7 +6459,7 @@ class WhileStatementTests {
     while false
 //  ^^^^^^^^^^^^ meta.statement.loop.while.java
 //  ^^^^^ keyword.control.loop.while.java
-//        ^^^^^ constant.language.boolean.java
+//        ^^^^^ constant.language.boolean.false.java
 
     while (false)
 //  ^^^^^^^^^^^^^^ - meta.statement.loop.while meta.statement.loop.while
@@ -6468,7 +6468,7 @@ class WhileStatementTests {
 //               ^ meta.statement.loop.while.java - meta.group
 //  ^^^^^ keyword.control.loop.while.java
 //        ^ punctuation.section.group.begin.java
-//         ^^^^^ constant.language.boolean.java
+//         ^^^^^ constant.language.boolean.false.java
 //              ^ punctuation.section.group.end.java
 
     while (false) {  }
@@ -6479,7 +6479,7 @@ class WhileStatementTests {
 //                ^^^^ meta.statement.loop.while.java meta.block.java
 //  ^^^^^ keyword.control.loop.while.java
 //        ^ punctuation.section.group.begin.java
-//         ^^^^^ constant.language.boolean.java
+//         ^^^^^ constant.language.boolean.false.java
 //              ^ punctuation.section.group.end.java
 //                ^ punctuation.section.block.begin.java
 //                   ^ punctuation.section.block.end.java
@@ -6491,7 +6491,7 @@ class WhileStatementTests {
 //               ^^^^ meta.statement.loop.while.java meta.block.java
 //  ^^^^^ keyword.control.loop.while.java
 //        ^ punctuation.section.group.begin.java
-//         ^^^^^ constant.language.boolean.java
+//         ^^^^^ constant.language.boolean.false.java
 //               ^ punctuation.section.block.begin.java
 //                  ^ punctuation.section.block.end.java
   }
@@ -7857,7 +7857,7 @@ class MethodInvocationExpressionsTests {
 //                 ^ punctuation.accessor.dot.java
 //                  ^^^^^^^^^^^^ variable.function.java
 //                              ^ punctuation.section.group.begin.java
-//                               ^^^^ constant.language.boolean.java
+//                               ^^^^ constant.language.boolean.true.java
 //                                   ^ punctuation.section.group.end.java
 //                                    ^ punctuation.terminator.java
 
@@ -7879,7 +7879,7 @@ class MethodInvocationExpressionsTests {
 //                  ^ punctuation.accessor.dot.java
 //                   ^^^^^^^^^^^^ variable.function.java
 //                               ^ punctuation.section.group.begin.java
-//                                ^^^^ constant.language.boolean.java
+//                                ^^^^ constant.language.boolean.true.java
 //                                    ^ punctuation.section.group.end.java
 //                                     ^ punctuation.terminator.java
   }
@@ -8101,7 +8101,7 @@ class InstanceCreationExpressionsTests {
 //                   ^^^^^^^^ support.class.java
 //                           ^^^ meta.brackets.java
 //                              ^ punctuation.separator.comma.java
-//                                ^^^^ constant.language.boolean.java
+//                                ^^^^ constant.language.boolean.true.java
 //                                    ^ punctuation.section.group.end.java
 //                                     ^ punctuation.terminator.java
 
@@ -8142,7 +8142,7 @@ class InstanceCreationExpressionsTests {
 //         ^ punctuation.section.group.begin.java
 //          ^^^ variable.other.java
 //              ^^ keyword.operator.comparison.java
-//                 ^^^^ constant.language.boolean.java
+//                 ^^^^ constant.language.boolean.true.java
 //                     ^ punctuation.section.group.end.java
 //                       ^ punctuation.section.block.begin.java
 //                        ^ punctuation.section.block.end.java
@@ -9924,7 +9924,7 @@ class LambdasExpressionsTests {
 //                         ^ punctuation.section.group.begin.java
 //                          ^ punctuation.section.group.end.java
 //                            ^^ keyword.declaration.function.arrow.java
-//                               ^^^^ constant.language.boolean.java
+//                               ^^^^ constant.language.boolean.true.java
 //                                   ^ punctuation.terminator.java
 
   Supplier<Foo> supplier = _ -> true;
@@ -9933,7 +9933,7 @@ class LambdasExpressionsTests {
 //                       ^ keyword.operator.assignment.java
 //                         ^ variable.language.anonymous.java
 //                           ^^ keyword.declaration.function.arrow.java
-//                              ^^^^ constant.language.boolean.java
+//                              ^^^^ constant.language.boolean.true.java
 //                                  ^ punctuation.terminator.java
 }
 
@@ -10344,7 +10344,7 @@ public class Foo {
 //    ^ constant.numeric.value.java
 //     ^ punctuation.section.brackets.end.java
 //       ^ keyword.operator.assignment.java
-//         ^^^^ constant.language.boolean.java
+//         ^^^^ constant.language.boolean.true.java
 //             ^ punctuation.terminator.java
 
     a[0][0] = true;
@@ -10359,7 +10359,7 @@ public class Foo {
 //       ^ constant.numeric.value.java
 //        ^ punctuation.section.brackets.end.java
 //          ^ keyword.operator.assignment.java
-//            ^^^^ constant.language.boolean.java
+//            ^^^^ constant.language.boolean.true.java
 //                ^ punctuation.terminator.java
 
     a [ 0 ] [ 0 ] = true;
@@ -10377,7 +10377,7 @@ public class Foo {
 //            ^ constant.numeric.value.java
 //              ^ punctuation.section.brackets.end.java
 //                ^ keyword.operator.assignment.java
-//                  ^^^^ constant.language.boolean.java
+//                  ^^^^ constant.language.boolean.true.java
 //                      ^ punctuation.terminator.java
 
     a /**/ [ /**/ 0 /**/ ] /**/ [ /**/ 0 /**/ ] /**/ = /**/ true;
@@ -10396,7 +10396,7 @@ public class Foo {
 //                                     ^ constant.numeric.value.java
 //                                            ^ punctuation.section.brackets.end.java
 //                                                   ^ keyword.operator.assignment.java
-//                                                          ^^^^ constant.language.boolean.java
+//                                                          ^^^^ constant.language.boolean.true.java
 //                                                              ^ punctuation.terminator.java
 
     a
@@ -10415,7 +10415,7 @@ public class Foo {
     =
 //  ^ keyword.operator.assignment.java
     true;
-//  ^^^^ constant.language.boolean.java
+//  ^^^^ constant.language.boolean.true.java
 //      ^ punctuation.terminator.java
 
     a.c = true;
@@ -10428,7 +10428,7 @@ public class Foo {
 //   ^ punctuation.accessor.dot.java
 //    ^ variable.other.java
 //      ^ keyword.operator.assignment.java
-//        ^^^^ constant.language.boolean.java
+//        ^^^^ constant.language.boolean.true.java
 //            ^ punctuation.terminator.java
 
     a[0].c[1] = true;
@@ -10449,11 +10449,11 @@ public class Foo {
 //         ^ constant.numeric.value.java
 //          ^ punctuation.section.brackets.end.java
 //            ^ keyword.operator.assignment.java
-//              ^^^^ constant.language.boolean.java
+//              ^^^^ constant.language.boolean.true.java
 //                  ^ punctuation.terminator.java
 
     int foo = true ? 1 : 2;
-//            ^^^^ constant.language.boolean.java
+//            ^^^^ constant.language.boolean.true.java
 //                 ^ keyword.operator.ternary.java
 //                   ^ meta.number.integer.decimal.java constant.numeric.value.java
 //                     ^ keyword.operator.ternary.java

--- a/Java/tests/syntax_test_jsp.jsp
+++ b/Java/tests/syntax_test_jsp.jsp
@@ -948,7 +948,7 @@
 //                      ^^^^^^^^^^^^^ meta.path.jstl
 //                      ^^^^^^^ variable.namespace.jstl
 //                             ^ punctuation.accessor.namespace.jstl
-//                              ^^^^^ constant.language.boolean.jstl
+//                              ^^^^^ constant.language.boolean.false.jstl
 //                                   ^ punctuation.section.embedded.end.jstl
 
     ${obj1 != null &&

--- a/Lisp/Lisp.sublime-syntax
+++ b/Lisp/Lisp.sublime-syntax
@@ -1253,8 +1253,11 @@ contexts:
       scope: storage.type.lisp
       pop: 1
     # constants
-    - match: (?i:true|false){{break}}
-      scope: constant.language.boolean.lisp
+    - match: (?i:false){{break}}
+      scope: constant.language.boolean.false.lisp
+      pop: 1
+    - match: (?i:true){{break}}
+      scope: constant.language.boolean.true.lisp
       pop: 1
     - match: (?i:nil|null){{break}}
       scope: constant.language.null.lisp

--- a/Lisp/tests/syntax_test_lisp.lisp
+++ b/Lisp/tests/syntax_test_lisp.lisp
@@ -1290,10 +1290,10 @@
 ;       ^ constant.language
 
 (print true)
-;      ^^^^ constant.language.boolean.lisp
+;      ^^^^ constant.language.boolean.true.lisp
 
 (print false)
-;      ^^^^^ constant.language.boolean.lisp
+;      ^^^^^ constant.language.boolean.false.lisp
 
 (print nil)
 ;      ^^^ constant.language.null.lisp
@@ -2446,7 +2446,7 @@
 ;                         ^^^ keyword.operator.logical.lisp
 ;                             ^^^^ variable.other.lisp
 ;                                  ^ keyword.operator.lisp
-;                                    ^^^^ constant.language.boolean.lisp
+;                                    ^^^^ constant.language.boolean.true.lisp
 
 ;;; for-as-claus
 
@@ -2484,9 +2484,9 @@
   var = true then false
 ; ^^^ variable.other.lisp
 ;     ^ keyword.operator.lisp
-;       ^^^^ constant.language.boolean.lisp
+;       ^^^^ constant.language.boolean.true.lisp
 ;            ^^^^ keyword.control.conditional.lisp
-;                 ^^^^^ constant.language.boolean.lisp
+;                 ^^^^^ constant.language.boolean.false.lisp
 
 ;;; for-as-across
 

--- a/Lua/Lua.sublime-syntax
+++ b/Lua/Lua.sublime-syntax
@@ -539,8 +539,11 @@ contexts:
       pop: 1
 
   builtin:
-    - match: (?:true|false){{identifier_break}}
-      scope: constant.language.boolean.lua
+    - match: false{{identifier_break}}
+      scope: constant.language.boolean.false.lua
+      pop: 1
+    - match: true{{identifier_break}}
+      scope: constant.language.boolean.true.lua
       pop: 1
     - match: nil{{identifier_break}}
       scope: constant.language.null.lua

--- a/Lua/tests/syntax_test_lua.lua
+++ b/Lua/tests/syntax_test_lua.lua
@@ -146,10 +146,10 @@
 --CONSTANTS
 
     true;
---  ^^^^ constant.language.boolean.lua
+--  ^^^^ constant.language.boolean.true
 
     false;
---  ^^^^^ constant.language.boolean.lua
+--  ^^^^^ constant.language.boolean.false
 
     nil;
 --  ^^^ constant.language.null
@@ -342,7 +342,7 @@
 
     not true;
 --  ^^^ keyword.operator.logical
---      ^^^^ constant.language.boolean.lua
+--      ^^^^ constant.language.boolean.true
 
     2 + 2 - 2 * 2 / 2 // 2 % 2 ^ 2;
 --    ^ keyword.operator.arithmetic
@@ -490,7 +490,7 @@
     foo[return] foo[false]
 --      ^^^^^^ invalid.unexpected-keyword.lua
 --            ^ - meta.brackets
---                  ^^^^^ constant.language.boolean.lua
+--                  ^^^^^ constant.language.boolean.false
 
     some.return
 --       ^^^^^^ invalid.unexpected-keyword.lua
@@ -648,7 +648,7 @@
 --      ^^^ invalid.illegal.unexpected-end
     until true;
 --  ^^^^^ keyword.control.loop
---        ^^^^ constant.language.boolean.lua
+--        ^^^^ constant.language.boolean.true
 
     for x = 1, y, z do end
 --  ^^^ keyword.control.loop

--- a/Matlab/Matlab.sublime-syntax
+++ b/Matlab/Matlab.sublime-syntax
@@ -1168,7 +1168,13 @@ contexts:
 
   # Functions that return essential constants, usually used without parameters
   builtin-constants:
-    - match: \b(true|false|eps|pi|Inf|NaN|NaT|flintmax|intmax|intmin|realmax|realmin|namelengthmax)\b
+    - match: \bfalse\b
+      scope: constant.language.boolean.false.matlab
+      push: maybe-transpose
+    - match: \btrue\b
+      scope: constant.language.boolean.true.matlab
+      push: maybe-transpose
+    - match: \b(eps|pi|Inf|NaN|NaT|flintmax|intmax|intmin|realmax|realmin|namelengthmax)\b
       scope: constant.language.matlab
       push: maybe-transpose
 

--- a/Matlab/syntax_test_matlab.matlab
+++ b/Matlab/syntax_test_matlab.matlab
@@ -49,7 +49,7 @@ classdef (Sealed = verLessThan('matlab', '8.4'), ~Hidden) ClassName < SuperClass
 %                                 ^ punctuation.separator.sequence.matlab
 %                                   ^^^^^^^^^ variable.parameter.attribute.matlab
 %                                             ^ keyword.operator.assignment.matlab
-%                                               ^^^^ constant.language.matlab
+%                                               ^^^^ constant.language.boolean.true.matlab
 %                                                   ^ punctuation.section.parens.end.matlab
 %                                                      ^^^^^^^^^^ comment.line.percentage.matlab
       PropName
@@ -482,8 +482,8 @@ end
 % Built-in constants
 
   true; false
-% ^^^^ constant.language.matlab
-%       ^^^^^ constant.language.matlab
+% ^^^^ constant.language.boolean.true.matlab
+%       ^^^^^ constant.language.boolean.false.matlab
   Inf; NaN
 % ^^^ constant.language.matlab
 %      ^^^ constant.language.matlab
@@ -793,10 +793,10 @@ l = {l.n}';
    "string with missing closing quote mark
 %                                         ^ invalid.illegal.unclosed-string.matlab
    true'
-%  ^^^^ constant.language.matlab
+%  ^^^^ constant.language.boolean.true.matlab
 %      ^ keyword.operator.transpose.matlab
    true.'
-%  ^^^^ constant.language.matlab
+%  ^^^^ constant.language.boolean.true.matlab
 %      ^^ keyword.operator.transpose.matlab
 
 % If a built-in function is followed by a transpose operator, we assume that the

--- a/OCaml/OCaml.sublime-syntax
+++ b/OCaml/OCaml.sublime-syntax
@@ -391,8 +391,10 @@ contexts:
         1: meta.empty-typing-pair.ocaml
         2: meta.empty-typing-pair.parens.ocaml
         3: meta.empty-typing-pair.ocaml
-    - match: \b(true|false)\b
-      scope: constant.language.boolean.ocaml
+    - match: \bfalse\b
+      scope: constant.language.boolean.false.ocaml
+    - match: \btrue\b
+      scope: constant.language.boolean.true.ocaml
     - match: '''(.|\\(x[a-fA-F0-9][a-fA-F0-9]|[0-2]\d\d|[bnrt''"\\]))'''
       scope: constant.character.ocaml
 

--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -2107,8 +2107,10 @@ contexts:
 ###[ CONSTANTS ]##############################################################
 
   constants:
-    - match: (?i:true|false)\b
-      scope: constant.language.boolean.php
+    - match: (?i:false)\b
+      scope: constant.language.boolean.false.php
+    - match: (?i:true)\b
+      scope: constant.language.boolean.true.php
     - match: (?i:null)\b
       scope: constant.language.null.php
     - match: (?i:__CLASS__|__DIR__|__FILE__|__FUNCTION__|__LINE__|__METHOD__|__NAMESPACE__)\b

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -1746,7 +1746,7 @@ class TestTypedProperties {
 //          ^^^^ storage.type.primitive.php
 //               ^^^^^ variable.other.php
 //                     ^ keyword.operator.assignment.php
-//                       ^^^^ constant.language.boolean.php
+//                       ^^^^ constant.language.boolean.true.php
 //                           ^ punctuation.terminator.statement.php
     private readonly $prop;
 //          ^^^^^^^^ storage.modifier
@@ -1945,7 +1945,7 @@ $fn = fn ($value): bool => true;
 //               ^ punctuation.separator.colon.php
 //                 ^^^^ storage.type.primitive.php
 //                      ^^ keyword.declaration.function.arrow.php
-//                         ^^^^ constant.language.boolean.php
+//                         ^^^^ constant.language.boolean.true.php
 //                             ^ punctuation.terminator.statement.php
 
 $fn = fn ($x): stringSpace\Test1 => null;
@@ -3109,7 +3109,7 @@ if ((include 'vars.php') == TRUE) {
 //           ^^^^^^^^^^ meta.string.php string.quoted.single.php
 //                     ^ punctuation.section.group.end.php
 //                       ^^ keyword.operator.comparison.php
-//                          ^^^^ constant.language.boolean.php
+//                          ^^^^ constant.language.boolean.true.php
 //                              ^ punctuation.section.group.end.php
 //                                ^ punctuation.section.block.begin.php
 }
@@ -3130,7 +3130,7 @@ if (include('vars.php') == TRUE) {
 //          ^^^^^^^^^^ meta.string.php string.quoted.single.php
 //                    ^ punctuation.section.group.end.php
 //                      ^^ keyword.operator.comparison.php
-//                         ^^^^ constant.language.boolean.php
+//                         ^^^^ constant.language.boolean.true.php
 //                             ^ punctuation.section.group.end.php
 //                               ^ punctuation.section.block.begin.php
 }
@@ -3235,7 +3235,7 @@ func_call(true, 1, "string");
 //                          ^ - meta.function-call
 //^^^^^^^ variable.function.php
 //       ^ punctuation.section.group.begin.php
-//        ^^^^ constant.language.boolean.php
+//        ^^^^ constant.language.boolean.true.php
 //            ^ punctuation.separator.sequence.php
 //              ^ meta.number.integer.decimal.php constant.numeric.value.php
 //               ^ punctuation.separator.sequence.php
@@ -3313,11 +3313,11 @@ $statement = match ($this->lexer->lookahead['type']) {
 //               ^ punctuation.section.block.begin.php
 //                ^^^^^^ meta.string.php string.quoted.double.php
 //                       ^^ punctuation.separator.key-value.php
-//                          ^^^^ constant.language.boolean.php
+//                          ^^^^ constant.language.boolean.true.php
 //                              ^ punctuation.separator.sequence.php
 //                                ^^^^^^^ meta.string.php string.quoted.double.php
 //                                        ^^ punctuation.separator.key-value.php
-//                                           ^^^^^ constant.language.boolean.php
+//                                           ^^^^^ constant.language.boolean.false.php
 //                                                 ^ punctuation.section.block.end.php
 //                                                   ^ punctuation.section.group.end.php
 
@@ -3336,11 +3336,11 @@ $statement = match ($this->lexer->lookahead['type']) {
 //               ^ punctuation.section.block.begin.php
 //                ^^^^^^ meta.string.php string.quoted.double.php
 //                       ^^ punctuation.separator.key-value.php
-//                          ^^^^ constant.language.boolean.php
+//                          ^^^^ constant.language.boolean.true.php
 //                              ^ punctuation.separator.sequence.php
 //                                ^^^^^^^ meta.string.php string.quoted.double.php
 //                                        ^^ punctuation.separator.key-value.php
-//                                           ^^^^^ constant.language.boolean.php
+//                                           ^^^^^ constant.language.boolean.false.php
 //                                                 ^ punctuation.section.block.end.php
 //                                                   ^ punctuation.section.sequence.end.php
 
@@ -3359,11 +3359,11 @@ $statement = match ($this->lexer->lookahead['type']) {
 //               ^ punctuation.section.block.begin.php
 //                ^^^^^^ meta.string.php string.quoted.double.php
 //                       ^^ punctuation.separator.key-value.php
-//                          ^^^^ constant.language.boolean.php
+//                          ^^^^ constant.language.boolean.true.php
 //                              ^ punctuation.separator.sequence.php
 //                                ^^^^^^^ meta.string.php string.quoted.double.php
 //                                        ^^ punctuation.separator.key-value.php
-//                                           ^^^^^ constant.language.boolean.php
+//                                           ^^^^^ constant.language.boolean.false.php
 //                                                 ^ punctuation.section.block.end.php
 //                                                   ^ punctuation.section.block.end.php
 

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -2432,8 +2432,11 @@ contexts:
       scope: constant.language.python
 
   booleans:
-    - match: (?:True|False)\b
-      scope: constant.language.boolean.python
+    - match: False\b
+      scope: constant.language.boolean.false.python
+      push: illegal-assignment
+    - match: True\b
+      scope: constant.language.boolean.true.python
       push: illegal-assignment
 
   nones:

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -675,7 +675,7 @@ def _():
 #        ^ keyword.operator.assignment
 #          ^ punctuation.section.function.begin
 #           ^^^^^ meta.function.inline.body
-#            ^^^^ constant.language.boolean.python
+#            ^^^^ constant.language.boolean.true.python
 
     lambda as, in=2: 0
 #          ^^ invalid.illegal.name
@@ -1163,7 +1163,7 @@ def _():
         pass
     elif False :
 #   ^^^^^^^^^^^^ meta.statement.conditional.elseif.python
-#        ^^^^^ constant.language.boolean.python
+#        ^^^^^ constant.language.boolean.false.python
 #              ^ punctuation.section.block.conditional.elseif.python
         pass
     else  :
@@ -1174,7 +1174,7 @@ def _():
     if \
         True:
 #       ^^^^^ meta.statement.conditional.if.python
-#       ^^^^ constant.language.boolean.python
+#       ^^^^ constant.language.boolean.true.python
 #           ^ punctuation.section.block.conditional.if.python
 #
 
@@ -1325,7 +1325,7 @@ def _():
 #           ^^ keyword.control.conditional.if.python
 #              ^^^ meta.generic-name.python
 #                  ^^ keyword.operator.logical.python
-#                     ^^^^ constant.language.boolean.python
+#                     ^^^^ constant.language.boolean.true.python
 #                         ^ punctuation.section.block.conditional.case.python
 
     case (,) if foo in ('bar', 'baz'):
@@ -1392,7 +1392,7 @@ def _():
 #           ^^ keyword.control.conditional.if.python
 #              ^^^ meta.generic-name.python
 #                  ^^ keyword.operator.logical.python
-#                     ^^^^ constant.language.boolean.python
+#                     ^^^^ constant.language.boolean.true.python
 #                         ^ punctuation.section.block.conditional.case.python
 
     case { s_key : 'value' , num.key: 100, **pattern} if foo in {'foo', 'bar'}:
@@ -2179,11 +2179,11 @@ class DataClass(TypedDict, None, total=False, True=False):
 #                              ^ punctuation.separator.inheritance.python
 #                                ^^^^^ variable.parameter.class-inheritance.python
 #                                     ^ keyword.operator.assignment.python
-#                                      ^^^^^ constant.language.boolean.python
+#                                      ^^^^^ constant.language.boolean.false.python
 #                                           ^ punctuation.separator.inheritance.python
-#                                             ^^^^ constant.language.boolean.python
+#                                             ^^^^ constant.language.boolean.true.python
 #                                                 ^ invalid.illegal.assignment.python
-#                                                  ^^^^^ constant.language.boolean.python
+#                                                  ^^^^^ constant.language.boolean.false.python
 
 
 class MyClass:

--- a/R/R.sublime-syntax
+++ b/R/R.sublime-syntax
@@ -59,7 +59,13 @@ contexts:
   constants:
     - match: \b(pi|letters|LETTERS|month\.abb|month\.name)\b
       scope: support.constant.misc.r
-    - match: \b(TRUE|FALSE|NULL|NA|NA_integer_|NA_real_|NA_complex_|NA_character_|Inf|NaN)\b
+    - match: \bFALSE\b
+      scope: constant.language.boolean.false.r
+    - match: \bTRUE\b
+      scope: constant.language.boolean.true.r
+    - match: \bNULL\b
+      scope: constant.language.null.r
+    - match: \b(NA|NA_integer_|NA_real_|NA_complex_|NA_character_|Inf|NaN)\b
       scope: constant.language.r
     # complex imaginary
     - match: \b(0[xX])(\h+)(?:(i)|(I))\b

--- a/R/syntax_test_r.R
+++ b/R/syntax_test_r.R
@@ -84,11 +84,11 @@ month.name
 month.abb
 # <- support.constant.misc.r
 TRUE
-# <- constant.language.r
+# <- constant.language.boolean.true.r
 FALSE
-# <- constant.language.r
+# <- constant.language.boolean.false.r
 NULL
-# <- constant.language.r
+# <- constant.language.null.r
 NA
 # <- constant.language.r
 NA_integer_

--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -210,8 +210,10 @@ contexts:
     - match: '\b(nil)\b(?![?!])'
       scope: constant.language.null.ruby
       push: after-constant
-    - match: '\b(true|false)\b(?![?!])'
-      scope: constant.language.boolean.ruby
+    - match: '\bfalse\b(?![?!])'
+      scope: constant.language.boolean.false.ruby
+    - match: '\btrue\b(?![?!])'
+      scope: constant.language.boolean.true.ruby
       push: after-constant
     - match: '\b(__(FILE|LINE|ENCODING)__|self)\b(?![?!])'
       scope: variable.language.ruby

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -1257,9 +1257,9 @@ class ::MyModule::MyClass < MyModule::InheritedClass
 #                     ^^^ constant.language.null
 #                        ^ punctuation.separator
 #                           ^ punctuation.separator
-#                             ^^^^ constant.language.boolean
+#                             ^^^^ constant.language.boolean.true
 #                                 ^ punctuation.separator.ruby
-#                                      ^^^^^ constant.language.boolean.ruby
+#                                      ^^^^^ constant.language.boolean.false.ruby
   end
 
   def multiline_args(a, # a comment

--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -1732,8 +1732,10 @@ contexts:
       scope: punctuation.separator.rust
 
   bool:
-    - match: \b(true|false)\b
-      scope: constant.language.rust
+    - match: \bfalse\b
+      scope: constant.language.boolean.false.rust
+    - match: \btrue\b
+      scope: constant.language.boolean.true.rust
 
   raw-pointer:
     - match: '\*\s*(?:const|mut)\b'

--- a/SQL/SQL.sublime-syntax
+++ b/SQL/SQL.sublime-syntax
@@ -95,8 +95,10 @@ contexts:
       scope: storage.modifier.sql
     - match: \b\d+\b
       scope: constant.numeric.sql
-    - match: (?i:\b(true|false)\b)
-      scope: constant.language.boolean.sql
+    - match: (?i:\bfalse\b)
+      scope: constant.language.boolean.false.sql
+    - match: (?i:\btrue\b)
+      scope: constant.language.boolean.true.sql
     - match: (?i:\b(null)\b)
       scope: constant.language.null.sql
     - match: (?i:\b(select(\s+(distinct|top))?|insert(\s+(ignore\s+)?into)?|update|delete|truncate|from|set|where|group\s+by|with|case|when|then|else|end|union(\s+all)?|using|order\s+by|limit|(inner|cross)\s+join|join|straight_join|(left|right)(\s+outer)?\s+join|natural(\s+(left|right)(\s+outer)?)?\s+join)\b)

--- a/SQL/syntax_test_sql.sql
+++ b/SQL/syntax_test_sql.sql
@@ -70,7 +70,7 @@ create table IF NOT EXISTS `testing123` (
     `col` bool DEFAULT FALSE,
 --        ^^^^ storage.type.sql
 --             ^^^^^^^ storage.modifier.sql
---                     ^^^^^ constant.language.boolean.sql
+--                     ^^^^^ constant.language.boolean.false.sql
 --                          ^ punctuation.separator.sequence
     `fkey` INT UNSIGNED NULL REFERENCES test2(id),
 --                           ^^^^^^^^^^ storage.modifier.sql

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -274,8 +274,12 @@ contexts:
     - match: \b(?:Unit|Boolean|Byte|Char|Short|Int|Float|Long|Double|Any|AnyRef|AnyVal|Nothing)\b
       scope: storage.type.primitive.scala
   literal-constants:
-    - match: \b(?:false|null|true)\b
-      scope: constant.language.scala
+    - match: \bfalse\b
+      scope: constant.language.boolean.false.scala
+    - match: \btrue\b
+      scope: constant.language.boolean.true.scala
+    - match: \bnull\b
+      scope: constant.language.null.scala
     # TODO negation
     # source: http://www.scala-lang.org/files/archive/spec/2.11/01-lexical-syntax.html#floating-point-literals
     - match: |-

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -334,13 +334,13 @@ type Foo = Bar[A] forSome { type A }
 // ^^^^^^^^ constant.character.literal.scala
 
    true
-// ^^^^ constant.language.scala
+// ^^^^ constant.language.boolean.true.scala
 
    false
-// ^^^^^ constant.language.scala
+// ^^^^^ constant.language.boolean.false.scala
 
    null
-// ^^^^ constant.language.scala
+// ^^^^ constant.language.null.scala
 
    Nil
 // ^^^ support.constant.scala
@@ -629,7 +629,7 @@ type Foo = Bar[A] forSome { type A }
 //       ^^^ entity.name.tag
 
    case true =>
-//      ^^^ constant.language.scala
+//      ^^^ constant.language.boolean.true.scala
 
    case _ ⇒ _
 //          ^ - keyword
@@ -1047,7 +1047,7 @@ def foo(a: A =:= B)
 
 def foo(a: A =:= B = null)
 //                 ^ keyword.operator.assignment.scala
-//                   ^^^^ constant.language.scala
+//                   ^^^^ constant.language.null.scala
 
 def foo(a: A :: B)
 //           ^^ support.type.scala
@@ -1063,7 +1063,7 @@ class Foo(a: A =:= B)
 
 class Foo(a: A =:= B = null)
 //                   ^ keyword.operator.assignment.scala
-//                     ^^^^ constant.language.scala
+//                     ^^^^ constant.language.null.scala
 
 class Foo(a: A :: B)
 //             ^^ support.type.scala

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -1492,12 +1492,17 @@ contexts:
 ###[ CONSTANTS ]###############################################################
 
   booleans:
-    - match: (?:true|false)\b
-      scope: constant.language.boolean.shell
+    - match: false\b
+      scope: constant.language.boolean.false.shell
+    - match: true\b
+      scope: constant.language.boolean.true.shell
 
   boolean:
-    - match: (?:true|false)\b
-      scope: constant.language.boolean.shell
+    - match: false\b
+      scope: constant.language.boolean.false.shell
+      pop: 1
+    - match: true\b
+      scope: constant.language.boolean.true.shell
       pop: 1
 
   numbers:

--- a/ShellScript/test/syntax_test_bash.sh
+++ b/ShellScript/test/syntax_test_bash.sh
@@ -541,9 +541,9 @@ foo -nfv --opt1 arg1 -p=true -d false
 #              ^ - variable - punctuation
 #                    ^^ meta.parameter.option.shell variable.parameter.option.shell
 #                      ^ keyword.operator.assignment.shell
-#                       ^^^^ constant.language.boolean.shell
+#                       ^^^^ constant.language.boolean.true.shell
 #                            ^^ meta.parameter.option.shell variable.parameter.option.shell
-#                               ^^^^^ constant.language.boolean.shell
+#                               ^^^^^ constant.language.boolean.false.shell
 
 foo --\
 opt1=10
@@ -1089,7 +1089,7 @@ do echo bar; until ! { [[ true ]]; }
 #                  ^ keyword.operator.logical.shell
 #                    ^ punctuation.section.compound.begin.shell
 #                      ^^ support.function.test.begin.shell
-#                         ^^^^ constant.language.boolean.shell
+#                         ^^^^ constant.language.boolean.true.shell
 #                              ^^ support.function.test.end.shell
 #                                ^ punctuation.terminator.statement.shell
 #                                  ^ punctuation.section.compound.end.shell
@@ -1105,7 +1105,7 @@ while true; do
 # <- keyword.control.loop.while
 #^^^^ keyword.control.loop.while.shell
 #    ^ - constant - keyword
-#     ^^^^ constant.language.boolean.shell
+#     ^^^^ constant.language.boolean.true.shell
 #         ^ punctuation.terminator.statement.shell
 #           ^^ keyword.control.loop.do.shell
     break
@@ -1126,7 +1126,7 @@ done
 while ! true; do echo bar; done
 # <- keyword.control.loop.while.shell
 #     ^ keyword.operator.logical.shell
-#       ^^^^ constant.language.boolean.shell
+#       ^^^^ constant.language.boolean.true.shell
 #           ^ punctuation.terminator.statement.shell
 #             ^^ keyword.control.loop.do.shell
 #                ^^^^ support.function.echo.shell
@@ -1137,7 +1137,7 @@ while ! { true; }; do echo bar; done
 # <- keyword.control.loop.while.shell
 #     ^ keyword.operator.logical.shell
 #       ^ punctuation.section.compound.begin.shell
-#         ^^^^ constant.language.boolean.shell
+#         ^^^^ constant.language.boolean.true.shell
 #             ^ punctuation.terminator.statement.shell
 #               ^ punctuation.section.compound.end.shell
 #                ^ punctuation.terminator.statement.shell
@@ -1149,7 +1149,7 @@ while ! { [[ true ]]; }; do echo bar; done
 #     ^ keyword.operator.logical.shell
 #       ^ punctuation.section.compound.begin.shell
 #         ^^ support.function.test.begin.shell
-#            ^^^^ constant.language.boolean.shell
+#            ^^^^ constant.language.boolean.true.shell
 #                 ^^ support.function.test.end.shell
 #                   ^ punctuation.terminator.statement.shell
 #                     ^ punctuation.section.compound.end.shell
@@ -1162,7 +1162,7 @@ while ! ( [[ true ]] ); do echo bar; done
 #     ^ keyword.operator.logical.shell
 #       ^ punctuation.section.compound.begin.shell
 #         ^^ support.function.test.begin.shell
-#            ^^^^ constant.language.boolean.shell
+#            ^^^^ constant.language.boolean.true.shell
 #                 ^^ support.function.test.end.shell
 #                    ^ punctuation.section.compound.end.shell
 #                     ^ punctuation.terminator.statement.shell
@@ -1552,10 +1552,10 @@ fi
 
 if true ; then false ; fi
 #^ keyword.control.conditional.if.shell
-#  ^^^^ constant.language.boolean.shell
+#  ^^^^ constant.language.boolean.true.shell
 #       ^ punctuation.terminator.statement.shell
 #         ^^^^ keyword.control.conditional.then.shell
-#              ^^^^^ constant.language.boolean.shell
+#              ^^^^^ constant.language.boolean.false.shell
 #                    ^ punctuation.terminator.statement.shell
 #                      ^^ keyword.control.conditional.end.shell
 
@@ -2731,12 +2731,12 @@ true=false
 # <- variable.other.readwrite.shell - constant
 #^^^ variable.other.readwrite.shell - constant
 #   ^ keyword.operator.assignment.shell
-#    ^^^^^ constant.language.boolean.shell
+#    ^^^^^ constant.language.boolean.false.shell
 false=true
 # <- variable.other.readwrite.shell - constant
 #^^^^ variable.other.readwrite.shell - constant
 #    ^ keyword.operator.assignment.shell
-#     ^^^^ constant.language.boolean.shell
+#     ^^^^ constant.language.boolean.true.shell
 charclass=\}ower
 # <- meta.variable.shell variable.other.readwrite.shell
 #^^^^^^^^ meta.variable.shell variable.other.readwrite.shell
@@ -5902,7 +5902,7 @@ local foo+=10 bar-=true
 #          ^^ meta.number.integer.decimal.shell constant.numeric.value.shell
 #             ^^^ meta.variable.shell variable.other.readwrite.shell
 #                ^^ keyword.operator.assignment.shell
-#                  ^^^^ constant.language.boolean.shell
+#                  ^^^^ constant.language.boolean.true.shell
 
 local pid="$(cat "$PIDFILE" 2>/dev/null)"
 # <- meta.declaration.variable.shell keyword.declaration.variable.shell
@@ -6088,7 +6088,7 @@ test $var == true
 #^^^ meta.function-call.identifier.shell support.function.test.shell
 #   ^^^^^^^^^^^^^ meta.function-call.arguments.shell - meta.string.regexp
 #         ^^ keyword.operator.comparison.shell
-#            ^^^^ constant.language.boolean.shell
+#            ^^^^ constant.language.boolean.true.shell
 
 test str == "str"
 #<- meta.function-call.identifier.shell support.function.test.shell
@@ -6586,10 +6586,10 @@ sudo --reset-timestamp -n -f -- rm -rf
 ###############################################################################
 
 true false
-# <- constant.language.boolean.shell
-#^^^ constant.language.boolean.shell
+# <- constant.language.boolean.true.shell
+#^^^ constant.language.boolean.true.shell
 #   ^ - constant
-#    ^^^^^ constant.language.boolean.shell
+#    ^^^^^ constant.language.boolean.false.shell
 #         ^ - constant
 
 (( 0 ))

--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -153,14 +153,21 @@ variables:
   _type_null: (?:null|Null|NULL|~)
 
   # http://yaml.org/type/bool.html
-  _type_bool_11: |-
+  _type_bool_false_11: |-
     (?x:
-       y|Y|yes|Yes|YES|n|N|no|No|NO
-      |true|True|TRUE|false|False|FALSE
-      |on|On|ON|off|Off|OFF
+       n|N|no|No|NO
+      |false|False|FALSE
+      |off|Off|OFF
+    )
+  _type_bool_true_11: |-
+    (?x:
+       y|Y|yes|Yes|YES
+      |true|True|TRUE
+      |on|On|ON
     )
   # https://yaml.org/spec/1.2/spec.html#id2805071
-  _type_bool_12: (?x:true | True | TRUE | false | False | FALSE)
+  _type_bool_false_12: (?x:false | False | FALSE)
+  _type_bool_true_12: (?x:true | True | TRUE)
 
   # http://yaml.org/type/int.html
   _type_int_binary: ([-+]?)(0b)([0-1_]+) # (base 2)
@@ -544,14 +551,18 @@ contexts:
       pop: 1
 
   flow-scalar-plain-in-implicit-type-11:
-    - match: '{{_type_bool_11}}{{_flow_scalar_end_plain_in}}'
-      scope: constant.language.boolean.yaml
+    - match: '{{_type_bool_false_11}}{{_flow_scalar_end_plain_in}}'
+      scope: constant.language.boolean.false.yaml
+    - match: '{{_type_bool_true_11}}{{_flow_scalar_end_plain_in}}'
+      scope: constant.language.boolean.true.yaml
     - include: flow-scalar-plain-in-implicit-type-common
 
   flow-scalar-plain-in-implicit-type-12:
     # Less aggressive variant based on the YAML 1.2 core schema
-    - match: '{{_type_bool_12}}{{_flow_scalar_end_plain_in}}'
-      scope: constant.language.boolean.yaml
+    - match: '{{_type_bool_false_12}}{{_flow_scalar_end_plain_in}}'
+      scope: constant.language.boolean.false.yaml
+    - match: '{{_type_bool_true_12}}{{_flow_scalar_end_plain_in}}'
+      scope: constant.language.boolean.true.yaml
     - include: flow-scalar-plain-in-implicit-type-common
 
   flow-scalar-plain-in-implicit-type-common:
@@ -647,14 +658,18 @@ contexts:
       pop: 1
 
   flow-scalar-plain-out-implicit-type-11:
-    - match: '{{_type_bool_11}}{{_flow_scalar_end_plain_out}}'
-      scope: constant.language.boolean.yaml
+    - match: '{{_type_bool_false_11}}{{_flow_scalar_end_plain_out}}'
+      scope: constant.language.boolean.false.yaml
+    - match: '{{_type_bool_true_11}}{{_flow_scalar_end_plain_out}}'
+      scope: constant.language.boolean.true.yaml
     - include: flow-scalar-plain-out-implicit-type-common
 
   flow-scalar-plain-out-implicit-type-12:
     # Less aggressive variant based on the YAML 1.2 core schema
-    - match: '{{_type_bool_12}}{{_flow_scalar_end_plain_out}}'
-      scope: constant.language.boolean.yaml
+    - match: '{{_type_bool_false_12}}{{_flow_scalar_end_plain_out}}'
+      scope: constant.language.boolean.false.yaml
+    - match: '{{_type_bool_true_12}}{{_flow_scalar_end_plain_out}}'
+      scope: constant.language.boolean.true.yaml
     - include: flow-scalar-plain-out-implicit-type-common
 
   flow-scalar-plain-out-implicit-type-common:

--- a/YAML/tests/syntax_test_flow.yaml
+++ b/YAML/tests/syntax_test_flow.yaml
@@ -173,9 +173,9 @@ unquoted'string'
 #^^^^^^^^^^^^^^^^^^^^^ meta.mapping - meta.mapping meta.mapping
 #^^^^^ variable.other.alias
 #     ^ punctuation.separator.sequence
-#       ^^^^ meta.mapping.key.yaml constant.language.boolean.yaml - string
+#       ^^^^ meta.mapping.key.yaml constant.language.boolean.true.yaml - string
 #            ^     punctuation.separator.key-value.mapping
-#              ^^^^^ meta.mapping.value.yaml constant.language.boolean.yaml
+#              ^^^^^ meta.mapping.value.yaml constant.language.boolean.false.yaml
 #                    ^ meta.mapping.yaml punctuation.definition.mapping.end
 
  { 1: 2 }

--- a/YAML/tests/syntax_test_types.yaml
+++ b/YAML/tests/syntax_test_types.yaml
@@ -22,15 +22,15 @@
 ## http://yaml.org/type/bool.html
 
 - [yes, no, true, false, No, y, ON, off, Off, ~, oFF, nO, false true]
-#  ^^^                                                               constant.language.boolean
-#       ^^                                                           constant.language.boolean
-#           ^^^^                                                     constant.language.boolean
-#                 ^^^^^                                              constant.language.boolean
-#                        ^^                                          constant.language.boolean
-#                            ^                                       constant.language.boolean
-#                               ^^                                   constant.language.boolean
-#                                   ^^^                              constant.language.boolean
-#                                        ^^^                         constant.language.boolean
+#  ^^^                                                               constant.language.boolean.true
+#       ^^                                                           constant.language.boolean.false
+#           ^^^^                                                     constant.language.boolean.true
+#                 ^^^^^                                              constant.language.boolean.false
+#                        ^^                                          constant.language.boolean.false
+#                            ^                                       constant.language.boolean.true
+#                               ^^                                   constant.language.boolean.true
+#                                   ^^^                              constant.language.boolean.false
+#                                        ^^^                         constant.language.boolean.false
 #                                                ^^^^^^^^^^^^^^^^^^^ - constant
 
 
@@ -202,9 +202,9 @@
 ## In a mapping
 
 true: false
-#^^^        constant.language.boolean
+#^^^        constant.language.boolean.true
 #   ^       punctuation.separator.key-value.mapping
-#     ^^^^^ constant.language.boolean
+#     ^^^^^ constant.language.boolean.false
 3.e-3: 3.e+3
 #^^^^ meta.number.float.decimal.yaml constant.numeric.value.yaml
 #^ punctuation.separator.decimal.yaml
@@ -222,4 +222,4 @@ true: false
 #                   ^ punctuation.separator.date.yaml
 y: n
 # <- -constant
-#  ^ constant.language.boolean.yaml
+#  ^ constant.language.boolean.false.yaml


### PR DESCRIPTION
This is good for those who want to use different colors for true/false.

---

This PR changes scopes of booleans in most languages.

Splits scope `XXX.boolean.LANG` into

- `XXX.boolean.true.LANG`
- `XXX.boolean.false.LANG`

Some also introduce new detailed scope for `null`/`nil`.