### PR TITLE
[JavaScript] Fix module declaration

### DIFF
--- a/JavaScript/Symbol List.tmPreferences
+++ b/JavaScript/Symbol List.tmPreferences
@@ -3,14 +3,19 @@
 <dict>
 	<key>scope</key>
 	<string>
-		entity.name.interface.js
+		entity.name.interface.js,
+		entity.name.module.js
 	</string>
 	<key>settings</key>
 	<dict>
 		<key>showInSymbolList</key>
 		<string>1</string>
+		<key>symbolTransformation</key>
+		<string>s/^["']|["']$//g;</string>
 		<key>showInIndexedSymbolList</key>
 		<string>1</string>
+		<key>symbolIndexTransformation</key>
+		<string>s/^["']|["']$//g;</string>
 	</dict>
 </dict>
 </plist>

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -254,7 +254,7 @@ contexts:
       set:
         - ts-meta-module
         - block
-        - literal-string
+        - ts-module-name
     - include: declaration
     - match: (?={{identifier_start}})
       pop: 1
@@ -265,6 +265,40 @@ contexts:
     - meta_include_prototype: false
     - meta_scope: meta.module.js
     - include: immediately-pop
+
+  ts-module-name:
+    - match: \"
+      scope: punctuation.definition.quoted.begin.js
+      set: ts-double-quoted-module-name-content
+    - match: \'
+      scope: punctuation.definition.quoted.begin.js
+      set: ts-single-quoted-module-name-content
+    - match: '{{non_reserved_identifier}}'
+      scope: entity.name.module.js
+      pop: 1
+    - include: else-pop
+
+  ts-double-quoted-module-name-content:
+    - meta_include_prototype: false
+    - meta_scope: entity.name.module.js
+    - match: \"
+      scope: punctuation.definition.quoted.end.js
+      pop: 1
+    - match: \n
+      scope: invalid.illegal.newline.js
+      pop: 1
+    - include: string-content
+
+  ts-single-quoted-module-name-content:
+    - meta_include_prototype: false
+    - meta_scope: entity.name.module.js
+    - match: \'
+      scope: punctuation.definition.quoted.end.js
+      pop: 1
+    - match: \n
+      scope: invalid.illegal.newline.js
+      pop: 1
+    - include: string-content
 
   ts-abstract-class:
     - match: abstract{{identifier_break}}

--- a/JavaScript/tests/syntax_test_typescript_declarations.d.ts
+++ b/JavaScript/tests/syntax_test_typescript_declarations.d.ts
@@ -177,9 +177,27 @@
 //                      ^ punctuation.section.block.begin
 //                       ^ punctuation.section.block.end
 
+    declare module module {}
+//  ^^^^^^^ storage.modifier
+//          ^^^^^^^^^^^^^^^^ meta.module
+//          ^^^^^^ keyword.declaration.module
+//                 ^^^^^^ entity.name.module.js
+//                        ^^ meta.block
+
     declare module 'module' {}
 //  ^^^^^^^ storage.modifier
 //          ^^^^^^^^^^^^^^^^^^ meta.module
 //          ^^^^^^ keyword.declaration.module
-//                 ^^^^^^^^ meta.string string.quoted.single
+//                 ^^^^^^^^ entity.name.module.js
+//                 ^ punctuation.definition.quoted.begin.js
+//                        ^ punctuation.definition.quoted.end.js
+//                          ^^ meta.block
+
+    declare module "module" {}
+//  ^^^^^^^ storage.modifier
+//          ^^^^^^^^^^^^^^^^^^ meta.module
+//          ^^^^^^ keyword.declaration.module
+//                 ^^^^^^^^ entity.name.module.js
+//                 ^ punctuation.definition.quoted.begin.js
+//                        ^ punctuation.definition.quoted.end.js
 //                          ^^ meta.block


### PR DESCRIPTION
Fixes #4010

This commit...

1. adds support for unquoted identifiers in module declarations
2. scopes quoted identifiers entity.name.modules, instead of "string".
3. adds module declaration names to symbol list and global symbol index.
4. removes possible leading and trailing quotes from symbols.