### PR TITLE
[C/C++] Fix broken tests

### DIFF
--- a/C++/syntax_test_c.c
+++ b/C++/syntax_test_c.c
@@ -356,8 +356,7 @@ int disabled_func() {
 #endif
 
 #if 0000000
-/*
-    ^^^^^^^ meta.number constant.numeric.value
+/*  ^^^^^^^ meta.number constant.numeric.value
 */
 #endif
 
@@ -372,8 +371,7 @@ int disabled_func() {
 #endif
 
 #if 0090
-/*
-    ^^^^ meta.number constant.numeric.value
+/*  ^^^^ meta.number constant.numeric.value
 */
 #endif
 

--- a/C++/syntax_test_cpp.cpp
+++ b/C++/syntax_test_cpp.cpp
@@ -249,14 +249,12 @@ some_namespace::some_function(int a_parameter, double another_parameter) {
 #endif
 
 #if 0000000
-/*
-    ^^^^^^^ meta.number constant.numeric.value
+/*  ^^^^^^^ meta.number constant.numeric.value
 */
 #endif
 
 #if 0090
-/*
-    ^^^^ meta.number constant.numeric.value
+/*  ^^^^ meta.number constant.numeric.value
 */
 #endif
 


### PR DESCRIPTION
These tests weren't being run because the `/*` needs to be on the same line as the test.