### PR TITLE
[Go] Add support for YAML Go templates

### DIFF
--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -747,8 +747,24 @@ contexts:
     - match: \%(?:\[\d+\])?[ .\d*#+-]*[A-Za-z]
       scope: constant.other.placeholder.go
 
+  match-block-string-templates:
+    # This context is used for interpolation within quoted or unquoted multiline strings.
+    # Doesn't check for closing `}}` as it might be located on a sub-sequent line.
+    # It clears the `string` scope of the owning context.
+    # Note: used by YAML (Go).sublime-syntax
+    - match: ({{)(-?)
+      captures:
+        1: punctuation.section.interpolation.begin.go
+        2: keyword.operator.template.trim.left.go
+      push:
+        - pop-now-clear-scope
+        - match-template-inner
+        - match-template-function
+        - match-template-keyword
+
   match-string-templates:
     # This context is used for interpolation within quoted or unquoted strings.
+    # Matchs only if closing `}}` is found on same line to avoid false positives.
     # It clears the `string` scope of the owning context.
     - match: ({{)(-?)(?=.*?}})
       captures:

--- a/Go/Snippets/Template/block-end.sublime-snippet
+++ b/Go/Snippets/Template/block-end.sublime-snippet
@@ -3,6 +3,6 @@
 $0
 ${TM_TEMPLATE_START}end${TM_TEMPLATE_END}]]></content>
 <tabTrigger>tblockend</tabTrigger>
-<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.go string) - source.go.template</scope>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.go string) - source.go.template</scope>
 <description>{{block "name"}} ... {{end}}</description>
 </snippet>

--- a/Go/Snippets/Template/block-end.sublime-snippet
+++ b/Go/Snippets/Template/block-end.sublime-snippet
@@ -3,6 +3,6 @@
 $0
 ${TM_TEMPLATE_START}end${TM_TEMPLATE_END}]]></content>
 <tabTrigger>tblockend</tabTrigger>
-<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.go string) - source.go.template</scope>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.yaml.go | source.go string) - source.go.template</scope>
 <description>{{block "name"}} ... {{end}}</description>
 </snippet>

--- a/Go/Snippets/Template/block.sublime-snippet
+++ b/Go/Snippets/Template/block.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 <content><![CDATA[${TM_TEMPLATE_START}block "${1:name}"${TM_TEMPLATE_END}]]></content>
 <tabTrigger>tblock</tabTrigger>
-<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.go string) - source.go.template</scope>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.go string) - source.go.template</scope>
 <description>{{block "name"}}</description>
 </snippet>

--- a/Go/Snippets/Template/block.sublime-snippet
+++ b/Go/Snippets/Template/block.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 <content><![CDATA[${TM_TEMPLATE_START}block "${1:name}"${TM_TEMPLATE_END}]]></content>
 <tabTrigger>tblock</tabTrigger>
-<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.go string) - source.go.template</scope>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.yaml.go | source.go string) - source.go.template</scope>
 <description>{{block "name"}}</description>
 </snippet>

--- a/Go/Snippets/Template/break.sublime-snippet
+++ b/Go/Snippets/Template/break.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 <content><![CDATA[${TM_TEMPLATE_START}break${TM_TEMPLATE_END}]]></content>
 <tabTrigger>tbreak</tabTrigger>
-<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.go string) - source.go.template</scope>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.yaml.go | source.go string) - source.go.template</scope>
 <description>{{break}}</description>
 </snippet>

--- a/Go/Snippets/Template/break.sublime-snippet
+++ b/Go/Snippets/Template/break.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 <content><![CDATA[${TM_TEMPLATE_START}break${TM_TEMPLATE_END}]]></content>
 <tabTrigger>tbreak</tabTrigger>
-<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.go string) - source.go.template</scope>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.go string) - source.go.template</scope>
 <description>{{break}}</description>
 </snippet>

--- a/Go/Snippets/Template/continue.sublime-snippet
+++ b/Go/Snippets/Template/continue.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 <content><![CDATA[${TM_TEMPLATE_START}continue${TM_TEMPLATE_END}]]></content>
 <tabTrigger>tcontinue</tabTrigger>
-<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.go string) - source.go.template</scope>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.yaml.go | source.go string) - source.go.template</scope>
 <description>{{continue}}</description>
 </snippet>

--- a/Go/Snippets/Template/continue.sublime-snippet
+++ b/Go/Snippets/Template/continue.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 <content><![CDATA[${TM_TEMPLATE_START}continue${TM_TEMPLATE_END}]]></content>
 <tabTrigger>tcontinue</tabTrigger>
-<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.go string) - source.go.template</scope>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.go string) - source.go.template</scope>
 <description>{{continue}}</description>
 </snippet>

--- a/Go/Snippets/Template/define.sublime-snippet
+++ b/Go/Snippets/Template/define.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 <content><![CDATA[${TM_TEMPLATE_START}define "${1:name}"${TM_TEMPLATE_END}]]></content>
 <tabTrigger>tdefine</tabTrigger>
-<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.go string) - source.go.template</scope>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.go string) - source.go.template</scope>
 <description>{{define "name"}}</description>
 </snippet>

--- a/Go/Snippets/Template/define.sublime-snippet
+++ b/Go/Snippets/Template/define.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 <content><![CDATA[${TM_TEMPLATE_START}define "${1:name}"${TM_TEMPLATE_END}]]></content>
 <tabTrigger>tdefine</tabTrigger>
-<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.go string) - source.go.template</scope>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.yaml.go | source.go string) - source.go.template</scope>
 <description>{{define "name"}}</description>
 </snippet>

--- a/Go/Snippets/Template/else if.sublime-snippet
+++ b/Go/Snippets/Template/else if.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 <content><![CDATA[${TM_TEMPLATE_START}else if ${1:pipeline}${TM_TEMPLATE_END}]]></content>
 <tabTrigger>telseif</tabTrigger>
-<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.go string) - source.go.template</scope>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.yaml.go | source.go string) - source.go.template</scope>
 <description>{{else if ...}}</description>
 </snippet>

--- a/Go/Snippets/Template/else if.sublime-snippet
+++ b/Go/Snippets/Template/else if.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 <content><![CDATA[${TM_TEMPLATE_START}else if ${1:pipeline}${TM_TEMPLATE_END}]]></content>
 <tabTrigger>telseif</tabTrigger>
-<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.go string) - source.go.template</scope>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.go string) - source.go.template</scope>
 <description>{{else if ...}}</description>
 </snippet>

--- a/Go/Snippets/Template/else.sublime-snippet
+++ b/Go/Snippets/Template/else.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 <content><![CDATA[${TM_TEMPLATE_START}else${TM_TEMPLATE_END}]]></content>
 <tabTrigger>telse</tabTrigger>
-<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.go string) - source.go.template</scope>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.yaml.go | source.go string) - source.go.template</scope>
 <description>{{else}}</description>
 </snippet>

--- a/Go/Snippets/Template/else.sublime-snippet
+++ b/Go/Snippets/Template/else.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 <content><![CDATA[${TM_TEMPLATE_START}else${TM_TEMPLATE_END}]]></content>
 <tabTrigger>telse</tabTrigger>
-<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.go string) - source.go.template</scope>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.go string) - source.go.template</scope>
 <description>{{else}}</description>
 </snippet>

--- a/Go/Snippets/Template/end.sublime-snippet
+++ b/Go/Snippets/Template/end.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 <content><![CDATA[${TM_TEMPLATE_START}end${TM_TEMPLATE_END}]]></content>
 <tabTrigger>tend</tabTrigger>
-<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.go string) - source.go.template</scope>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.go string) - source.go.template</scope>
 <description>{{end}}</description>
 </snippet>

--- a/Go/Snippets/Template/end.sublime-snippet
+++ b/Go/Snippets/Template/end.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 <content><![CDATA[${TM_TEMPLATE_START}end${TM_TEMPLATE_END}]]></content>
 <tabTrigger>tend</tabTrigger>
-<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.go string) - source.go.template</scope>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.yaml.go | source.go string) - source.go.template</scope>
 <description>{{end}}</description>
 </snippet>

--- a/Go/Snippets/Template/if-end.sublime-snippet
+++ b/Go/Snippets/Template/if-end.sublime-snippet
@@ -3,6 +3,6 @@
 $0
 ${TM_TEMPLATE_START}end${TM_TEMPLATE_END}]]></content>
 <tabTrigger>tifend</tabTrigger>
-<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.go string) - source.go.template</scope>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.yaml.go | source.go string) - source.go.template</scope>
 <description>{{if ...}} ... {{end}}</description>
 </snippet>

--- a/Go/Snippets/Template/if-end.sublime-snippet
+++ b/Go/Snippets/Template/if-end.sublime-snippet
@@ -3,6 +3,6 @@
 $0
 ${TM_TEMPLATE_START}end${TM_TEMPLATE_END}]]></content>
 <tabTrigger>tifend</tabTrigger>
-<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.go string) - source.go.template</scope>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.go string) - source.go.template</scope>
 <description>{{if ...}} ... {{end}}</description>
 </snippet>

--- a/Go/Snippets/Template/if.sublime-snippet
+++ b/Go/Snippets/Template/if.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 <content><![CDATA[${TM_TEMPLATE_START}if ${1:pipeline}${TM_TEMPLATE_END}]]></content>
 <tabTrigger>tif</tabTrigger>
-<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.go string) - source.go.template</scope>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.go string) - source.go.template</scope>
 <description>{{if ...}}</description>
 </snippet>

--- a/Go/Snippets/Template/if.sublime-snippet
+++ b/Go/Snippets/Template/if.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 <content><![CDATA[${TM_TEMPLATE_START}if ${1:pipeline}${TM_TEMPLATE_END}]]></content>
 <tabTrigger>tif</tabTrigger>
-<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.go string) - source.go.template</scope>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.yaml.go | source.go string) - source.go.template</scope>
 <description>{{if ...}}</description>
 </snippet>

--- a/Go/Snippets/Template/partial.sublime-snippet
+++ b/Go/Snippets/Template/partial.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 <content><![CDATA[${TM_TEMPLATE_START}partial "${1:name}"${TM_TEMPLATE_END}]]></content>
 <tabTrigger>tpartial</tabTrigger>
-<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.go string) - source.go.template</scope>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.yaml.go | source.go string) - source.go.template</scope>
 <description>{{partial "name"}}</description>
 </snippet>

--- a/Go/Snippets/Template/partial.sublime-snippet
+++ b/Go/Snippets/Template/partial.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 <content><![CDATA[${TM_TEMPLATE_START}partial "${1:name}"${TM_TEMPLATE_END}]]></content>
 <tabTrigger>tpartial</tabTrigger>
-<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.go string) - source.go.template</scope>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.go string) - source.go.template</scope>
 <description>{{partial "name"}}</description>
 </snippet>

--- a/Go/Snippets/Template/range-end.sublime-snippet
+++ b/Go/Snippets/Template/range-end.sublime-snippet
@@ -3,6 +3,6 @@
 $0
 ${TM_TEMPLATE_START}end${TM_TEMPLATE_END}]]></content>
 <tabTrigger>trangeend</tabTrigger>
-<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.go string) - source.go.template</scope>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.yaml.go | source.go string) - source.go.template</scope>
 <description>{{range ...}}...{{end}}</description>
 </snippet>

--- a/Go/Snippets/Template/range-end.sublime-snippet
+++ b/Go/Snippets/Template/range-end.sublime-snippet
@@ -3,6 +3,6 @@
 $0
 ${TM_TEMPLATE_START}end${TM_TEMPLATE_END}]]></content>
 <tabTrigger>trangeend</tabTrigger>
-<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.go string) - source.go.template</scope>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.go string) - source.go.template</scope>
 <description>{{range ...}}...{{end}}</description>
 </snippet>

--- a/Go/Snippets/Template/range.sublime-snippet
+++ b/Go/Snippets/Template/range.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 <content><![CDATA[${TM_TEMPLATE_START}range ${1:pipeline}${TM_TEMPLATE_END}]]></content>
 <tabTrigger>trange</tabTrigger>
-<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.go string) - source.go.template</scope>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.go string) - source.go.template</scope>
 <description>{{range ...}}</description>
 </snippet>

--- a/Go/Snippets/Template/range.sublime-snippet
+++ b/Go/Snippets/Template/range.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 <content><![CDATA[${TM_TEMPLATE_START}range ${1:pipeline}${TM_TEMPLATE_END}]]></content>
 <tabTrigger>trange</tabTrigger>
-<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.go string) - source.go.template</scope>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.yaml.go | source.go string) - source.go.template</scope>
 <description>{{range ...}}</description>
 </snippet>

--- a/Go/Snippets/Template/template.sublime-snippet
+++ b/Go/Snippets/Template/template.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 <content><![CDATA[${TM_TEMPLATE_START}template "${1:header}" ${0:.}${TM_TEMPLATE_END}]]></content>
 <tabTrigger>ttemplate</tabTrigger>
-<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.go string) - source.go.template</scope>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.go string) - source.go.template</scope>
 <description>{{template "name" .}}</description>
 </snippet>

--- a/Go/Snippets/Template/template.sublime-snippet
+++ b/Go/Snippets/Template/template.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 <content><![CDATA[${TM_TEMPLATE_START}template "${1:header}" ${0:.}${TM_TEMPLATE_END}]]></content>
 <tabTrigger>ttemplate</tabTrigger>
-<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.go string) - source.go.template</scope>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.yaml.go | source.go string) - source.go.template</scope>
 <description>{{template "name" .}}</description>
 </snippet>

--- a/Go/Snippets/Template/var.sublime-snippet
+++ b/Go/Snippets/Template/var.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 <content><![CDATA[${TM_TEMPLATE_START}.${0:Var}${TM_TEMPLATE_END}]]></content>
 <tabTrigger>tvar</tabTrigger>
-<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.go string) - source.go.template</scope>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.go string) - source.go.template</scope>
 <description>{{.Var}}</description>
 </snippet>

--- a/Go/Snippets/Template/var.sublime-snippet
+++ b/Go/Snippets/Template/var.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 <content><![CDATA[${TM_TEMPLATE_START}.${0:Var}${TM_TEMPLATE_END}]]></content>
 <tabTrigger>tvar</tabTrigger>
-<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.go string) - source.go.template</scope>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.yaml.go | source.go string) - source.go.template</scope>
 <description>{{.Var}}</description>
 </snippet>

--- a/Go/Snippets/Template/with-end.sublime-snippet
+++ b/Go/Snippets/Template/with-end.sublime-snippet
@@ -3,6 +3,6 @@
 $0
 ${TM_TEMPLATE_START}end${TM_TEMPLATE_END}]]></content>
 <tabTrigger>twithend</tabTrigger>
-<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.go string) - source.go.template</scope>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.go string) - source.go.template</scope>
 <description>{{with ...}}...{{end}}</description>
 </snippet>

--- a/Go/Snippets/Template/with-end.sublime-snippet
+++ b/Go/Snippets/Template/with-end.sublime-snippet
@@ -3,6 +3,6 @@
 $0
 ${TM_TEMPLATE_START}end${TM_TEMPLATE_END}]]></content>
 <tabTrigger>twithend</tabTrigger>
-<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.go string) - source.go.template</scope>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.yaml.go | source.go string) - source.go.template</scope>
 <description>{{with ...}}...{{end}}</description>
 </snippet>

--- a/Go/Snippets/Template/with.sublime-snippet
+++ b/Go/Snippets/Template/with.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 <content><![CDATA[${TM_TEMPLATE_START}with ${1:pipeline}${TM_TEMPLATE_END}]]></content>
 <tabTrigger>twith</tabTrigger>
-<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.go string) - source.go.template</scope>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.yaml.go | source.go string) - source.go.template</scope>
 <description>{{with ...}}</description>
 </snippet>

--- a/Go/Snippets/Template/with.sublime-snippet
+++ b/Go/Snippets/Template/with.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 <content><![CDATA[${TM_TEMPLATE_START}with ${1:pipeline}${TM_TEMPLATE_END}]]></content>
 <tabTrigger>twith</tabTrigger>
-<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.go string) - source.go.template</scope>
+<scope>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.go string) - source.go.template</scope>
 <description>{{with ...}}</description>
 </snippet>

--- a/Go/Template.tmPreferences
+++ b/Go/Template.tmPreferences
@@ -10,7 +10,7 @@
 	whether templates are wrapped with whitespace.
 	 -->
 	<key>scope</key>
-	<string>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.go string) - source.go.template</string>
+	<string>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.go string) - source.go.template</string>
 	<key>settings</key>
 	<dict>
 		<key>shellVariables</key>

--- a/Go/Template.tmPreferences
+++ b/Go/Template.tmPreferences
@@ -10,7 +10,7 @@
 	whether templates are wrapped with whitespace.
 	 -->
 	<key>scope</key>
-	<string>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.go string) - source.go.template</string>
+	<string>(text.html.go | text.html.markdown.go | source.css.go | source.js.go | source.json.go | source.yaml.go | source.go string) - source.go.template</string>
 	<key>settings</key>
 	<dict>
 		<key>shellVariables</key>

--- a/Go/YAML (Go).sublime-syntax
+++ b/Go/YAML (Go).sublime-syntax
@@ -16,18 +16,76 @@ file_extensions:
 variables:
   ns_plain_first_plain_in: |- # c=plain-in
     (?x:
+        {{yaml_ns_plain_first_plain_in}}
+      | (?:[?:-] )?{{  # begins with go interpolation
+    )
+
+  # original value from YAML
+  yaml_ns_plain_first_plain_in: |- # c=plain-in
+    (?x:
         [^\s{{c_indicator}}]
       | [?:-] [^\s{{c_flow_indicator}}]
-      | (?:[?:-] )?{{  # begins with go interpolation
-
     )
 
   ns_plain_first_plain_out: |- # c=plain-out
     (?x:
-        [^\s{{c_indicator}}]
-      | [?:-] \S
+        {{yaml_ns_plain_first_plain_out}}
       | (?:[?:-] )?{{  # begins with go interpolation
     )
+
+  # original value from YAML
+  yaml_ns_plain_first_plain_out: |- # c=plain-out
+    (?x:
+        [^\s{{c_indicator}}]
+      | [?:-] \S
+    )
+
+  _flow_key_in_lookahead: |-
+    (?x:
+      (?=
+        (
+            (?:
+              {{yaml_ns_plain_first_plain_in}}
+              | {{go_interpolation}}  # begins with interpolation
+            )
+            ( [^\s:{{c_flow_indicator}}]
+            | : [^\s{{c_flow_indicator}}]
+            | \s+ (?![#\s])
+            | {{go_interpolation}}    # ignore interpolation
+            )*
+          | \".*\" # simplified
+          | \'.*\'
+        )
+        \s*
+        :
+        (?:\s|$)
+      )
+    )
+
+  _flow_key_out_lookahead: |-
+    (?x:
+      (?=
+
+        (
+            (?:
+              {{yaml_ns_plain_first_plain_out}}
+              | {{go_interpolation}}  # begins with interpolation
+            )
+            ( [^\s:]
+            | : \S
+            | \s+ (?![#\s])
+            | {{go_interpolation}}    # ignore interpolation
+            )*
+          | \".*\" # simplified
+          | \'.*\'
+        )
+        \s*
+        :
+        (?:\s|$)
+      )
+    )
+
+  go_interpolation: '{{.*?}}'
 
 contexts:
 

--- a/Go/YAML (Go).sublime-syntax
+++ b/Go/YAML (Go).sublime-syntax
@@ -1,0 +1,61 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/syntax.html
+name: YAML (Go)
+scope: source.yaml.go
+version: 2
+
+extends: Packages/YAML/YAML.sublime-syntax
+
+file_extensions:
+  - goyaml
+  - go.yaml
+  - goyml
+  - go.yml
+
+variables:
+  ns_plain_first_plain_in: |- # c=plain-in
+    (?x:
+        [^\s{{c_indicator}}]
+      | [?:-] [^\s{{c_flow_indicator}}]
+      | (?:[?:-] )?{{  # begins with go interpolation
+
+    )
+
+  ns_plain_first_plain_out: |- # c=plain-out
+    (?x:
+        [^\s{{c_indicator}}]
+      | [?:-] \S
+      | (?:[?:-] )?{{  # begins with go interpolation
+    )
+
+contexts:
+
+  main:
+    - meta_prepend: true
+    - meta_scope: meta.template.go
+
+  block-scalar-body:
+    - meta_prepend: true
+    - include: scope:source.go#match-string-templates
+
+  flow-scalar-plain-in-body:
+    - meta_prepend: true
+    - include: scope:source.go#match-string-templates
+
+  flow-scalar-plain-out-body:
+    - meta_prepend: true
+    - include: scope:source.go#match-string-templates
+
+  flow-scalar-double-quoted-body:
+    - meta_prepend: true
+    - include: scope:source.go#match-string-templates
+
+  flow-scalar-single-quoted-body:
+    - meta_prepend: true
+    - include: scope:source.go#match-string-templates
+
+  flow-mapping:
+    - match: \{(?![{%#])
+      scope: punctuation.definition.mapping.begin.yaml
+      push: flow-mapping-body

--- a/Go/YAML (Go).sublime-syntax
+++ b/Go/YAML (Go).sublime-syntax
@@ -37,23 +37,23 @@ contexts:
 
   block-scalar-body:
     - meta_prepend: true
-    - include: scope:source.go#match-string-templates
+    - include: scope:source.go#match-block-string-templates
 
   flow-scalar-plain-in-body:
     - meta_prepend: true
-    - include: scope:source.go#match-string-templates
+    - include: scope:source.go#match-block-string-templates
 
   flow-scalar-plain-out-body:
     - meta_prepend: true
-    - include: scope:source.go#match-string-templates
+    - include: scope:source.go#match-block-string-templates
 
   flow-scalar-double-quoted-body:
     - meta_prepend: true
-    - include: scope:source.go#match-string-templates
+    - include: scope:source.go#match-block-string-templates
 
   flow-scalar-single-quoted-body:
     - meta_prepend: true
-    - include: scope:source.go#match-string-templates
+    - include: scope:source.go#match-block-string-templates
 
   flow-mapping:
     - match: \{(?![{%#])

--- a/Go/tests/syntax_test_template.html
+++ b/Go/tests/syntax_test_template.html
@@ -67,6 +67,18 @@
   </head>
 
   <body>
+
+    {{/*
+|  ^ - meta.interpolation
+|   ^^ meta.interpolation.go punctuation.section.interpolation.begin.go
+|     ^^ meta.interpolation.go source.go.template comment.block.go punctuation.definition.comment.begin.go
+      Spread a key-value map into the "env" list
+|    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.interpolation.go source.go.template comment.block.go
+    */}}
+|   ^^ meta.interpolation.go source.go.template comment.block.go punctuation.definition.comment.end.go
+|     ^^ meta.interpolation.go punctuation.section.interpolation.end.go
+|       ^ - meta.interpolation
+
     {{ block "main" . }}
 |   ^^^^^^^^^^^^^^^^^^^^ meta.interpolation.go
 |   ^^ punctuation.section.interpolation.begin.go

--- a/Go/tests/syntax_test_template.md
+++ b/Go/tests/syntax_test_template.md
@@ -21,6 +21,16 @@
 |                     ^ keyword.operator.template.trim.right.go
 |                      ^^ punctuation.section.interpolation.end.go - source.go
 
+  {{/* 
+|^ meta.paragraph.markdown - meta.interpolation
+| ^^ meta.paragraph.markdown meta.interpolation.go punctuation.section.interpolation.begin.go
+|   ^^ meta.paragraph.markdown meta.interpolation.go source.go.template comment.block.go punctuation.definition.comment.begin.go
+    Spread a key-value map into the "env" list 
+|  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph.markdown meta.interpolation.go source.go.template comment.block.go
+  */}}
+| ^^ meta.paragraph.markdown meta.interpolation.go source.go.template comment.block.go punctuation.definition.comment.end.go
+|   ^^ meta.paragraph.markdown meta.interpolation.go punctuation.section.interpolation.end.go
+|     ^ meta.paragraph.markdown - meta.interpolation
 
 # My {{ .Site.Title }} homepage
 | <- markup.heading.1.markdown punctuation.definition.heading.begin.markdown

--- a/Go/tests/syntax_test_template.yaml
+++ b/Go/tests/syntax_test_template.yaml
@@ -13,6 +13,17 @@
 #   ^^ meta.string.yaml meta.interpolation.go punctuation.section.interpolation.end.go
 #     ^ - meta.string - meta.interpolation
 
+{{- printf "- name: %s" $key -}}
+# <- meta.string.yaml meta.interpolation.go punctuation.section.interpolation.begin.go - meta.mapping
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.yaml meta.interpolation.go - meta.mapping
+#                             ^^ punctuation.section.interpolation.end.go
+
+{{- printf "- name: %s" $key -}}:
+# <- meta.mapping.key.yaml meta.string.yaml meta.interpolation.go punctuation.section.interpolation.begin.go
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.key.yaml meta.string.yaml meta.interpolation.go
+#                             ^^ punctuation.section.interpolation.end.go
+#                               ^ punctuation.separator.key-value.mapping.yaml
+
 key: {{ /*comment*/ }}
 #    ^^^^^^^^^^^^^^^^^ meta.string.yaml meta.interpolation.go - string
 #    ^^ punctuation.section.interpolation.begin.go

--- a/Go/tests/syntax_test_template.yaml
+++ b/Go/tests/syntax_test_template.yaml
@@ -1,0 +1,72 @@
+# SYNTAX TEST "Packages/Go/YAML (Go).sublime-syntax"
+
+key: {{ /*comment*/ }}
+#    ^^^^^^^^^^^^^^^^^ meta.string.yaml meta.interpolation.go - string
+#    ^^ punctuation.section.interpolation.begin.go
+#      ^^^^^^^^^^^^^ source.go.template
+#                   ^^ punctuation.section.interpolation.end.go
+
+{{ if $var true }}
+# <- meta.string.yaml meta.interpolation.go punctuation.section.interpolation.begin.go
+#^^^^^^^^^^^^^^^^^ meta.string.yaml meta.interpolation.go
+#^ punctuation.section.interpolation.begin.go
+# ^^^^^^^^^^^^^^ meta.string.yaml meta.interpolation.go source.go.template
+#               ^^ punctuation.section.interpolation.end.go
+
+    {{ .keyname }}: "String{{value}}"
+#   ^^^^^^^^^^^^^^ meta.mapping.key.yaml meta.string.yaml meta.interpolation.go
+#   ^^ punctuation.section.interpolation.begin.go
+#     ^^^^^^^^^^ source.go.template
+#               ^^ punctuation.section.interpolation.end.go
+#                 ^ punctuation.separator.key-value.mapping.yaml
+#                   ^^^^^^^ meta.string.yaml string.quoted.double.yaml
+#                          ^^^^^^^^^ meta.string.yaml meta.interpolation.go
+#                                   ^ meta.string.yaml string.quoted.double.yaml punctuation.definition.string.end.yaml
+
+{{ else }}
+# <- meta.string.yaml meta.interpolation.go punctuation.section.interpolation.begin.go
+#^^^^^^^^^ meta.string.yaml meta.interpolation.go
+#^ punctuation.section.interpolation.begin.go
+# ^^^^^^ meta.string.yaml meta.interpolation.go source.go.template
+#       ^^ punctuation.section.interpolation.end.go
+
+    {{ .keyname }}:
+#   ^^^^^^^^^^^^^^ meta.mapping.key.yaml meta.string.yaml meta.interpolation.go
+#   ^^ punctuation.section.interpolation.begin.go
+#     ^^^^^^^^^^ source.go.template
+#               ^^ punctuation.section.interpolation.end.go
+#                 ^ punctuation.separator.key-value.mapping.yaml
+        - Val{{ $ue }}
+#       ^ punctuation.definition.block.sequence.item.yaml
+#         ^^^ meta.string.yaml string.unquoted.plain.out.yaml
+#            ^^^^^^^^^ meta.template.go meta.string.yaml meta.interpolation.go
+#            ^^ punctuation.section.interpolation.begin.go
+#               ^^^ variable.other.template.go
+#                   ^^ punctuation.section.interpolation.end.go
+
+        - 'Val{{ $ue }}'
+#       ^ punctuation.definition.block.sequence.item.yaml
+#         ^^^^ meta.template.go meta.string.yaml string.quoted.single.yaml
+#         ^ punctuation.definition.string.begin.yaml
+#             ^^^^^^^^^ meta.template.go meta.string.yaml meta.interpolation.go
+#             ^^ punctuation.section.interpolation.begin.go
+#                ^^^ variable.other.template.go
+#                    ^^ punctuation.section.interpolation.end.go
+#                      ^ punctuation.definition.string.end.yaml
+
+        - "Val{{ $ue }}"
+#       ^ punctuation.definition.block.sequence.item.yaml
+#         ^^^^ meta.template.go meta.string.yaml string.quoted.double.yaml
+#         ^ punctuation.definition.string.begin.yaml
+#             ^^^^^^^^^ meta.template.go meta.string.yaml meta.interpolation.go
+#             ^^ punctuation.section.interpolation.begin.go
+#                ^^^ variable.other.template.go
+#                    ^^ punctuation.section.interpolation.end.go
+#                      ^ punctuation.definition.string.end.yaml
+
+{{ end }}
+# <- meta.string.yaml meta.interpolation.go punctuation.section.interpolation.begin.go
+#^^^^^^^^ meta.string.yaml meta.interpolation.go
+#^ punctuation.section.interpolation.begin.go
+# ^^^^^ meta.string.yaml meta.interpolation.go source.go.template
+#      ^^ punctuation.section.interpolation.end.go

--- a/Go/tests/syntax_test_template.yaml
+++ b/Go/tests/syntax_test_template.yaml
@@ -1,5 +1,18 @@
 # SYNTAX TEST "Packages/Go/YAML (Go).sublime-syntax"
 
+  {{/*
+#^ - meta.string - meta.interpolation
+# ^^ meta.string.yaml meta.interpolation.go punctuation.section.interpolation.begin.go
+#   ^^ meta.string.yaml meta.interpolation.go source.go.template comment.block.go punctuation.definition.comment.begin.go
+  Spread a key-value map into the "env" list
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.yaml meta.interpolation.go source.go.template comment.block.go
+  */}}
+# <- meta.string.yaml meta.interpolation.go source.go.template comment.block.go
+#^ meta.string.yaml meta.interpolation.go source.go.template comment.block.go - punctuation
+# ^^ meta.string.yaml meta.interpolation.go source.go.template comment.block.go punctuation.definition.comment.end.go
+#   ^^ meta.string.yaml meta.interpolation.go punctuation.section.interpolation.end.go
+#     ^ - meta.string - meta.interpolation
+
 key: {{ /*comment*/ }}
 #    ^^^^^^^^^^^^^^^^^ meta.string.yaml meta.interpolation.go - string
 #    ^^ punctuation.section.interpolation.begin.go
@@ -36,33 +49,46 @@ key: {{ /*comment*/ }}
 #     ^^^^^^^^^^ source.go.template
 #               ^^ punctuation.section.interpolation.end.go
 #                 ^ punctuation.separator.key-value.mapping.yaml
-        - Val{{ $ue }}
+        - Multi{{ printf
 #       ^ punctuation.definition.block.sequence.item.yaml
-#         ^^^ meta.string.yaml string.unquoted.plain.out.yaml
-#            ^^^^^^^^^ meta.template.go meta.string.yaml meta.interpolation.go
-#            ^^ punctuation.section.interpolation.begin.go
-#               ^^^ variable.other.template.go
-#                   ^^ punctuation.section.interpolation.end.go
+#         ^^^^^ meta.string.yaml string.unquoted.plain.out.yaml
+#              ^^^^^^^^^^ meta.string.yaml meta.interpolation.go - string
+#              ^^ punctuation.section.interpolation.begin.go
+#                 ^^^^^^ support.function.builtin.go
+          $line }} string
+#        ^^^^^^^^^ meta.string.yaml meta.interpolation.go - string
+#         ^^^^^ variable.other.template.go
+#               ^^ punctuation.section.interpolation.end.go
+#                 ^^^^^^^ meta.string.yaml string.unquoted.plain.out.yaml - meta.interpolation
 
-        - 'Val{{ $ue }}'
+        - 'Multi{{ printf
 #       ^ punctuation.definition.block.sequence.item.yaml
-#         ^^^^ meta.template.go meta.string.yaml string.quoted.single.yaml
+#         ^^^^^^ meta.string.yaml string.quoted.single.yaml
 #         ^ punctuation.definition.string.begin.yaml
-#             ^^^^^^^^^ meta.template.go meta.string.yaml meta.interpolation.go
-#             ^^ punctuation.section.interpolation.begin.go
-#                ^^^ variable.other.template.go
-#                    ^^ punctuation.section.interpolation.end.go
-#                      ^ punctuation.definition.string.end.yaml
+#               ^^^^^^^^^^ meta.string.yaml meta.interpolation.go - string
+#               ^^ punctuation.section.interpolation.begin.go
+#                  ^^^^^^ support.function.builtin.go
+          $line }} string'
+#        ^^^^^^^^^ meta.string.yaml meta.interpolation.go - string
+#         ^^^^^ variable.other.template.go
+#               ^^ punctuation.section.interpolation.end.go
+#                 ^^^^^^^^ meta.string.yaml string.quoted.single.yaml - meta.interpolation
+#                        ^ punctuation.definition.string.end.yaml
 
-        - "Val{{ $ue }}"
+        - "Multi{{ printf
 #       ^ punctuation.definition.block.sequence.item.yaml
-#         ^^^^ meta.template.go meta.string.yaml string.quoted.double.yaml
+#         ^^^^^^ meta.string.yaml string.quoted.double.yaml
 #         ^ punctuation.definition.string.begin.yaml
-#             ^^^^^^^^^ meta.template.go meta.string.yaml meta.interpolation.go
-#             ^^ punctuation.section.interpolation.begin.go
-#                ^^^ variable.other.template.go
-#                    ^^ punctuation.section.interpolation.end.go
-#                      ^ punctuation.definition.string.end.yaml
+#               ^^^^^^^^^^ meta.string.yaml meta.interpolation.go - string
+#               ^^ punctuation.section.interpolation.begin.go
+#                  ^^^^^^ support.function.builtin.go
+
+          $line }} string"
+#        ^^^^^^^^^ meta.string.yaml meta.interpolation.go - string
+#         ^^^^^ variable.other.template.go
+#               ^^ punctuation.section.interpolation.end.go
+#                 ^^^^^^^^ meta.string.yaml string.quoted.double.yaml - meta.interpolation
+#                        ^ punctuation.definition.string.end.yaml
 
 {{ end }}
 # <- meta.string.yaml meta.interpolation.go punctuation.section.interpolation.begin.go


### PR DESCRIPTION
This PR...

1. fixes missing `source.json.go` scope in snippet selectors
2. adds _YAML (Go).sublime-syntax_ with YAML highlighted Go Templates