### PR TITLE
[CI] Disable tests against ST4169

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,9 @@ jobs:
 
           # latest stable build
           # https://www.sublimetext.com/download
-          - sublime-channel: stable
-            sublime-build: 4169
-            optional: true
+          # - sublime-channel: stable
+          #   sublime-build: 4169
+          #   optional: true
 
           # latest dev build
           # https://www.sublimetext.com/dev


### PR DESCRIPTION
This change is required for #4015 to succeed.

We can re-enable stable tests, once the next stable release is made.