### PR TITLE
[HTML] Tweak embedded script/style code boundaries and comment indentation

### DIFF
--- a/ASP/syntax_test_asp.asp
+++ b/ASP/syntax_test_asp.asp
@@ -161,9 +161,8 @@
             Dim var = 0
     '  ^^^^^^^^^^^^^^^^^ source.asp.embedded.html - meta.tag
         -->
-    ' <- source.asp.embedded.html
-    '^^^ source.asp.embedded.html
-    '   ^^^^ - meta.tag - source
+    ' <- - source
+    '^^^^^^^ - meta.tag - source
     '   ^^^ comment.block.html punctuation.definition.comment.end.html
     </script>
     ' ^^^^^^^ meta.tag - source
@@ -200,11 +199,11 @@
         <!--
     '  ^ - meta.tag - comment - source
     '   ^^^^ comment.block.html punctuation.definition.comment.begin.html - source
-    '       ^ source.css.embedded.html - comment
+    '       ^ - comment - source
             h1 {}
     '      ^^^^^^^ source.css.embedded.html
         -->
-    '  ^ source.css.embedded.html - comment
+    '  ^ - comment - source
     '   ^^^ comment.block.html punctuation.definition.comment.end.html - source
     '      ^ - meta.tag - comment - source
     </style>

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -142,8 +142,9 @@ variables:
   # - https://github.com/sublimehq/sublime_text/issues/4701
   script_content_begin: |-
     (?x:
-    # whitespace followed by opening html comment begin punctuation
-      \s*(<!--)
+    # whitespace followed by opening html comment begin punctuation,
+    # optionally followed by whitespeace until end of line
+      \s*(<!--) (?:\s*\n)?
     # or any other non-whitespace character ahead
     | (?=\s*(?!<!--)\S)
     # or beginning of a line
@@ -151,18 +152,22 @@ variables:
     )
   script_content_end: |-
     (?x:
-    # optional html comment end punctuation followed by </script> tag
-      (?: (\s*) (-->) \s* )? (?=</(?i:script){{tag_name_break_char}})
+    # optional html comment end punctuation or any whitespace at beginning of
+    # line followed by </script> tag
+      (?: (?: ^ \s* | (\s*) ) (-->) \s* | ^ \s* )? (?=</(?i:script){{tag_name_break_char}})
     # or standalone html comment end punctuation in a line
-    |   ^ (\s*) (-->) \s* $
+    # note: Keep empty capture group for compatibility with existing 3rd-party syntaxes!
+    | ^ \s* () (-->) \s* $
     )
   style_content_begin: '{{script_content_begin}}'
   style_content_end: |-
     (?x:
-    # optional html comment end punctuation followed by </style> tag
-      (?: (\s*) (-->) \s* )? (?=</(?i:style){{tag_name_break_char}})
+    # optional html comment end punctuation or any whitespace at beginning of
+    # line followed by </style> tag
+      (?: (?: ^ \s* | (\s*) ) (-->) \s* | ^ \s* )? (?=</(?i:style){{tag_name_break_char}})
     # or standalone html comment end punctuation in a line
-    |   ^ (\s*) (-->) \s* $
+    # note: Keep empty capture group for compatibility with existing 3rd-party syntaxes!
+    | ^ \s* () (-->) \s* $
     )
 
   event_attribute_names: |-

--- a/HTML/Indentation Rules - Comments.tmPreferences
+++ b/HTML/Indentation Rules - Comments.tmPreferences
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>scope</key>
+	<string>text.html comment.block.html</string>
+	<key>settings</key>
+	<dict>
+		<!-- ignore anything until standalone closing comment punctuation -->
+		<key>unIndentedLinePattern</key>
+		<string>^(?!\s*-->)</string>
+	</dict>
+</dict>
+</plist>

--- a/HTML/Indentation Rules.tmPreferences
+++ b/HTML/Indentation Rules.tmPreferences
@@ -12,8 +12,9 @@
 			  ^[^<>]*+ </ (?!html[\t\n\f /<>])[^\t\n\f /<>]+ [^>]* >
 			| ^[\t\n\f ]*+
 			(
-				# closing comment punctuation, optionally preceded by an end "comment selector"
-				  (<!\[ .*? \])?-->
+				# the beginning of the line followed by closing HTML comment
+				# and </script> or </style> tag
+				  --> [\t\n\f ]* </ (?: script | style )[\t\n\f /<>]
 				# closing directive/section punctuation
 				| [?%]>
 				# closing curly brace
@@ -38,8 +39,6 @@
 					# not closing in the same line
 					(?! .* </\k<html_tag>)
 				)
-				# comments that don't close themselves on the same line
-				| <!--(?!.*?-->)
 				# directives that don't close themselves on the same line
 				| <\?(?!.*?\?>)
 				# sections that don't close themselves on the same line

--- a/HTML/syntax_test_html.html
+++ b/HTML/syntax_test_html.html
@@ -62,11 +62,11 @@
             <!--
         ## ^^^^^ - meta.tag - source
         ##  ^^^^ comment.block.html punctuation.definition.comment.begin.html
-        ##      ^ source.js.embedded.html - meta.tag - comment
+        ##      ^ - source.js.embedded - meta.tag - comment
             var i = 0;
         ## ^^^^^^^^^^^^ source.js.embedded.html - meta.tag
             -->
-        ##^^ source.js.embedded.html - meta.tag - comment
+        ##^^ - source - meta.tag - comment
         ##  ^^^^ - source - meta.tag
         ##  ^^^ comment.block.html punctuation.definition.comment.end.html
             var i = 0;
@@ -101,11 +101,10 @@
         ##^^^^^^ meta.tag.script.begin.html - meta.tag meta.tag - meta.attribute-with-value - source
         ##      ^^^^^^^^^^^^^^^^^^^^^^ meta.tag.script.begin.html meta.attribute-with-value.html - meta.tag meta.tag - meta.attribute-with-value meta.attribute-with-value - source
         ##                            ^ meta.tag.script.begin.html - meta.tag meta.tag - meta.attribute-with-value - source
-        ##                             ^^^^^ - meta.tag  - source
+        ##                             ^^^^^^ - meta.tag  - source
         ## ^ entity.name.tag.script
         ##            ^ string.quoted.double.html
         ##                              ^^^^ comment.block.html punctuation.definition.comment.begin.html
-        ##                                  ^ source.js.embedded.html
             var foo = 100;
             var baz = function() {
                 ## <- entity.name.function.js
@@ -129,6 +128,9 @@
             var foo = 100;
         ##  ^^^^^^^^^^^^^^^ source.js.embedded
         </script>
+## <- - source.js.embedded
+##^^^^^^ - source.js.embedded
+##      ^^^^^^^^^ meta.tag.script.end.html
 
         <script type=application/json>
             {
@@ -139,21 +141,33 @@
             }
         ##  ^ source.json.embedded.html meta.mapping.json punctuation.section.mapping.end.json
         </script>
+## <- - source.json.embedded
+##^^^^^^ - source.json.embedded
+##      ^^^^^^^^^ meta.tag.script.end.html
 
         <script type="application/ld+json">
             { "@id": {"key": "value" } }
         ##  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.json.embedded.html
         </script>
+## <- - source.json.embedded
+##^^^^^^ - source.json.embedded
+##      ^^^^^^^^^ meta.tag.script.end.html
 
         <script type="application/f̱oo+json">
             { "@id": {"key": "value" } }
         ##  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - source.json
         </script>
+## <- - source.json.embedded
+##^^^^^^ - source.json.embedded
+##      ^^^^^^^^^ meta.tag.script.end.html
 
         <script type="application/ld+json;charset=utf-8">
             { "@id": {"key": "value" } }
         ##  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.json.embedded.html
         </script>
+## <- - source.json.embedded
+##^^^^^^ - source.json.embedded
+##      ^^^^^^^^^ meta.tag.script.end.html
 
         <script type="whatever+json">
             <![CDATA[
@@ -166,6 +180,9 @@
         ##      ^ meta.tag.sgml.cdata.html source.json.embedded.html meta.mapping.json punctuation.section.mapping.end.json
             ]]>
         </script>
+## <- - source.json.embedded
+##^^^^^^ - source.json.embedded
+##      ^^^^^^^^^ meta.tag.script.end.html
 
         <script type = "text/html"> <!--
         ##^^^^^^ meta.tag.script.begin.html - meta.tag meta.tag - meta.attribute-with-value
@@ -205,8 +222,7 @@
 ##          ^^^^ punctuation.definition.comment.begin.html
 ##              ^^^^^^^ source.js.embedded.html
             -->
-##      ^^^^ source.js.embedded.html
-##          ^^^^ - source
+##      ^^^^^^^^ - source
 ##          ^^^ comment.block.html punctuation.definition.comment.end.html
         </script>
 
@@ -326,16 +342,19 @@
 ## <- source.css.embedded.html
 ## ^^^^^^^^^^^^^ source.css.embedded.html
         </style>
+## <- - source.css.embedded
+##^^^^^^ - source.css.embedded
+##      ^^^^^^^^ meta.tag.style.end.html
 
         <style type="text/css">
             <!--
         ## ^ - meta.tag - comment - source
         ##  ^^^^ comment.block.html punctuation.definition.comment.begin.html - source
-        ##      ^ source.css.embedded.html - comment
+        ##      ^ - comment - source
                 h1 {}
         ##     ^^^^^^^ source.css.embedded.html
             -->
-        ## ^ source.css.embedded.html - comment
+        ## ^ - comment - source
         ##  ^^^ comment.block.html punctuation.definition.comment.end.html - source
         ##     ^ - meta.tag - comment - source
         </style>
@@ -343,8 +362,7 @@
 
         <style type="text/css"> <!--
         ## ^^^^^^^^^^^^^^^^^^^^ meta.tag.style.begin.html - source.css
-        ##                     ^^^^^ - meta.tag - source.css
-        ##                          ^ source.css.embedded.html
+        ##                     ^^^^^^ - meta.tag - source.css
         ## ^^^ entity.name.tag.style.html
         ##    ^ - entity
         ##     ^^^^ entity.other.attribute-name

--- a/HTML/syntax_test_html_indentation.html
+++ b/HTML/syntax_test_html_indentation.html
@@ -6,9 +6,49 @@
     <meta charset="utf-8" />
     <title>Page Title Here</title>
     <!-- this comment's
-        indentation should
-        be unchanged
+         indentation should
+         be unchanged
     -->
+    <script>
+        var i = 0;
+        function foo() {
+            return i;
+        }
+    </script>
+    <!-- this comment's
+    indentation should
+    be unchanged -->
+    <script>
+        <!--
+        var i = 0;
+        function foo() {
+            return i;
+        }
+        -->
+    </script>
+    <script> <!--
+        var i = 0;
+        function foo() {
+            return i;
+        }
+    --> </script>
+    <style>
+        p {
+            font-family: Helvetica;
+        }
+    </style>
+    <style>
+        <!--
+        p {
+            font-family: Helvetica;
+        }
+        -->
+    </style>
+    <style> <!--
+        p {
+            font-family: Helvetica;
+        }
+    --> </style>
 </head>
 <body>
 
@@ -20,6 +60,16 @@
     </div>
 
     <script type="text/javascript" src="/some_script.js"></script>
+
+    <script type="text/json">
+        {
+            "dict": {
+                "list": [
+                    "value"
+                ]
+            }
+        }
+    </script>
 
     <!-- Curly braces -->
     foo {

--- a/Rails/tests/syntax_test_rails.html.erb
+++ b/Rails/tests/syntax_test_rails.html.erb
@@ -39,11 +39,11 @@
     <!--
 #  ^^^^^ - meta.tag - source
 #   ^^^^ comment.block.html punctuation.definition.comment.begin.html
-#       ^ source.js.embedded.html - meta.tag - comment
+#       ^ - comment - source
     var i = 0;
 #  ^^^^^^^^^^^^ source.js.embedded.html - meta.tag
     -->
-# ^^ source.js.embedded.html - meta.tag - comment
+# ^^ - comment - source - meta.tag
 #   ^^^^ - source - meta.tag
 #   ^^^ comment.block.html punctuation.definition.comment.end.html
     var i = 0;


### PR DESCRIPTION
This PR...

1. teaches HTML to consume

   - any trailing whitespace until end of line after opening script/style tags or optionally following `<!--` punctuation. 
   - any leading whitespace in front of closing script/style tags or optionally preceded `-->` punctuation.

   to not apply embedded syntax's scope after standalone opening or in front of standalone closing tags.

   This change makes sure to ...

   - always apply HTML specific indentation rules to enclosing script/style tags or comment punctuation.

   - apply custom background highlighting of embedded syntaxes only on full lines, but not after or in front of standalone tags.

2. modifies indentation rules for HTML comments to ignore indentation of comments' content.

   This is primarily required to correctly handle indentation of embedded script/style source code, if it is enclosed in HTML comments. In such cases, additional indentation level is probably undesirable.


### Highlighting changes 

Before:

| without comments   | with enclosing comments
|--- |---
| ![grafik](https://github.com/user-attachments/assets/8ac0af2b-0e40-46bf-b802-854d02370929) | ![grafik](https://github.com/user-attachments/assets/588e693c-4d4a-499e-90d2-fa025b310b1e)


After: 

| without comments   | with enclosing comments
|--- |---
| ![grafik](https://github.com/user-attachments/assets/1f800c6e-9134-4884-b41f-fc1c26b5eb02) | ![grafik](https://github.com/user-attachments/assets/233798d0-ade2-4f9b-bbb6-c2c59ac1565e)

_Background in front of closing `</script>` no longer has custom `source.js.embedded` background._

![grafik](https://github.com/user-attachments/assets/6fc6574b-f0e0-4f07-a5e7-7db7351d404f) 

_However everything between tags is scoped `source.<name>.embedded` if tags and code exist in same line(s)._