### PR TITLE
[JavaScript] fix tagged template string key bindings regression

### DIFF
--- a/JavaScript/Default.sublime-keymap
+++ b/JavaScript/Default.sublime-keymap
@@ -33,6 +33,26 @@
         ]
     },
 
+    // Add indented line in backquotes
+    { "keys": ["enter"], "command": "insert_snippet", "args": {"contents": "\n\t$0\n"}, "context":
+        [
+            { "key": "setting.auto_indent" },
+            { "key": "selection_empty", "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "meta.string.template.js" },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "`$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^`", "match_all": true }
+        ]
+    },
+    { "keys": ["keypad_enter"], "command": "insert_snippet", "args": {"contents": "\n\t$0\n"}, "context":
+        [
+            { "key": "setting.auto_indent" },
+            { "key": "selection_empty", "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "meta.string.template.js" },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "`$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^`", "match_all": true }
+        ]
+    },
+
     // Auto-pair interpolation
     { "keys": ["{"], "command": "insert_snippet", "args": {"contents": "{$0}"}, "context":
         [

--- a/JavaScript/Default.sublime-keymap
+++ b/JavaScript/Default.sublime-keymap
@@ -2,7 +2,7 @@
     // Auto-pair backticks
     { "keys": ["`"], "command": "insert_snippet", "args": {"contents": "`$0`"}, "context":
         [
-            { "key": "selector", "operator": "equal", "operand": "(source.js, source.ts) - string" },
+            { "key": "selector", "operator": "equal", "operand": "source.js - source.js meta.string, source.ts - source.ts meta.string" },
             { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|\\}|>|$)", "match_all": true },
@@ -10,35 +10,33 @@
     },
     { "keys": ["`"], "command": "insert_snippet", "args": {"contents": "`${0:$SELECTION}`"}, "context":
         [
-            { "key": "selector", "operator": "equal", "operand": "(source.js, source.ts) - string" },
+            { "key": "selector", "operator": "equal", "operand": "source.js - source.js meta.string, source.ts - source.ts meta.string" },
             { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
             { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true }
         ]
     },
     { "keys": ["`"], "command": "move", "args": {"by": "characters", "forward": true}, "context":
         [
-            { "key": "selector", "operator": "equal", "operand": "source.js, source.ts" },
+            { "key": "selector", "operator": "equal", "operand": "meta.string.template.js - meta.string.template.js punctuation.definition.string.begin" },
             { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "following_text", "operator": "regex_contains", "operand": "^`", "match_all": true },
-            { "key": "selector", "operator": "not_equal", "operand": "punctuation.definition.string.begin", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^`", "match_all": true }
         ]
     },
     { "keys": ["backspace"], "command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"}, "context":
         [
-            { "key": "selector", "operator": "equal", "operand": "string.quoted.other.js" },
+            { "key": "selector", "operator": "equal", "operand": "meta.string.template.js - meta.string.template.js punctuation.definition.string.begin" },
             { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "`$", "match_all": true },
-            { "key": "following_text", "operator": "regex_contains", "operand": "^`", "match_all": true },
-            { "key": "selector", "operator": "not_equal", "operand": "punctuation.definition.string.begin", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^`", "match_all": true }
         ]
     },
 
     // Auto-pair interpolation
     { "keys": ["{"], "command": "insert_snippet", "args": {"contents": "{$0}"}, "context":
         [
-            { "key": "selector", "operator": "equal", "operand": "string.quoted.other.js", "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "meta.string.template.js", "match_all": true },
             { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "\\$$", "match_all": true }
@@ -46,7 +44,7 @@
     },
     { "keys": ["$"], "command": "insert_snippet", "args": {"contents": "\\${${0:$SELECTION}}"}, "context":
         [
-            { "key": "selector", "operator": "equal", "operand": "string.quoted.other.js", "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "meta.string.template.js", "match_all": true },
             { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
             { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true }
         ]

--- a/JavaScript/Default.sublime-keymap
+++ b/JavaScript/Default.sublime-keymap
@@ -2,32 +2,32 @@
     // Auto-pair backticks
     { "keys": ["`"], "command": "insert_snippet", "args": {"contents": "`$0`"}, "context":
         [
-            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
-            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "selector", "operator": "equal", "operand": "source.js - source.js meta.string, source.jsx - source.jsx meta.string, source.ts - source.ts meta.string, source.tsx - source.tsx meta.string", "match_all": true },
+            { "key": "setting.auto_match_enabled" },
+            { "key": "selection_empty", "match_all": true },
+            { "key": "selector", "operand": "source.js - source.js meta.string, source.jsx - source.jsx meta.string, source.ts - source.ts meta.string, source.tsx - source.tsx meta.string", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|\\}|>|$)", "match_all": true },
         ]
     },
     { "keys": ["`"], "command": "insert_snippet", "args": {"contents": "`${0:$SELECTION}`"}, "context":
         [
-            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
-            { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
-            { "key": "selector", "operator": "equal", "operand": "source.js - source.js meta.string, source.jsx - source.jsx meta.string, source.ts - source.ts meta.string, source.tsx - source.tsx meta.string", "match_all": true }
+            { "key": "setting.auto_match_enabled" },
+            { "key": "selection_empty", "operand": false, "match_all": true },
+            { "key": "selector", "operand": "source.js - source.js meta.string, source.jsx - source.jsx meta.string, source.ts - source.ts meta.string, source.tsx - source.tsx meta.string", "match_all": true }
         ]
     },
     { "keys": ["`"], "command": "move", "args": {"by": "characters", "forward": true}, "context":
         [
-            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
-            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "selector", "operator": "equal", "operand": "meta.string.template.js - meta.string.template.js punctuation.definition.string.begin", "match_all": true },
+            { "key": "setting.auto_match_enabled" },
+            { "key": "selection_empty", "match_all": true },
+            { "key": "selector", "operand": "meta.string.template.js - meta.string.template.js punctuation.definition.string.begin", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "^`", "match_all": true }
         ]
     },
     { "keys": ["backspace"], "command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"}, "context":
         [
-            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
-            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "selector", "operator": "equal", "operand": "meta.string.template.js - meta.string.template.js punctuation.definition.string.begin", "match_all": true },
+            { "key": "setting.auto_match_enabled" },
+            { "key": "selection_empty", "match_all": true },
+            { "key": "selector", "operand": "meta.string.template.js - meta.string.template.js punctuation.definition.string.begin", "match_all": true },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "`$", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "^`", "match_all": true }
         ]
@@ -38,7 +38,7 @@
         [
             { "key": "setting.auto_indent" },
             { "key": "selection_empty", "match_all": true },
-            { "key": "selector", "operator": "equal", "operand": "meta.string.template.js", "match_all": true },
+            { "key": "selector", "operand": "meta.string.template.js", "match_all": true },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "`$", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "^`", "match_all": true }
         ]
@@ -47,7 +47,7 @@
         [
             { "key": "setting.auto_indent" },
             { "key": "selection_empty", "match_all": true },
-            { "key": "selector", "operator": "equal", "operand": "meta.string.template.js", "match_all": true },
+            { "key": "selector", "operand": "meta.string.template.js", "match_all": true },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "`$", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "^`", "match_all": true }
         ]
@@ -56,17 +56,17 @@
     // Auto-pair interpolation
     { "keys": ["{"], "command": "insert_snippet", "args": {"contents": "{$0}"}, "context":
         [
-            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
-            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "selector", "operator": "equal", "operand": "meta.string.template.js", "match_all": true },
+            { "key": "setting.auto_match_enabled" },
+            { "key": "selection_empty", "match_all": true },
+            { "key": "selector", "operand": "meta.string.template.js", "match_all": true },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "\\$$", "match_all": true }
         ]
     },
     { "keys": ["$"], "command": "insert_snippet", "args": {"contents": "\\${${0:$SELECTION}}"}, "context":
         [
-            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
-            { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
-            { "key": "selector", "operator": "equal", "operand": "meta.string.template.js", "match_all": true }
+            { "key": "setting.auto_match_enabled" },
+            { "key": "selection_empty", "operand": false, "match_all": true },
+            { "key": "selector", "operand": "meta.string.template.js", "match_all": true }
         ]
     },
 ]

--- a/JavaScript/Default.sublime-keymap
+++ b/JavaScript/Default.sublime-keymap
@@ -34,7 +34,7 @@
     },
 
     // Add indented line in backticks
-    { "keys": ["enter"], "command": "insert_snippet", "args": {"contents": "\n\t$0\n"}, "context":
+    { "keys": ["enter"], "command": "run_macro_file", "args": {"file": "res://Packages/Default/Add Line in Braces.sublime-macro"}, "context":
         [
             { "key": "setting.auto_indent" },
             { "key": "selection_empty", "match_all": true },
@@ -43,7 +43,7 @@
             { "key": "following_text", "operator": "regex_contains", "operand": "^`", "match_all": true }
         ]
     },
-    { "keys": ["keypad_enter"], "command": "insert_snippet", "args": {"contents": "\n\t$0\n"}, "context":
+    { "keys": ["keypad_enter"], "command": "run_macro_file", "args": {"file": "res://Packages/Default/Add Line in Braces.sublime-macro"}, "context":
         [
             { "key": "setting.auto_indent" },
             { "key": "selection_empty", "match_all": true },

--- a/JavaScript/Default.sublime-keymap
+++ b/JavaScript/Default.sublime-keymap
@@ -2,32 +2,32 @@
     // Auto-pair backticks
     { "keys": ["`"], "command": "insert_snippet", "args": {"contents": "`$0`"}, "context":
         [
-            { "key": "selector", "operator": "equal", "operand": "source.js - source.js meta.string, source.ts - source.ts meta.string" },
             { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "source.js - source.js meta.string, source.jsx - source.jsx meta.string, source.ts - source.ts meta.string, source.tsx - source.tsx meta.string" },
             { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|\\}|>|$)", "match_all": true },
         ]
     },
     { "keys": ["`"], "command": "insert_snippet", "args": {"contents": "`${0:$SELECTION}`"}, "context":
         [
-            { "key": "selector", "operator": "equal", "operand": "source.js - source.js meta.string, source.ts - source.ts meta.string" },
             { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
-            { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true }
+            { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "source.js - source.js meta.string, source.jsx - source.jsx meta.string, source.ts - source.ts meta.string, source.tsx - source.tsx meta.string" }
         ]
     },
     { "keys": ["`"], "command": "move", "args": {"by": "characters", "forward": true}, "context":
         [
-            { "key": "selector", "operator": "equal", "operand": "meta.string.template.js - meta.string.template.js punctuation.definition.string.begin" },
             { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "meta.string.template.js - meta.string.template.js punctuation.definition.string.begin" },
             { "key": "following_text", "operator": "regex_contains", "operand": "^`", "match_all": true }
         ]
     },
     { "keys": ["backspace"], "command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"}, "context":
         [
-            { "key": "selector", "operator": "equal", "operand": "meta.string.template.js - meta.string.template.js punctuation.definition.string.begin" },
             { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "meta.string.template.js - meta.string.template.js punctuation.definition.string.begin" },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "`$", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "^`", "match_all": true }
         ]
@@ -56,17 +56,17 @@
     // Auto-pair interpolation
     { "keys": ["{"], "command": "insert_snippet", "args": {"contents": "{$0}"}, "context":
         [
-            { "key": "selector", "operator": "equal", "operand": "meta.string.template.js", "match_all": true },
             { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "meta.string.template.js", "match_all": true },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "\\$$", "match_all": true }
         ]
     },
     { "keys": ["$"], "command": "insert_snippet", "args": {"contents": "\\${${0:$SELECTION}}"}, "context":
         [
-            { "key": "selector", "operator": "equal", "operand": "meta.string.template.js", "match_all": true },
             { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
-            { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true }
+            { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "meta.string.template.js", "match_all": true }
         ]
     },
 ]

--- a/JavaScript/Default.sublime-keymap
+++ b/JavaScript/Default.sublime-keymap
@@ -4,7 +4,7 @@
         [
             { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "selector", "operator": "equal", "operand": "source.js - source.js meta.string, source.jsx - source.jsx meta.string, source.ts - source.ts meta.string, source.tsx - source.tsx meta.string" },
+            { "key": "selector", "operator": "equal", "operand": "source.js - source.js meta.string, source.jsx - source.jsx meta.string, source.ts - source.ts meta.string, source.tsx - source.tsx meta.string", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|\\}|>|$)", "match_all": true },
         ]
     },
@@ -12,14 +12,14 @@
         [
             { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
             { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
-            { "key": "selector", "operator": "equal", "operand": "source.js - source.js meta.string, source.jsx - source.jsx meta.string, source.ts - source.ts meta.string, source.tsx - source.tsx meta.string" }
+            { "key": "selector", "operator": "equal", "operand": "source.js - source.js meta.string, source.jsx - source.jsx meta.string, source.ts - source.ts meta.string, source.tsx - source.tsx meta.string", "match_all": true }
         ]
     },
     { "keys": ["`"], "command": "move", "args": {"by": "characters", "forward": true}, "context":
         [
             { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "selector", "operator": "equal", "operand": "meta.string.template.js - meta.string.template.js punctuation.definition.string.begin" },
+            { "key": "selector", "operator": "equal", "operand": "meta.string.template.js - meta.string.template.js punctuation.definition.string.begin", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "^`", "match_all": true }
         ]
     },
@@ -27,7 +27,7 @@
         [
             { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "selector", "operator": "equal", "operand": "meta.string.template.js - meta.string.template.js punctuation.definition.string.begin" },
+            { "key": "selector", "operator": "equal", "operand": "meta.string.template.js - meta.string.template.js punctuation.definition.string.begin", "match_all": true },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "`$", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "^`", "match_all": true }
         ]
@@ -38,7 +38,7 @@
         [
             { "key": "setting.auto_indent" },
             { "key": "selection_empty", "match_all": true },
-            { "key": "selector", "operator": "equal", "operand": "meta.string.template.js" },
+            { "key": "selector", "operator": "equal", "operand": "meta.string.template.js", "match_all": true },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "`$", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "^`", "match_all": true }
         ]
@@ -47,7 +47,7 @@
         [
             { "key": "setting.auto_indent" },
             { "key": "selection_empty", "match_all": true },
-            { "key": "selector", "operator": "equal", "operand": "meta.string.template.js" },
+            { "key": "selector", "operator": "equal", "operand": "meta.string.template.js", "match_all": true },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "`$", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "^`", "match_all": true }
         ]

--- a/JavaScript/Default.sublime-keymap
+++ b/JavaScript/Default.sublime-keymap
@@ -33,7 +33,7 @@
         ]
     },
 
-    // Add indented line in backquotes
+    // Add indented line in backticks
     { "keys": ["enter"], "command": "insert_snippet", "args": {"contents": "\n\t$0\n"}, "context":
         [
             { "key": "setting.auto_indent" },

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1238,62 +1238,62 @@ contexts:
     - match: (css)\s*((\`){{trailing_wspace}}?)
       captures:
         1: variable.function.tagged-template.js
-        2: meta.string.js string.quoted.other.js
+        2: meta.string.template.js string.quoted.other.js
         3: punctuation.definition.string.begin.js
       embed: scope:source.css.js-template
-      embed_scope: meta.string.js source.css.embedded.js
+      embed_scope: meta.string.template.js source.css.embedded.js
       escape: '{{leading_wspace}}?(\`)'
       escape_captures:
-        0: meta.string.js string.quoted.other.js
+        0: meta.string.template.js string.quoted.other.js
         1: punctuation.definition.string.end.js
       pop: 1
     - match: (html)\s*((\`){{trailing_wspace}}?)
       captures:
         1: variable.function.tagged-template.js
-        2: meta.string.js string.quoted.other.js
+        2: meta.string.template.js string.quoted.other.js
         3: punctuation.definition.string.begin.js
       embed: scope:text.html.js-template
-      embed_scope: meta.string.js text.html.embedded.js
+      embed_scope: meta.string.template.js text.html.embedded.js
       escape: '{{leading_wspace}}?(\`)'
       escape_captures:
-        0: meta.string.js string.quoted.other.js
+        0: meta.string.template.js string.quoted.other.js
         1: punctuation.definition.string.end.js
       pop: 1
     - match: (js)\s*((\`){{trailing_wspace}}?)
       captures:
         1: variable.function.tagged-template.js
-        2: meta.string.js string.quoted.other.js
+        2: meta.string.template.js string.quoted.other.js
         3: punctuation.definition.string.begin.js
       embed: scope:source.js.js-template
-      embed_scope: meta.string.js source.js.embedded.js
+      embed_scope: meta.string.template.js source.js.embedded.js
       escape: '{{leading_wspace}}?(\`)'
       escape_captures:
-        0: meta.string.js string.quoted.other.js
+        0: meta.string.template.js string.quoted.other.js
         1: punctuation.definition.string.end.js
       pop: 1
     - match: (json)\s*((\`){{trailing_wspace}}?)
       captures:
         1: variable.function.tagged-template.js
-        2: meta.string.js string.quoted.other.js
+        2: meta.string.template.js string.quoted.other.js
         3: punctuation.definition.string.begin.js
       embed: scope:source.json.js-template
-      embed_scope: meta.string.js source.json.embedded.js
+      embed_scope: meta.string.template.js source.json.embedded.js
       escape: '{{leading_wspace}}?(\`)'
       escape_captures:
-        0: meta.string.js string.quoted.other.js
+        0: meta.string.template.js string.quoted.other.js
         1: punctuation.definition.string.end.js
       pop: 1
     - match: (?:({{identifier_name}})\s*)?(\`)
       captures:
         1: variable.function.tagged-template.js
-        2: meta.string.js string.quoted.other.js punctuation.definition.string.begin.js
+        2: meta.string.template.js string.quoted.other.js punctuation.definition.string.begin.js
       set: literal-string-template-content
 
   literal-string-template-content:
     - meta_include_prototype: false
-    - meta_content_scope: meta.string.js string.quoted.other.js
+    - meta_content_scope: meta.string.template.js string.quoted.other.js
     - match: \`
-      scope: meta.string.js string.quoted.other.js punctuation.definition.string.end.js
+      scope: meta.string.template.js string.quoted.other.js punctuation.definition.string.end.js
       pop: 1
     - include: string-interpolations
     - include: string-content

--- a/JavaScript/tests/syntax_test_js_template.js
+++ b/JavaScript/tests/syntax_test_js_template.js
@@ -5,14 +5,14 @@
  */
 
 var html = html` <p>${content}</p> `
-/*             ^^^^^^^^^^^^^^^^^^^^^ meta.string.js */
+/*             ^^^^^^^^^^^^^^^^^^^^^ meta.string.template.js */
 /*             ^ string.quoted.other.js punctuation.definition.string.begin.js - text.html.embedded */
 /*              ^^^^^^^^^^^^^^^^^^^ text.html.embedded.js - string */
 /*                                 ^ string.quoted.other.js punctuation.definition.string.end.js - text.html.embedded */
 
 var html = html`
 /*         ^^^^ variable.function.tagged-template */
-/*             ^^ meta.string.js string.quoted.other.js */
+/*             ^^ meta.string.template.js string.quoted.other.js */
 /*             ^ punctuation.definition.string.begin.js */
 /*              ^ - text.html.embedded */
 
@@ -77,18 +77,18 @@ var html = html`
     </style>
 
     <p style="width: ${width}%" class="${class_name}" onclick="${click}">${content}</p>
-/*  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.js text.html.embedded.js meta.tag.block.any.html */
+/*  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.template.js text.html.embedded.js meta.tag.block.any.html */
 /*     ^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.style.html */
 /*                   ^^^^^^^^ source.css.embedded.html meta.property-value.css meta.interpolation.js */
 /*                              ^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.class.html */
 /*                                     ^^^^^^^^^^^^^ meta.class-name.html meta.string.html meta.interpolation.js */
 /*                                                    ^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.event.html */
 /*                                                             ^^^^^^^^ source.js.embedded.html meta.interpolation.js */
-/*                                                                       ^^^^^^^^^^ meta.string.js text.html.embedded.js meta.interpolation.js */
-/*                                                                                 ^^^^ meta.string.js text.html.embedded.js meta.tag.block.any.html */
+/*                                                                       ^^^^^^^^^^ meta.string.template.js text.html.embedded.js meta.interpolation.js */
+/*                                                                                 ^^^^ meta.string.template.js text.html.embedded.js meta.tag.block.any.html */
     `
-/* <- meta.string.js string.quoted.other.js - text.html.embedded */
-/*^^^ meta.string.js string.quoted.other.js - text.html.embedded */
+/* <- meta.string.template.js string.quoted.other.js - text.html.embedded */
+/*^^^ meta.string.template.js string.quoted.other.js - text.html.embedded */
 /*  ^ punctuation.definition.string.end.js */
 /*   ^ - meta.string */
 
@@ -97,37 +97,37 @@ var html = html`
  */
 
 var json = json` { "key": "value" } `
-/*             ^^^^^^^^^^^^^^^^^^^^^^ meta.string.js */
+/*             ^^^^^^^^^^^^^^^^^^^^^^ meta.string.template.js */
 /*             ^ string.quoted.other.js punctuation.definition.string.begin.js - source.json.embedded */
 /*              ^^^^^^^^^^^^^^^^^^^^ source.json.embedded.js */
 /*                                  ^ string.quoted.other.js punctuation.definition.string.end.js - source.json.embedded */
 
 var json = json`
 /*         ^^^^ variable.function.tagged-template */
-/*             ^^ meta.string.js string.quoted.other.js */
+/*             ^^ meta.string.template.js string.quoted.other.js */
 /*             ^ punctuation.definition.string.begin.js */
 /*              ^ - source.json.embedded */
     {
-/*  ^ meta.string.js source.json.embedded.js meta.mapping.json punctuation.section.mapping.begin.json */
+/*  ^ meta.string.template.js source.json.embedded.js meta.mapping.json punctuation.section.mapping.begin.json */
 
         "key1": "val${ue}",
-/*      ^^^^^^ meta.string.js source.json.embedded.js meta.mapping.key.json string.quoted.double.json */
-/*            ^ meta.string.js source.json.embedded.js meta.mapping.json punctuation.separator.key-value.json */
-/*              ^^^^ meta.string.js source.json.embedded.js meta.mapping.value.json meta.string.json string.quoted.double.json */
-/*                  ^^^^^ meta.string.js source.json.embedded.js meta.mapping.value.json meta.string.json meta.interpolation.js */
-/*                       ^ meta.string.js source.json.embedded.js meta.mapping.value.json meta.string.json string.quoted.double.json */
-/*                        ^ meta.string.js source.json.embedded.js meta.mapping.json punctuation.separator.sequence.json */
+/*      ^^^^^^ meta.string.template.js source.json.embedded.js meta.mapping.key.json string.quoted.double.json */
+/*            ^ meta.string.template.js source.json.embedded.js meta.mapping.json punctuation.separator.key-value.json */
+/*              ^^^^ meta.string.template.js source.json.embedded.js meta.mapping.value.json meta.string.json string.quoted.double.json */
+/*                  ^^^^^ meta.string.template.js source.json.embedded.js meta.mapping.value.json meta.string.json meta.interpolation.js */
+/*                       ^ meta.string.template.js source.json.embedded.js meta.mapping.value.json meta.string.json string.quoted.double.json */
+/*                        ^ meta.string.template.js source.json.embedded.js meta.mapping.json punctuation.separator.sequence.json */
 
         ${key}: ${value},
-/*      ^^^^^^ meta.string.js source.json.embedded.js meta.mapping.json meta.interpolation.js */
-/*            ^ meta.string.js source.json.embedded.js meta.mapping.json punctuation.separator.key-value.json */
-/*              ^^^^^^^^ meta.string.js source.json.embedded.js meta.mapping.value.json meta.interpolation.js */
-/*                      ^ meta.string.js source.json.embedded.js meta.mapping.json punctuation.separator.sequence.json */
+/*      ^^^^^^ meta.string.template.js source.json.embedded.js meta.mapping.json meta.interpolation.js */
+/*            ^ meta.string.template.js source.json.embedded.js meta.mapping.json punctuation.separator.key-value.json */
+/*              ^^^^^^^^ meta.string.template.js source.json.embedded.js meta.mapping.value.json meta.interpolation.js */
+/*                      ^ meta.string.template.js source.json.embedded.js meta.mapping.json punctuation.separator.sequence.json */
 
         "key2": [${val1}, "val${no}"],
-/*      ^^^^^^ meta.string.js source.json.embedded.js meta.mapping.key.json string.quoted.double.json */
-/*            ^ meta.string.js source.json.embedded.js meta.mapping.json punctuation.separator.key-value.json */
-/*              ^^^^^^^^^^^^^^^^^^^^^ meta.string.js source.json.embedded.js meta.mapping.value.json meta.sequence.json */
+/*      ^^^^^^ meta.string.template.js source.json.embedded.js meta.mapping.key.json string.quoted.double.json */
+/*            ^ meta.string.template.js source.json.embedded.js meta.mapping.json punctuation.separator.key-value.json */
+/*              ^^^^^^^^^^^^^^^^^^^^^ meta.string.template.js source.json.embedded.js meta.mapping.value.json meta.sequence.json */
 /*              ^ punctuation.section.sequence.begin.json */
 /*               ^^^^^^^ meta.interpolation.js */
 /*                      ^ punctuation.separator.sequence.json */
@@ -137,10 +137,10 @@ var json = json`
 /*                                  ^ punctuation.section.sequence.end.json */
 /*                                   ^ punctuation.separator.sequence.json */
     }
-/*  ^ meta.string.js source.json.embedded.js meta.mapping.json punctuation.section.mapping.end.json */
+/*  ^ meta.string.template.js source.json.embedded.js meta.mapping.json punctuation.section.mapping.end.json */
     `
-/* <- meta.string.js string.quoted.other.js - source.json.embedded */
-/*^^^ meta.string.js string.quoted.other.js - source.json.embedded */
+/* <- meta.string.template.js string.quoted.other.js - source.json.embedded */
+/*^^^ meta.string.template.js string.quoted.other.js - source.json.embedded */
 /*  ^ punctuation.definition.string.end.js */
 /*   ^ - meta.string */
 
@@ -149,25 +149,25 @@ var json = json`
  */
 
 var script = js` var = 0 `
-/*             ^^^^^^^^^^^ meta.string.js */
+/*             ^^^^^^^^^^^ meta.string.template.js */
 /*             ^ string.quoted.other.js punctuation.definition.string.begin.js - source.js.embedded */
 /*              ^^^^^^^^^ source.js.embedded.js */
 /*                       ^ string.quoted.other.js punctuation.definition.string.end.js - source.js.embedded */
 
 var script = js`
 /*           ^^ variable.function.tagged-template */
-/*             ^^ meta.string.js string.quoted.other.js */
+/*             ^^ meta.string.template.js string.quoted.other.js */
 /*             ^ punctuation.definition.string.begin.js */
 /*              ^ - source.js.embedded */
 
     var ${name} = "Value ${interpol}"
 /*      ^^^^^^^ meta.interpolation.js */
-/*                ^^^^^^^ meta.string.js source.js.embedded.js meta.string.js string.quoted.double.js */
-/*                       ^^^^^^^^^^^ meta.string.js source.js.embedded.js meta.string.js meta.interpolation.js */
-/*                                  ^ meta.string.js source.js.embedded.js meta.string.js string.quoted.double.js */
+/*                ^^^^^^^ meta.string.template.js source.js.embedded.js meta.string.js string.quoted.double.js */
+/*                       ^^^^^^^^^^^ meta.string.template.js source.js.embedded.js meta.string.js meta.interpolation.js */
+/*                                  ^ meta.string.template.js source.js.embedded.js meta.string.js string.quoted.double.js */
     `
-/* <- meta.string.js string.quoted.other.js - source.js.embedded */
-/*^^^ meta.string.js string.quoted.other.js - source.js.embedded */
+/* <- meta.string.template.js string.quoted.other.js - source.js.embedded */
+/*^^^ meta.string.template.js string.quoted.other.js - source.js.embedded */
 /*  ^ punctuation.definition.string.end.js */
 /*   ^ - meta.string */
 
@@ -177,14 +177,14 @@ var script = js`
 
 
 var style = css` tr {  } `
-/*             ^^^^^^^^^^^ meta.string.js */
+/*             ^^^^^^^^^^^ meta.string.template.js */
 /*             ^ string.quoted.other.js punctuation.definition.string.begin.js - source.css.embedded */
 /*              ^^^^^^^^^ source.css.embedded.js */
 /*                       ^ string.quoted.other.js punctuation.definition.string.end.js - source.css.embedded */
 
 var style = css`
 /*          ^^^ variable.function.tagged-template */
-/*             ^^ meta.string.js string.quoted.other.js */
+/*             ^^ meta.string.template.js string.quoted.other.js */
 /*             ^ punctuation.definition.string.begin.js */
 /*              ^ - source.css.embedded */
 
@@ -204,8 +204,8 @@ var style = css`
     }
 /*  ^ meta.block.css punctuation.section.block.end.css */
     `
-/* <- meta.string.js string.quoted.other.js - source.css.embedded */
-/*^^^ meta.string.js string.quoted.other.js - source.css.embedded */
+/* <- meta.string.template.js string.quoted.other.js - source.css.embedded */
+/*^^^ meta.string.template.js string.quoted.other.js - source.css.embedded */
 /*  ^ punctuation.definition.string.end.js */
 /*   ^ - meta.string */
 
@@ -215,27 +215,27 @@ var style = css`
 
 var other = other`
 /*          ^^^^^ variable.function.tagged-template */
-/*               ^ meta.string.js punctuation.definition.string.begin.js */
+/*               ^ meta.string.template.js punctuation.definition.string.begin.js */
     Any content ${type}.
-/* ^^^^^^^^^^^^^ meta.string.js string.quoted.other.js */
-/*              ^^^^^^^ meta.string.js meta.interpolation.js - string */
-/*                     ^^ meta.string.js string.quoted.other.js */
+/* ^^^^^^^^^^^^^ meta.string.template.js string.quoted.other.js */
+/*              ^^^^^^^ meta.string.template.js meta.interpolation.js - string */
+/*                     ^^ meta.string.template.js string.quoted.other.js */
     `
-/* <- meta.string.js string.quoted.other.js */
-/*^^^ meta.string.js string.quoted.other.js */
+/* <- meta.string.template.js string.quoted.other.js */
+/*^^^ meta.string.template.js string.quoted.other.js */
 /*  ^ punctuation.definition.string.end.js */
 /*   ^ - meta.string */
 
 var other = `
-/*          ^^ meta.string.js */
+/*          ^^ meta.string.template.js */
 /*          ^ punctuation.definition.string.begin.js */
 /*           ^ string.quoted.other.js */
     Any content ${type}.
-/* ^^^^^^^^^^^^^ meta.string.js string.quoted.other.js */
-/*              ^^^^^^^ meta.string.js meta.interpolation.js - string */
-/*                     ^^ meta.string.js string.quoted.other.js */
+/* ^^^^^^^^^^^^^ meta.string.template.js string.quoted.other.js */
+/*              ^^^^^^^ meta.string.template.js meta.interpolation.js - string */
+/*                     ^^ meta.string.template.js string.quoted.other.js */
     `
-/* <- meta.string.js string.quoted.other.js */
-/*^^^ meta.string.js string.quoted.other.js */
+/* <- meta.string.template.js string.quoted.other.js */
+/*^^^ meta.string.template.js string.quoted.other.js */
 /*  ^ punctuation.definition.string.end.js */
 /*   ^ - meta.string */


### PR DESCRIPTION
This PR...

1. scopes tagged template strings `meta.string.template` to give all of them a common scope without regards of used syntax highlighting
2. uses that scope in key bindings' selectors to enable them in syntax highlighted tagged templates.
3. restrict ` to JavaScript strings by enforcing scope order in selectors in binding 1 and 2
4. merge "selector" keys in binding 3 and 4

It fixes no longer working key bindings in syntax highlighted tagged templates, regressed by #4019.