### PR TITLE
[JavaScript] Fix regression with ternary operators

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -846,11 +846,12 @@ contexts:
 
   for-condition:
     - match: \(
-      scope: meta.group.js punctuation.section.group.begin.js
+      scope: punctuation.section.group.begin.js
       branch_point: for-in-of
       branch:
         - for-in-of
         - for-oldstyle
+      pop: 1
     - include: else-pop
 
   for-condition-end:
@@ -864,6 +865,7 @@ contexts:
 
   for-in-of:
     - meta_include_prototype: false
+    - meta_scope: meta.group.js
     - match: ''
       set:
         - for-condition-end
@@ -916,6 +918,7 @@ contexts:
 
   for-oldstyle:
     - meta_include_prototype: false
+    - meta_scope: meta.group.js
     - match: ''
       set:
         - for-condition-end

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -858,13 +858,15 @@ contexts:
     - match: \)
       scope: punctuation.section.group.end.js
       pop: 1
+    - match: ;
+      scope: invalid.illegal.unexpected-token.js
+    - include: expressions
 
   for-in-of:
     - meta_include_prototype: false
     - match: ''
       set:
         - for-condition-end
-        - expression
         - for-in-of-word
         - for-in-of-declaration
 
@@ -916,23 +918,25 @@ contexts:
     - meta_include_prototype: false
     - match: ''
       set:
-        - for-oldstyle-rest
-        - for-oldstyle-first
+        - for-condition-end
+        - for-oldstyle-separator
+        - expression
+        - for-oldstyle-separator
+        - for-oldstyle-declaration
 
-  for-oldstyle-first:
+  for-oldstyle-declaration:
     - match: (?:const|let|var){{identifier_break}}
       scope: keyword.declaration.js
       set:
         - variable-binding-list-top
         - variable-binding-top
-    - include: else-pop
+    - include: expression
 
-  for-oldstyle-rest:
-    - meta_scope: meta.group.js
+  for-oldstyle-separator:
     - match: ;
       scope: punctuation.separator.expression.js
-    - include: for-condition-end
-    - include: expressions
+      pop: 1
+    - include: else-pop
 
   block-scope:
     - include: block
@@ -1507,7 +1511,7 @@ contexts:
   ternary-operator-expect-colon:
     - match: ':'
       scope: keyword.operator.ternary.js
-      set: expression
+      set: expression-no-comma
     - include: else-pop
 
   postfix-operators:

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -1506,7 +1506,7 @@ var o = {
 }
 
 var query = {
-    type: type==undefined ? null : {$in: type.split(',')}
+    type: type==undefined ? null : {$in: type.split(',')},
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping
 //              ^^^^^^^^^ constant.language.undefined
 //                        ^ keyword.operator.ternary
@@ -1516,6 +1516,26 @@ var query = {
 //                                   ^^ meta.mapping.key.js
 //                                     ^ punctuation.separator.key-value.js
 //                                                      ^ punctuation.section.mapping.end
+//                                                       ^ punctuation.separator.comma.js
+
+    key: foo > 2 ? foo < 5 ? '2 to 5' : '>=5' : '<=2',
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.js
+//  ^^^ meta.mapping.key.js
+//     ^ punctuation.separator.key-value.js
+//       ^^^ variable.other.readwrite.js
+//           ^ keyword.operator.comparison.js
+//             ^ constant.numeric.value.js
+//               ^ keyword.operator.ternary.js
+//                 ^^^ variable.other.readwrite.js
+//                     ^ keyword.operator.comparison.js
+//                       ^ constant.numeric.value.js
+//                         ^ keyword.operator.ternary.js
+//                           ^^^^^^^^ string.quoted.single.js
+//                                    ^ keyword.operator.ternary.js
+//                                      ^^^^^ string.quoted.single.js
+//                                            ^ keyword.operator.ternary.js
+//                                              ^^^^^ string.quoted.single.js
+//                                                   ^ punctuation.separator.comma.js
 };
 
 var str = `Hello, ${name}!`;

--- a/JavaScript/tests/syntax_test_js_control.js
+++ b/JavaScript/tests/syntax_test_js_control.js
@@ -306,6 +306,10 @@
 //                                   ^ punctuation.section.group.end
 //                                     ^^ meta.block
 
+    for (var in list) (i = 0 ; i < 10; i++)
+//  ^^^^^^^^^^^^^^^^^^ meta.for.js
+//                    ^^^^^^^^^^^^^^^^^^^^^ meta.group.js - meta.for
+
 for
     42;
 //  ^^ constant.numeric - meta.for

--- a/JavaScript/tests/syntax_test_js_control.js
+++ b/JavaScript/tests/syntax_test_js_control.js
@@ -125,14 +125,15 @@
 //           ^^ keyword.operator
 //                  ^ punctuation.separator.expression
 
-    for (a[x in list];;) {}
-//  ^^^^^^^^^^^^^^^^^^^^^^^ meta.for
+    for (a[x in list];;;) {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
 //  ^^^ keyword.control.loop.for
 //      ^^^^^^^^^^^^^^^^ meta.group
 //        ^^^^^^^^^^^ meta.brackets
 //           ^^ keyword.operator
 //                   ^ punctuation.separator.expression
 //                    ^ punctuation.separator.expression
+//                     ^ invalid.illegal.unexpected-token
 
     for (;function () {}/a/g;) {}
 //                      ^ keyword.operator
@@ -157,13 +158,13 @@
 //      ^^^^^^^^^^^ meta.group
 //         ^^ keyword.operator.word
 
-    for (a in b, c ? d: e, f(g())) {};
+    for (a in b, c ? d: e, f(g());) {};
 //  ^^^^ meta.for - meta.group
 //      ^^^^^^^^^^^^^^^^^^^ meta.for meta.group - meta.function-call
 //                         ^^^^^^ meta.for meta.group meta.function-call
-//                               ^ meta.for meta.group - meta.function-call
-//                                ^ meta.for - meta.block - meta.group
-//                                 ^^ meta.for meta.block
+//                               ^^ meta.for meta.group - meta.function-call
+//                                 ^ meta.for - meta.block - meta.group
+//                                  ^^ meta.for meta.block
 //  ^^^ keyword.control.loop.for
 //      ^ punctuation.section.group.begin
 //       ^ variable.other.readwrite
@@ -180,9 +181,11 @@
 //                          ^ punctuation.section.group.begin
 //                           ^ variable.function
 //                            ^ punctuation.section.group.begin
-//                             ^^^ punctuation.section.group.end
-//                                 ^ punctuation.section.block.begin
-//                                  ^ punctuation.section.block.end
+//                             ^^ punctuation.section.group.end
+//                               ^ invalid.illegal.unexpected-token
+//                                ^ punctuation.section.group.end
+//                                  ^ punctuation.section.block.begin
+//                                   ^ punctuation.section.block.end
 
     for (x of list) {}
 //  ^^^^^^^^^^^^^^^^^^ meta.for


### PR DESCRIPTION
This PR fixes a regression, introduced by #3986, which breaks syntax highlighting in objects, as comma is no longer consumed as key-value-pair separator.

It's not the ternary expression, which allows commas, but the for statement, which allows multiple expressions, separated by comma after `in` keyword.

    for (var in <expr>, <expr>, ...)

    expr: any valid expression, maybe ternary, maybe function-call

The change to ternary expressions is reverted and for-condition context is modified instead to allow multiple expressions after `in` keyword.

Also scope `;` invalid if there are too many.