### PR TITLE
[PHP] Modify `throw` to an expression keyword

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -51,9 +51,8 @@ variables:
     | {{class_modifier}}
     | {{static_modifier}}
     | {{builtin_variables}}
+    | {{expression_keywords}}
     | function\b
-    | as\b
-    | yield\b
     )
 
   keywords: |-
@@ -72,9 +71,11 @@ variables:
     (?xi: case | catch | default | do | (?: end )? (?: for(?:each)? | if | switch | while )
     | else | elseif | finally | switch | try )\b
   flow_keywords: |-
-    (?xi: break | continue | die | exit | finally | goto | return | throw )\b
+    (?xi: break | continue | die | exit | finally | goto | return )\b
 
   # Expression Level Keywords
+  expression_keywords: |-
+    (?xi: as | throw | yield )\b
   builtin_functions: |-
     (?xi: echo | print | empty | eval | isset | list | unset )\b
   builtin_variables: |-
@@ -1308,8 +1309,6 @@ contexts:
       scope: keyword.control.flow.panic.php
     - match: (?i:return)\b
       scope: keyword.control.flow.return.php
-    - match: (?i:throw)\b
-      scope: keyword.control.flow.throw.php
 
   goto-label:
     - match: '{{guarded_identifier}}'
@@ -2191,6 +2190,9 @@ contexts:
       scope: keyword.other.clone.php
     - match: (?i:insteadof)\b
       scope: keyword.other.insteadof.php
+    # throw is an expression keyword as of PHP8
+    - match: (?i:throw)\b
+      scope: keyword.control.flow.throw.php
     # yield from ( http://php.net/manual/en/language.generators.syntax.php#control-structures.yield.from )
     - match: (?i:yield)\b
       scope: keyword.control.flow.yield.php

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -2020,6 +2020,23 @@ $var = function(array $ar=array(), ClassName $cls) use ($var1, &$var2) {
 //                                                                   ^ punctuation.section.group.end.php
 //                                                                     ^ punctuation.section.block.begin.php
 
+   some_function(fn() => throw $exception);
+//              ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.php meta.group.php
+//                       ^^^^^^^^^^^^^^^^ meta.function.anonymous.php
+//                       ^^^^^ keyword.control.flow.throw.php
+//                             ^^^^^^^^^^ variable.other.php
+//                                       ^ punctuation.section.group.end.php
+
+   some_function(fn() => throw $exception, 'some other argument');
+//              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.php meta.group.php
+//                       ^^^^^^^^^^^^^^^^ meta.function.anonymous.php
+//                                       ^^^^^^^^^^^^^^^^^^^^^^^^ - meta.function.anonymous
+//                       ^^^^^ keyword.control.flow.throw.php
+//                             ^^^^^^^^^^ variable.other.php
+//                                       ^ punctuation.separator.sequence.php
+//                                         ^^^^^^^^^^^^^^^^^^^^^ meta.string.php string.quoted.single.php
+//                                                              ^ punctuation.section.group.end.php
+
 };
 // <- meta.function.php meta.block.php punctuation.section.block.end.php
 


### PR DESCRIPTION
Fixes #4026

Implements RFC https://wiki.php.net/rfc/throw_expression

Note: Creates an `expression_keywords` variable to group it together with other expression-level keywords.