### PR TITLE
[CSS] Don't show incorrect keybinding in menu

### DIFF
--- a/CSS/Default.sublime-keymap
+++ b/CSS/Default.sublime-keymap
@@ -31,7 +31,7 @@
 	},
 	// Move the caret to the next line and leave the terminating semicolon untouched.
 	// This is to not bother with semicolons even though completions end up with the caret directy in front of it.
-	{ "keys": ["enter"], "command": "run_macro_file", "args": {"file": "res://Packages/Default/Add Line.sublime-macro"} , "context":
+	{ "keys": ["enter"], "command": "run_macro_file", "args": {"file": "res://Packages/Default/Add Line.sublime-macro", "hide_from_menu": true} , "context":
 		[
 			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
 			{ "key": "auto_complete_visible", "operator": "equal", "operand": false },


### PR DESCRIPTION
This command matches the *Edit > Text > Insert Line After* menu item and so it will show the incorrect keybinding (`enter` instead of `ctrl+enter`).

To fix this we can simply make the command not match the one in the menu. The `"hide_from_menu"` is not functional.