### PR TITLE
[CSharp] Add the C# 11 type modifier `file` feature support

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -32,7 +32,7 @@ variables:
   unicode_char: '(?:\\u\h{4}|\\U\h{8})'
   escaped_char: '(?:\\[abfnrtv"''\\]|{{unicode_char}}|\\x[0-9a-fA-F]{1,4}|\\[0-9]{1,3})'
 
-  visibility: \b(?:public|private|protected|internal|protected\s+internal)\b
+  visibility: \b(?:public|private|protected|internal|protected\s+internal|file)\b
   base_type: (?:(?:bool|byte|sbyte|char|decimal|double|float|int|uint|nint|nuint|long|ulong|short|ushort|object|string|void)\b)
   type_suffix: (?:\s*(?:\[,*\]|\*|\?)*)
   generic_declaration: \s*(<[^={};]*>)?\s*

--- a/C#/tests/syntax_test_C#11.cs
+++ b/C#/tests/syntax_test_C#11.cs
@@ -198,3 +198,16 @@ public readonly struct Distance(double dx, double dy)
     public readonly double Magnitude { get; } = Math.Sqrt(dx * dx + dy * dy);
     public readonly double Direction { get; } = Math.Atan2(dy, dx);
 }
+
+file record struct Person(string Name);
+/// ^^ storage.modifier.access
+///    ^^^^^^^^^^^^^^^^^^^^ meta.class.record - meta.class.constructor.parameters
+///                        ^^^^^^^^^^^^^ meta.class.constructor.parameters
+///    ^^^^^^ keyword.declaration.class.record
+///           ^^^^^^ keyword.declaration.struct.record
+///                  ^^^^^^ entity.name.class
+///                        ^ punctuation.section.parameters.begin
+///                         ^^^^^^ storage.type
+///                                ^^^^ variable.parameter
+///                                    ^ punctuation.section.parameters.end
+///                                     ^ punctuation.terminator.statement

--- a/C#/tests/syntax_test_C#11.cs
+++ b/C#/tests/syntax_test_C#11.cs
@@ -199,8 +199,8 @@ public readonly struct Distance(double dx, double dy)
     public readonly double Direction { get; } = Math.Atan2(dy, dx);
 }
 
-file record struct Person(string Name);
-/// ^^ storage.modifier.access
+  file record struct Person(string Name);
+///^^^ storage.modifier.access
 ///    ^^^^^^^^^^^^^^^^^^^^ meta.class.record - meta.class.constructor.parameters
 ///                        ^^^^^^^^^^^^^ meta.class.constructor.parameters
 ///    ^^^^^^ keyword.declaration.class.record


### PR DESCRIPTION
See https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/file

The `file` is the keyword of type modifier as the type visibility.