### PR TITLE
[JavaScript] Separate tagged template strings for TypeScript

### DIFF
--- a/JavaScript/Embeddings/CSS (for TS template).sublime-syntax
+++ b/JavaScript/Embeddings/CSS (for TS template).sublime-syntax
@@ -1,0 +1,33 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/syntax.html
+# highlight tagged template strings
+scope: source.css.ts-template
+version: 2
+hidden: true
+
+extends: Packages/CSS/CSS.sublime-syntax
+
+variables:
+
+    ident_start: (?:{{nmstart}}|\${)
+
+contexts:
+
+  prototype:
+    - meta_prepend: true
+    - include: scope:source.ts#text-interpolations
+
+  strings-content:
+    - meta_prepend: true
+    - include: scope:source.ts#string-interpolations
+
+  main:
+    # support properties in top-level context
+    - include: comments
+    - include: property-lists
+    - include: properties-or-selectors
+    - include: at-rules
+    - include: rule-terminators
+    - include: illegal-commas
+    - include: illegal-groups

--- a/JavaScript/Embeddings/HTML (for TS template).sublime-syntax
+++ b/JavaScript/Embeddings/HTML (for TS template).sublime-syntax
@@ -1,0 +1,122 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/syntax.html
+# highlight tagged template strings
+scope: text.html.ts-template
+version: 2
+hidden: true
+
+extends: Packages/HTML/HTML.sublime-syntax
+
+variables:
+
+  tag_name_start: (?:[A-Za-z]|\${)
+
+contexts:
+
+  prototype:
+    - meta_prepend: true
+    - include: scope:source.ts#text-interpolations
+
+  cdata-content:
+    - meta_prepend: true
+    - include: scope:source.ts#string-interpolations
+
+  script-javascript-content:
+    - meta_include_prototype: false
+    - match: '{{script_content_begin}}'
+      captures:
+        1: comment.block.html punctuation.definition.comment.begin.html
+      pop: 1  # make sure to match only once
+      embed: scope:source.js.ts-template
+      embed_scope: source.js.embedded.html
+      escape: '{{script_content_end}}'
+      escape_captures:
+        1: source.js.embedded.html
+        2: comment.block.html punctuation.definition.comment.end.html
+        3: source.js.embedded.html
+        4: comment.block.html punctuation.definition.comment.end.html
+
+  script-json-content:
+    - meta_include_prototype: false
+    - match: '{{script_content_begin}}'
+      captures:
+        1: comment.block.html punctuation.definition.comment.begin.html
+      pop: 1  # make sure to match only once
+      embed: scope:source.json.ts-template
+      embed_scope: source.json.embedded.html
+      escape: '{{script_content_end}}'
+      escape_captures:
+        1: source.json.embedded.html
+        2: comment.block.html punctuation.definition.comment.end.html
+        3: source.json.embedded.html
+        4: comment.block.html punctuation.definition.comment.end.html
+
+  style-css-content:
+    - meta_include_prototype: false
+    - match: '{{style_content_begin}}'
+      captures:
+        1: comment.block.html punctuation.definition.comment.begin.html
+      pop: 1  # make sure to match only once
+      embed: scope:source.css.ts-template
+      embed_scope: source.css.embedded.html
+      escape: '{{style_content_end}}'
+      escape_captures:
+        1: source.css.embedded.html
+        2: comment.block.html punctuation.definition.comment.end.html
+        3: source.css.embedded.html
+        4: comment.block.html punctuation.definition.comment.end.html
+
+  tag-event-attribute-value:
+    - match: \"
+      scope:
+        meta.string.html string.quoted.double.html
+        punctuation.definition.string.begin.html
+      embed: scope:source.js.ts-template
+      embed_scope: meta.string.html meta.embedded.html source.js.embedded.html
+      escape: \"
+      escape_captures:
+        0: meta.string.html string.quoted.double.html
+           punctuation.definition.string.end.html
+    - match: \'
+      scope:
+        meta.string.html string.quoted.single.html
+        punctuation.definition.string.begin.html
+      embed: scope:source.js.ts-template
+      embed_scope: meta.string.html meta.embedded.html source.js.embedded.html
+      escape: \'
+      escape_captures:
+        0: meta.string.html string.quoted.single.html
+           punctuation.definition.string.end.html
+    - include: else-pop
+
+  tag-style-attribute-value:
+    - match: \"
+      scope:
+        meta.string.html string.quoted.double.html
+        punctuation.definition.string.begin.html
+      embed: scope:source.css.ts-template#rule-list-body
+      embed_scope: meta.string.html meta.embedded.html source.css.embedded.html
+      escape: \"
+      escape_captures:
+        0: meta.string.html string.quoted.double.html
+           punctuation.definition.string.end.html
+    - match: \'
+      scope:
+        meta.string.html string.quoted.single.html
+        punctuation.definition.string.begin.html
+      embed: scope:source.css.ts-template#rule-list-body
+      embed_scope: meta.string.html meta.embedded.html source.css.embedded.html
+      escape: \'
+      escape_captures:
+        0: meta.string.html string.quoted.single.html
+           punctuation.definition.string.end.html
+    - include: else-pop
+
+  tag-attribute-value-content:
+    - meta_prepend: true
+    - include: scope:source.js#string-interpolations
+
+  strings-common-content:
+    - meta_prepend: true
+    - include: scope:source.js#string-interpolations

--- a/JavaScript/Embeddings/JSON (TS template).sublime-syntax
+++ b/JavaScript/Embeddings/JSON (TS template).sublime-syntax
@@ -1,0 +1,18 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/syntax.html
+# highlight tagged template strings
+scope: source.json.ts-template
+version: 2
+hidden: true
+
+extends: Packages/JSON/JSON.sublime-syntax
+
+contexts:
+  prototype:
+    - meta_prepend: true
+    - include: scope:source.ts#text-interpolations
+
+  string-prototype:
+    - meta_prepend: true
+    - include: scope:source.ts#string-interpolations

--- a/JavaScript/Embeddings/JavaScript (TS template).sublime-syntax
+++ b/JavaScript/Embeddings/JavaScript (TS template).sublime-syntax
@@ -1,0 +1,19 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/syntax.html
+# highlight tagged template strings
+scope: source.js.ts-template
+version: 2
+hidden: true
+
+extends: Packages/JavaScript/JavaScript.sublime-syntax
+
+contexts:
+
+  prototype:
+    - meta_prepend: true
+    - include: scope:source.ts#text-interpolations
+
+  string-content:
+    - meta_prepend: true
+    - include: scope:source.ts#string-interpolations

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1233,9 +1233,14 @@ contexts:
 
   literal-string-templates:
     - match: (?=(?:{{identifier_name}}\s*)?`)
-      push: literal-string-template
+      push: literal-string-template-begin
 
   literal-string-template:
+    - match: (?=(?:{{identifier_name}}\s*)?`)
+      set: literal-string-template-begin
+
+  literal-string-template-begin:
+    - meta_include_prototype: false
     # Notes:
     #  Consume trailing whitespace after opening punctuation
     #  and leading whitespace in front of closing punctuation
@@ -1295,6 +1300,7 @@ contexts:
         1: variable.function.tagged-template.js
         2: meta.string.template.js string.quoted.other.js punctuation.definition.string.begin.js
       set: literal-string-template-content
+    - include: immediately-pop
 
   literal-string-template-content:
     - meta_include_prototype: false

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -1238,3 +1238,64 @@ contexts:
   function-call-arguments:
     - meta_prepend: true
     - include: ts-non-null-assertion
+
+  literal-string-template:
+    # Notes:
+    #  Consume trailing whitespace after opening punctuation
+    #  and leading whitespace in front of closing punctuation
+    #  to maintain JavaScript indentation rules until embedded
+    #  code really begins/ends. It's required for embedded code
+    #  to be indented using global JavaScript indentation rules.
+    - match: (css)\s*((\`){{trailing_wspace}}?)
+      captures:
+        1: variable.function.tagged-template.js
+        2: meta.string.template.js string.quoted.other.js
+        3: punctuation.definition.string.begin.js
+      embed: scope:source.css.ts-template
+      embed_scope: meta.string.template.js source.css.embedded.js
+      escape: '{{leading_wspace}}?(\`)'
+      escape_captures:
+        0: meta.string.template.js string.quoted.other.js
+        1: punctuation.definition.string.end.js
+      pop: 1
+    - match: (html)\s*((\`){{trailing_wspace}}?)
+      captures:
+        1: variable.function.tagged-template.js
+        2: meta.string.template.js string.quoted.other.js
+        3: punctuation.definition.string.begin.js
+      embed: scope:text.html.ts-template
+      embed_scope: meta.string.template.js text.html.embedded.js
+      escape: '{{leading_wspace}}?(\`)'
+      escape_captures:
+        0: meta.string.template.js string.quoted.other.js
+        1: punctuation.definition.string.end.js
+      pop: 1
+    - match: (js)\s*((\`){{trailing_wspace}}?)
+      captures:
+        1: variable.function.tagged-template.js
+        2: meta.string.template.js string.quoted.other.js
+        3: punctuation.definition.string.begin.js
+      embed: scope:source.js.ts-template
+      embed_scope: meta.string.template.js source.js.embedded.js
+      escape: '{{leading_wspace}}?(\`)'
+      escape_captures:
+        0: meta.string.template.js string.quoted.other.js
+        1: punctuation.definition.string.end.js
+      pop: 1
+    - match: (json)\s*((\`){{trailing_wspace}}?)
+      captures:
+        1: variable.function.tagged-template.js
+        2: meta.string.template.js string.quoted.other.js
+        3: punctuation.definition.string.begin.js
+      embed: scope:source.json.ts-template
+      embed_scope: meta.string.template.js source.json.embedded.js
+      escape: '{{leading_wspace}}?(\`)'
+      escape_captures:
+        0: meta.string.template.js string.quoted.other.js
+        1: punctuation.definition.string.end.js
+      pop: 1
+    - match: (?:({{identifier_name}})\s*)?(\`)
+      captures:
+        1: variable.function.tagged-template.js
+        2: meta.string.template.js string.quoted.other.js punctuation.definition.string.begin.js
+      set: literal-string-template-content

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -1239,7 +1239,7 @@ contexts:
     - meta_prepend: true
     - include: ts-non-null-assertion
 
-  literal-string-template:
+  literal-string-template-begin:
     # Notes:
     #  Consume trailing whitespace after opening punctuation
     #  and leading whitespace in front of closing punctuation
@@ -1299,3 +1299,4 @@ contexts:
         1: variable.function.tagged-template.js
         2: meta.string.template.js string.quoted.other.js punctuation.definition.string.begin.js
       set: literal-string-template-content
+    - include: immediately-pop

--- a/JavaScript/tests/syntax_test_typescript_template.ts
+++ b/JavaScript/tests/syntax_test_typescript_template.ts
@@ -1,0 +1,257 @@
+/* SYNTAX TEST "Packages/JavaScript/TypeScript.sublime-syntax" */
+
+/*
+ * HTML Templates
+ */
+
+var html = html` <p>${content}</p> `
+/*             ^^^^^^^^^^^^^^^^^^^^^ meta.string.template.js */
+/*             ^ string.quoted.other.js punctuation.definition.string.begin.js - text.html.embedded */
+/*              ^^^^^^^^^^^^^^^^^^^ text.html.embedded.js - string */
+/*                                 ^ string.quoted.other.js punctuation.definition.string.end.js - text.html.embedded */
+
+var html = html`
+/*         ^^^^ variable.function.tagged-template */
+/*             ^^ meta.string.template.js string.quoted.other.js */
+/*             ^ punctuation.definition.string.begin.js */
+/*              ^ - text.html.embedded */
+
+    <script type="text/javascript">
+        var ${name} = "Value ${interpol}"
+    /*      ^^^^^^^ meta.interpolation.js */
+    /*                ^^^^^^^ source.js.embedded.html meta.string.js string.quoted.double.js */
+    /*                       ^^^^^^^^^^^ source.js.embedded.html meta.string.js meta.interpolation.js */
+    /*                                  ^ source.js.embedded.html meta.string.js string.quoted.double.js */
+    </script>
+
+    <script type="text/json">
+        {
+    /*  ^ source.json.embedded.html meta.mapping.json punctuation.section.mapping.begin.json */
+
+            "key1": "val${ue}",
+    /*      ^^^^^^ source.json.embedded.html meta.mapping.key.json string.quoted.double.json */
+    /*            ^ source.json.embedded.html meta.mapping.json punctuation.separator.key-value.json */
+    /*              ^^^^ source.json.embedded.html meta.mapping.value.json meta.string.json string.quoted.double.json */
+    /*                  ^^^^^ source.json.embedded.html meta.mapping.value.json meta.string.json meta.interpolation.js */
+    /*                       ^ source.json.embedded.html meta.mapping.value.json meta.string.json string.quoted.double.json */
+    /*                        ^ source.json.embedded.html meta.mapping.json punctuation.separator.sequence.json */
+
+            ${key}: ${value},
+    /*      ^^^^^^ source.json.embedded.html meta.mapping.json meta.interpolation.js */
+    /*            ^ source.json.embedded.html meta.mapping.json punctuation.separator.key-value.json */
+    /*              ^^^^^^^^ source.json.embedded.html meta.mapping.value.json meta.interpolation.js */
+    /*                      ^ source.json.embedded.html meta.mapping.json punctuation.separator.sequence.json */
+
+            "key2": [${val1}, "val${no}"],
+    /*      ^^^^^^ source.json.embedded.html meta.mapping.key.json string.quoted.double.json */
+    /*            ^ source.json.embedded.html meta.mapping.json punctuation.separator.key-value.json */
+    /*              ^^^^^^^^^^^^^^^^^^^^^ source.json.embedded.html meta.mapping.value.json meta.sequence.json */
+    /*              ^ punctuation.section.sequence.begin.json */
+    /*               ^^^^^^^ meta.interpolation.js */
+    /*                      ^ punctuation.separator.sequence.json */
+    /*                        ^^^^ meta.string.json string.quoted.double.json */
+    /*                            ^^^^^ meta.string.json meta.interpolation.js */
+    /*                                 ^ meta.string.json string.quoted.double.json */
+    /*                                  ^ punctuation.section.sequence.end.json */
+    /*                                   ^ punctuation.separator.sequence.json */
+        }
+    /*  ^ source.json.embedded.html meta.mapping.json punctuation.section.mapping.end.json */
+    </script>
+
+    <style type="text/css">
+        tr, .${sel} {
+    /*  ^^^^^^^^^^^^ source.css.embedded.html meta.selector.css */
+    /*  ^^ source.css.embedded.html entity.name.tag.html.css */
+    /*    ^ source.css.embedded.html punctuation.separator.sequence.css */
+    /*      ^ source.css.embedded.html entity.other.attribute-name.class.css punctuation.definition.entity.css */
+    /*       ^^^^^^ source.css.embedded.html entity.other.attribute-name.class.css meta.interpolation.js */
+    /*              ^ source.css.embedded.html meta.block.css punctuation.section.block.begin.css */
+
+            background-${attr}: ${value};
+    /*      ^^^^^^^^^^^^^^^^^^ source.css.embedded.html meta.property-name.css support.type.property-name.css */
+    /*                 ^^^^^^^ source.css.embedded.html meta.interpolation.js */
+    /*                        ^ source.css.embedded.html punctuation.separator.key-value.css */
+    /*                          ^^^^^^^^ source.css.embedded.html meta.property-value.css meta.interpolation.js */
+        }
+    /*  ^ source.css.embedded.html meta.block.css punctuation.section.block.end.css */
+    </style>
+
+    <p style="width: ${width}%" class="${class_name}" onclick="${click}">${content}</p>
+/*  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.template.js text.html.embedded.js meta.tag.block.any.html */
+/*     ^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.style.html */
+/*                   ^^^^^^^^ source.css.embedded.html meta.property-value.css meta.interpolation.js */
+/*                              ^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.class.html */
+/*                                     ^^^^^^^^^^^^^ meta.class-name.html meta.string.html meta.interpolation.js */
+/*                                                    ^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.event.html */
+/*                                                             ^^^^^^^^ source.js.embedded.html meta.interpolation.js */
+/*                                                                       ^^^^^^^^^^ meta.string.template.js text.html.embedded.js meta.interpolation.js */
+/*                                                                                 ^^^^ meta.string.template.js text.html.embedded.js meta.tag.block.any.html */
+    `
+/* <- meta.string.template.js string.quoted.other.js - text.html.embedded */
+/*^^^ meta.string.template.js string.quoted.other.js - text.html.embedded */
+/*  ^ punctuation.definition.string.end.js */
+/*   ^ - meta.string */
+
+/*
+ * JSON Templates
+ */
+
+var json = json` { "key": "value" } `
+/*             ^^^^^^^^^^^^^^^^^^^^^^ meta.string.template.js */
+/*             ^ string.quoted.other.js punctuation.definition.string.begin.js - source.json.embedded */
+/*              ^^^^^^^^^^^^^^^^^^^^ source.json.embedded.js */
+/*                                  ^ string.quoted.other.js punctuation.definition.string.end.js - source.json.embedded */
+
+var json = json`
+/*         ^^^^ variable.function.tagged-template */
+/*             ^^ meta.string.template.js string.quoted.other.js */
+/*             ^ punctuation.definition.string.begin.js */
+/*              ^ - source.json.embedded */
+    {
+/*  ^ meta.string.template.js source.json.embedded.js meta.mapping.json punctuation.section.mapping.begin.json */
+
+        "key1": "val${ue}",
+/*      ^^^^^^ meta.string.template.js source.json.embedded.js meta.mapping.key.json string.quoted.double.json */
+/*            ^ meta.string.template.js source.json.embedded.js meta.mapping.json punctuation.separator.key-value.json */
+/*              ^^^^ meta.string.template.js source.json.embedded.js meta.mapping.value.json meta.string.json string.quoted.double.json */
+/*                  ^^^^^ meta.string.template.js source.json.embedded.js meta.mapping.value.json meta.string.json meta.interpolation.js */
+/*                       ^ meta.string.template.js source.json.embedded.js meta.mapping.value.json meta.string.json string.quoted.double.json */
+/*                        ^ meta.string.template.js source.json.embedded.js meta.mapping.json punctuation.separator.sequence.json */
+
+        ${key}: ${value},
+/*      ^^^^^^ meta.string.template.js source.json.embedded.js meta.mapping.json meta.interpolation.js */
+/*            ^ meta.string.template.js source.json.embedded.js meta.mapping.json punctuation.separator.key-value.json */
+/*              ^^^^^^^^ meta.string.template.js source.json.embedded.js meta.mapping.value.json meta.interpolation.js */
+/*                      ^ meta.string.template.js source.json.embedded.js meta.mapping.json punctuation.separator.sequence.json */
+
+        "key2": [${val1}, "val${no}"],
+/*      ^^^^^^ meta.string.template.js source.json.embedded.js meta.mapping.key.json string.quoted.double.json */
+/*            ^ meta.string.template.js source.json.embedded.js meta.mapping.json punctuation.separator.key-value.json */
+/*              ^^^^^^^^^^^^^^^^^^^^^ meta.string.template.js source.json.embedded.js meta.mapping.value.json meta.sequence.json */
+/*              ^ punctuation.section.sequence.begin.json */
+/*               ^^^^^^^ meta.interpolation.js */
+/*                      ^ punctuation.separator.sequence.json */
+/*                        ^^^^ meta.string.json string.quoted.double.json */
+/*                            ^^^^^ meta.string.json meta.interpolation.js */
+/*                                 ^ meta.string.json string.quoted.double.json */
+/*                                  ^ punctuation.section.sequence.end.json */
+/*                                   ^ punctuation.separator.sequence.json */
+    }
+/*  ^ meta.string.template.js source.json.embedded.js meta.mapping.json punctuation.section.mapping.end.json */
+    `
+/* <- meta.string.template.js string.quoted.other.js - source.json.embedded */
+/*^^^ meta.string.template.js string.quoted.other.js - source.json.embedded */
+/*  ^ punctuation.definition.string.end.js */
+/*   ^ - meta.string */
+
+/*
+ * JavaScript Templates
+ */
+
+var script = js` var = 0 `
+/*             ^^^^^^^^^^^ meta.string.template.js */
+/*             ^ string.quoted.other.js punctuation.definition.string.begin.js - source.js.embedded */
+/*              ^^^^^^^^^ source.js.embedded.js */
+/*                       ^ string.quoted.other.js punctuation.definition.string.end.js - source.js.embedded */
+
+var script = js`
+/*           ^^ variable.function.tagged-template */
+/*             ^^ meta.string.template.js string.quoted.other.js */
+/*             ^ punctuation.definition.string.begin.js */
+/*              ^ - source.js.embedded */
+
+    var ${name} = "Value ${interpol}"
+/*      ^^^^^^^ meta.interpolation.js */
+/*                ^^^^^^^ meta.string.template.js source.js.embedded.js meta.string.js string.quoted.double.js */
+/*                       ^^^^^^^^^^^ meta.string.template.js source.js.embedded.js meta.string.js meta.interpolation.js */
+/*                                  ^ meta.string.template.js source.js.embedded.js meta.string.js string.quoted.double.js */
+    `
+/* <- meta.string.template.js string.quoted.other.js - source.js.embedded */
+/*^^^ meta.string.template.js string.quoted.other.js - source.js.embedded */
+/*  ^ punctuation.definition.string.end.js */
+/*   ^ - meta.string */
+
+/*
+ * CSS Templates
+ */
+
+
+var style = css` tr {  } `
+/*             ^^^^^^^^^^^ meta.string.template.js */
+/*             ^ string.quoted.other.js punctuation.definition.string.begin.js - source.css.embedded */
+/*              ^^^^^^^^^ source.css.embedded.js */
+/*                       ^ string.quoted.other.js punctuation.definition.string.end.js - source.css.embedded */
+
+var style = css`
+/*          ^^^ variable.function.tagged-template */
+/*             ^^ meta.string.template.js string.quoted.other.js */
+/*             ^ punctuation.definition.string.begin.js */
+/*              ^ - source.css.embedded */
+
+    @media screen {}
+/*  ^^^^^^^^^^^^^ meta.at-rule.media.css */
+/*         ^^^^^^ support.constant.media.css */
+
+    tr, .${sel} {
+/*  ^^^^^^^^^^^^ meta.selector.css */
+/*  ^^ entity.name.tag.html.css */
+/*    ^ punctuation.separator.sequence.css */
+/*      ^ entity.other.attribute-name.class.css punctuation.definition.entity.css */
+/*       ^^^^^^ entity.other.attribute-name.class.css meta.interpolation.js */
+/*              ^ meta.block.css punctuation.section.block.begin.css */
+
+        background-${attr}: ${value};
+/*      ^^^^^^^^^^^^^^^^^^ meta.property-name.css support.type.property-name.css */
+/*                 ^^^^^^^ meta.interpolation.js */
+/*                        ^ punctuation.separator.key-value.css */
+/*                          ^^^^^^^^ meta.property-value.css meta.interpolation.js */
+    }
+/*  ^ meta.block.css punctuation.section.block.end.css */
+
+    background: var(--color);
+/* ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.template.js source.css.embedded.js */
+/*  ^^^^^^^^^^ meta.property-name.css support.type.property-name.css */
+/*            ^ punctuation.separator.key-value.css */
+/*              ^^^^^^^^^^^^ meta.property-value.css */
+/*              ^^^ meta.function-call.identifier.css support.function.var.css */
+/*                 ^^^^^^^^^ meta.function-call.arguments.css meta.group.css */
+/*                 ^ punctuation.section.group.begin.css */
+/*                  ^^^^^^^ variable.other.custom-property.css */
+/*                         ^ punctuation.section.group.end.css */
+/*                          ^ punctuation.terminator.rule.css */
+    `
+/* <- meta.string.template.js string.quoted.other.js - source.css.embedded */
+/*^^^ meta.string.template.js string.quoted.other.js - source.css.embedded */
+/*  ^ punctuation.definition.string.end.js */
+/*   ^ - meta.string */
+
+/*
+ * Unknown Template
+ */
+
+var other = other`
+/*          ^^^^^ variable.function.tagged-template */
+/*               ^ meta.string.template.js punctuation.definition.string.begin.js */
+    Any content ${type}.
+/* ^^^^^^^^^^^^^ meta.string.template.js string.quoted.other.js */
+/*              ^^^^^^^ meta.string.template.js meta.interpolation.js - string */
+/*                     ^^ meta.string.template.js string.quoted.other.js */
+    `
+/* <- meta.string.template.js string.quoted.other.js */
+/*^^^ meta.string.template.js string.quoted.other.js */
+/*  ^ punctuation.definition.string.end.js */
+/*   ^ - meta.string */
+
+var other = `
+/*          ^^ meta.string.template.js */
+/*          ^ punctuation.definition.string.begin.js */
+/*           ^ string.quoted.other.js */
+    Any content ${type}.
+/* ^^^^^^^^^^^^^ meta.string.template.js string.quoted.other.js */
+/*              ^^^^^^^ meta.string.template.js meta.interpolation.js - string */
+/*                     ^^ meta.string.template.js string.quoted.other.js */
+    `
+/* <- meta.string.template.js string.quoted.other.js */
+/*^^^ meta.string.template.js string.quoted.other.js */
+/*  ^ punctuation.definition.string.end.js */
+/*   ^ - meta.string */


### PR DESCRIPTION
This PR...

1. creates separate embedded syntaxes for tagged template strings, used in TypeScript to ensure TypeScript being used in interpolations.
2. improves extensibility of tagged template strings by providing a single context to add further variants of tagged templates to. This may help 3rd-party packages to more easily add features.