### PR TITLE
[Java] Fix literal backslash in strings

### DIFF
--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -2503,8 +2503,6 @@ contexts:
       scope: constant.character.escape.octal.java
     - match: '{{escape_other}}'
       scope: constant.character.escape.other.java
-    - match: \\.
-      scope: invalid.illegal.escape.java
 
 ###[ OPERATORS ]###############################################################
 

--- a/Java/tests/syntax_test_java.java
+++ b/Java/tests/syntax_test_java.java
@@ -11154,12 +11154,8 @@ class LiteralsTests {
 //
 
     String illegalEscapes = "\x \+ \8 \9"
-//                          ^^^^^^^^^^^^^ meta.string.java string.quoted.double.java
+//                          ^^^^^^^^^^^^^ meta.string.java string.quoted.double.java - constant.character
 //                          ^ punctuation.definition.string.begin.java
-//                           ^^ invalid.illegal.escape
-//                              ^^ invalid.illegal.escape
-//                                 ^^ invalid.illegal.escape
-//                                    ^^ invalid.illegal.escape
 //                                      ^ punctuation.definition.string.end.java
 
     String incompleteString = "String without closing quote


### PR DESCRIPTION
This commit removes `invalid.illegal` scope from unsupported escape sequences.

Actually `\` is interpreted literal if it doesn't start a supported escape sequence.

The following is a valid string without illegals:

```java
new Source("src\main\java\com\example\application\views\HomeView.java")
```