### PR TITLE
[CSS] Add patterns to scope calc() language constants

### DIFF
--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -2819,6 +2819,12 @@ contexts:
     - include: function-arguments-prototype
     - include: comma-delimiters
     - include: attr-functions
+    - match: (?:e|pi){{break}}
+      scope: constant.language.css
+    - match: -?infinity{{break}}
+      scope: constant.language.infinity.css
+    - match: NaN{{break}}
+      scope: constant.language.nan.css
     - match: '{{float}}({{units}})?'
       scope: meta.number.float.decimal.css
       captures:

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -3606,6 +3606,13 @@
 /*                                                                  ^ meta.number.integer.decimal.css constant.numeric.value.css */
 /*                                                                   ^ punctuation.section.group.end.css */
 /*                                                                    ^ punctuation.terminator.rule.css - meta.group */
+
+    top: calc(NaN * -infinity + infinity / e - pi);
+/*            ^^^ constant.language.nan.css */
+/*                   ^^^^^^^^ constant.language.infinity.css */
+/*                              ^^^^^^^^ constant.language.infinity.css */
+/*                                         ^ constant.language.css */
+/*                                             ^^ constant.language.css */
 }
 
 .test-toggle-function {


### PR DESCRIPTION
This commit adds scopes for `e`, `pi`, `infinity` and `NaN` constants in calc().

see: https://developer.mozilla.org/en-US/docs/Web/CSS/calc#formal_syntax