### PR TITLE
[CSS] Add rounding strategy keywords

### DIFF
--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -2819,6 +2819,10 @@ contexts:
     - include: function-arguments-prototype
     - include: comma-delimiters
     - include: attr-functions
+    # round() keywords
+    - match: (?:down|nearest|to-zero|up){{break}}
+      scope: keyword.other.round.strategy.css
+    # common constants
     - match: (?:e|pi){{break}}
       scope: constant.language.css
     - match: -?infinity{{break}}

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -3615,6 +3615,40 @@
 /*                                             ^^ constant.language.css */
 }
 
+.test-round-function {
+    top: round(down 10px var(--interval));
+/*       ^^^^^ meta.function-call.identifier.css support.function.calc.css */
+/*            ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.css meta.group.css */
+/*             ^^^^ keyword.other.round.strategy.css */
+/*                  ^^^^ meta.number.integer.decimal.css */
+/*                       ^^^ support.function.var.css */
+/*                           ^^^^^^^^^^ variable.other.custom-property.css */
+
+    top: round(nearest 10px var(--interval));
+/*       ^^^^^ meta.function-call.identifier.css support.function.calc.css */
+/*            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.css meta.group.css */
+/*             ^^^^^^^ keyword.other.round.strategy.css */
+/*                     ^^^^ meta.number.integer.decimal.css */
+/*                          ^^^ support.function.var.css */
+/*                              ^^^^^^^^^^ variable.other.custom-property.css */
+
+    top: round(to-zero 10px var(--interval));
+/*       ^^^^^ meta.function-call.identifier.css support.function.calc.css */
+/*            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.css meta.group.css */
+/*             ^^^^^^^ keyword.other.round.strategy.css */
+/*                     ^^^^ meta.number.integer.decimal.css */
+/*                          ^^^ support.function.var.css */
+/*                              ^^^^^^^^^^ variable.other.custom-property.css */
+
+    top: round(up 10px var(--interval));
+/*       ^^^^^ meta.function-call.identifier.css support.function.calc.css */
+/*            ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.css meta.group.css */
+/*             ^^ keyword.other.round.strategy.css */
+/*                ^^^^ meta.number.integer.decimal.css */
+/*                     ^^^ support.function.var.css */
+/*                         ^^^^^^^^^^ variable.other.custom-property.css */
+}
+
 .test-toggle-function {
     top: toggle(5px red preserve-3d);
 /*       ^^^^^^ support.function.toggle.css */


### PR DESCRIPTION
This commit adds scopes to highlight round() strategies.

Note:

round() uses common `calc-function-arguments-content` context, so these keywords are also highlighted in other functions, they don't have special meaning in.

IMHO, chances to run into conflicts are however too low to justify a new dedicated context for round() arguments.

see: https://developer.mozilla.org/en-US/docs/Web/CSS/round#rounding-strategy