### PR TITLE
[CSS] Fix custom property definitions

### DIFF
--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -1550,6 +1550,7 @@ contexts:
 ###[ PROPERTY IDENTIFIERS ]####################################################
 
   properties-or-selectors:
+    - include: custom-properties
     - match: '{{property_or_selector_begin}}'
       branch_point: property-or-selector
       branch:

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -2167,6 +2167,21 @@
 }
 
 .test-var-functions {
+    --custom-theme: { color: white; };
+/*^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.css meta.block.css */
+/*  ^^^^^^^^^^^^^^ meta.property-name.css entity.other.custom-property.css */
+/*                ^ punctuation.separator.key-value.css */
+/*                 ^ meta.property-value.css */
+/*                  ^^^^^^^^^^^^^^^^^ meta.property-list.css meta.block.css */
+/*                  ^ punctuation.section.block.begin.css */
+/*                    ^^^^^ meta.property-name.css support.type.property-name.css */
+/*                         ^ punctuation.separator.key-value.css */
+/*                          ^^^^^^ meta.property-value.css */
+/*                           ^^^^^ support.constant.color.w3c.standard.css */
+/*                                ^ punctuation.terminator.rule.css */
+/*                                  ^ punctuation.section.block.end.css */
+/*                                   ^ punctuation.terminator.rule.css */
+
     --test-var: arial;
 /*  ^^^^^^^^^^ entity.other.custom-property.css */
 /*            ^ punctuation.separator.key-value.css*/


### PR DESCRIPTION
This commit fixes custom property definitions with declaration-list values.

Custom properties...
1. can take all sorts of values.
2. never start a selector.

Without this commit, leading `--` is ignored and custom property name being consumed as html tag, starting a selector.