### PR TITLE
[JavaScript] Assign typescript to *.cts and *.mts extensions

### DIFF
--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -8,6 +8,8 @@ extends: JavaScript.sublime-syntax
 
 file_extensions:
   - ts
+  - mts
+  - cts
 
 first_line_match: |-
   (?xi:


### PR DESCRIPTION
This commit adds counter-parts for JavaScript's `*.cjs` and `*.mjs` file extensions to Typescript.