### PR TITLE
[Python] Scope self and cls in function parameter lists

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -2408,6 +2408,8 @@ contexts:
 
   parameter-names:
     - include: illegal-names
+    - match: (?:self|cls)\b
+      scope: variable.parameter.python variable.language.python
     - match: '{{identifier}}'
       scope: variable.parameter.python
 

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -2124,6 +2124,9 @@ class MyClass():
 #            ^^ meta.class.inheritance.python - meta.class meta.class
 #              ^ meta.class.python - meta.class meta.class punctuation.section.class.begin
     def my_func(self, param1, # Multi-line function definition
+#               ^^^^ variable.parameter.python variable.language.python
+#                   ^ punctuation.separator.parameters.python
+#                     ^^^^^^ variable.parameter.python - variable.language
 #                             ^ comment.line.number-sign
         # This is defaulted
 #       ^ comment.line.number-sign


### PR DESCRIPTION
This commit scopes `cls` and `self` special in parameter lists, to enable highlighting them as their references in function bodies.