### PR TITLE
[PHP] Optimize embedded CSS/JS syntax definitions

### DIFF
--- a/PHP/Embeddings/CSS (for PHP double-quoted).sublime-syntax
+++ b/PHP/Embeddings/CSS (for PHP double-quoted).sublime-syntax
@@ -7,11 +7,20 @@ hidden: true
 extends: Packages/PHP/CSS (PHP).sublime-syntax
 
 contexts:
+  main:
+    - include: rule-list-body
 
-  prototype:
+  quoted-strings:
     - meta_prepend: true
     - match: (?=")
       pop: 1
 
-  main:
-    - include: rule-list-body
+  quoted-string:
+    - meta_prepend: true
+    - match: (?=")
+      pop: 1
+
+  quoted-urls:
+    - meta_prepend: true
+    - match: (?=")
+      pop: 1

--- a/PHP/Embeddings/CSS (for PHP single-quoted).sublime-syntax
+++ b/PHP/Embeddings/CSS (for PHP single-quoted).sublime-syntax
@@ -7,11 +7,20 @@ hidden: true
 extends: Packages/PHP/CSS (PHP).sublime-syntax
 
 contexts:
+  main:
+    - include: rule-list-body
 
-  prototype:
+  quoted-strings:
     - meta_prepend: true
     - match: (?=')
       pop: 1
 
-  main:
-    - include: rule-list-body
+  quoted-string:
+    - meta_prepend: true
+    - match: (?=')
+      pop: 1
+
+  quoted-urls:
+    - meta_prepend: true
+    - match: (?=')
+      pop: 1

--- a/PHP/Embeddings/JavaScript (for PHP double-quoted).sublime-syntax
+++ b/PHP/Embeddings/JavaScript (for PHP double-quoted).sublime-syntax
@@ -7,7 +7,20 @@ hidden: true
 extends: Packages/PHP/JavaScript (PHP).sublime-syntax
 
 contexts:
-  prototype:
+  main:
+    - include: expressions
+
+  field-name:
     - meta_prepend: true
     - match: (?=")
       pop: 1
+
+  method-name:
+    - meta_prepend: true
+    - match: (?=")
+      pop: 1
+
+  literal-double-quoted-string:
+    - match: (?=")
+      pop: 1
+

--- a/PHP/Embeddings/JavaScript (for PHP single-quoted).sublime-syntax
+++ b/PHP/Embeddings/JavaScript (for PHP single-quoted).sublime-syntax
@@ -7,7 +7,19 @@ hidden: true
 extends: Packages/PHP/JavaScript (PHP).sublime-syntax
 
 contexts:
-  prototype:
+  main:
+    - include: expressions
+
+  field-name:
     - meta_prepend: true
+    - match: (?=')
+      pop: 1
+
+  method-name:
+    - meta_prepend: true
+    - match: (?=')
+      pop: 1
+
+  literal-single-quoted-string:
     - match: (?=')
       pop: 1


### PR DESCRIPTION
This PR makes sure to pop CSS/JS contexts off stack, if quotation mark is matched by customizing relevant CSS/JS contexts only.

By not injecting required lookahead into each context via `prototype`, compiled syntax cache size is reduced by round about 200kB as more contexts share same patterns.

Modified syntax definitions are designed for being included into inline event and style attributes of HTML tags.

Note: This commit does not change behavior, just saves some RAM.