### PR TITLE
[C++] Add support for new preprocessor directives

### DIFF
--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -846,7 +846,7 @@ contexts:
       scope: punctuation.section.block.begin.c++
       push:
         - meta_scope: meta.block.c++
-        - match: (?=^\s*#\s*(elif|else|endif)\b)
+        - match: (?=^\s*#\s*(elif|elifdef|elifndef|else|endif)\b)
           pop: true
         - match: '\}'
           scope: punctuation.section.block.end.c++
@@ -1281,7 +1281,7 @@ contexts:
         - match: '\}'
           scope: meta.function.c++ meta.block.c++ punctuation.section.block.end.c++
           pop: true
-        - match: (?=^\s*#\s*(elif|else|endif)\b)
+        - match: (?=^\s*#\s*(elif|elifdef|elifndef|else|endif)\b)
           pop: true
         - match: '(?=({{before_tag}})([^(;]+$|.*\{))'
           push: data-structures
@@ -1776,7 +1776,7 @@ contexts:
         - match: '\}'
           scope: meta.method.c++ meta.block.c++ punctuation.section.block.end.c++
           pop: true
-        - match: (?=^\s*#\s*(elif|else|endif)\b)
+        - match: (?=^\s*#\s*(elif|elifdef|elifndef|else|endif)\b)
           pop: true
         - match: '(?=({{before_tag}})([^(;]+$|.*\{))'
           push: data-structures
@@ -1923,11 +1923,11 @@ contexts:
         - include: scope:source.c#preprocessor-comments
         - match: \bdefined\b
           scope: keyword.control.c++
-        # Enter a new scope where all elif/else branches have their
-        # contexts popped by a subsequent elif/else/endif. This ensures that
-        # preprocessor branches don't push multiple meta.block scopes on
-        # the stack, thus messing up the "global" context's detection of
-        # functions.
+        # Enter a new scope where all elif/elifdef/elifndef/else branches have
+        # their contexts popped by a subsequent elif/elifdef/elifndef/else/endif.
+        # This ensures that preprocessor branches don't push multiple meta.block
+        # scopes on the stack, thus messing up the "global" context's detection
+        # of functions.
         - match: $\n
           set: preprocessor-if-branch-global
 
@@ -1939,8 +1939,8 @@ contexts:
       captures:
         1: meta.preprocessor.c++ keyword.control.import.c++
       pop: true
-    - match: (?=^\s*#\s*(elif|else)\b)
-      push: preprocessor-elif-else-branch-global
+    - match: (?=^\s*#\s*(elif|elifdef|elifndef|else)\b)
+      push: preprocessor-elif-elifdef-elifndef-else-branch-global
     - match: \{
       scope: punctuation.section.block.begin.c++
       set: preprocessor-block-if-branch-global
@@ -1954,8 +1954,8 @@ contexts:
       captures:
         1: meta.preprocessor.c++ keyword.control.import.c++
       set: preprocessor-block-finish-global
-    - match: (?=^\s*#\s*(elif|else)\b)
-      push: preprocessor-elif-else-branch-global
+    - match: (?=^\s*#\s*(elif|elifdef|elifndef|else)\b)
+      push: preprocessor-elif-elifdef-elifndef-else-branch-global
     - match: \}
       scope: punctuation.section.block.end.c++
       set: preprocessor-if-branch-global
@@ -1982,7 +1982,7 @@ contexts:
       set: preprocessor-if-branch-global
     - include: statements
 
-  preprocessor-elif-else-branch-global:
+  preprocessor-elif-elifdef-elifndef-else-branch-global:
     - match: (?=^\s*#\s*(endif)\b)
       pop: true
     - include: preprocessor-global
@@ -2069,8 +2069,8 @@ contexts:
       captures:
         1: meta.preprocessor.c++ keyword.control.import.c++
       pop: true
-    - match: (?=^\s*#\s*(elif|else)\b)
-      push: preprocessor-elif-else-branch-statements
+    - match: (?=^\s*#\s*(elif|elifdef|elifndef|else)\b)
+      push: preprocessor-elif-elifdef-elifndef-else-branch-statements
     - match: \{
       scope: punctuation.section.block.begin.c++
       set: preprocessor-block-if-branch-statements
@@ -2100,7 +2100,7 @@ contexts:
     - match : \)
       scope: meta.function-call.c++ meta.group.c++ punctuation.section.group.end.c++
       set: preprocessor-if-branch-statements
-    - match: ^\s*(#\s*(?:elif|else))\b
+    - match: ^\s*(#\s*(?:elif|elifdef|elifndef|else))\b
       captures:
         1: meta.preprocessor.c++ keyword.control.import.c++
       set: preprocessor-if-branch-statements
@@ -2123,8 +2123,8 @@ contexts:
       captures:
         1: meta.preprocessor.c++ keyword.control.import.c++
       set: preprocessor-block-finish-statements
-    - match: (?=^\s*#\s*(elif|else)\b)
-      push: preprocessor-elif-else-branch-statements
+    - match: (?=^\s*#\s*(elif|elifdef|elifndef|else)\b)
+      push: preprocessor-elif-elifdef-elifndef-else-branch-statements
     - match: \}
       scope: punctuation.section.block.end.c++
       set: preprocessor-if-branch-statements
@@ -2151,7 +2151,7 @@ contexts:
       set: preprocessor-if-branch-statements
     - include: statements
 
-  preprocessor-elif-else-branch-statements:
+  preprocessor-elif-elifdef-elifndef-else-branch-statements:
     - match: (?=^\s*#\s*endif\b)
       pop: true
     - include: negated-block
@@ -2166,7 +2166,7 @@ contexts:
         - match: '\{'
           scope: punctuation.section.block.begin.c++
           pop: true
-        - match: (?=^\s*#\s*(elif|else|endif)\b)
+        - match: (?=^\s*#\s*(elif|elifdef|elifndef|else|endif)\b)
           pop: true
         - include: statements
 
@@ -2267,7 +2267,7 @@ contexts:
           pop: true
 
   preprocessor-other:
-    - match: ^\s*(#\s*(?:if|ifdef|ifndef|elif|else|line|pragma|undef))\b
+    - match: ^\s*(#\s*(?:if|ifdef|ifndef|elif|elifdef|elifndef|else|line|pragma|undef))\b
       captures:
         1: keyword.control.import.c++
       push:

--- a/C++/C.sublime-syntax
+++ b/C++/C.sublime-syntax
@@ -620,7 +620,7 @@ contexts:
         - match: '\}'
           scope: meta.function.c meta.block.c punctuation.section.block.end.c
           pop: true
-        - match: (?=^\s*#\s*(elif|else|endif)\b)
+        - match: (?=^\s*#\s*(elif|elifdef|elifndef|else|endif)\b)
           pop: true
         - match: '(?=({{before_tag}})([^(;]+$|.*\{))'
           push: data-structures
@@ -775,7 +775,7 @@ contexts:
       scope: punctuation.section.block.begin.c
       push:
         - meta_scope: meta.block.c
-        - match: (?=^\s*#\s*(elif|else|endif)\b)
+        - match: (?=^\s*#\s*(elif|elifdef|elifndef|else|endif)\b)
           pop: true
         - match: '\}'
           scope: punctuation.section.block.end.c
@@ -1041,8 +1041,8 @@ contexts:
       captures:
         1: meta.preprocessor.c keyword.control.import.c
       pop: true
-    - match: (?=^\s*#\s*(elif|else)\b)
-      push: preprocessor-elif-else-branch-global
+    - match: (?=^\s*#\s*(elif|elifdef|elifndef|else)\b)
+      push: preprocessor-elif-elifdef-elifndef-else-branch-global
     - match: \{
       scope: punctuation.section.block.begin.c
       set: preprocessor-block-if-branch-global
@@ -1056,8 +1056,8 @@ contexts:
       captures:
         1: meta.preprocessor.c keyword.control.import.c
       set: preprocessor-block-finish-global
-    - match: (?=^\s*#\s*(elif|else)\b)
-      push: preprocessor-elif-else-branch-global
+    - match: (?=^\s*#\s*(elif|elifdef|elifndef|else)\b)
+      push: preprocessor-elif-elifdef-elifndef-else-branch-global
     - match: \}
       scope: punctuation.section.block.end.c
       set: preprocessor-if-branch-global
@@ -1084,7 +1084,7 @@ contexts:
       set: preprocessor-if-branch-global
     - include: statements
 
-  preprocessor-elif-else-branch-global:
+  preprocessor-elif-elifdef-elifndef-else-branch-global:
     - match: (?=^\s*#\s*endif\b)
       pop: true
     - include: negated-block
@@ -1144,11 +1144,11 @@ contexts:
         - include: preprocessor-comments
         - match: \bdefined\b
           scope: keyword.control.c
-        # Enter a new scope where all elif/else branches have their
-        # contexts popped by a subsequent elif/else/endif. This ensures that
-        # preprocessor branches don't push multiple meta.block scopes on
-        # the stack, thus messing up the "global" context's detection of
-        # functions.
+        # Enter a new scope where all elif/elifdef/elifndef/else branches have
+        # their contexts popped by a subsequent elif/elifdef/elifndef/else/endif.
+        # This ensures that preprocessor branches don't push multiple meta.block
+        # scopes on the stack, thus messing up the "global" context's detection
+        # of functions.
         - match: $\n
           set: preprocessor-if-branch-statements
 
@@ -1160,8 +1160,8 @@ contexts:
       captures:
         1: meta.preprocessor.c keyword.control.import.c
       pop: true
-    - match: (?=^\s*#\s*(elif|else)\b)
-      push: preprocessor-elif-else-branch-statements
+    - match: (?=^\s*#\s*(elif|elifdef|elifndef|else)\b)
+      push: preprocessor-elif-elifdef-elifndef-else-branch-statements
     - match: \{
       scope: punctuation.section.block.begin.c
       set: preprocessor-block-if-branch-statements
@@ -1184,7 +1184,7 @@ contexts:
     - match : \)
       scope: meta.function-call.c meta.group.c punctuation.section.group.end.c
       set: preprocessor-if-branch-statements
-    - match: ^\s*(#\s*(?:elif|else))\b
+    - match: ^\s*(#\s*(?:elif|elifdef|elifndef|else))\b
       captures:
         1: meta.preprocessor.c keyword.control.import.c
       set: preprocessor-if-branch-statements
@@ -1207,8 +1207,8 @@ contexts:
       captures:
         1: meta.preprocessor.c keyword.control.import.c
       set: preprocessor-block-finish-statements
-    - match: (?=^\s*#\s*(elif|else)\b)
-      push: preprocessor-elif-else-branch-statements
+    - match: (?=^\s*#\s*(elif|elifdef|elifndef|else)\b)
+      push: preprocessor-elif-elifdef-elifndef-else-branch-statements
     - match: \}
       scope: punctuation.section.block.end.c
       set: preprocessor-if-branch-statements
@@ -1235,7 +1235,7 @@ contexts:
       set: preprocessor-if-branch-statements
     - include: statements
 
-  preprocessor-elif-else-branch-statements:
+  preprocessor-elif-elifdef-elifndef-else-branch-statements:
     - match: (?=^\s*#\s*endif\b)
       pop: true
     - include: negated-block
@@ -1250,7 +1250,7 @@ contexts:
         - match: '\{'
           scope: punctuation.section.block.begin.c
           pop: true
-        - match: (?=^\s*#\s*(elif|else|endif)\b)
+        - match: (?=^\s*#\s*(elif|elifdef|elifndef|else|endif)\b)
           pop: true
         - include: statements
 
@@ -1354,7 +1354,7 @@ contexts:
         - include: expressions
 
   preprocessor-other:
-    - match: ^\s*(#\s*(?:if|ifdef|ifndef|elif|else|line|pragma|undef))\b
+    - match: ^\s*(#\s*(?:if|ifdef|ifndef|elif|elifdef|elifndef|else|line|pragma|undef))\b
       captures:
         1: keyword.control.import.c
       push:

--- a/C++/Completion Rules.tmPreferences
+++ b/C++/Completion Rules.tmPreferences
@@ -6,7 +6,7 @@
 	<key>settings</key>
 	<dict>
 		<key>cancelCompletion</key>
-		<string>(^.*\bconst\s*$)|^\s*(\}?\s*(else|try|do|#if|#ifdef|#else|#elif|#endif|#pragma\s+once)|(class|struct|union|enum|namespace)\s*[a-zA-Z_0-9]+*)$</string>
+		<string>(^.*\bconst\s*$)|^\s*(\}?\s*(else|try|do|#if|#ifdef|#else|#elif|#elifdef|#elifndef|#endif|#pragma\s+once)|(class|struct|union|enum|namespace)\s*[a-zA-Z_0-9]+*)$</string>
 	</dict>
 </dict>
 </plist>

--- a/C++/syntax_test_c.c
+++ b/C++/syntax_test_c.c
@@ -437,8 +437,16 @@ if (1) {
 if (2) {
 # elif BAZ
 if (3) {
-# else
+#elifdef BAR2
 if (4) {
+# elifdef BAZ2
+if (5) {
+#elifndef BAR3
+if (6) {
+# elifndef BAZ3
+if (7) {
+# else
+if (8) {
 #endif
     int bar = 1;
 }


### PR DESCRIPTION
This adds support for the new #elifdef and #elifndef preprocessor directives that are a combination of #else with #ifdef or #ifndef. This has already made it into recent C and C++ compilers and is part of the C23 and C++23 standards.