### PR TITLE
[C] Add support for new preprocessor directives

### DIFF
--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -846,7 +846,7 @@ contexts:
       scope: punctuation.section.block.begin.c++
       push:
         - meta_scope: meta.block.c++
-        - match: (?=^\s*#\s*(elif|else|endif)\b)
+        - match: (?=^\s*#\s*(elif|elifdef|elifndef|else|endif)\b)
           pop: true
         - match: '\}'
           scope: punctuation.section.block.end.c++
@@ -1281,7 +1281,7 @@ contexts:
         - match: '\}'
           scope: meta.function.c++ meta.block.c++ punctuation.section.block.end.c++
           pop: true
-        - match: (?=^\s*#\s*(elif|else|endif)\b)
+        - match: (?=^\s*#\s*(elif|elifdef|elifndef|else|endif)\b)
           pop: true
         - match: '(?=({{before_tag}})([^(;]+$|.*\{))'
           push: data-structures
@@ -1776,7 +1776,7 @@ contexts:
         - match: '\}'
           scope: meta.method.c++ meta.block.c++ punctuation.section.block.end.c++
           pop: true
-        - match: (?=^\s*#\s*(elif|else|endif)\b)
+        - match: (?=^\s*#\s*(elif|elifdef|elifndef|else|endif)\b)
           pop: true
         - match: '(?=({{before_tag}})([^(;]+$|.*\{))'
           push: data-structures
@@ -1923,11 +1923,11 @@ contexts:
         - include: scope:source.c#preprocessor-comments
         - match: \bdefined\b
           scope: keyword.control.c++
-        # Enter a new scope where all elif/else branches have their
-        # contexts popped by a subsequent elif/else/endif. This ensures that
-        # preprocessor branches don't push multiple meta.block scopes on
-        # the stack, thus messing up the "global" context's detection of
-        # functions.
+        # Enter a new scope where all elif/elifdef/elifndef/else branches have
+        # their contexts popped by a subsequent elif/elifdef/elifndef/else/endif.
+        # This ensures that preprocessor branches don't push multiple meta.block
+        # scopes on the stack, thus messing up the "global" context's detection
+        # of functions.
         - match: $\n
           set: preprocessor-if-branch-global
 
@@ -1939,7 +1939,7 @@ contexts:
       captures:
         1: meta.preprocessor.c++ keyword.control.import.c++
       pop: true
-    - match: (?=^\s*#\s*(elif|else)\b)
+    - match: (?=^\s*#\s*(elif|elifdef|elifndef|else)\b)
       push: preprocessor-elif-else-branch-global
     - match: \{
       scope: punctuation.section.block.begin.c++
@@ -1954,7 +1954,7 @@ contexts:
       captures:
         1: meta.preprocessor.c++ keyword.control.import.c++
       set: preprocessor-block-finish-global
-    - match: (?=^\s*#\s*(elif|else)\b)
+    - match: (?=^\s*#\s*(elif|elifdef|elifndef|else)\b)
       push: preprocessor-elif-else-branch-global
     - match: \}
       scope: punctuation.section.block.end.c++
@@ -2053,11 +2053,11 @@ contexts:
         - include: scope:source.c#preprocessor-comments
         - match: \bdefined\b
           scope: keyword.control.c++
-        # Enter a new scope where all elif/else branches have their
-        # contexts popped by a subsequent elif/else/endif. This ensures that
-        # preprocessor branches don't push multiple meta.block scopes on
-        # the stack, thus messing up the "global" context's detection of
-        # functions.
+        # Enter a new scope where all elif/elifdef/elifndef/else branches have
+        # their contexts popped by a subsequent elif/elifdef/elifndef/else/endif.
+        # This ensures that preprocessor branches don't push multiple meta.block
+        # scopes on the stack, thus messing up the "global" context's detection
+        # of functions.
         - match: $\n
           set: preprocessor-if-branch-statements
 
@@ -2069,7 +2069,7 @@ contexts:
       captures:
         1: meta.preprocessor.c++ keyword.control.import.c++
       pop: true
-    - match: (?=^\s*#\s*(elif|else)\b)
+    - match: (?=^\s*#\s*(elif|elifdef|elifndef|else)\b)
       push: preprocessor-elif-else-branch-statements
     - match: \{
       scope: punctuation.section.block.begin.c++
@@ -2100,7 +2100,7 @@ contexts:
     - match : \)
       scope: meta.function-call.c++ meta.group.c++ punctuation.section.group.end.c++
       set: preprocessor-if-branch-statements
-    - match: ^\s*(#\s*(?:elif|else))\b
+    - match: ^\s*(#\s*(?:elif|elifdef|elifndef|else))\b
       captures:
         1: meta.preprocessor.c++ keyword.control.import.c++
       set: preprocessor-if-branch-statements
@@ -2123,7 +2123,7 @@ contexts:
       captures:
         1: meta.preprocessor.c++ keyword.control.import.c++
       set: preprocessor-block-finish-statements
-    - match: (?=^\s*#\s*(elif|else)\b)
+    - match: (?=^\s*#\s*(elif|elifdef|elifndef|else)\b)
       push: preprocessor-elif-else-branch-statements
     - match: \}
       scope: punctuation.section.block.end.c++
@@ -2166,7 +2166,7 @@ contexts:
         - match: '\{'
           scope: punctuation.section.block.begin.c++
           pop: true
-        - match: (?=^\s*#\s*(elif|else|endif)\b)
+        - match: (?=^\s*#\s*(elif|elifdef|elifndef|else|endif)\b)
           pop: true
         - include: statements
 
@@ -2267,7 +2267,7 @@ contexts:
           pop: true
 
   preprocessor-other:
-    - match: ^\s*(#\s*(?:if|ifdef|ifndef|elif|else|line|pragma|undef))\b
+    - match: ^\s*(#\s*(?:if|ifdef|ifndef|elif|elifdef|elifndef|else|line|pragma|undef))\b
       captures:
         1: keyword.control.import.c++
       push:

--- a/C++/C.sublime-syntax
+++ b/C++/C.sublime-syntax
@@ -620,7 +620,7 @@ contexts:
         - match: '\}'
           scope: meta.function.c meta.block.c punctuation.section.block.end.c
           pop: true
-        - match: (?=^\s*#\s*(elif|else|endif)\b)
+        - match: (?=^\s*#\s*(elif|elifdef|elifndef|else|endif)\b)
           pop: true
         - match: '(?=({{before_tag}})([^(;]+$|.*\{))'
           push: data-structures
@@ -775,7 +775,7 @@ contexts:
       scope: punctuation.section.block.begin.c
       push:
         - meta_scope: meta.block.c
-        - match: (?=^\s*#\s*(elif|else|endif)\b)
+        - match: (?=^\s*#\s*(elif|elifdef|elifndef|else|endif)\b)
           pop: true
         - match: '\}'
           scope: punctuation.section.block.end.c
@@ -1025,11 +1025,11 @@ contexts:
         - include: preprocessor-comments
         - match: \bdefined\b
           scope: keyword.control.c
-        # Enter a new scope where all elif/else branches have their
-        # contexts popped by a subsequent elif/else/endif. This ensures that
-        # preprocessor branches don't push multiple meta.block scopes on
-        # the stack, thus messing up the "global" context's detection of
-        # functions.
+        # Enter a new scope where all elif/elifdef/elifndef/else branches have
+        # their contexts popped by a subsequent elif/elifdef/elifndef/else/endif.
+        # This ensures that preprocessor branches don't push multiple meta.block
+        # scopes on the stack, thus messing up the "global" context's detection
+        # of functions.
         - match: $\n
           set: preprocessor-if-branch-global
 
@@ -1041,7 +1041,7 @@ contexts:
       captures:
         1: meta.preprocessor.c keyword.control.import.c
       pop: true
-    - match: (?=^\s*#\s*(elif|else)\b)
+    - match: (?=^\s*#\s*(elif|elifdef|elifndef|else)\b)
       push: preprocessor-elif-else-branch-global
     - match: \{
       scope: punctuation.section.block.begin.c
@@ -1056,7 +1056,7 @@ contexts:
       captures:
         1: meta.preprocessor.c keyword.control.import.c
       set: preprocessor-block-finish-global
-    - match: (?=^\s*#\s*(elif|else)\b)
+    - match: (?=^\s*#\s*(elif|elifdef|elifndef|else)\b)
       push: preprocessor-elif-else-branch-global
     - match: \}
       scope: punctuation.section.block.end.c
@@ -1144,11 +1144,11 @@ contexts:
         - include: preprocessor-comments
         - match: \bdefined\b
           scope: keyword.control.c
-        # Enter a new scope where all elif/else branches have their
-        # contexts popped by a subsequent elif/else/endif. This ensures that
-        # preprocessor branches don't push multiple meta.block scopes on
-        # the stack, thus messing up the "global" context's detection of
-        # functions.
+        # Enter a new scope where all elif/elifdef/elifndef/else branches have
+        # their contexts popped by a subsequent elif/elifdef/elifndef/else/endif.
+        # This ensures that preprocessor branches don't push multiple meta.block
+        # scopes on the stack, thus messing up the "global" context's detection
+        # of functions.
         - match: $\n
           set: preprocessor-if-branch-statements
 
@@ -1160,7 +1160,7 @@ contexts:
       captures:
         1: meta.preprocessor.c keyword.control.import.c
       pop: true
-    - match: (?=^\s*#\s*(elif|else)\b)
+    - match: (?=^\s*#\s*(elif|elifdef|elifndef|else)\b)
       push: preprocessor-elif-else-branch-statements
     - match: \{
       scope: punctuation.section.block.begin.c
@@ -1184,7 +1184,7 @@ contexts:
     - match : \)
       scope: meta.function-call.c meta.group.c punctuation.section.group.end.c
       set: preprocessor-if-branch-statements
-    - match: ^\s*(#\s*(?:elif|else))\b
+    - match: ^\s*(#\s*(?:elif|elifdef|elifndef|else))\b
       captures:
         1: meta.preprocessor.c keyword.control.import.c
       set: preprocessor-if-branch-statements
@@ -1207,7 +1207,7 @@ contexts:
       captures:
         1: meta.preprocessor.c keyword.control.import.c
       set: preprocessor-block-finish-statements
-    - match: (?=^\s*#\s*(elif|else)\b)
+    - match: (?=^\s*#\s*(elif|elifdef|elifndef|else)\b)
       push: preprocessor-elif-else-branch-statements
     - match: \}
       scope: punctuation.section.block.end.c
@@ -1250,7 +1250,7 @@ contexts:
         - match: '\{'
           scope: punctuation.section.block.begin.c
           pop: true
-        - match: (?=^\s*#\s*(elif|else|endif)\b)
+        - match: (?=^\s*#\s*(elif|elifdef|elifndef|else|endif)\b)
           pop: true
         - include: statements
 
@@ -1354,7 +1354,7 @@ contexts:
         - include: expressions
 
   preprocessor-other:
-    - match: ^\s*(#\s*(?:if|ifdef|ifndef|elif|else|line|pragma|undef))\b
+    - match: ^\s*(#\s*(?:if|ifdef|ifndef|elif|elifdef|elifndef|else|line|pragma|undef))\b
       captures:
         1: keyword.control.import.c
       push:

--- a/C++/Completion Rules.tmPreferences
+++ b/C++/Completion Rules.tmPreferences
@@ -6,7 +6,7 @@
 	<key>settings</key>
 	<dict>
 		<key>cancelCompletion</key>
-		<string>(^.*\bconst\s*$)|^\s*(\}?\s*(else|try|do|#if|#ifdef|#else|#elif|#endif|#pragma\s+once)|(class|struct|union|enum|namespace)\s*[a-zA-Z_0-9]+*)$</string>
+		<string>(^.*\bconst\s*$)|^\s*(\}?\s*(else|try|do|#if|#ifdef|#else|#elif|#elifdef|#elifndef|#endif|#pragma\s+once)|(class|struct|union|enum|namespace)\s*[a-zA-Z_0-9]+*)$</string>
 	</dict>
 </dict>
 </plist>

--- a/C++/syntax_test_c.c
+++ b/C++/syntax_test_c.c
@@ -589,9 +589,17 @@ int foo(int val, float val2[])
     if (val == -1) {
 /*  ^^ keyword.control */
 /*                 ^ meta.block meta.block punctuation.section.block.begin */
+#elifdef BAR
+ /* ^ meta.block meta.block */
+    if (val == -2) {
+/*                 ^ meta.block meta.block punctuation.section.block.begin */
+#elifndef BAZ
+ /* ^ meta.block meta.block */
+    if (val == -3) {
+/*                 ^ meta.block meta.block punctuation.section.block.begin */
 #else
  /* <- keyword.control.import */
-    if (val == -2) {
+    if (val == -4) {
 /*                 ^ meta.block meta.block punctuation.section.block.begin */
 #endif
  /* <- keyword.control.import */

--- a/C++/syntax_test_c.c
+++ b/C++/syntax_test_c.c
@@ -590,11 +590,11 @@ int foo(int val, float val2[])
 /*  ^^ keyword.control */
 /*                 ^ meta.block meta.block punctuation.section.block.begin */
 #elifdef BAR
- /* ^ meta.block meta.block */
+ /* <- keyword.control.import */
     if (val == -2) {
 /*                 ^ meta.block meta.block punctuation.section.block.begin */
 #elifndef BAZ
- /* ^ meta.block meta.block */
+ /* <- keyword.control.import */
     if (val == -3) {
 /*                 ^ meta.block meta.block punctuation.section.block.begin */
 #else

--- a/Objective-C/Objective-C++.sublime-syntax
+++ b/Objective-C/Objective-C++.sublime-syntax
@@ -364,7 +364,7 @@ contexts:
           scope: punctuation.section.block.begin.objc++
           set:
             - meta_scope: meta.block.objc++
-            - match: (?=^\s*#\s*(elif|else|endif)\b)
+            - match: (?=^\s*#\s*(elif|elifdef|elifndef|else|endif)\b)
               pop: true
             - match: (?=@end\b)
               pop: true
@@ -740,7 +740,7 @@ contexts:
       scope: punctuation.section.block.begin.objc++
       push:
         - meta_scope: meta.block.objc++
-        - match: (?=^\s*#\s*(elif|else|endif)\b)
+        - match: (?=^\s*#\s*(elif|elifdef|elifndef|else|endif)\b)
           pop: true
         - match: '\}'
           scope: punctuation.section.block.end.objc++
@@ -1169,7 +1169,7 @@ contexts:
         - match: '\}'
           scope: meta.function.objc++ meta.block.objc++ punctuation.section.block.end.objc++
           pop: true
-        - match: (?=^\s*#\s*(elif|else|endif)\b)
+        - match: (?=^\s*#\s*(elif|elifdef|elifndef|else|endif)\b)
           pop: true
         - match: '(?=({{before_tag}})([^(;]+$|.*\{))'
           push: data-structures
@@ -1667,7 +1667,7 @@ contexts:
         - match: '\}'
           scope: meta.method.objc++ meta.block.objc++ punctuation.section.block.end.objc++
           pop: true
-        - match: (?=^\s*#\s*(elif|else|endif)\b)
+        - match: (?=^\s*#\s*(elif|elifdef|elifndef|else|endif)\b)
           pop: true
         - match: '(?=({{before_tag}})([^(;]+$|.*\{))'
           push: data-structures
@@ -1814,11 +1814,11 @@ contexts:
         - include: scope:source.c#preprocessor-comments
         - match: \bdefined\b
           scope: keyword.control.objc++
-        # Enter a new scope where all elif/else branches have their
-        # contexts popped by a subsequent elif/else/endif. This ensures that
-        # preprocessor branches don't push multiple meta.block scopes on
-        # the stack, thus messing up the "global" context's detection of
-        # functions.
+        # Enter a new scope where all elif/elifdef/elifndef/else branches have
+        # their contexts popped by a subsequent elif/elifdef/elifndef/else/endif.
+        # This ensures that preprocessor branches don't push multiple meta.block
+        # scopes on the stack, thus messing up the "global" context's detection
+        # of functions.
         - match: $\n
           set: preprocessor-if-branch-global
 
@@ -1830,7 +1830,7 @@ contexts:
       captures:
         1: meta.preprocessor.objc++ keyword.control.import.objc++
       pop: true
-    - match: (?=^\s*#\s*(elif|else)\b)
+    - match: (?=^\s*#\s*(elif|elifdef|elifndef|else)\b)
       push: preprocessor-elif-else-branch-global
     - match: \{
       scope: punctuation.section.block.begin.objc++
@@ -1845,7 +1845,7 @@ contexts:
       captures:
         1: meta.preprocessor.objc++ keyword.control.import.objc++
       set: preprocessor-block-finish-global
-    - match: (?=^\s*#\s*(elif|else)\b)
+    - match: (?=^\s*#\s*(elif|elifdef|elifndef|else)\b)
       push: preprocessor-elif-else-branch-global
     - match: \}
       scope: punctuation.section.block.end.objc++
@@ -1944,11 +1944,11 @@ contexts:
         - include: scope:source.c#preprocessor-comments
         - match: \bdefined\b
           scope: keyword.control.objc++
-        # Enter a new scope where all elif/else branches have their
-        # contexts popped by a subsequent elif/else/endif. This ensures that
-        # preprocessor branches don't push multiple meta.block scopes on
-        # the stack, thus messing up the "global" context's detection of
-        # functions.
+        # Enter a new scope where all elif/elifdef/elifndef/else branches have
+        # their contexts popped by a subsequent elif/elifdef/elifndef/else/endif.
+        # This ensures that preprocessor branches don't push multiple meta.block
+        # scopes on the stack, thus messing up the "global" context's detection
+        # of functions.
         - match: $\n
           set: preprocessor-if-branch-statements
 
@@ -1960,7 +1960,7 @@ contexts:
       captures:
         1: meta.preprocessor.objc++ keyword.control.import.objc++
       pop: true
-    - match: (?=^\s*#\s*(elif|else)\b)
+    - match: (?=^\s*#\s*(elif|elifdef|elifndef|else)\b)
       push: preprocessor-elif-else-branch-statements
     - match: \{
       scope: punctuation.section.block.begin.objc++
@@ -1991,7 +1991,7 @@ contexts:
     - match : \)
       scope: meta.function-call.objc++ meta.group.objc++ punctuation.section.group.end.objc++
       set: preprocessor-if-branch-statements
-    - match: ^\s*(#\s*(?:elif|else))\b
+    - match: ^\s*(#\s*(?:elif|elifdef|elifndef|else))\b
       captures:
         1: meta.preprocessor.objc++ keyword.control.import.objc++
       set: preprocessor-if-branch-statements
@@ -2014,7 +2014,7 @@ contexts:
       captures:
         1: meta.preprocessor.objc++ keyword.control.import.objc++
       set: preprocessor-block-finish-statements
-    - match: (?=^\s*#\s*(elif|else)\b)
+    - match: (?=^\s*#\s*(elif|elifdef|elifndef|else)\b)
       push: preprocessor-elif-else-branch-statements
     - match: \}
       scope: punctuation.section.block.end.objc++
@@ -2057,7 +2057,7 @@ contexts:
         - match: '\{'
           scope: punctuation.section.block.begin.objc++
           pop: true
-        - match: (?=^\s*#\s*(elif|else|endif)\b)
+        - match: (?=^\s*#\s*(elif|elifdef|elifndef|else|endif)\b)
           pop: true
         - include: statements
 
@@ -2141,7 +2141,7 @@ contexts:
     - include: expressions
 
   preprocessor-other:
-    - match: ^\s*(#\s*(?:if|ifdef|ifndef|elif|else|line|pragma|undef))\b
+    - match: ^\s*(#\s*(?:if|ifdef|ifndef|elif|elifdef|elifndef|else|line|pragma|undef))\b
       captures:
         1: keyword.control.import.objc++
       push:

--- a/Objective-C/Objective-C.sublime-syntax
+++ b/Objective-C/Objective-C.sublime-syntax
@@ -423,7 +423,7 @@ contexts:
           scope: punctuation.section.block.begin.objc
           set:
             - meta_scope: meta.block.objc
-            - match: (?=^\s*#\s*(elif|else|endif)\b)
+            - match: (?=^\s*#\s*(elif|elifdef|elifndef|else|endif)\b)
               pop: true
             - match: (?=@end\b)
               pop: true
@@ -649,7 +649,7 @@ contexts:
         - match: '\}'
           scope: meta.function.objc meta.block.objc punctuation.section.block.end.objc
           pop: true
-        - match: (?=^\s*#\s*(elif|else|endif)\b)
+        - match: (?=^\s*#\s*(elif|elifdef|elifndef|else|endif)\b)
           pop: true
         - match: '(?=({{before_tag}})([^(;]+$|.*\{))'
           push: data-structures
@@ -804,7 +804,7 @@ contexts:
       scope: punctuation.section.block.begin.objc
       push:
         - meta_scope: meta.block.objc
-        - match: (?=^\s*#\s*(elif|else|endif)\b)
+        - match: (?=^\s*#\s*(elif|elifdef|elifndef|else|endif)\b)
           pop: true
         - match: '\}'
           scope: punctuation.section.block.end.objc
@@ -1065,11 +1065,11 @@ contexts:
         - include: scope:source.c#preprocessor-comments
         - match: \bdefined\b
           scope: keyword.control.objc
-        # Enter a new scope where all elif/else branches have their
-        # contexts popped by a subsequent elif/else/endif. This ensures that
-        # preprocessor branches don't push multiple meta.block scopes on
-        # the stack, thus messing up the "global" context's detection of
-        # functions.
+        # Enter a new scope where all elif/elifdef/elifndef/else branches have
+        # their contexts popped by a subsequent elif/elifdef/elifndef/else/endif.
+        # This ensures that preprocessor branches don't push multiple meta.block
+        # scopes on the stack, thus messing up the "global" context's detection
+        # of functions.
         - match: $\n
           set: preprocessor-if-branch-global
 
@@ -1081,7 +1081,7 @@ contexts:
       captures:
         1: meta.preprocessor.objc keyword.control.import.objc
       pop: true
-    - match: (?=^\s*#\s*(elif|else)\b)
+    - match: (?=^\s*#\s*(elif|elifdef|elifndef|else)\b)
       push: preprocessor-elif-else-branch-global
     - match: \{
       scope: punctuation.section.block.begin.objc
@@ -1096,7 +1096,7 @@ contexts:
       captures:
         1: meta.preprocessor.objc keyword.control.import.objc
       set: preprocessor-block-finish-global
-    - match: (?=^\s*#\s*(elif|else)\b)
+    - match: (?=^\s*#\s*(elif|elifdef|elifndef|else)\b)
       push: preprocessor-elif-else-branch-global
     - match: \}
       scope: punctuation.section.block.end.objc
@@ -1195,11 +1195,11 @@ contexts:
         - include: scope:source.c#preprocessor-comments
         - match: \bdefined\b
           scope: keyword.control.objc
-        # Enter a new scope where all elif/else branches have their
-        # contexts popped by a subsequent elif/else/endif. This ensures that
-        # preprocessor branches don't push multiple meta.block scopes on
-        # the stack, thus messing up the "global" context's detection of
-        # functions.
+        # Enter a new scope where all elif/elifdef/elifndef/else branches have
+        # their contexts popped by a subsequent elif/elifdef/elifndef/else/endif.
+        # This ensures that preprocessor branches don't push multiple meta.block
+        # scopes on the stack, thus messing up the "global" context's detection
+        # of functions.
         - match: $\n
           set: preprocessor-if-branch-statements
 
@@ -1211,7 +1211,7 @@ contexts:
       captures:
         1: meta.preprocessor.objc keyword.control.import.objc
       pop: true
-    - match: (?=^\s*#\s*(elif|else)\b)
+    - match: (?=^\s*#\s*(elif|elifdef|elifndef|else)\b)
       push: preprocessor-elif-else-branch-statements
     - match: \{
       scope: punctuation.section.block.begin.objc
@@ -1235,7 +1235,7 @@ contexts:
     - match : \)
       scope: meta.function-call.objc meta.group.objc punctuation.section.group.end.objc
       set: preprocessor-if-branch-statements
-    - match: ^\s*(#\s*(?:elif|else))\b
+    - match: ^\s*(#\s*(?:elif|elifdef|elifndef|else))\b
       captures:
         1: meta.preprocessor.objc keyword.control.import.objc
       set: preprocessor-if-branch-statements
@@ -1258,7 +1258,7 @@ contexts:
       captures:
         1: meta.preprocessor.objc keyword.control.import.objc
       set: preprocessor-block-finish-statements
-    - match: (?=^\s*#\s*(elif|else)\b)
+    - match: (?=^\s*#\s*(elif|elifdef|elifndef|else)\b)
       push: preprocessor-elif-else-branch-statements
     - match: \}
       scope: punctuation.section.block.end.objc
@@ -1301,7 +1301,7 @@ contexts:
         - match: '\{'
           scope: punctuation.section.block.begin.objc
           pop: true
-        - match: (?=^\s*#\s*(elif|else|endif)\b)
+        - match: (?=^\s*#\s*(elif|elifdef|elifndef|else|endif)\b)
           pop: true
         - include: statements
 
@@ -1375,7 +1375,7 @@ contexts:
     - include: expressions
 
   preprocessor-other:
-    - match: ^\s*(#\s*(?:if|ifdef|ifndef|elif|else|line|pragma|undef))\b
+    - match: ^\s*(#\s*(?:if|ifdef|ifndef|elif|elifdef|elifndef|else|line|pragma|undef))\b
       captures:
         1: keyword.control.import.objc
       push:

--- a/Objective-C/syntax_test_objc.m
+++ b/Objective-C/syntax_test_objc.m
@@ -534,9 +534,17 @@ int foo(int val, float val2[])
 
     if (val == -1) {
 /*                 ^ meta.block meta.block punctuation.section.block.begin */
+#elifdef BAR
+ /* ^ meta.block meta.block */
+    if (val == -2) {
+/*                 ^ meta.block meta.block punctuation.section.block.begin */
+#elifndef BAZ
+ /* ^ meta.block meta.block */
+    if (val == -3) {
+/*                 ^ meta.block meta.block punctuation.section.block.begin */
 #else
  /* <- keyword.control.import */
-    if (val == -2) {
+    if (val == -4) {
 /*                 ^ meta.block meta.block punctuation.section.block.begin */
 #endif
  /* <- keyword.control.import */

--- a/Objective-C/syntax_test_objc.m
+++ b/Objective-C/syntax_test_objc.m
@@ -535,11 +535,11 @@ int foo(int val, float val2[])
     if (val == -1) {
 /*                 ^ meta.block meta.block punctuation.section.block.begin */
 #elifdef BAR
- /* ^ meta.block meta.block */
+ /* <- keyword.control.import */
     if (val == -2) {
 /*                 ^ meta.block meta.block punctuation.section.block.begin */
 #elifndef BAZ
- /* ^ meta.block meta.block */
+ /* <- keyword.control.import */
     if (val == -3) {
 /*                 ^ meta.block meta.block punctuation.section.block.begin */
 #else


### PR DESCRIPTION
This adds support for the new #elifdef and #elifndef preprocessor directives that are a combination of #else with #ifdef or #ifndef.

C++, Objective-C, and Objective-C++ are also updated because they derive from the C syntax family as well.

This has already made it into recent C and C++ compilers and is part of the C23 and C++23 standards.