### PR TITLE
[C] Add support for binary file inclusion preprocessor directive

### DIFF
--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -2291,7 +2291,7 @@ contexts:
         - include: strings
         - match: '\S+'
           scope: string.unquoted.c++
-    - match: ^\s*(#\s*(?:include|include_next|import))\b
+    - match: ^\s*(#\s*(?:include|include_next|embed|import))\b
       captures:
         1: keyword.control.import.include.c++
       push:

--- a/C++/C.sublime-syntax
+++ b/C++/C.sublime-syntax
@@ -1378,7 +1378,7 @@ contexts:
         - include: strings
         - match: '\S+'
           scope: string.unquoted.c
-    - match: ^\s*(#\s*(?:include|include_next|import))\b
+    - match: ^\s*(#\s*(?:include|include_next|embed|import))\b
       captures:
         1: keyword.control.import.include.c
       push:

--- a/C++/syntax_test_c.c
+++ b/C++/syntax_test_c.c
@@ -812,6 +812,11 @@ func_call(foo
 /*                   ^ punctuation.definition.string.end */
 #endif
 
+static const unsigned char image_png[] = {
+#embed <image.png>
+/* <- keyword.control.import.include */
+};
+
 #include<iostream>
 /* <- keyword.control.import.include */
 /*      ^ punctuation.definition.string.begin */

--- a/Objective-C/Objective-C++.sublime-syntax
+++ b/Objective-C/Objective-C++.sublime-syntax
@@ -2165,7 +2165,7 @@ contexts:
         - include: strings
         - match: '\S+'
           scope: string.unquoted.objc++
-    - match: ^\s*(#\s*(?:include|include_next))\b
+    - match: ^\s*(#\s*(?:include|include_next|embed))\b
       captures:
         1: keyword.control.import.include.objc++
       push:

--- a/Objective-C/Objective-C.sublime-syntax
+++ b/Objective-C/Objective-C.sublime-syntax
@@ -1400,7 +1400,7 @@ contexts:
         - include: strings
         - match: '\S+'
           scope: string.unquoted.objc
-    - match: ^\s*(#\s*(?:include|include_next))\b
+    - match: ^\s*(#\s*(?:include|include_next|embed))\b
       captures:
         1: keyword.control.import.include.objc
       push:

--- a/Objective-C/syntax_test_objc.m
+++ b/Objective-C/syntax_test_objc.m
@@ -809,6 +809,11 @@ NSPredicate *predicate = [NSPredicate predicateWithFormat:@"%K like %@",
 /*                   ^ punctuation.definition.string.end */
 #endif
 
+static const unsigned char image_png[] = {
+#embed <image.png>
+/* <- keyword.control.import.include */
+};
+
 #include<iostream>
 /* <- keyword.control.import.include */
 /*      ^ punctuation.definition.string.begin */


### PR DESCRIPTION
This adds support for the new #embed preprocessor directive that can be used to directly include binary files into program variables without the use of external code generators.

C++, Objective-C, and Objective-C++ are also updated because they derive from the C syntax family as well.

This has already made it into recent C and C++ compilers and is also part of the C23 standard.