### PR TITLE
[C] Add support for nullptr keyword

### DIFF
--- a/C++/C.sublime-syntax
+++ b/C++/C.sublime-syntax
@@ -215,7 +215,7 @@ contexts:
       scope: constant.language.boolean.false.c
     - match: \b(true|TRUE)\b
       scope: constant.language.boolean.true.c
-    - match: \bNULL\b
+    - match: \b(nullptr|NULL)\b
       scope: constant.language.null.c
     - match: \b__func__\b
       scope: constant.language.c

--- a/C++/syntax_test_c.c
+++ b/C++/syntax_test_c.c
@@ -295,6 +295,12 @@ bool still_C_code_here = true;
 /* <- storage.type */
 /*                       ^ constant.language */
 
+void *null_pointer1 = NULL;
+                    /* ^ constant.language.null */
+
+void *null_pointer2 = nullptr;
+                    /* ^ constant.language.null */
+
 FOOBAR
 hello() {
     /* <- meta.function entity.name.function */


### PR DESCRIPTION
It was added in C23 and is effectively an alias for the NULL macro already in use, so it is just treated as an alias for the existing null constant.