### PR TITLE
[C] Add support for static_assert and its aliases

### DIFF
--- a/C++/C.sublime-syntax
+++ b/C++/C.sublime-syntax
@@ -48,7 +48,7 @@ variables:
   type_qualifier: 'const|volatile'
   compiler_directive: 'inline|restrict|__restrict__|__restrict'
   modifiers: '{{storage_classes}}|{{type_qualifier}}|{{compiler_directive}}'
-  non_func_keywords: 'if|for|switch|while|decltype|typeof|typeof_unqual|sizeof|__declspec|__attribute__'
+  non_func_keywords: 'if|for|switch|while|decltype|typeof|typeof_unqual|sizeof|static_assert|_Static_assert|__declspec|__attribute__'
 
 contexts:
   main:
@@ -197,7 +197,7 @@ contexts:
       scope: keyword.control.flow.return.c
     - match: \b({{control_keywords}})\b
       scope: keyword.control.c
-    - match: \bsizeof\b
+    - match: \b(sizeof|static_assert|_Static_assert)\b
       scope: keyword.operator.word.c
 
   modifiers:

--- a/C++/syntax_test_c.c
+++ b/C++/syntax_test_c.c
@@ -218,6 +218,12 @@ typeof_unqual(i) dt;
 /*           ^ punctuation.section.group.begin */
 /*             ^ punctuation.section.group.end */
 
+static_assert(sizeof(int) == 4);
+/* <- keyword.operator.word */
+
+_Static_assert(sizeof(int) == 4);
+/* <- keyword.operator.word */
+
 void build_default_prototype(Function *ret) {
     static typeof(*ret->params) params[4];
            /* <- keyword.declaration.type */


### PR DESCRIPTION
This was first added in C11 but has since been revised by C23. It functions like sizeof in that it takes an argument as if it were a function so we implement it as an extension of sizeof.