### PR TITLE
[C] Update keywords-parens for alignof and static_assert

### DIFF
--- a/C++/C.sublime-syntax
+++ b/C++/C.sublime-syntax
@@ -854,7 +854,7 @@ contexts:
           scope: constant.other.c
 
   keywords-parens:
-    - match: '\b(sizeof)\b\s*(\()'
+    - match: '\b(sizeof|alignof|_Alignof|static_assert|_Static_assert)\b\s*(\()'
       captures:
         1: keyword.operator.word.c
         2: meta.group.c punctuation.section.group.begin.c


### PR DESCRIPTION
I overlooked this previously but I believe this is an optimization for sizeof that would also apply these two that I previously added.