### PR TITLE
[XML] Restrict tag snippets

### DIFF
--- a/XML/Snippets/xml-cdata.sublime-snippet
+++ b/XML/Snippets/xml-cdata.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
-	<description>CDATA</description>
 	<content>&lt;![CDATA[${0:$SELECTION}]]&gt;</content>
 	<tabTrigger>cdata</tabTrigger>
 	<scope>text.xml</scope>
+	<description>CDATA</description>
 </snippet>

--- a/XML/Snippets/xml-declaration.sublime-snippet
+++ b/XML/Snippets/xml-declaration.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[<?xml version="1.0" encoding="UTF-8"?>]]></content>
 	<tabTrigger>xml-declaration</tabTrigger>
-	<scope>text.xml</scope>
+	<scope>text.xml - text.xml meta.tag - text.xml meta.embedded - text.xml meta.interpolation - text.xml comment - text.xml string - text.xml source</scope>
 	<description>XML Declaration</description>
 </snippet>

--- a/XML/Snippets/xml-long-tag.sublime-snippet
+++ b/XML/Snippets/xml-long-tag.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[<${1:p}>${0:$SELECTION}</${1/([^ ]+).*/$1/}>]]></content>
 	<tabTrigger>lt</tabTrigger>
-	<scope>text.xml - meta.tag - comment - string</scope>
+	<scope>text.xml - text.xml meta.tag - text.xml meta.embedded - text.xml meta.interpolation - text.xml comment - text.xml string - text.xml source</scope>
 	<description>Long Tag</description>
 </snippet>

--- a/XML/Snippets/xml-model.sublime-snippet
+++ b/XML/Snippets/xml-model.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[<?xml-model href="${1:http://}" schematypens="${2:http://}"?>$0]]></content>
 	<tabTrigger>xml-model</tabTrigger>
-	<scope>text.xml</scope>
+	<scope>text.xml - text.xml meta.tag - text.xml meta.embedded - text.xml meta.interpolation - text.xml comment - text.xml string - text.xml source</scope>
 	<description>XML Model</description>
 </snippet>

--- a/XML/Snippets/xml-short-tag.sublime-snippet
+++ b/XML/Snippets/xml-short-tag.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[<${1:name} />]]></content>
 	<tabTrigger>st</tabTrigger>
-	<scope>text.xml - meta.tag - comment - string</scope>
+	<scope>text.xml - text.xml meta.tag - text.xml meta.embedded - text.xml meta.interpolation - text.xml comment - text.xml string - text.xml source</scope>
 	<description>Short Tag</description>
 </snippet>

--- a/XML/Snippets/xml-stylesheet.sublime-snippet
+++ b/XML/Snippets/xml-stylesheet.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[<?xml-stylesheet type='${2:text/xsd}' href='${2:file.xsd}'?>$0]]></content>
 	<tabTrigger>xml-stylesheet</tabTrigger>
-	<scope>text.xml</scope>
+	<scope>text.xml - text.xml meta.tag - text.xml meta.embedded - text.xml meta.interpolation - text.xml comment - text.xml string - text.xml source</scope>
 	<description>XML Stylesheet</description>
 </snippet>


### PR DESCRIPTION
This commit makes sure to only provide XML tag snippets in top-level contexts by excluding them from `meta.tag`, comments, strings and possible embedded or interpolated expressions.

Inspired by PR #4056