### PR TITLE
[HTML] Restrict main HTML snippet

### DIFF
--- a/HTML/Snippets/html (begin tag).sublime-snippet
+++ b/HTML/Snippets/html (begin tag).sublime-snippet
@@ -11,6 +11,9 @@ $0
 </body>
 </html>]]></content>
 	<tabTrigger>html</tabTrigger>
-	<scope>text.html entity.name.tag, text.html meta.character.less-than</scope>
+	<scope>
+		(text.html entity.name.tag, text.html meta.character.less-than)
+		- (text.html.markdown - markup.raw.code-fence text.html)
+	</scope>
 	<description>html</description>
 </snippet>

--- a/HTML/Snippets/html.sublime-snippet
+++ b/HTML/Snippets/html.sublime-snippet
@@ -11,6 +11,17 @@ $0
 </body>
 </html>]]></content>
 	<tabTrigger>html</tabTrigger>
-	<scope>text.html - (meta.tag | meta.character.less-than) - source.php</scope>
+	<scope>
+		text.html
+		- text.html meta.tag
+		- text.html meta.character.less-than
+		- text.html meta.embedded
+		- text.html meta.interpolation
+		- text.html meta.string
+		- text.html source
+		- text.html comment
+		- text.html string
+		- (text.html.markdown - markup.raw.code-fence text.html)
+	</scope>
 	<description>html</description>
 </snippet>


### PR DESCRIPTION
This PR disables `html` snippet in ...

- comments
- literal or interpolated strings
- embedded or interpolated code blocks (from template languages)
- HTML tags
- Markdown files (but not in fenced code blocks)

Using `- text.html <scope>` in order to only exclude scopes belonging to possibly embedded HTML code block in question.

This is required to enable snippets if HTML is embedded in `source` code,

    source.astro text.html

but disable it in embedded CSS/JS or any other source code.

    text.html source.css

This PR is related with and triggered by https://github.com/SublimeText/Astro/issues/10 as an example of why it is important to correctly prefix negative scopes.