### PR TITLE
[HTML] Fix auto completion selectors

### DIFF
--- a/HTML/HTML.sublime-settings
+++ b/HTML/HTML.sublime-settings
@@ -6,10 +6,8 @@
     // Can be a list of strings which are joined before matching.
     "default_completions_selector": [
         // Plain HTML
-        "text.html - source - string - text.html.markdown, ",
+        "text.html - text.html meta.embedded - text.html meta.interpolation - text.html source - (text.html.markdown - markup.raw.code-fence text.html), ",
         // Embedded HTML blocks
-        "text.html.embedded - text.html.embedded source, ",
-        // Markdown fenced code blocks
-        "markup.raw.code-fence text.html - markup.raw.code-fence text.html source"
+        "text.html.embedded - text.html.embedded meta.embedded - text.html.embedded meta.interpolation - text.html.embedded source",
     ]
 }


### PR DESCRIPTION
This PR updates default HTML completions selector to...

1. enable auto completions if HTML is embedded in source code

   Current `text.html - source` disables completions if HTML is embedded, resulting in a scope like `source.astro text.html`.

2. but still disable them in embedded CSS/JS/JSON/... source code

   by `text.html - text.html source`

3. disable them in embedded/interpolated template tags

4. merge Markdown specific selectors into first line

   by `text.html ... - (text.html.markdown - markup.raw.code-fence text.html)`

   in order to avoid duplicating all negative selectors again.

   For those who want HTML tag completions in Markdown, they can remove that part.

This PR addresses https://github.com/SublimeText/Astro/issues/10 as an example of why it is important to correctly prefix negative scopes.