### PR TITLE
[C] Add atomic type aliases

### DIFF
--- a/C++/C.sublime-syntax
+++ b/C++/C.sublime-syntax
@@ -42,6 +42,7 @@ variables:
   before_tag: 'struct|union|enum'
   microsoft_types: '__int8|__int16|__int32|__int64'
   windows_types: 'APIENTRY|ATOM|BOOL|BOOLEAN|BYTE|CALLBACK|CCHAR|CHAR|COLORREF|CONST|DWORD|DWORDLONG|DWORD_PTR|DWORD32|DWORD64|FLOAT|HACCEL|HALF_PTR|HANDLE|HBITMAP|HBRUSH|HCOLORSPACE|HCONV|HCONVLIST|HCURSOR|HDC|HDDEDATA|HDESK|HDROP|HDWP|HENHMETAFILE|HFILE|HFONT|HGDIOBJ|HGLOBAL|HHOOK|HICON|HINSTANCE|HKEY|HKL|HLOCAL|HMENU|HMETAFILE|HMODULE|HMONITOR|HPALETTE|HPEN|HRESULT|HRGN|HRSRC|HSZ|HWINSTA|HWND|INT|INT_PTR|INT8|INT16|INT32|INT64|LANGID|LCID|LCTYPE|LGRPID|LONG|LONGLONG|LONG_PTR|LONG32|LONG64|LPARAM|LPBOOL|LPBYTE|LPCOLORREF|LPCSTR|LPCTSTR|LPCVOID|LPCWSTR|LPDWORD|LPHANDLE|LPINT|LPLONG|LPSTR|LPTSTR|LPVOID|LPWORD|LPWSTR|LRESULT|PBOOL|PBOOLEAN|PBYTE|PCHAR|PCSTR|PCTSTR|PCWSTR|PDWORD|PDWORDLONG|PDWORD_PTR|PDWORD32|PDWORD64|PFLOAT|PHALF_PTR|PHANDLE|PHKEY|PINT|PINT_PTR|PINT8|PINT16|PINT32|PINT64|PLCID|PLONG|PLONGLONG|PLONG_PTR|PLONG32|PLONG64|POINTER_32|POINTER_64|POINTER_SIGNED|POINTER_UNSIGNED|PSHORT|PSIZE_T|PSSIZE_T|PSTR|PTBYTE|PTCHAR|PTSTR|PUCHAR|PUHALF_PTR|PUINT|PUINT_PTR|PUINT8|PUINT16|PUINT32|PUINT64|PULONG|PULONGLONG|PULONG_PTR|PULONG32|PULONG64|PUSHORT|PVOID|PWCHAR|PWORD|PWSTR|QWORD|SC_HANDLE|SC_LOCK|SERVICE_STATUS_HANDLE|SHORT|SIZE_T|SSIZE_T|TBYTE|TCHAR|UCHAR|UHALF_PTR|UINT|UINT_PTR|UINT8|UINT16|UINT32|UINT64|ULONG|ULONGLONG|ULONG_PTR|ULONG32|ULONG64|UNICODE_STRING|USHORT|USN|VOID|WCHAR|WINAPI|WORD|WPARAM'
+  stdatomic: 'atomic_(bool|char|schar|uchar|short|ushort|int|uint|long|ulong|llong|ullong|char8_t|char16_t|char32_t|wchar_t|int_least8_t|uint_least8_t|int_least16_t|uint_least16_t|int_least32_t|uint_least32_t|int_least64_t|uint_least64_t|int_fast8_t|uint_fast8_t|int_fast16_t|uint_fast16_t|int_fast32_t|uint_fast32_t|int_fast64_t|uint_fast64_t|intptr_t|uintptr_t|size_t|ptrdiff_t|intmax_t|uintmax_t)'
   stdint: 'int8_t|int16_t|int32_t|int64_t|uint8_t|uint16_t|uint32_t|uint64_t|int_least8_t|int_least16_t|int_least32_t|int_least64_t|uint_least8_t|uint_least16_t|uint_least32_t|uint_least64_t|int_fast8_t|int_fast16_t|int_fast32_t|int_fast64_t|uint_fast8_t|uint_fast16_t|uint_fast32_t|uint_fast64_t|intptr_t|uintptr_t|intmax_t|intmax_t|uintmax_t|uintmax_t'
   stddef: 'size_t|ptrdiff_t|max_align_t|nullptr_t'
   wchar: 'wchar_t|wint_t|wctrans_t|wctype_t'
@@ -243,6 +244,8 @@ contexts:
       scope: support.type.sys-types.c
     - match: \b(pthread_attr_t|pthread_cond_t|pthread_condattr_t|pthread_mutex_t|pthread_mutexattr_t|pthread_once_t|pthread_rwlock_t|pthread_rwlockattr_t|pthread_t|pthread_key_t)\b
       scope: support.type.pthread.c
+    - match: \b({{stdatomic}})\b
+      scope: support.type.stdatomic.c
     - match: \b({{stdint}})\b
       scope: support.type.stdint.c
     - match: \b({{stddef}})\b

--- a/C++/syntax_test_c.c
+++ b/C++/syntax_test_c.c
@@ -319,6 +319,120 @@ bool still_C_code_here = true;
 /* <- storage.type */
 /*                       ^ constant.language */
 
+atomic_bool atomic_bool_var;
+/* <- support.type.stdatomic */
+
+atomic_char atomic_char_var;
+/* <- support.type.stdatomic */
+
+atomic_schar atomic_schar_var;
+/* <- support.type.stdatomic */
+
+atomic_uchar atomic_uchar_var;
+/* <- support.type.stdatomic */
+
+atomic_short atomic_short_var;
+/* <- support.type.stdatomic */
+
+atomic_ushort atomic_ushort_var;
+/* <- support.type.stdatomic */
+
+atomic_int atomic_int_var;
+/* <- support.type.stdatomic */
+
+atomic_uint atomic_uint_var;
+/* <- support.type.stdatomic */
+
+atomic_long atomic_long_var;
+/* <- support.type.stdatomic */
+
+atomic_ulong atomic_ulong_var;
+/* <- support.type.stdatomic */
+
+atomic_llong atomic_llong_var;
+/* <- support.type.stdatomic */
+
+atomic_ullong atomic_ullong_var;
+/* <- support.type.stdatomic */
+
+atomic_char8_t atomic_char8_t_var;
+/* <- support.type.stdatomic */
+
+atomic_char16_t atomic_char16_t_var;
+/* <- support.type.stdatomic */
+
+atomic_char32_t atomic_char32_t_var;
+/* <- support.type.stdatomic */
+
+atomic_wchar_t atomic_wchar_t_var;
+/* <- support.type.stdatomic */
+
+atomic_int_least8_t atomic_int_least8_t_var;
+/* <- support.type.stdatomic */
+
+atomic_uint_least8_t atomic_uint_least8_t_var;
+/* <- support.type.stdatomic */
+
+atomic_int_least16_t atomic_int_least16_t_var;
+/* <- support.type.stdatomic */
+
+atomic_uint_least16_t atomic_uint_least16_t_var;
+/* <- support.type.stdatomic */
+
+atomic_int_least32_t atomic_int_least32_t_var;
+/* <- support.type.stdatomic */
+
+atomic_uint_least32_t atomic_uint_least32_t_var;
+/* <- support.type.stdatomic */
+
+atomic_int_least64_t atomic_int_least64_t_var;
+/* <- support.type.stdatomic */
+
+atomic_uint_least64_t atomic_uint_least64_t_var;
+/* <- support.type.stdatomic */
+
+atomic_int_fast8_t atomic_int_fast8_t_var;
+/* <- support.type.stdatomic */
+
+atomic_uint_fast8_t atomic_uint_fast8_t_var;
+/* <- support.type.stdatomic */
+
+atomic_int_fast16_t atomic_int_fast16_t_var;
+/* <- support.type.stdatomic */
+
+atomic_uint_fast16_t atomic_uint_fast16_t_var;
+/* <- support.type.stdatomic */
+
+atomic_int_fast32_t atomic_int_fast32_t_var;
+/* <- support.type.stdatomic */
+
+atomic_uint_fast32_t atomic_uint_fast32_t_var;
+/* <- support.type.stdatomic */
+
+atomic_int_fast64_t atomic_int_fast64_t_var;
+/* <- support.type.stdatomic */
+
+atomic_uint_fast64_t atomic_uint_fast64_t_var;
+/* <- support.type.stdatomic */
+
+atomic_intptr_t atomic_intptr_t_var;
+/* <- support.type.stdatomic */
+
+atomic_uintptr_t atomic_uintptr_t_var;
+/* <- support.type.stdatomic */
+
+atomic_size_t atomic_size_t_var;
+/* <- support.type.stdatomic */
+
+atomic_ptrdiff_t atomic_ptrdiff_t_var;
+/* <- support.type.stdatomic */
+
+atomic_intmax_t atomic_intmax_t_var;
+/* <- support.type.stdatomic */
+
+atomic_uintmax_t atomic_uintmax_t_var;
+/* <- support.type.stdatomic */
+
 size_t size_t_var;
 /* <- support.type.stddef */
 


### PR DESCRIPTION
These were first defined in stdatomic.h in C11 and expanded on in C23. They're just atomic type aliases for a bunch of standard integer types.