### PR TITLE
[ShellScript] Fix variable length expansions

### DIFF
--- a/ShellScript/Zsh.sublime-syntax
+++ b/ShellScript/Zsh.sublime-syntax
@@ -432,14 +432,16 @@ contexts:
       captures:
         1: punctuation.definition.variable.shell
       push: zsh-parameter-subscription
+    # length operator has precedence over special parameters
+    - match: (\$)(\#?){{identifier}}
+      scope: meta.interpolation.parameter.shell variable.other.readwrite.shell
+      captures:
+        1: punctuation.definition.variable.shell
+        2: keyword.operator.expansion.length.shell
+      push: zsh-parameter-subscription
     # https://www.gnu.org/software/bash/manual/bash.html#Special-Parameters
     - match: (\$){{special_variables}}
       scope: variable.language.special.shell
-      captures:
-        1: punctuation.definition.variable.shell
-      push: zsh-parameter-subscription
-    - match: (\$){{identifier}}
-      scope: variable.other.readwrite.shell
       captures:
         1: punctuation.definition.variable.shell
       push: zsh-parameter-subscription

--- a/ShellScript/Zsh/tests/syntax_test_scope.zsh
+++ b/ShellScript/Zsh/tests/syntax_test_scope.zsh
@@ -1497,6 +1497,46 @@ function {
 ip=10.10.20.14
 #  ^^^^^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
+###############################################################################
+#  Special Parameters                                                         #
+###############################################################################
+
+# Expands to the number of positional parameters in decimal.
+: $# ${#} ${!#} ${##} _$#_
+# ^^ meta.interpolation.parameter.shell variable.language.special.shell
+# ^ punctuation.definition.variable.shell
+#    ^^^^ meta.interpolation.parameter.shell
+#    ^ punctuation.definition.variable.shell
+#     ^ punctuation.section.interpolation.begin.shell
+#      ^ variable.language.special.shell
+#       ^ punctuation.section.interpolation.end.shell
+#         ^^^^^ meta.interpolation.parameter.shell
+#         ^ punctuation.definition.variable.shell
+#          ^ punctuation.section.interpolation.begin.shell
+#           ^ keyword.operator.expansion.indirection.shell
+#            ^ variable.language.special.shell
+#             ^ punctuation.section.interpolation.end.shell
+#               ^^^^^ meta.interpolation.parameter.shell
+#               ^ punctuation.definition.variable.shell
+#                ^ punctuation.section.interpolation.begin.shell
+#                 ^ keyword.operator.expansion.length.shell
+#                  ^ variable.language.special.shell
+#                   ^ punctuation.section.interpolation.end.shell
+#                     ^ meta.string.glob.shell string.unquoted.shell
+#                      ^^^ meta.string.glob.shell meta.interpolation.parameter.shell variable.other.readwrite.shell
+
+: $#__ints {1..$#__hits}
+# ^^^^^^^^ meta.interpolation.parameter.shell meta.interpolation.parameter.shell variable.other.readwrite.shell
+# ^ punctuation.definition.variable.shell
+#  ^ keyword.operator.expansion.length.shell
+#          ^^^^^^^^^^^^^ meta.interpolation.brace.shell
+#          ^ punctuation.section.interpolation.begin.shell
+#           ^ meta.number.integer.decimal.shell constant.numeric.value.shell
+#            ^^ keyword.operator.range.shell
+#              ^^^^^^^^ meta.interpolation.parameter.shell meta.interpolation.parameter.shell variable.other.readwrite.shell
+#              ^ punctuation.definition.variable.shell
+#               ^ keyword.operator.expansion.length.shell
+#                      ^ punctuation.section.interpolation.end.shell
 
 ###############################################################################
 # 14.3 Parameter Expansion                                                    #


### PR DESCRIPTION
This commit fixes an syntax highlighting issue with `$#var` in ZSH.

In Bash `${#var}` is required to return length os a variable. 

In Zsh however `$#var` overrides special `$#` expansion.