### PR TITLE
[C] Add more ISO C types

### DIFF
--- a/C++/C.sublime-syntax
+++ b/C++/C.sublime-syntax
@@ -42,9 +42,18 @@ variables:
   before_tag: 'struct|union|enum'
   microsoft_types: '__int8|__int16|__int32|__int64'
   windows_types: 'APIENTRY|ATOM|BOOL|BOOLEAN|BYTE|CALLBACK|CCHAR|CHAR|COLORREF|CONST|DWORD|DWORDLONG|DWORD_PTR|DWORD32|DWORD64|FLOAT|HACCEL|HALF_PTR|HANDLE|HBITMAP|HBRUSH|HCOLORSPACE|HCONV|HCONVLIST|HCURSOR|HDC|HDDEDATA|HDESK|HDROP|HDWP|HENHMETAFILE|HFILE|HFONT|HGDIOBJ|HGLOBAL|HHOOK|HICON|HINSTANCE|HKEY|HKL|HLOCAL|HMENU|HMETAFILE|HMODULE|HMONITOR|HPALETTE|HPEN|HRESULT|HRGN|HRSRC|HSZ|HWINSTA|HWND|INT|INT_PTR|INT8|INT16|INT32|INT64|LANGID|LCID|LCTYPE|LGRPID|LONG|LONGLONG|LONG_PTR|LONG32|LONG64|LPARAM|LPBOOL|LPBYTE|LPCOLORREF|LPCSTR|LPCTSTR|LPCVOID|LPCWSTR|LPDWORD|LPHANDLE|LPINT|LPLONG|LPSTR|LPTSTR|LPVOID|LPWORD|LPWSTR|LRESULT|PBOOL|PBOOLEAN|PBYTE|PCHAR|PCSTR|PCTSTR|PCWSTR|PDWORD|PDWORDLONG|PDWORD_PTR|PDWORD32|PDWORD64|PFLOAT|PHALF_PTR|PHANDLE|PHKEY|PINT|PINT_PTR|PINT8|PINT16|PINT32|PINT64|PLCID|PLONG|PLONGLONG|PLONG_PTR|PLONG32|PLONG64|POINTER_32|POINTER_64|POINTER_SIGNED|POINTER_UNSIGNED|PSHORT|PSIZE_T|PSSIZE_T|PSTR|PTBYTE|PTCHAR|PTSTR|PUCHAR|PUHALF_PTR|PUINT|PUINT_PTR|PUINT8|PUINT16|PUINT32|PUINT64|PULONG|PULONGLONG|PULONG_PTR|PULONG32|PULONG64|PUSHORT|PVOID|PWCHAR|PWORD|PWSTR|QWORD|SC_HANDLE|SC_LOCK|SERVICE_STATUS_HANDLE|SHORT|SIZE_T|SSIZE_T|TBYTE|TCHAR|UCHAR|UHALF_PTR|UINT|UINT_PTR|UINT8|UINT16|UINT32|UINT64|ULONG|ULONGLONG|ULONG_PTR|ULONG32|ULONG64|UNICODE_STRING|USHORT|USN|VOID|WCHAR|WINAPI|WORD|WPARAM'
-  stdatomic: 'atomic_(bool|char|schar|uchar|short|ushort|int|uint|long|ulong|llong|ullong|char8_t|char16_t|char32_t|wchar_t|int_least8_t|uint_least8_t|int_least16_t|uint_least16_t|int_least32_t|uint_least32_t|int_least64_t|uint_least64_t|int_fast8_t|uint_fast8_t|int_fast16_t|uint_fast16_t|int_fast32_t|uint_fast32_t|int_fast64_t|uint_fast64_t|intptr_t|uintptr_t|size_t|ptrdiff_t|intmax_t|uintmax_t)'
+  complex: 'complex|imaginary'
+  fenv: 'fenv_t|fexcept_t'
+  setjmp: 'jmp_buf'
+  signal: 'sig_atomic_t'
+  stdarg: 'va_list'
+  stdatomic: 'atomic_(bool|char|schar|uchar|short|ushort|int|uint|long|ulong|llong|ullong|char8_t|char16_t|char32_t|wchar_t|int_least8_t|uint_least8_t|int_least16_t|uint_least16_t|int_least32_t|uint_least32_t|int_least64_t|uint_least64_t|int_fast8_t|uint_fast8_t|int_fast16_t|uint_fast16_t|int_fast32_t|uint_fast32_t|int_fast64_t|uint_fast64_t|intptr_t|uintptr_t|size_t|ptrdiff_t|intmax_t|uintmax_t|flag)|memory_order'
   stdint: 'int8_t|int16_t|int32_t|int64_t|uint8_t|uint16_t|uint32_t|uint64_t|int_least8_t|int_least16_t|int_least32_t|int_least64_t|uint_least8_t|uint_least16_t|uint_least32_t|uint_least64_t|int_fast8_t|int_fast16_t|int_fast32_t|int_fast64_t|uint_fast8_t|uint_fast16_t|uint_fast32_t|uint_fast64_t|intptr_t|uintptr_t|intmax_t|intmax_t|uintmax_t|uintmax_t'
+  stdio: 'FILE|fpos_t'
+  stdlib: 'div_t|ldiv_t|lldiv_t|imaxdiv_t'
   stddef: 'size_t|ptrdiff_t|max_align_t|nullptr_t'
+  time: 'time_t|clock_t'
+  threads: 'thrd_t|thrd_start_t|mtx_t|cnd_t|tss_t|tss_dtor_t|once_flag'
   wchar: 'wchar_t|wint_t|wctrans_t|wctype_t'
   uchar: 'mbstate_t|char8_t|char16_t|char32_t'
   declspec: '__declspec\(\s*\w+(?:\([^)]+\))?\s*\)'
@@ -240,20 +249,38 @@ contexts:
       scope: keyword.declaration.c
     - match: \b({{basic_types}})\b
       scope: storage.type.c
-    - match: \b(u_char|u_short|u_int|u_long|ushort|uint|u_quad_t|quad_t|qaddr_t|caddr_t|daddr_t|dev_t|fixpt_t|blkcnt_t|blksize_t|gid_t|in_addr_t|in_port_t|ino_t|key_t|mode_t|nlink_t|id_t|pid_t|off_t|segsz_t|swblk_t|uid_t|id_t|clock_t|ssize_t|time_t|useconds_t|suseconds_t)\b
+    - match: \b(u_char|u_short|u_int|u_long|ushort|uint|u_quad_t|quad_t|qaddr_t|caddr_t|daddr_t|dev_t|fixpt_t|blkcnt_t|blksize_t|gid_t|in_addr_t|in_port_t|ino_t|key_t|mode_t|nlink_t|id_t|pid_t|off_t|segsz_t|swblk_t|uid_t|id_t|ssize_t|useconds_t|suseconds_t)\b
       scope: support.type.sys-types.c
     - match: \b(pthread_attr_t|pthread_cond_t|pthread_condattr_t|pthread_mutex_t|pthread_mutexattr_t|pthread_once_t|pthread_rwlock_t|pthread_rwlockattr_t|pthread_t|pthread_key_t)\b
       scope: support.type.pthread.c
+    - match: \b({{complex}})\b
+      scope: support.type.complex.c
+    - match: \b({{fenv}})\b
+      scope: support.type.fenv.c
+    - match: \b({{setjmp}})\b
+      scope: support.type.setjmp.c
+    - match: \b({{signal}})\b
+      scope: support.type.signal.c
+    - match: \b({{stdarg}})\b
+      scope: support.type.stdarg.c
     - match: \b({{stdatomic}})\b
       scope: support.type.stdatomic.c
     - match: \b({{stdint}})\b
       scope: support.type.stdint.c
+    - match: \b({{stdio}})\b
+      scope: support.type.stdio.c
+    - match: \b({{stdlib}})\b
+      scope: support.type.stdlib.c
     - match: \b({{stddef}})\b
       scope: support.type.stddef.c
     - match: \b({{wchar}})\b
       scope: support.type.wchar.c
     - match: \b({{uchar}})\b
       scope: support.type.uchar.c
+    - match: \b({{time}})\b
+      scope: support.type.time.c
+    - match: \b({{threads}})\b
+      scope: support.type.threads.c
     - match: '\b({{microsoft_types}})\b'
       scope: support.type.microsoft.c
     - match: '\b({{windows_types}})\b'

--- a/C++/syntax_test_c.c
+++ b/C++/syntax_test_c.c
@@ -327,6 +327,27 @@ bool still_C_code_here = true;
 /* <- storage.type */
 /*                       ^ constant.language */
 
+complex complex_t_var;
+/* <- support.type.complex */
+
+imaginary imaginary_t_var;
+/* <- support.type.complex */
+
+fenv_t fenv_t_var;
+/* <- support.type.fenv */
+
+fexcept_t fexcept_t_var;
+/* <- support.type.fenv */
+
+jmp_buf jmp_buf_var;
+/* <- support.type.setjmp */
+
+sig_atomic_t sig_atomic_t_var;
+/* <- support.type.signal */
+
+va_list va_list_var;
+/* <- support.type.stdarg */
+
 atomic_bool atomic_bool_var;
 /* <- support.type.stdatomic */
 
@@ -441,6 +462,30 @@ atomic_intmax_t atomic_intmax_t_var;
 atomic_uintmax_t atomic_uintmax_t_var;
 /* <- support.type.stdatomic */
 
+atomic_flag atomic_flag_var;
+/* <- support.type.stdatomic */
+
+memory_order memory_order_var;
+/* <- support.type.stdatomic */
+
+FILE *FILE_var;
+/* <- support.type.stdio */
+
+fpos_t fpos_t_var;
+/* <- support.type.stdio */
+
+div_t div_t_var;
+/* <- support.type.stdlib */
+
+ldiv_t ldiv_t_var;
+/* <- support.type.stdlib */
+
+lldiv_t lldiv_t_var;
+/* <- support.type.stdlib */
+
+imaxdiv_t imaxdiv_t_var;
+/* <- support.type.stdlib */
+
 size_t size_t_var;
 /* <- support.type.stddef */
 
@@ -476,6 +521,33 @@ char16_t char16_t_var;
 
 char32_t char32_t_var;
 /* <- support.type.uchar */
+
+time_t time_t_var;
+/* <- support.type.time */
+
+clock_t clock_t_var;
+/* <- support.type.time */
+
+thrd_t thrd_t_var;
+/* <- support.type.threads */
+
+thrd_start_t thrd_start_t_var;
+/* <- support.type.threads */
+
+mtx_t mtx_t_var;
+/* <- support.type.threads */
+
+cnd_t cnd_t_var;
+/* <- support.type.threads */
+
+tss_t tss_t_var;
+/* <- support.type.threads */
+
+tss_dtor_t tss_dtor_t_var;
+/* <- support.type.threads */
+
+once_flag once_flag_var;
+/* <- support.type.threads */
 
 void *null_pointer1 = NULL;
                     /* ^ constant.language.null */


### PR DESCRIPTION
This includes most typedefs or macro type aliases from ISO C headers from C99, C11, and C23. A few from time.h were not included because they're just structs and not typedefs.