### PR TITLE
[JavaScript] Add SQL embedding

### DIFF
--- a/JavaScript/Embeddings/SQL (for JS template).sublime-syntax
+++ b/JavaScript/Embeddings/SQL (for JS template).sublime-syntax
@@ -1,0 +1,14 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/syntax.html
+# highlight tagged template strings
+scope: source.sql.js-template
+version: 1
+hidden: true
+
+extends: Packages/SQL/SQL.sublime-syntax
+
+contexts:
+  prototype:
+    - meta_prepend: true
+    - include: scope:source.js#text-interpolations

--- a/JavaScript/Embeddings/SQL (for TS template).sublime-syntax
+++ b/JavaScript/Embeddings/SQL (for TS template).sublime-syntax
@@ -1,0 +1,14 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/syntax.html
+# highlight tagged template strings
+scope: source.sql.ts-template
+version: 1
+hidden: true
+
+extends: Packages/SQL/SQL.sublime-syntax
+
+contexts:
+  prototype:
+    - meta_prepend: true
+    - include: scope:source.ts#text-interpolations

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1295,6 +1295,18 @@ contexts:
         0: meta.string.template.js string.quoted.other.js
         1: punctuation.definition.string.end.js
       pop: 1
+    - match: (sql|SQL)\s*((\`){{trailing_wspace}}?)
+      captures:
+        1: variable.function.tagged-template.js
+        2: meta.string.template.js string.quoted.other.js
+        3: punctuation.definition.string.begin.js
+      embed: scope:source.sql.js-template
+      embed_scope: meta.string.template.js source.sql.embedded.js
+      escape: '{{leading_wspace}}?(\`)'
+      escape_captures:
+        0: meta.string.template.js string.quoted.other.js
+        1: punctuation.definition.string.end.js
+      pop: 1
     - match: (?:({{identifier_name}})\s*)?(\`)
       captures:
         1: variable.function.tagged-template.js

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -1296,6 +1296,18 @@ contexts:
         0: meta.string.template.js string.quoted.other.js
         1: punctuation.definition.string.end.js
       pop: 1
+    - match: (sql|SQL)\s*((\`){{trailing_wspace}}?)
+      captures:
+        1: variable.function.tagged-template.js
+        2: meta.string.template.js string.quoted.other.js
+        3: punctuation.definition.string.begin.js
+      embed: scope:source.sql.ts-template
+      embed_scope: meta.string.template.js source.sql.embedded.js
+      escape: '{{leading_wspace}}?(\`)'
+      escape_captures:
+        0: meta.string.template.js string.quoted.other.js
+        1: punctuation.definition.string.end.js
+      pop: 1
     - match: (?:({{identifier_name}})\s*)?(\`)
       captures:
         1: variable.function.tagged-template.js

--- a/JavaScript/tests/syntax_test_js_template.js
+++ b/JavaScript/tests/syntax_test_js_template.js
@@ -210,6 +210,60 @@ var style = css`
 /*   ^ - meta.string */
 
 /*
+ * SQL Templates
+ */
+
+var sql = sql`SELECT * FROM "foo";`
+/*           ^^^^^^^^^^^^^^^^^^^^^^ meta.string.template.js */
+/*           ^ string.quoted.other.js punctuation.definition.string.begin.js - source.sql.embedded */
+/*            ^^^^^^^^^^^^^^^^^^^^ source.sql.embedded.js */
+/*                                ^ string.quoted.other.js punctuation.definition.string.end.js - source.sql.embedded */
+
+
+var sql = SQL`SELECT * FROM "foo";`
+/*           ^^^^^^^^^^^^^^^^^^^^^^ meta.string.template.js */
+/*           ^ string.quoted.other.js punctuation.definition.string.begin.js - source.sql.embedded */
+/*            ^^^^^^^^^^^^^^^^^^^^ source.sql.embedded.js */
+/*                                ^ string.quoted.other.js punctuation.definition.string.end.js - source.sql.embedded */
+
+var sql = sql`
+/*        ^^^ variable.function.tagged-template */
+/*           ^^ meta.string.template.js string.quoted.other.js */
+/*           ^ punctuation.definition.string.begin.js */
+/*            ^ - source.sql.embedded */
+
+SELECT  *,
+/* ^^^ keyword.other.DML.sql */
+/*      ^ constant.other.wildcard.asterisk.sql */
+        f.id AS database_id
+/*           ^^ keyword.operator.assignment.alias.sql */
+FROM    foo
+WHERE   f.a IS NULL
+/* ^^ keyword.other.DML.sql */
+/*          ^^ keyword.operator.logical.sql */
+/*             ^^^^ constant.language.null.sql */
+        AND f.b IS NOT NULL
+/*      ^^^ keyword.operator.logical.sql */
+/*              ^^ keyword.operator.logical.sql */
+/*                 ^^^ keyword.operator.logical.sql */
+/*                     ^^^^ constant.language.null.sql */
+
+    `
+/* <- meta.string.template.js string.quoted.other.js - source.sql.embedded */
+/*^^^ meta.string.template.js string.quoted.other.js - source.sql.embedded */
+/*  ^ punctuation.definition.string.end.js */
+/*   ^ - meta.string */
+
+var sql = sql`SELECT * FROM ${users};`
+/*            ^^^^^^^^^^^^^^ meta.string.template.js source.sql.embedded.js - meta.interpolation.js */
+/*                          ^^^^^^^^ meta.string.template.js source.sql.embedded.js meta.interpolation.js */
+/*                          ^^ punctuation.section.interpolation.begin.js */
+/*                            ^^^^^ source.js.embedded variable.other.readwrite.js */
+/*                                 ^ punctuation.section.interpolation.end.js */
+/*                                  ^ punctuation.terminator.statement.sql - meta.interpolation.js */
+/*                                   ^ string.quoted.other.js punctuation.definition.string.end.js */
+
+/*
  * Unknown Template
  */
 

--- a/JavaScript/tests/syntax_test_typescript_template.ts
+++ b/JavaScript/tests/syntax_test_typescript_template.ts
@@ -226,6 +226,60 @@ var style = css`
 /*   ^ - meta.string */
 
 /*
+ * SQL Templates
+ */
+
+var sql = sql`SELECT * FROM "foo";`
+/*           ^^^^^^^^^^^^^^^^^^^^^^ meta.string.template.js */
+/*           ^ string.quoted.other.js punctuation.definition.string.begin.js - source.sql.embedded */
+/*            ^^^^^^^^^^^^^^^^^^^^ source.sql.embedded.js */
+/*                                ^ string.quoted.other.js punctuation.definition.string.end.js - source.sql.embedded */
+
+
+var sql = SQL`SELECT * FROM "foo";`
+/*           ^^^^^^^^^^^^^^^^^^^^^^ meta.string.template.js */
+/*           ^ string.quoted.other.js punctuation.definition.string.begin.js - source.sql.embedded */
+/*            ^^^^^^^^^^^^^^^^^^^^ source.sql.embedded.js */
+/*                                ^ string.quoted.other.js punctuation.definition.string.end.js - source.sql.embedded */
+
+var sql = sql`
+/*        ^^^ variable.function.tagged-template */
+/*           ^^ meta.string.template.js string.quoted.other.js */
+/*           ^ punctuation.definition.string.begin.js */
+/*            ^ - source.sql.embedded */
+
+SELECT  *,
+/* ^^^ keyword.other.DML.sql */
+/*      ^ constant.other.wildcard.asterisk.sql */
+        f.id AS database_id
+/*           ^^ keyword.operator.assignment.alias.sql */
+FROM    foo
+WHERE   f.a IS NULL
+/* ^^ keyword.other.DML.sql */
+/*          ^^ keyword.operator.logical.sql */
+/*             ^^^^ constant.language.null.sql */
+        AND f.b IS NOT NULL
+/*      ^^^ keyword.operator.logical.sql */
+/*              ^^ keyword.operator.logical.sql */
+/*                 ^^^ keyword.operator.logical.sql */
+/*                     ^^^^ constant.language.null.sql */
+
+    `
+/* <- meta.string.template.js string.quoted.other.js - source.sql.embedded */
+/*^^^ meta.string.template.js string.quoted.other.js - source.sql.embedded */
+/*  ^ punctuation.definition.string.end.js */
+/*   ^ - meta.string */
+
+var sql = sql`SELECT * FROM ${users};`
+/*            ^^^^^^^^^^^^^^ meta.string.template.js source.sql.embedded.js - meta.interpolation.js */
+/*                          ^^^^^^^^ meta.string.template.js source.sql.embedded.js meta.interpolation.js */
+/*                          ^^ punctuation.section.interpolation.begin.js */
+/*                            ^^^^^ source.js.embedded variable.other.readwrite.js */
+/*                                 ^ punctuation.section.interpolation.end.js */
+/*                                  ^ punctuation.terminator.statement.sql - meta.interpolation.js */
+/*                                   ^ string.quoted.other.js punctuation.definition.string.end.js */
+
+/*
  * Unknown Template
  */
 


### PR DESCRIPTION
- [x] My commit messages start with the package name in square brackets, e.g. `[XML] `.
- [x] I have included new or enhanced [syntax tests](https://www.sublimetext.com/docs/syntax.html#testing) to cover the changes.


This is useful for server-side JS.

Especially using one of the following libraries:
https://github.com/felixfbecker/node-sql-template-strings
https://github.com/blakeembrey/sql-template-tag
https://github.com/XeCycle/pg-template-tag

Using `version: 1` for the Embedding syntaxes since they need to match the inherited `SQL.sublime-syntax`.

It does not currently handle interpolation inside SQL strings.

--- 

~~The SQL template is detected but the SQL syntax highlighting is not performed (`source.sql.embedded.js` is the deepest scope anything within the template string gets).~~

**Edit:** If I change `extends: Packages/SQL/SQL.sublime-syntax` to `CSS.sublime-syntax` in `SQL (JS template).sublime-syntax`, it highlights as CSS correctly.

**Edit2** It was caused by a differing version.