### PR TITLE
[batch] prevent ^ from counting as an escape for %

### DIFF
--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -1753,7 +1753,7 @@ contexts:
     - include: quoted-eol-pop
 
   escaped-characters:
-    - match: \^.
+    - match: \^[^%\n]
       scope: constant.character.escape.dosbatch
 
   escaped-variables:

--- a/Batch File/tests/syntax_test_batch_file.bat
+++ b/Batch File/tests/syntax_test_batch_file.bat
@@ -443,6 +443,12 @@ ECHO : Not a comment ^
 ::  ^^ entity.name.label.dosbatch constant.character.escape.dosbatch - punctuation
 ::    ^ - entity
 
+   :^%
+::^^ - entity
+:: ^ punctuation.definition.label.dosbatch
+::  ^^ entity.name.label.dosbatch - constant.character.escape - punctuation
+::    ^ - entity
+
    :%%
 ::^^ - entity
 :: ^ punctuation.definition.label.dosbatch
@@ -795,6 +801,17 @@ ECHO : Not a comment ^
 ::      ^ punctuation.definition.label.dosbatch
 ::      ^^^ variable.label.dosbatch - keyword
 ::       ^^ constant.character.escape.dosbatch
+::          ^^ meta.number.integer.decimal.dosbatch constant.numeric.value.dosbatch
+
+   CALL :^% 10
+::^ - meta.function-call
+:: ^^^^^ meta.function-call.dosbatch
+::      ^^^ meta.function-call.identifier.dosbatch
+::         ^^^ meta.function-call.arguments.dosbatch
+::            ^ - meta.function-call
+:: ^^^^ keyword.control.flow.call.dosbatch
+::      ^ punctuation.definition.label.dosbatch
+::      ^^^ variable.label.dosbatch - keyword - constant.character
 ::          ^^ meta.number.integer.decimal.dosbatch constant.numeric.value.dosbatch
 
    CALL :%% 10
@@ -1277,6 +1294,23 @@ bar baz
 ::     ^ - keyword - variable
 ::      ^ variable.label.dosbatch
 ::       ^ - variable
+
+   GOTO ^%
+:: ^^^^^^^ meta.command.goto.dosbatch
+::        ^ - meta.command
+:: ^^^^ keyword.control.flow.goto.dosbatch
+::     ^ - keyword - variable
+::      ^^ variable.label.dosbatch - constant.character
+::        ^ - variable
+
+   GOTO ^%var%
+:: ^^^^^^^^^^^ meta.command.goto.dosbatch
+::            ^ - meta.command
+:: ^^^^ keyword.control.flow.goto.dosbatch
+::     ^ - keyword - variable
+::      ^ variable.label.dosbatch - meta.interpolation - constant.character
+::       ^^^^^ variable.label.dosbatch meta.interpolation.dosbatch - constant.character
+::            ^ - variable
 
    GOTO %var% ignored content ( & echo foo
 :: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.command.goto.dosbatch
@@ -2507,6 +2541,12 @@ put arg1 arg2
 ::                         ^ punctuation.section.interpolation.begin.dosbatch
 ::                         ^^^^^^^ meta.interpolation.dosbatch
 ::                               ^ punctuation.section.interpolation.end.dosbatch
+
+   ren example.txt example_^%today%.txt
+::                         ^ - constant.character.escape
+::                          ^ punctuation.section.interpolation.begin.dosbatch
+::                          ^^^^^^^ meta.interpolation.dosbatch
+::                                ^ punctuation.section.interpolation.end.dosbatch
 
    powershell get-date -uformat "%%Y%%m%%d">today.txt
 ::           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.dosbatch


### PR DESCRIPTION
In batch scripts (but not on the command line itself), `%` is only escaped by another `%`

You can test this by making a bat file that reads:
```
@echo off
setlocal
set var=A
if ^A==A echo test1
if ^%var%==A echo test2
if "^A"==^"^^A^" echo test3
if "^%var%"==^"^^%var%^" echo test4
if "^%%var%%"==^"^^%%var%%^" echo test5
endlocal
pause
```