### PR TITLE
[ShellScript] Fix ZSH case clause termination

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -1222,7 +1222,7 @@ contexts:
     - include: statements
 
   case-clause-end:
-    - match: ;;&?|;&
+    - match: '{{case_clause_end}}'
       scope: meta.clause.shell punctuation.terminator.clause.shell
       pop: 1
 
@@ -3112,6 +3112,8 @@ variables:
   # A lookbehind used in embed..escape patterns, to check for unescaped characters
   # in embed...escape statements.
   no_escape_behind: (?<![^\\]\\)(?<![\\]{3})
+
+  case_clause_end: ;;&?|;&
 
   # Parameter expansions
   is_interpolation: (?=\$[({{{identifier_char}}{{special_variables}}]|`)

--- a/ShellScript/Zsh.sublime-syntax
+++ b/ShellScript/Zsh.sublime-syntax
@@ -175,7 +175,7 @@ contexts:
     - meta_scope: meta.clause.patterns.shell
     # comment, end of clause or end of line
     # indicate pattern being enclosed in balanced parentheses
-    - match: (?=(?:$|;;&?|;&|}|esac{{cmd_break}})|\s+#)
+    - match: (?=(?:$|}|{{case_clause_end}}|esac{{cmd_break}})|\s+#)
       fail: case-clause-paren-pattern
     - include: case-clause-pattern-body
 
@@ -1113,6 +1113,8 @@ variables:
   dec_digit: '[\d_]'
   hex_digit: '[\h_]'
   oct_digit: '[0-7_]'
+
+  case_clause_end: ;[;&|]
 
   # Parameter expansions
   is_interpolation: (?=\$[({\[{{identifier_char}}{{special_variables}}]|`)

--- a/ShellScript/Zsh/tests/syntax_test_scope.zsh
+++ b/ShellScript/Zsh/tests/syntax_test_scope.zsh
@@ -540,7 +540,7 @@ case $word {
         ;;
 #       ^^ punctuation.terminator.clause.shell
 
-    ((foo|bar)baz) cmd arg ;;
+    ((foo|bar)baz) cmd arg ;|
 #   ^ meta.clause.patterns.shell - meta.string - string
 #    ^^^^^^^^^ meta.clause.patterns.shell meta.string.glob.shell meta.group.regexp.shell string.unquoted.shell
 #             ^^^ meta.clause.patterns.shell meta.string.glob.shell string.unquoted.shell
@@ -556,7 +556,7 @@ case $word {
 #                      ^^^ meta.string.glob.shell string.unquoted.shell
 #                          ^^ punctuation.terminator.clause.shell
 
-    (foo|bar)baz) cmd arg ;;
+    (foo|bar)baz) cmd arg ;&
 #   ^^^^^^^^^ meta.clause.patterns.shell meta.string.glob.shell meta.group.regexp.shell string.unquoted.shell
 #            ^^^ meta.clause.patterns.shell meta.string.glob.shell string.unquoted.shell
 #               ^ meta.clause.patterns.shell - meta.string - string


### PR DESCRIPTION
This commit implements different sets of case clause terminators supported by each shell script dialect:

 - Bash: `;;`, `;&` and `;;&`
 - ZSH:  `;;`, `;&` and `;|`