### PR TITLE
[SQL] Bump syntax version to 2

### DIFF
--- a/Go/Embeddings/SQL (for Go Embedded Backtick Strings).sublime-syntax
+++ b/Go/Embeddings/SQL (for Go Embedded Backtick Strings).sublime-syntax
@@ -2,7 +2,7 @@
 ---
 name: SQL inside Go backtick string
 scope: source.sql.go-embedded-backtick-string
-version: 1
+version: 2
 hidden: true
 
 extends: Packages/SQL/SQL.sublime-syntax

--- a/PHP/Embeddings/SQL (for PHP Interpolated).sublime-syntax
+++ b/PHP/Embeddings/SQL (for PHP Interpolated).sublime-syntax
@@ -1,6 +1,7 @@
 %YAML 1.2
 ---
 scope: source.sql.interpolated.php
+version: 2
 hidden: true
 
 extends: Packages/SQL/SQL.sublime-syntax

--- a/PHP/Embeddings/SQL (for PHP).sublime-syntax
+++ b/PHP/Embeddings/SQL (for PHP).sublime-syntax
@@ -1,6 +1,7 @@
 %YAML 1.2
 ---
 scope: source.sql.embedded.php
+version: 2
 hidden: true
 
 extends: Packages/SQL/SQL.sublime-syntax

--- a/Rails/SQL (Rails).sublime-syntax
+++ b/Rails/SQL (Rails).sublime-syntax
@@ -2,6 +2,7 @@
 ---
 name: SQL (Rails)
 scope: source.sql.rails
+version: 2
 
 extends: Packages/SQL/SQL.sublime-syntax
 

--- a/Ruby/Embeddings/SQL (for Ruby).sublime-syntax
+++ b/Ruby/Embeddings/SQL (for Ruby).sublime-syntax
@@ -1,7 +1,7 @@
 %YAML 1.2
 ---
 scope: source.sql.embedded.ruby
-# version: 2
+version: 2
 hidden: true
 
 extends: Packages/SQL/SQL.sublime-syntax

--- a/SQL/SQL.sublime-syntax
+++ b/SQL/SQL.sublime-syntax
@@ -2,6 +2,7 @@
 ---
 name: SQL
 scope: source.sql
+version: 2
 
 file_extensions:
   - sql


### PR DESCRIPTION
- [x] My commit messages start with the package name in square brackets, e.g. `[XML] `.
- [ ] I have included new or enhanced [syntax tests](https://www.sublimetext.com/docs/syntax.html#testing) to cover the changes.
    **this should be covered by the existing tests**

To allow embedding it in version 2 syntaxes.
