### PR TITLE
[C] Add digit separator like is already implemented for C++

### DIFF
--- a/C++/C.sublime-syntax
+++ b/C++/C.sublime-syntax
@@ -15,10 +15,10 @@ first_line_match: |-
 
 variables:
   # number digits
-  bin_digit: '[01]'
-  oct_digit: '[0-7]'
-  dec_digit: '\d'
-  hex_digit: '\h'
+  bin_digit: '[01'']'
+  oct_digit: '[0-7'']'
+  dec_digit: '[\d'']'
+  hex_digit: '[\h'']'
 
   # number exponents
   dec_exponent: '(?:[eE][-+]?{{dec_digit}}*)'

--- a/C++/syntax_test_c.c
+++ b/C++/syntax_test_c.c
@@ -1133,6 +1133,7 @@ static const unsigned char image_png[] = {
 dec0 = 0;
 /*     ^ meta.number.integer.decimal.c constant.numeric.value.c */
 /*      ^ punctuation.terminator - constant */
+
 dec1 = 1234567890;
 /*     ^^^^^^^^^^ meta.number.integer.decimal.c constant.numeric.value.c */
 /*               ^ punctuation.terminator - constant */
@@ -1173,12 +1174,18 @@ dec7 = 1234567890uLL;
 /*                  ^ punctuation.terminator - constant */
 
 dec8 = 1'234_567'890s0f;
-/*     ^ meta.number.integer.decimal.c constant.numeric.value.c */
-/*      ^^^^^^^^^ string.quoted.single */
+/*     ^^^^^ constant.numeric.value.c */
+/*          ^^^^ invalid.illegal.numeric.suffix.c */
 /*               ^^^^^^ meta.number.integer.decimal.c */
 /*               ^^^ constant.numeric.value.c */
 /*                  ^^^ invalid.illegal.numeric.suffix.c */
 /*                     ^ punctuation.terminator - constant */
+
+dec9 = 2'354'202'076LL;
+/*     ^^^^^^^^^^^^^^^ meta.number.integer.decimal.c */
+/*     ^^^^^^^^^^^^^ constant.numeric.value.c */
+/*                  ^^ constant.numeric.suffix.c */
+/*                    ^ punctuation.terminator - constant */
 
 oct1 = 01234567;
 /*     ^^^^^^^^ meta.number.integer.octal.c */
@@ -1207,12 +1214,18 @@ oct4 = 01234567ulL;
 /*             ^^^ constant.numeric.suffix.c */
 /*                ^ punctuation.terminator - constant */
 
-oct2 = 01284967Z0L;
+oct5 = 01284967Z0L;
 /*     ^^^^^^^^^^^ meta.number.integer.octal.c */
 /*     ^ constant.numeric.base.c */
 /*      ^^ constant.numeric.value.c */
 /*        ^^^^^^^^ invalid.illegal.numeric.suffix.c */
 /*                ^ punctuation.terminator - constant */
+
+oct6 = 014'70;
+/*     ^^^^^^ meta.number.integer.octal.c */
+/*     ^ constant.numeric.base.c */
+/*      ^^^^^ constant.numeric.value.c */
+/*           ^ punctuation.terminator - constant */
 
 hex1 = 0x0+0xFL+0xaull+0xallu+0xfu+0x'f'12_4uz;
 /*     ^^^ meta.number.integer.hexadecimal.c */
@@ -1234,11 +1247,9 @@ hex1 = 0x0+0xFL+0xaull+0xallu+0xfu+0x'f'12_4uz;
 /*                            ^^ constant.numeric.base.c */
 /*                              ^ constant.numeric.value.c */
 /*                               ^ constant.numeric.suffix.c */
-/*                                 ^^ meta.number.integer.hexadecimal.c */
+/*                                 ^^^^^^^ meta.number.integer.hexadecimal.c */
 /*                                 ^^ constant.numeric.base.c */
-/*                                   ^^^ string.quoted.single.c */
-/*                                      ^^^^^^ meta.number.integer.decimal.c */
-/*                                      ^^ constant.numeric.value.c */
+/*                                   ^^^^^ constant.numeric.value.c */
 /*                                        ^^^^ invalid.illegal.numeric.suffix.c */
 /*                                            ^ punctuation.terminator - constant */
 
@@ -1254,6 +1265,30 @@ hex2 = 0xc1.01AbFp-1+0x1.45c778p+7f;
 /*                      ^ punctuation.separator.decimal.c */
 /*                                ^ constant.numeric.suffix.c */
 /*                                 ^ punctuation.terminator - constant */
+
+hex3 = 0xA7'45'8C'38;
+/*     ^^^^^^^^^^^^^ meta.number.integer.hexadecimal.c */
+/*     ^^ constant.numeric.base.c */
+/*       ^^^^^^^^^^^ constant.numeric.value.c */
+/*                  ^ punctuation.terminator - constant */
+
+bin1 = 0b010110;
+/*     ^^^^^^^^ meta.number.integer.binary */
+/*     ^^ constant.numeric.base */
+/*       ^^^^^^ constant.numeric.value */
+/*             ^ punctuation.terminator - constant */
+
+bin2 = 0B010010;
+/*     ^^^^^^^^ meta.number.integer.binary */
+/*     ^^ constant.numeric.base */
+/*       ^^^^^^ constant.numeric.value */
+/*             ^ punctuation.terminator - constant */
+
+bin3 = 0b1001'1101'0010'1100;
+/*     ^^^^^^^^^^^^^^^^^^^^^ meta.number.integer.binary */
+/*     ^^ constant.numeric.base */
+/*       ^^^^^^^^^^^^^^^^^^^ constant.numeric.value */
+/*                          ^ punctuation.terminator - constant */
 
 f = 1.1+1.1e1+1.1e-1+1.1f+1.1e1f+1.1e-1f+1.1L+1.1e1L+1.1e-1L;
 /*  ^^^ meta.number.float.decimal.c */

--- a/C++/syntax_test_c.c
+++ b/C++/syntax_test_c.c
@@ -1174,9 +1174,9 @@ dec7 = 1234567890uLL;
 /*                  ^ punctuation.terminator - constant */
 
 dec8 = 1'234_567'890s0f;
+/*     ^^^^^^^^^^^^^^^^ meta.number.integer.decimal.c */
 /*     ^^^^^ constant.numeric.value.c */
 /*          ^^^^ invalid.illegal.numeric.suffix.c */
-/*               ^^^^^^ meta.number.integer.decimal.c */
 /*               ^^^ constant.numeric.value.c */
 /*                  ^^^ invalid.illegal.numeric.suffix.c */
 /*                     ^ punctuation.terminator - constant */

--- a/Objective-C/syntax_test_objc.m
+++ b/Objective-C/syntax_test_objc.m
@@ -920,8 +920,8 @@ dec7 = 1234567890uLL;
 /*                  ^ punctuation.terminator - constant */
 
 dec8 = 1'234_567'890s0f;
-/*     ^ meta.number.integer.decimal.c constant.numeric.value.c */
-/*      ^^^^^^^^^ string.quoted.single */
+/*     ^^^^^ constant.numeric.value.c */
+/*          ^^^^ invalid.illegal.numeric.suffix.c */
 /*               ^^^^^^ meta.number.integer.decimal.c */
 /*               ^^^ constant.numeric.value.c */
 /*                  ^^^ invalid.illegal.numeric.suffix.c */
@@ -981,11 +981,9 @@ hex1 = 0x0+0xFL+0xaull+0xallu+0xfu+0x'f'12_4uz;
 /*                            ^^ constant.numeric.base.c */
 /*                              ^ constant.numeric.value.c */
 /*                               ^ constant.numeric.suffix.c */
-/*                                 ^^ meta.number.integer.hexadecimal.c */
+/*                                 ^^^^^^^ meta.number.integer.hexadecimal.c */
 /*                                 ^^ constant.numeric.base.c */
-/*                                   ^^^ string.quoted.single.c */
-/*                                      ^^^^^^ meta.number.integer.decimal.c */
-/*                                      ^^ constant.numeric.value.c */
+/*                                   ^^^^^ constant.numeric.value.c */
 /*                                        ^^^^ invalid.illegal.numeric.suffix.c */
 /*                                            ^ punctuation.terminator - constant */
 

--- a/Objective-C/syntax_test_objc.m
+++ b/Objective-C/syntax_test_objc.m
@@ -920,9 +920,9 @@ dec7 = 1234567890uLL;
 /*                  ^ punctuation.terminator - constant */
 
 dec8 = 1'234_567'890s0f;
+/*     ^^^^^^^^^^^^^^^^ meta.number.integer.decimal.c */
 /*     ^^^^^ constant.numeric.value.c */
 /*          ^^^^ invalid.illegal.numeric.suffix.c */
-/*               ^^^^^^ meta.number.integer.decimal.c */
 /*               ^^^ constant.numeric.value.c */
 /*                  ^^^ invalid.illegal.numeric.suffix.c */
 /*                     ^ punctuation.terminator - constant */


### PR DESCRIPTION
C23 added this feature previously available in C++. This should close #3972 as well as both C and C++ now have syntax support for the ' digit separator.

This was implemented by just copying the digit variables from the C++ syntax file as it is the same construct in the end. The existing tests were updated to fix the part of the existing tests were broken by this new feature.

Furthermore, some tests from C++ were adapted for C to add better testing for the new digit seperator. I also included tests for the newer base 2 integer contants. The C file did not have any tests for that yet.