### PR TITLE
[CI] Lock syntax test runner to build 4183

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,11 +50,16 @@ jobs:
           #   sublime-build: 4169
           #   optional: true
 
+          # latest working dev build
+          - sublime-channel: dev
+            sublime-build: 4183
+            optional: false
+
           # latest dev build
           # https://www.sublimetext.com/dev
-          - sublime-channel: dev
-            sublime-build: latest
-            optional: false
+          # - sublime-channel: dev
+          #   sublime-build: latest
+          #   optional: false
 
     steps:
 


### PR DESCRIPTION
Workaround for https://github.com/sublimehq/sublime_text/issues/6539 until it is fixed upstream.