### PR TITLE
[Graphviz] Set default file extension to .gv

### DIFF
--- a/Graphviz/DOT.sublime-syntax
+++ b/Graphviz/DOT.sublime-syntax
@@ -5,8 +5,8 @@ name: Graphviz (DOT)
 scope: source.dot
 
 file_extensions:
-  - dot
   - gv
+  - dot
 
 first_line_match: |-
   (?xi:


### PR DESCRIPTION
`.dot` is shared with Microsoft Word. `.gv` is less ambiguous.

The downside is people who (conceivably) have created build systems where the specific Graphviz renderer used is picked by the file extension. But this doesn't stop those people from saving with their various extensions, mapping them to the Graphviz syntax, and they'll load correctly.