### PR TITLE
[Ruby] Safe accessor

### DIFF
--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -184,7 +184,7 @@ contexts:
       pop: true
 
   name-parts:
-    - match: ({{identifier}})?(?:(::)|(\.))
+    - match: ({{identifier}})?(?:(::)|(&?\.))
       captures:
         1: support.other.namespace.ruby
         2: punctuation.accessor.double-colon.ruby
@@ -572,7 +572,7 @@ contexts:
     - match: '!+|&&|\|\|'
       scope: keyword.operator.logical.ruby
       push: after-operator
-    - match: '[~&|^]'
+    - match: '(?:[~|^]|&(?!\.))'
       scope: keyword.operator.bitwise.ruby
       push: after-operator
     - match: \?
@@ -626,7 +626,7 @@ contexts:
         - match: ''
           set: after-identifier
     # This consumes attribute access so we don't need a lookbehind for .
-    - match: \.(?={{identifier}}{{method_punctuation}})
+    - match: '&?\.(?={{identifier}}{{method_punctuation}})'
       scope: punctuation.accessor.dot.ruby
       push:
         - include: well-known-methods
@@ -637,7 +637,7 @@ contexts:
     - match: '{{identifier}}{{method_punctuation}}'
     # This consumes module/class accessor so we don't need a lookbehind for ::
       push: after-identifier
-    - match: \.
+    - match: '&?\.'
       scope: punctuation.accessor.dot.ruby
     - match: '::'
       scope: punctuation.accessor.double-colon.ruby

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -409,6 +409,10 @@ CONST << 10
 #^^ meta.number.integer.decimal.ruby constant.numeric.value.ruby
 #  ^ punctuation.accessor - constant.numeric - invalid.illegal
 #   ^^ - constant.numeric - invalid.illegal - storage.type.numeric
+ 12&.ir
+#^^ meta.number.integer.decimal.ruby constant.numeric.value.ruby
+#  ^^ punctuation.accessor - constant.numeric - invalid.illegal - keyword.operator
+#    ^^ - constant.numeric - invalid.illegal - storage.type.numeric
 
  12.34
 #^^^^^ meta.number.float.decimal.ruby constant.numeric.value.ruby
@@ -978,12 +982,14 @@ module: 'module'
 # ^ punctuation.terminator.statement.ruby
   .
 # ^ punctuation.accessor.dot.ruby
+  &.
+# ^^ punctuation.accessor.dot.ruby
   ::
 # ^^ punctuation.accessor.double-colon.ruby
   <<=
 # ^^^ keyword.operator.assignment.augmented.ruby
   &&=
-# ^^^ keyword.operator.assignment.augmented.ruby
+# ^^^ keyword.operator.assignment.augmented.ruby - punctuation
   ||=
 # ^^^ keyword.operator.assignment.augmented.ruby
   **=
@@ -1037,7 +1043,7 @@ module: 'module'
   <
 # ^ keyword.operator.comparison.ruby
   &&
-# ^^ keyword.operator.logical.ruby
+# ^^ keyword.operator.logical.ruby - punctuation
   ||
 # ^^ keyword.operator.logical.ruby
   !
@@ -1049,7 +1055,7 @@ module: 'module'
   ~
 # ^ keyword.operator.bitwise.ruby
   &
-# ^ keyword.operator.bitwise.ruby
+# ^ keyword.operator.bitwise.ruby - punctuation
   |
 # ^ keyword.operator.bitwise.ruby
   ^


### PR DESCRIPTION
The safe navigation operator was [added in Ruby 2.3.0](https://docs.ruby-lang.org/en/master/NEWS/NEWS-2_3_0.html#label-Language+changes). (See second bullet. They don't have direct links to each change.) More [usage samples](https://mitrev.net/ruby/2015/11/13/the-operator-in-ruby/).

Fixes #3813