### PR TITLE
[Python] Regexp backref identifiers

### DIFF
--- a/Python/Embeddings/RegExp (for Python).sublime-syntax
+++ b/Python/Embeddings/RegExp (for Python).sublime-syntax
@@ -14,9 +14,8 @@ variables:
   other_modifiers: \?(?:[ixmsLua]*-)?[ixmsLua]+
 
   # capture group identifiers
-  capture_group_name: (?:[a-zA-Z_][a-zA-Z0-9_]*)
-  # non-ASCII is deprecated since v3.11
-  capture_group_name_deprecated: (?:[[:alpha:]][[:alnum:]_]*)
+  capture_group_name: (?:[[:alpha:]_]\w*)
+  capture_group: (?:[1-9][0-9]*|{{capture_group_name}})
 
 contexts:
   base:
@@ -34,48 +33,26 @@ contexts:
       captures:
         1: keyword.other.back-reference.named.regexp
         2: variable.other.backref-and-recursion.regexp
-    - match: (\?P=)({{capture_group_name_deprecated}})(?=\))
-      captures:
-        1: keyword.other.back-reference.named.regexp
-        2: variable.other.backref-and-recursion.regexp invalid.deprecated.regexp
     - match: (\?P)(<)({{capture_group_name}})(>)
       captures:
         1: keyword.other.backref-and-recursion.regexp
         2: punctuation.definition.capture-group-name.begin.regexp
         3: entity.name.capture-group.regexp
         4: punctuation.definition.capture-group-name.end.regexp
-    - match: (\?P)(<)({{capture_group_name_deprecated}})(>)
-      captures:
-        1: keyword.other.backref-and-recursion.regexp
-        2: punctuation.definition.capture-group-name.begin.regexp
-        3: entity.name.capture-group.regexp invalid.deprecated.regexp
-        4: punctuation.definition.capture-group-name.end.regexp
     # We can make this more sophisticated to match the | character that separates
     # yes-pattern from no-pattern, but it's not really necessary.
-    - match: (\?)(\()([1-9]\d*|{{capture_group_name}})(\))
+    - match: (\?)(\()({{capture_group}})(\))
       captures:
         1: keyword.other.backref-and-recursion.conditional.regexp
         2: punctuation.definition.group.begin.assertion.conditional.regexp
         3: variable.other.back-reference.regexp
         4: punctuation.definition.group.end.assertion.conditional.regexp
-    - match: (\?)(\()({{capture_group_name_deprecated}})(\))
-      captures:
-        1: keyword.other.backref-and-recursion.conditional.regexp
-        2: punctuation.definition.group.begin.assertion.conditional.regexp
-        3: variable.other.back-reference.regexp invalid.deprecated.regexp
-        4: punctuation.definition.group.end.assertion.conditional.regexp
 
   backrefs:
     - meta_prepend: true
-    - match: \\g(<)([1-9][0-9]*|{{capture_group_name}})(>)
+    - match: \\g(<)({{capture_group}})(>)
       scope: keyword.other.backref-and-recursion.regexp
       captures:
         1: punctuation.definition.capture-group-name.begin.regexp
         2: variable.other.backref-and-recursion.regexp
-        3: punctuation.definition.capture-group-name.end.regexp
-    - match: \\g(<)({{capture_group_name_deprecated}})(>)
-      scope: keyword.other.backref-and-recursion.regexp
-      captures:
-        1: punctuation.definition.capture-group-name.begin.regexp
-        2: variable.other.backref-and-recursion.regexp invalid.deprecated.regexp
         3: punctuation.definition.capture-group-name.end.regexp

--- a/Python/Embeddings/RegExp (for Python).sublime-syntax
+++ b/Python/Embeddings/RegExp (for Python).sublime-syntax
@@ -13,6 +13,11 @@ variables:
   deactivate_x_mode: (?:\?[imsLua]*-[imsLua]*x[imxsLua]*)
   other_modifiers: \?(?:[ixmsLua]*-)?[ixmsLua]+
 
+  # capture group identifiers
+  capture_group_name: (?:[a-zA-Z_][a-zA-Z0-9_]*)
+  # non-ASCII is deprecated since v3.11
+  capture_group_name_deprecated: (?:[[:alpha:]][[:alnum:]_]*)
+
 contexts:
   base:
     - meta_prepend: true
@@ -25,21 +30,52 @@ contexts:
 
   group-start:
     - meta_prepend: true
-    - match: (\?P=)([a-zA-Z_][a-zA-Z_0-9]*\w*)(?=\))
+    - match: (\?P=)({{capture_group_name}})(?=\))
       captures:
         1: keyword.other.back-reference.named.regexp
         2: variable.other.backref-and-recursion.regexp
-    - match: (\?P)(<)([a-z]\w*)(>)
+    - match: (\?P=)({{capture_group_name_deprecated}})(?=\))
+      captures:
+        1: keyword.other.back-reference.named.regexp
+        2: variable.other.backref-and-recursion.regexp invalid.deprecated.regexp
+    - match: (\?P)(<)({{capture_group_name}})(>)
       captures:
         1: keyword.other.backref-and-recursion.regexp
         2: punctuation.definition.capture-group-name.begin.regexp
         3: entity.name.capture-group.regexp
         4: punctuation.definition.capture-group-name.end.regexp
-    - match: (\?)(\()([1-9][0-9]?|[a-zA-Z_][a-zA-Z_0-9]*)(\))
-      # We can make this more sophisticated to match the | character that separates
-      # yes-pattern from no-pattern, but it's not really necessary.
+    - match: (\?P)(<)({{capture_group_name_deprecated}})(>)
+      captures:
+        1: keyword.other.backref-and-recursion.regexp
+        2: punctuation.definition.capture-group-name.begin.regexp
+        3: entity.name.capture-group.regexp invalid.deprecated.regexp
+        4: punctuation.definition.capture-group-name.end.regexp
+    # We can make this more sophisticated to match the | character that separates
+    # yes-pattern from no-pattern, but it's not really necessary.
+    - match: (\?)(\()([1-9]\d*|{{capture_group_name}})(\))
       captures:
         1: keyword.other.backref-and-recursion.conditional.regexp
         2: punctuation.definition.group.begin.assertion.conditional.regexp
         3: variable.other.back-reference.regexp
         4: punctuation.definition.group.end.assertion.conditional.regexp
+    - match: (\?)(\()({{capture_group_name_deprecated}})(\))
+      captures:
+        1: keyword.other.backref-and-recursion.conditional.regexp
+        2: punctuation.definition.group.begin.assertion.conditional.regexp
+        3: variable.other.back-reference.regexp invalid.deprecated.regexp
+        4: punctuation.definition.group.end.assertion.conditional.regexp
+
+  backrefs:
+    - meta_prepend: true
+    - match: \\g(<)([1-9][0-9]*|{{capture_group_name}})(>)
+      scope: keyword.other.backref-and-recursion.regexp
+      captures:
+        1: punctuation.definition.capture-group-name.begin.regexp
+        2: variable.other.backref-and-recursion.regexp
+        3: punctuation.definition.capture-group-name.end.regexp
+    - match: \\g(<)({{capture_group_name_deprecated}})(>)
+      scope: keyword.other.backref-and-recursion.regexp
+      captures:
+        1: punctuation.definition.capture-group-name.begin.regexp
+        2: variable.other.backref-and-recursion.regexp invalid.deprecated.regexp
+        3: punctuation.definition.capture-group-name.end.regexp

--- a/Python/tests/syntax_test_python_strings.py
+++ b/Python/tests/syntax_test_python_strings.py
@@ -102,8 +102,8 @@ conn.execute(u"""SELECT * FROM foobar WHERE %s and foo = '\t'""")
 #                                                          ^ constant.character.escape.python
 
 regex = r'\b ([fobar]*){1}(?:a|b)?'
-#         ^ meta.string.python keyword.control.anchor.regexp
-#                       ^ keyword.operator.quantifier.regexp
+#         ^^ meta.string.python keyword.control.anchor.regexp
+#                      ^^^ keyword.operator.quantifier.regexp
 
 regex = r'.* # Not a comment (yet)'
 #            ^^^^^^^^^^^^^^^^^^^^^ - comment
@@ -114,6 +114,76 @@ regex = r".* # Not a comment (yet)"
 #            ^^^^^^^^^^^^^^^^^^^^^ - comment
 #                                 ^ punctuation.definition.string.end.python - comment
 #                                  ^ - invalid
+
+regex = r"(backref) \1 "
+#                   ^^ keyword.other.backref-and-recursion.regexp
+#                    ^ variable.other.backref-and-recursion.regexp
+#                     ^ - keyword
+
+regex = r'(?P<quote>[\'"]).*?(?P=quote)'
+#          ^^ keyword.other.backref-and-recursion.regexp
+#            ^ punctuation.definition.capture-group-name.begin.regexp
+#             ^^^^^ entity.name.capture-group.regexp - invalid
+#                  ^ punctuation.definition.capture-group-name.end.regexp
+#                             ^^^ keyword.other.back-reference.named.regexp
+#                                ^^^^^ variable.other.backref-and-recursion.regexp - invalid
+
+regex = r'(?P<Quote>[\'"]).*?(?P=Quote)'
+#          ^^ keyword.other.backref-and-recursion.regexp
+#            ^ punctuation.definition.capture-group-name.begin.regexp
+#             ^^^^^ entity.name.capture-group.regexp - invalid
+#                  ^ punctuation.definition.capture-group-name.end.regexp
+#                             ^^^ keyword.other.back-reference.named.regexp
+#                                ^^^^^ variable.other.backref-and-recursion.regexp - invalid
+
+regex = r'(?P<àuote>[\'"]).*?(?P=àuote)'
+#          ^^ keyword.other.backref-and-recursion.regexp
+#            ^ punctuation.definition.capture-group-name.begin.regexp
+#             ^^^^^ entity.name.capture-group.regexp invalid.deprecated.regexp
+#                  ^ punctuation.definition.capture-group-name.end.regexp
+#                             ^^^ keyword.other.back-reference.named.regexp
+#                                ^^^^^ variable.other.backref-and-recursion.regexp invalid.deprecated.regexp
+
+regex = r'(?P<quàte>[\'"]).*?(?P=quàte)'
+#          ^^ keyword.other.backref-and-recursion.regexp
+#            ^ punctuation.definition.capture-group-name.begin.regexp
+#             ^^^^^ entity.name.capture-group.regexp invalid.deprecated.regexp
+#                  ^ punctuation.definition.capture-group-name.end.regexp
+#                             ^^^ keyword.other.back-reference.named.regexp
+#                                ^^^^^ variable.other.backref-and-recursion.regexp invalid.deprecated.regexp
+
+
+regex = r'(?P<quote>[\'"]).*?\g<quote>'
+#          ^^ keyword.other.backref-and-recursion.regexp
+#            ^ punctuation.definition.capture-group-name.begin.regexp
+#             ^^^^^ entity.name.capture-group.regexp - invalid
+#                  ^ punctuation.definition.capture-group-name.end.regexp
+#                            ^^ keyword.other.backref-and-recursion.regexp
+#                               ^^^^^ variable.other.backref-and-recursion.regexp - invalid
+
+regex = r'(?P<Quote>[\'"]).*?\g<Quote>'
+#          ^^ keyword.other.backref-and-recursion.regexp
+#            ^ punctuation.definition.capture-group-name.begin.regexp
+#             ^^^^^ entity.name.capture-group.regexp - invalid
+#                  ^ punctuation.definition.capture-group-name.end.regexp
+#                            ^^ keyword.other.backref-and-recursion.regexp
+#                               ^^^^^ variable.other.backref-and-recursion.regexp - invalid
+
+regex = r'(?P<àuote>[\'"]).*?\g<àuote>'
+#          ^^ keyword.other.backref-and-recursion.regexp
+#            ^ punctuation.definition.capture-group-name.begin.regexp
+#             ^^^^^ entity.name.capture-group.regexp invalid.deprecated.regexp
+#                  ^ punctuation.definition.capture-group-name.end.regexp
+#                            ^^ keyword.other.backref-and-recursion.regexp
+#                               ^^^^^ variable.other.backref-and-recursion.regexp invalid.deprecated.regexp
+
+regex = r'(?P<quàte>[\'"]).*?\g<quàte>'
+#          ^^ keyword.other.backref-and-recursion.regexp
+#            ^ punctuation.definition.capture-group-name.begin.regexp
+#             ^^^^^ entity.name.capture-group.regexp invalid.deprecated.regexp
+#                  ^ punctuation.definition.capture-group-name.end.regexp
+#                            ^^ keyword.other.backref-and-recursion.regexp
+#                               ^^^^^ variable.other.backref-and-recursion.regexp invalid.deprecated.regexp
 
 regex = r'''\b ([fobar]*){1}(?:a|b)?'''
 #           ^ keyword.control.anchor.regexp

--- a/Python/tests/syntax_test_python_strings.py
+++ b/Python/tests/syntax_test_python_strings.py
@@ -136,23 +136,6 @@ regex = r'(?P<Quote>[\'"]).*?(?P=Quote)'
 #                             ^^^ keyword.other.back-reference.named.regexp
 #                                ^^^^^ variable.other.backref-and-recursion.regexp - invalid
 
-regex = r'(?P<àuote>[\'"]).*?(?P=àuote)'
-#          ^^ keyword.other.backref-and-recursion.regexp
-#            ^ punctuation.definition.capture-group-name.begin.regexp
-#             ^^^^^ entity.name.capture-group.regexp invalid.deprecated.regexp
-#                  ^ punctuation.definition.capture-group-name.end.regexp
-#                             ^^^ keyword.other.back-reference.named.regexp
-#                                ^^^^^ variable.other.backref-and-recursion.regexp invalid.deprecated.regexp
-
-regex = r'(?P<quàte>[\'"]).*?(?P=quàte)'
-#          ^^ keyword.other.backref-and-recursion.regexp
-#            ^ punctuation.definition.capture-group-name.begin.regexp
-#             ^^^^^ entity.name.capture-group.regexp invalid.deprecated.regexp
-#                  ^ punctuation.definition.capture-group-name.end.regexp
-#                             ^^^ keyword.other.back-reference.named.regexp
-#                                ^^^^^ variable.other.backref-and-recursion.regexp invalid.deprecated.regexp
-
-
 regex = r'(?P<quote>[\'"]).*?\g<quote>'
 #          ^^ keyword.other.backref-and-recursion.regexp
 #            ^ punctuation.definition.capture-group-name.begin.regexp
@@ -168,22 +151,6 @@ regex = r'(?P<Quote>[\'"]).*?\g<Quote>'
 #                  ^ punctuation.definition.capture-group-name.end.regexp
 #                            ^^ keyword.other.backref-and-recursion.regexp
 #                               ^^^^^ variable.other.backref-and-recursion.regexp - invalid
-
-regex = r'(?P<àuote>[\'"]).*?\g<àuote>'
-#          ^^ keyword.other.backref-and-recursion.regexp
-#            ^ punctuation.definition.capture-group-name.begin.regexp
-#             ^^^^^ entity.name.capture-group.regexp invalid.deprecated.regexp
-#                  ^ punctuation.definition.capture-group-name.end.regexp
-#                            ^^ keyword.other.backref-and-recursion.regexp
-#                               ^^^^^ variable.other.backref-and-recursion.regexp invalid.deprecated.regexp
-
-regex = r'(?P<quàte>[\'"]).*?\g<quàte>'
-#          ^^ keyword.other.backref-and-recursion.regexp
-#            ^ punctuation.definition.capture-group-name.begin.regexp
-#             ^^^^^ entity.name.capture-group.regexp invalid.deprecated.regexp
-#                  ^ punctuation.definition.capture-group-name.end.regexp
-#                            ^^ keyword.other.backref-and-recursion.regexp
-#                               ^^^^^ variable.other.backref-and-recursion.regexp invalid.deprecated.regexp
 
 regex = r'''\b ([fobar]*){1}(?:a|b)?'''
 #           ^ keyword.control.anchor.regexp


### PR DESCRIPTION
Centralizes named capture group identifiers in a variable. Adds support for capital letters one place they were missing. Adds support for `\g<...>` backref style.

[Relevant documentation in v3.12](https://docs.python.org/3.12/library/re.html#index-18)

Previously included (but now removed) deprecation scopes for non-ASCII capture group identifiers.