### PR TITLE
[CI] Re-enable using latest syntax test runner (#4107)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,16 +50,11 @@ jobs:
           #   sublime-build: 4169
           #   optional: true
 
-          # latest working dev build
-          - sublime-channel: dev
-            sublime-build: 4183
-            optional: false
-
           # latest dev build
           # https://www.sublimetext.com/dev
-          # - sublime-channel: dev
-          #   sublime-build: latest
-          #   optional: false
+          - sublime-channel: dev
+            sublime-build: latest
+            optional: false
 
     steps:
 


### PR DESCRIPTION
This reverts commit f99e167a923ce278569b1138733af9b2a6c4fd2c.

ST4185 fixed symbol test failures.