### PR TITLE
[JavaScript] Fix const arrow functions in TSX 

### DIFF
--- a/JavaScript/JSX.sublime-syntax
+++ b/JavaScript/JSX.sublime-syntax
@@ -183,23 +183,25 @@ contexts:
 
   jsx-body:
     - meta_include_prototype: false
-    - match: '<(?=\s*[/>{{jsx_tag_name_start}}])'
-      scope: punctuation.definition.tag.begin.js
-      set:
-        - meta_include_prototype: false
-        - meta_scope: meta.tag.js
-
-        - match: '/'
-          scope: punctuation.definition.tag.begin.js
-          set:
-            - jsx-expect-tag-end
-            - jsx-tag-name
-
-        - match: (?=\S)
-          set:
-            - jsx-body
-            - jsx-tag-attributes
-            - jsx-tag-name
-
+    - include: jsx-child-tag
     - include: jsx-html-escapes
     - include: jsx-interpolation
+
+  jsx-child-tag:
+    - match: <(?=\s*[/>{{jsx_tag_name_start}}])
+      scope: punctuation.definition.tag.begin.js
+      set: jsx-child-tag-begin
+
+  jsx-child-tag-begin:
+    - meta_include_prototype: false
+    - meta_scope: meta.tag.js
+    - match: /
+      scope: punctuation.definition.tag.begin.js
+      set:
+        - jsx-expect-tag-end
+        - jsx-tag-name
+    - match: (?=\S)
+      set:
+        - jsx-body
+        - jsx-tag-attributes
+        - jsx-tag-name

--- a/JavaScript/JSX.sublime-syntax
+++ b/JavaScript/JSX.sublime-syntax
@@ -83,13 +83,18 @@ contexts:
     - match: /
       scope: punctuation.definition.tag.begin.js
       set:
-        - jsx-meta-unmatched-tag
-        - jsx-expect-tag-end
+        - jsx-expect-unmatched-tag-end
         - jsx-tag-name
     - match: (?=\S)
       set:
         - jsx-tag-attributes
         - jsx-tag-name
+
+  jsx-expect-unmatched-tag-end:
+    - meta_include_prototype: false
+    - meta_scope: invalid.illegal.unmatched-tag.js
+    - meta_content_scope: meta.tag.js
+    - include: jsx-expect-tag-end
 
   jsx-child-tag:
     - match: <(?=\s*[/>{{jsx_tag_name_start}}])
@@ -117,11 +122,6 @@ contexts:
       scope: meta.tag.js punctuation.definition.tag.end.js
       pop: 1
     - include: else-pop
-
-  jsx-meta-unmatched-tag:
-    - meta_include_prototype: false
-    - meta_scope: invalid.illegal.unmatched-tag.js
-    - include: immediately-pop
 
   jsx-tag-attributes:
     - meta_content_scope: meta.tag.attributes.js

--- a/JavaScript/JSX.sublime-syntax
+++ b/JavaScript/JSX.sublime-syntax
@@ -24,7 +24,7 @@ variables:
 contexts:
   expression-begin:
     - meta_prepend: true
-    - include: jsx-tag-hack
+    - include: jsx-tag
 
   jsx-interpolation:
     - match: (?={/\*)
@@ -66,9 +66,6 @@ contexts:
     - meta_include_prototype: false
     - meta_scope: meta.jsx.js
     - include: immediately-pop
-
-  jsx-tag-hack: # Ugly hack so that TSX can un-include this in expression-begin
-    - include: jsx-tag
 
   jsx-tag:
     - match: <(?=\s*[/>{{jsx_tag_name_start}}])

--- a/JavaScript/JSX.sublime-syntax
+++ b/JavaScript/JSX.sublime-syntax
@@ -62,6 +62,54 @@ contexts:
             pop: 1
         - expression
 
+  jsx-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.jsx.js
+    - include: immediately-pop
+
+  jsx-tag-hack: # Ugly hack so that TSX can un-include this in expression-begin
+    - include: jsx-tag
+
+  jsx-tag:
+    - match: <(?=\s*[/>{{jsx_tag_name_start}}])
+      scope: punctuation.definition.tag.begin.js
+      set:
+        - jsx-meta
+        - jsx-tag-begin
+
+  jsx-tag-begin:
+    - meta_include_prototype: false
+    - meta_scope: meta.tag.js
+    - match: /
+      scope: punctuation.definition.tag.begin.js
+      set:
+        - jsx-meta-unmatched-tag
+        - jsx-expect-tag-end
+        - jsx-tag-name
+    - match: (?=\S)
+      set:
+        - jsx-tag-attributes
+        - jsx-tag-name
+
+  jsx-child-tag:
+    - match: <(?=\s*[/>{{jsx_tag_name_start}}])
+      scope: punctuation.definition.tag.begin.js
+      set: jsx-child-tag-begin
+
+  jsx-child-tag-begin:
+    - meta_include_prototype: false
+    - meta_scope: meta.tag.js
+    - match: /
+      scope: punctuation.definition.tag.begin.js
+      set:
+        - jsx-expect-tag-end
+        - jsx-tag-name
+    - match: (?=\S)
+      set:
+        - jsx-body
+        - jsx-tag-attributes
+        - jsx-tag-name
+
   jsx-expect-tag-end:
     - meta_content_scope: meta.tag.js
     - match: '>{2,}' # ignore invalid punctuation
@@ -69,36 +117,6 @@ contexts:
       scope: meta.tag.js punctuation.definition.tag.end.js
       pop: 1
     - include: else-pop
-
-  jsx-meta:
-    - meta_include_prototype: false
-    - meta_scope: meta.jsx.js
-    - include: immediately-pop
-
-  jsx-tag:
-    - match: '<(?=\s*[/>{{jsx_tag_name_start}}])'
-      scope: punctuation.definition.tag.begin.js
-      set:
-        - jsx-meta
-        - jsx-tag-attributes-top
-
-  jsx-tag-hack: # Ugly hack so that TSX can un-include this in expression-begin
-    - include: jsx-tag
-
-  jsx-tag-attributes-top:
-    - meta_include_prototype: false
-    - meta_scope: meta.tag.js
-    - match: '/'
-      scope: punctuation.definition.tag.begin.js
-      set:
-        - jsx-meta-unmatched-tag
-        - jsx-expect-tag-end
-        - jsx-tag-name
-
-    - match: (?=\S)
-      set:
-        - jsx-tag-attributes
-        - jsx-tag-name
 
   jsx-meta-unmatched-tag:
     - meta_include_prototype: false
@@ -186,22 +204,3 @@ contexts:
     - include: jsx-child-tag
     - include: jsx-html-escapes
     - include: jsx-interpolation
-
-  jsx-child-tag:
-    - match: <(?=\s*[/>{{jsx_tag_name_start}}])
-      scope: punctuation.definition.tag.begin.js
-      set: jsx-child-tag-begin
-
-  jsx-child-tag-begin:
-    - meta_include_prototype: false
-    - meta_scope: meta.tag.js
-    - match: /
-      scope: punctuation.definition.tag.begin.js
-      set:
-        - jsx-expect-tag-end
-        - jsx-tag-name
-    - match: (?=\S)
-      set:
-        - jsx-body
-        - jsx-tag-attributes
-        - jsx-tag-name

--- a/JavaScript/JSX.sublime-syntax
+++ b/JavaScript/JSX.sublime-syntax
@@ -107,52 +107,43 @@ contexts:
 
   jsx-tag-attributes:
     - meta_content_scope: meta.tag.attributes.js
-
     - match: '>{2,}' # ignore invalid punctuation
     - match: '>'
       scope: meta.tag.js punctuation.definition.tag.end.js
       set: jsx-body
-
     - match: '/'
       scope: meta.tag.js punctuation.definition.tag.end.js
       set: jsx-expect-tag-end
-
-    - include: jsx-interpolation
-
     - match: '{{jsx_identifier}}'
       scope: entity.other.attribute-name.js
-
     - match: '='
       scope: punctuation.separator.key-value.js
-      push: jsx-attribute-value
-
-  jsx-attribute-value:
-    - include: jsx-tag
+    - match: \"
+      scope: punctuation.definition.string.begin.js
+      push: jsx-double-quoted-string-body
+    - match: \'
+      scope: punctuation.definition.string.begin.js
+      push: jsx-single-quoted-string-body
     - include: jsx-interpolation
 
-    - match: "'"
-      scope: punctuation.definition.string.begin.js
-      set:
-        - meta_include_prototype: false
-        - meta_scope: string.quoted.single.js
-        - match: \'
-          scope: punctuation.definition.string.end.js
-          pop: 1
-        - include: jsx-html-escapes
-    - match: '"'
-      scope: punctuation.definition.string.begin.js
-      set:
-        - meta_include_prototype: false
-        - meta_scope: string.quoted.double.js
-        - match: \"
-          scope: punctuation.definition.string.end.js
-          pop: 1
-        - include: jsx-html-escapes
+  jsx-double-quoted-string-body:
+    - meta_include_prototype: false
+    - meta_scope: meta.string.js string.quoted.double.js
+    - match: \"
+      scope: punctuation.definition.string.end.js
+      pop: 1
+    - include: jsx-html-escapes
 
-    - include: else-pop
+  jsx-single-quoted-string-body:
+    - meta_include_prototype: false
+    - meta_scope: meta.string.js string.quoted.single.js
+    - match: \'
+      scope: punctuation.definition.string.end.js
+      pop: 1
+    - include: jsx-html-escapes
 
   jsx-html-escapes:
-    - match: '(&)#?[[:alnum:]]+(;)'
+    - match: (&)#?[[:alnum:]]+(;)
       scope: constant.character.escape.js
       captures:
         1: punctuation.definition.entity.js

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1185,7 +1185,7 @@ contexts:
       set:
         - detect-arrow
         - parenthesized-expression
-    - match: (?={{identifier_start}})
+    - match: ''
       set:
         - detect-arrow
         - literal-variable
@@ -2055,13 +2055,14 @@ contexts:
   parenthesized-expression:
     - match: \(
       scope: punctuation.section.group.begin.js
-      set:
-        - meta_scope: meta.group.js
-        - match: \)
-          scope: punctuation.section.group.end.js
-          pop: 1
-        - match: (?=\S)
-          push: expression
+      set: parenthesized-expression-body
+
+  parenthesized-expression-body:
+    - meta_scope: meta.group.js
+    - match: \)
+      scope: punctuation.section.group.end.js
+      pop: 1
+    - include: expressions
 
   function-call-arguments:
     - meta_content_scope: meta.function-call.js

--- a/JavaScript/TSX.sublime-syntax
+++ b/JavaScript/TSX.sublime-syntax
@@ -23,6 +23,21 @@ contexts:
 
   jsx-tag-hack: []
 
+  jsx-tag-begin:
+    - meta_include_prototype: false
+    - meta_scope: meta.tag.js
+    - match: /
+      scope: punctuation.definition.tag.begin.js
+      set:
+        - jsx-meta-unmatched-tag
+        - jsx-expect-tag-end
+        - jsx-tag-name
+    - match: (?=\S)
+      set:
+        - jsx-tag-attributes
+        - tsx-tag-check
+        - jsx-tag-name
+
   jsx-tag-name:
     - meta_include_prototype: false
     - match: ''
@@ -36,24 +51,8 @@ contexts:
     - include: ts-generic-type-arguments
     - include: else-pop
 
-  jsx-tag-attributes-top:
-    - meta_include_prototype: false
-    - meta_scope: meta.tag.js
-    - match: '/'
-      scope: punctuation.definition.tag.begin.js
-      set:
-        - jsx-meta-unmatched-tag
-        - jsx-expect-tag-end
-        - jsx-tag-name
-
-    - match: (?=\S)
-      set:
-        - jsx-tag-attributes
-        - tsx-tag-check
-        - jsx-tag-name
-
   tsx-tag-check:
-    - match: 'extends{{jsx_identifier_break}}'
+    - match: extends{{jsx_identifier_break}}
       scope: entity.other.attribute-name.js
       set:
         - meta_include_prototype: false

--- a/JavaScript/TSX.sublime-syntax
+++ b/JavaScript/TSX.sublime-syntax
@@ -17,15 +17,23 @@ first_line_match: |-
   )
 
 contexts:
-  branch-possible-arrow-function:
-    - meta_prepend: true
-    - include: jsx-tag
 
-  jsx-tag-hack: []
+  ts-old-type-assertion:
+    # old type assertions are replaced by JSX tags
+    - match: <
+      scope: punctuation.definition.tag.begin.js
+      set:
+        - jsx-meta
+        - jsx-tag-begin
+
+  jsx-tag: []  # replaced by `ts-old-type-assertion`
 
   jsx-tag-begin:
     - meta_include_prototype: false
     - meta_scope: meta.tag.js
+    # note: type parameter modifiers indicate generic lambda
+    - match: (?=(?:in|out|const){{identifier_break}})
+      fail: arrow-function
     - match: /
       scope: punctuation.definition.tag.begin.js
       set:

--- a/JavaScript/TSX.sublime-syntax
+++ b/JavaScript/TSX.sublime-syntax
@@ -29,8 +29,7 @@ contexts:
     - match: /
       scope: punctuation.definition.tag.begin.js
       set:
-        - jsx-meta-unmatched-tag
-        - jsx-expect-tag-end
+        - jsx-expect-unmatched-tag-end
         - jsx-tag-name
     - match: (?=\S)
       set:

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -106,81 +106,6 @@ contexts:
         - match: (?=\S)
           fail: ts-export-type-from
 
-  parenthesized-expression:
-    - match: \(
-      scope: punctuation.section.group.begin.js
-      set:
-        - meta_scope: meta.group.js
-        - match: \)
-          scope: punctuation.section.group.end.js
-          pop: true
-        # Bail early when we see what looks like a type annotation.
-        - match: '\??:'
-          fail: arrow-function
-        - match: (?=\S)
-          push: expression
-
-  branch-possible-arrow-function:
-    - meta_prepend: true
-    - match: (?=\()
-      set:
-        - detect-arrow
-        - ts-detect-parenthesized-arrow-return-type
-        - parenthesized-expression
-
-    - match: \<
-      scope: punctuation.definition.assertion.begin.js
-      set:
-        - ts-old-type-assertion-check
-        - ts-old-type-assertion-end
-        - ts-type-expression-end
-        - ts-type-expression-end-no-line-terminator
-        - ts-type-expression-begin
-
-  ts-detect-parenthesized-arrow-return-type:
-    - match: (?=:)
-      pop: 1
-      branch_point: ts-arrow-function-return-type
-      branch:
-        - ts-detect-arrow-function-return-type
-        - immediately-pop
-    - include: else-pop
-
-  ts-detect-arrow-function-return-type:
-    - meta_include_prototype: false
-    - match: ''
-      set:
-        - ts-detect-arrow-after-return-type
-        - ts-type-annotation
-
-  ts-detect-arrow-after-return-type:
-    - match: (?==>)
-      fail: arrow-function
-    - match: (?=\S)
-      fail: ts-arrow-function-return-type
-
-  async-arrow-function:
-    - match: async{{identifier_break}}
-      scope: keyword.declaration.async.js
-      set:
-        - function-meta
-        - arrow-function-expect-body
-        - arrow-function-expect-arrow-or-fail-async
-        - ts-type-annotation
-        - arrow-function-expect-parameters
-        - ts-type-parameter-list
-
-  arrow-function-declaration:
-    - meta_include_prototype: false
-    - match: ''
-      set:
-        - function-meta
-        - arrow-function-expect-body
-        - arrow-function-expect-arrow
-        - ts-type-annotation
-        - arrow-function-expect-parameters
-        - ts-type-parameter-list
-
   ts-import-type:
     - match: (?=type{{identifier_break}})
       pop: 1
@@ -728,6 +653,11 @@ contexts:
         - method-declaration-prefix
         - class-element-modifiers
 
+  decorator-expression-end:
+    - meta_prepend: true
+    - include: ts-function-type-arguments-or-less-than
+    - include: ts-non-null-assertion
+
   left-expression-end:
     - meta_prepend: true
     - match: '{{function_call_after_lookahead}}'
@@ -739,10 +669,95 @@ contexts:
     - include: ts-type-assertion
     - include: ts-function-type-arguments-or-less-than
 
-  decorator-expression-end:
-    - meta_prepend: true
-    - include: ts-function-type-arguments-or-less-than
-    - include: ts-non-null-assertion
+  async-arrow-function:
+    - match: async{{identifier_break}}
+      scope: keyword.declaration.async.js
+      set:
+        - function-meta
+        - arrow-function-expect-body
+        - arrow-function-expect-arrow-or-fail-async
+        - ts-type-annotation
+        - arrow-function-expect-parameters
+        - ts-type-parameter-list
+
+  arrow-function-declaration:
+    - meta_include_prototype: false
+    - match: ''
+      set:
+        - function-meta
+        - arrow-function-expect-body
+        - arrow-function-expect-arrow
+        - ts-type-annotation
+        - arrow-function-expect-parameters
+        - ts-type-parameter-list
+
+  branch-possible-arrow-function:
+    - meta_include_prototype: false
+    - include: ts-old-type-assertion
+    - include: ts-parenthesized-expression
+    - match: ''
+      set:
+        - detect-arrow
+        - literal-variable
+
+  ts-old-type-assertion:
+    - match: \<
+      scope: punctuation.definition.assertion.begin.js
+      set:
+        - ts-old-type-assertion-check
+        - ts-old-type-assertion-body
+
+  ts-old-type-assertion-body:
+    - meta_scope: meta.assertion.js
+    - match: \>
+      scope: punctuation.definition.assertion.end.js
+      pop: 1
+    - match: (?=\S) # Cover ts-type-parameter-list-head
+      push:
+        - ts-type-expression-end
+        - ts-type-expression-end-no-line-terminator
+        - ts-type-expression-begin
+
+  ts-old-type-assertion-check:
+    - include: ts-parenthesized-expression
+    - include: else-pop
+
+  ts-parenthesized-expression:
+    - match: \(
+      scope: punctuation.section.group.begin.js
+      set:
+        - ts-detect-arrow
+        - ts-parenthesized-expression-body
+
+  ts-parenthesized-expression-body:
+    - meta_scope: meta.group.js
+    # Bail early when we see what looks like a type annotation.
+    - match: '\??:'
+      fail: arrow-function
+    - include: parenthesized-expression-body
+
+  ts-detect-arrow:
+    - match: (?=:)
+      branch_point: ts-detect-arrow
+      branch:
+        - ts-detect-arrow-return-type
+        - immediately-pop-2
+    - include: detect-arrow
+
+  ts-detect-arrow-return-type:
+    - meta_include_prototype: false
+    - match: ':'
+      set:
+        - ts-detect-arrow-after-return-type
+        - ts-type-expression-end
+        - ts-type-expression-end-no-line-terminator
+        - ts-type-expression-begin
+
+  ts-detect-arrow-after-return-type:
+    - match: (?==>)
+      fail: arrow-function
+    - match: (?=\S)
+      fail: ts-detect-arrow
 
   ts-function-type-arguments-or-less-than:
     - match: (?=<(?![<=]))
@@ -779,25 +794,6 @@ contexts:
     - match: '<'
       scope: keyword.operator.comparison.js
       set: expression-begin
-
-  ts-old-type-assertion-end:
-    - meta_scope: meta.assertion.js
-    - match: \>
-      scope: punctuation.definition.assertion.end.js
-      pop: 1
-    - match: (?=\S) # Cover ts-type-parameter-list-head
-      push:
-        - ts-type-expression-end
-        - ts-type-expression-end-no-line-terminator
-        - ts-type-expression-begin
-
-  ts-old-type-assertion-check:
-    - match: (?=\()
-      set:
-        - detect-arrow
-        - ts-detect-parenthesized-arrow-return-type
-        - parenthesized-expression
-    - include: else-pop
 
   ts-non-null-assertion:
     - match: '!(?!=)'

--- a/JavaScript/tests/syntax_test_jsx.jsx
+++ b/JavaScript/tests/syntax_test_jsx.jsx
@@ -183,13 +183,27 @@
 //  ^ punctuation.separator.key-value
 
     'test'
-//  ^^^^^^ string.quoted.single
+//  ^^^^^^ meta.string.js string.quoted.single
+
+    baz 'test'
+//  ^^^^^^^^^^ meta.jsx meta.tag.attributes
+//  ^^^ entity.other.attribute-name
+//      ^^^^^^ meta.string.js string.quoted.single
+//      ^ punctuation.definition.string.begin
+//           ^ punctuation.definition.string.end
 
     baz='test'
 //  ^^^^^^^^^^ meta.jsx meta.tag.attributes
 //  ^^^ entity.other.attribute-name
 //     ^ punctuation.separator.key-value
-//      ^^^^^^ string.quoted.single
+//      ^^^^^^ meta.string.js string.quoted.single
+//      ^ punctuation.definition.string.begin
+//           ^ punctuation.definition.string.end
+
+    baz "test"
+//  ^^^^^^^^^^ meta.jsx meta.tag.attributes
+//  ^^^ entity.other.attribute-name
+//      ^^^^^^ meta.string.js string.quoted.double
 //      ^ punctuation.definition.string.begin
 //           ^ punctuation.definition.string.end
 
@@ -197,12 +211,12 @@
 //  ^^^^^^^^^^ meta.jsx meta.tag.attributes
 //  ^^^ entity.other.attribute-name
 //     ^ punctuation.separator.key-value
-//      ^^^^^^ string.quoted.double
+//      ^^^^^^ meta.string.js string.quoted.double
 //      ^ punctuation.definition.string.begin
 //           ^ punctuation.definition.string.end
 
     baz="\n"
-//      ^^^^ string.quoted.double - constant.character.escape
+//      ^^^^ meta.string.js string.quoted.double - constant.character.escape
 
     baz="&nbsp;&nbsp"
 //       ^^^^^^ constant.character.escape
@@ -225,6 +239,11 @@
 //               ^^ meta.number.integer.decimal.js constant.numeric.value.js
 //                   ^ punctuation.definition.interpolation.end
 
+    {attr}name={value}
+//  ^^^^^^ meta.interpolation
+//        ^^^^ entity.other.attribute-name
+//            ^ punctuation.separator.key-value
+//             ^^^^^^^ meta.interpolation
 
     {...attrs}
 //  ^^^^^^^^^^ meta.interpolation

--- a/JavaScript/tests/syntax_test_jsx.jsx
+++ b/JavaScript/tests/syntax_test_jsx.jsx
@@ -146,6 +146,19 @@
 //                   ^^^^^^ - meta.tag
 //                         ^^^^^^ meta.tag
 
+    <foo>foo<bar>bar<baz>baz</baz>bar</bar>foo</foo>;
+//  ^^^^^ meta.tag
+//       ^^^ - meta.tag
+//          ^^^^^ meta.tag
+//               ^^^ - meta.tag
+//                  ^^^^^ meta.tag
+//                       ^^^ - meta.tag
+//                          ^^^^^^ meta.tag
+//                                ^^^ - meta.tag
+//                                   ^^^^^^ meta.tag
+//                                         ^^^ - meta.tag
+//                                            ^^^^^^ meta.tag
+
     <foo></foo><bar>
 //  ^^^^^^^^^^^ meta.jsx
 //             ^^^^^ - meta.jsx

--- a/JavaScript/tests/syntax_test_tsx.tsx
+++ b/JavaScript/tests/syntax_test_tsx.tsx
@@ -232,6 +232,84 @@ if (a < b || c <= d) {}
 //                                 ^ meta.tag.name entity.name.tag
 //                                   ^ punctuation.terminator.statement
 
+    <const T>() => {}; // </T>;
+//  ^^^^^^^^^ meta.function meta.generic - meta.function meta.function
+//           ^^ meta.function.parameters - meta.function meta.function
+//             ^^^^^^ meta.function - meta.function meta.function
+//  ^ punctuation.definition.generic.begin
+//   ^^^^^ storage.modifier.const
+//         ^ variable.parameter.generic
+//          ^ punctuation.definition.generic.end
+//           ^ punctuation.section.group.begin
+//            ^ punctuation.section.group.end
+//              ^^ keyword.declaration.function.arrow
+//                 ^^ meta.block
+//                 ^ punctuation.section.block.begin
+//                  ^ punctuation.section.block.end
+//                   ^ punctuation.terminator.statement
+//                     ^^^^^^^^ comment.line.double-slash
+//                     ^^ punctuation.definition.comment
+
+    <const T extends>() => {}; // </T>;
+//  ^^^^^^^^^^^^^^^^^ meta.function meta.generic - meta.function meta.function
+//                   ^^ meta.function.parameters - meta.function meta.function
+//                     ^^^^^^ meta.function - meta.function meta.function
+//  ^ punctuation.definition.generic.begin
+//   ^^^^^ storage.modifier.const
+//         ^ variable.parameter.generic
+//           ^^^^^^^ storage.modifier.extends
+//                  ^ punctuation.definition.generic.end
+//                   ^ punctuation.section.group.begin
+//                    ^ punctuation.section.group.end
+//                      ^^ keyword.declaration.function.arrow
+//                         ^^ meta.block
+//                         ^ punctuation.section.block.begin
+//                          ^ punctuation.section.block.end
+//                           ^ punctuation.terminator.statement
+//                             ^^^^^^^^ comment.line.double-slash
+//                             ^^ punctuation.definition.comment
+
+    <const T extends "s">() => {x}; // </T>;
+//  ^^^^^^^^^^^^^^^^^^^^^ meta.function meta.generic - meta.function meta.function
+//                       ^^ meta.function.parameters - meta.function meta.function
+//                         ^^^^^^^ meta.function - meta.function meta.function
+//  ^ punctuation.definition.generic.begin
+//   ^^^^^ storage.modifier.const
+//         ^ variable.parameter.generic
+//           ^^^^^^^ storage.modifier.extends
+//                   ^^^ meta.string string.quoted.double
+//                      ^ punctuation.definition.generic.end
+//                       ^ punctuation.section.group.begin
+//                        ^ punctuation.section.group.end
+//                          ^^ keyword.declaration.function.arrow
+//                             ^^^ meta.block
+//                             ^ punctuation.section.block.begin
+//                               ^ punctuation.section.block.end
+//                                ^ punctuation.terminator.statement
+//                                  ^^^^^^^^ comment.line.double-slash
+//                                  ^^ punctuation.definition.comment
+
+    <const T extends="s">() => {x}; // </T>;
+//  ^^^^^^^^^^^^^^^^^^^^^ meta.function meta.generic - meta.function meta.function
+//                       ^^ meta.function.parameters - meta.function meta.function
+//                         ^^^^^^ meta.function - meta.function meta.function
+//  ^ punctuation.definition.generic.begin
+//   ^^^^^ storage.modifier.const
+//         ^ variable.parameter.generic
+//           ^^^^^^^ storage.modifier.extends
+//                  ^ keyword.operator.assignment.js
+//                   ^^^ meta.string string.quoted.double
+//                      ^ punctuation.definition.generic.end
+//                       ^ punctuation.section.group.begin
+//                        ^ punctuation.section.group.end
+//                          ^^ keyword.declaration.function.arrow
+//                             ^^^ meta.block
+//                             ^ punctuation.section.block.begin
+//                               ^ punctuation.section.block.end
+//                                ^ punctuation.terminator.statement
+//                                  ^^^^^^^^ comment.line.double-slash
+//                                  ^^ punctuation.definition.comment
+
     <T {...}>() => {};</T>;
 //  ^^^^^^^^^^^^^^^^^^^^^^ meta.jsx
 //  ^^^^^^^^^ meta.tag

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -1247,12 +1247,66 @@ let x: (this: any) => any;
 
 let x: < T > ( ... foo : any ) => any;
 //     ^^^^^ meta.generic
+//     ^ punctuation.definition.generic.begin
 //       ^ variable.parameter.generic
+//         ^ punctuation.definition.generic.end
 //           ^^^^^^^^^^^^^^^^^ meta.group
+//           ^ punctuation.section.group.begin
 //             ^^^ keyword.operator.spread
 //                 ^^^ variable.parameter
 //                     ^ punctuation.separator.type
 //                       ^^^ support.type.any
+//                           ^ punctuation.section.group.end
+//                             ^^ keyword.declaration.function
+//                                ^^^ support.type.any
+
+let x: < const T > ( ... foo : any ) => any;
+//     ^^^^^^^^^^^ meta.generic
+//     ^ punctuation.definition.generic.begin
+//       ^^^^^ storage.modifier.const
+//             ^ variable.parameter.generic
+//               ^ punctuation.definition.generic.end
+//                 ^^^^^^^^^^^^^^^^^ meta.group
+//                 ^ punctuation.section.group.begin
+//                   ^^^ keyword.operator.spread
+//                       ^^^ variable.parameter
+//                           ^ punctuation.separator.type
+//                             ^^^ support.type.any
+//                                 ^ punctuation.section.group.end
+//                                   ^^ keyword.declaration.function
+//                                      ^^^ support.type.any
+
+let x: < in T > ( ... foo : any ) => any;
+//     ^^^^^^^^ meta.generic
+//     ^ punctuation.definition.generic.begin
+//       ^^ storage.modifier.variance
+//          ^ variable.parameter.generic
+//            ^ punctuation.definition.generic.end
+//              ^^^^^^^^^^^^^^^^^ meta.group
+//              ^ punctuation.section.group.begin
+//                ^^^ keyword.operator.spread
+//                    ^^^ variable.parameter
+//                        ^ punctuation.separator.type
+//                          ^^^ support.type.any
+//                              ^ punctuation.section.group.end
+//                                ^^ keyword.declaration.function
+//                                   ^^^ support.type.any
+
+let x: < out T > ( ... foo : any ) => any;
+//     ^^^^^^^^^ meta.generic
+//     ^ punctuation.definition.generic.begin
+//       ^^^ storage.modifier.variance
+//           ^ variable.parameter.generic
+//             ^ punctuation.definition.generic.end
+//               ^^^^^^^^^^^^^^^^^ meta.group
+//               ^ punctuation.section.group.begin
+//                 ^^^ keyword.operator.spread
+//                     ^^^ variable.parameter
+//                         ^ punctuation.separator.type
+//                           ^^^ support.type.any
+//                               ^ punctuation.section.group.end
+//                                 ^^ keyword.declaration.function
+//                                    ^^^ support.type.any
 
 let x: () => T
     U
@@ -1360,6 +1414,16 @@ let x: T.U
 [];
 //<- meta.sequence - meta.type
 
+    foo != bar
+//  ^^^ variable.other.readwrite
+//      ^^ keyword.operator.comparison
+//         ^^^ variable.other.readwrite
+
+    foo < bar
+//  ^^^ variable.other.readwrite
+//      ^ keyword.operator.comparison
+//        ^^^ variable.other.readwrite
+
     foo < bar > ();
 //  ^^^ variable.function
 //      ^^^^^^^ meta.generic
@@ -1367,12 +1431,6 @@ let x: T.U
 //        ^^^ support.class
 //            ^ punctuation.definition.generic.end
 //              ^^ meta.group
-
-    foo < bar
-//  ^^^ variable.other.readwrite
-//      ^ keyword.operator.comparison
-//        ^^^ variable.other.readwrite
-    ;
 
     new Foo<bar>;
 //  ^^^ keyword.operator.word.new
@@ -1420,8 +1478,71 @@ const f = <T, U = V<any>>() => {};
 //                          ^^ keyword.declaration.function.arrow
 //                             ^^ meta.block
 
-    a != b;
-//    ^^ keyword.operator.comparison
+const f = <const T>() => foo;
+//        ^^^^^^^^^ meta.function meta.generic - meta.function meta.function
+//                 ^^ meta.function.parameters - meta.function meta.function
+//                   ^^^^^^^ meta.function - meta.function meta.function
+//        ^ punctuation.definition.generic.begin
+//         ^^^^^ storage.modifier.const
+//               ^ variable.parameter.generic
+//                ^ punctuation.definition.generic.end
+//                 ^ punctuation.section.group.begin
+//                  ^ punctuation.section.group.end
+//                    ^^ keyword.declaration.function.arrow
+//                       ^^^ meta.block variable.other.readwrite
+//                          ^ punctuation.terminator.statement
+
+const f = <const T>(a: T,): T => foo;
+//        ^^^^^^^^^ meta.function meta.generic - meta.function meta.function
+//                 ^^^^^^^ meta.function.parameters - meta.function meta.function
+//                        ^ meta.function - meta.type - meta.function meta.function
+//                         ^^^ meta.function meta.type - meta.function meta.function
+//                            ^^^^^^ meta.function - meta.type - meta.function meta.function
+//        ^ punctuation.definition.generic.begin
+//         ^^^^^ storage.modifier.const
+//               ^ variable.parameter.generic
+//                ^ punctuation.definition.generic.end
+//                 ^ punctuation.section.group.begin
+//                  ^ variable.parameter.function
+//                   ^ punctuation.separator.type
+//                    ^^ meta.type
+//                     ^ support.class
+//                      ^ punctuation.separator.parameter.function
+//                       ^ punctuation.section.group.end
+//                        ^ punctuation.separator.type
+//                          ^ support.class
+//                            ^^ keyword.declaration.function.arrow
+//                               ^^^ meta.block variable.other.readwrite
+//                                  ^ punctuation.terminator.statement
+
+const f = <const T extends Foo, X extends Bar>(a: T,): X => foo;
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.js meta.generic.js
+//                                            ^^^^^^^ meta.function.parameters - meta.function meta.function
+//                                                   ^ meta.function - meta.type - meta.function meta.function
+//                                                    ^^^ meta.function meta.type - meta.function meta.function
+//                                                       ^^^^^^ meta.function - meta.type - meta.function meta.function
+//        ^ punctuation.definition.generic.begin
+//         ^^^^^ storage.modifier.const
+//               ^ variable.parameter.generic
+//                 ^^^^^^^ storage.modifier.extends
+//                         ^^^ support.class
+//                            ^ punctuation.separator.comma
+//                              ^ variable.parameter.generic
+//                                ^^^^^^^ storage.modifier.extends
+//                                        ^^^ support.class
+//                                           ^ punctuation.definition.generic.end
+//                                            ^ punctuation.section.group.begin
+//                                             ^ meta.binding.name variable.parameter.function
+//                                              ^ punctuation.separator.type
+//                                               ^^ meta.type
+//                                                ^ support.class
+//                                                 ^ punctuation.separator.parameter.function
+//                                                  ^ punctuation.section.group.end
+//                                                   ^ punctuation.separator.type
+//                                                     ^ support.class
+//                                                       ^^ keyword.declaration.function.arrow
+//                                                          ^^^ meta.block variable.other.readwrite
+//                                                             ^ punctuation.terminator.statement
 
 const x = {
     readonly: true,


### PR DESCRIPTION
Fixes #4112

This PR refactors JSX/TSX tag related contexts and arrow function detection to improve reliability, maintainability and fix some possible causes of former lockups as well as a conflict with generic arrow functions using constant type parameters.

It's a bit of fixing and cleaning.

Parsing performance is more or less unaffected.