### PR TITLE
[Common] Add more items to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,10 @@
+# MacOS specific ignores
 .DS_Store
+
+# excluded packages
+/Default/
+/User/
+
+# python cache files
+__pycache__/
+*.pyc


### PR DESCRIPTION
This commit...

1. excludes Default/ and User/ packages

   That's useful if whole repository is cloned to `${stdatadir}/Packages` to test/develop all bundled packages in a single ST instance.

   Make sure never to add a package with such special name to this repo.

2. excludes known python cache files as they are never to be published, if auto-created by any tool by accident.