### PR TITLE
[JavaScript] Fix JSX interpolation scopes

### DIFF
--- a/JavaScript/JSX.sublime-syntax
+++ b/JavaScript/JSX.sublime-syntax
@@ -38,7 +38,7 @@ contexts:
   jsx-interpolation-comment:
     - match: '({)(/\*)'
       captures:
-        1: punctuation.definition.interpolation.begin.js
+        1: punctuation.section.interpolation.begin.js
         2: punctuation.definition.comment.begin.js
       set:
         - meta_include_prototype: false
@@ -46,19 +46,19 @@ contexts:
         - match: '(\*/)(})'
           captures:
             1: punctuation.definition.comment.end.js
-            2: punctuation.definition.interpolation.end.js
+            2: punctuation.section.interpolation.end.js
           pop: 1
         - match: (?=\*/)
           fail: jsx-interpolation-comment
 
   jsx-interpolation-plain:
     - match: '{'
-      scope: punctuation.definition.interpolation.begin.js
+      scope: punctuation.section.interpolation.begin.js
       set:
         - - meta_scope: meta.interpolation.js
           - meta_content_scope: source.js.embedded.jsx
           - match: '}'
-            scope: punctuation.definition.interpolation.end.js
+            scope: punctuation.section.interpolation.end.js
             pop: 1
         - expression
 

--- a/JavaScript/JSX.sublime-syntax
+++ b/JavaScript/JSX.sublime-syntax
@@ -36,31 +36,35 @@ contexts:
       push: jsx-interpolation-plain
 
   jsx-interpolation-comment:
-    - match: '({)(/\*)'
+    - match: ({)(/\*)
       captures:
         1: punctuation.section.interpolation.begin.js
         2: punctuation.definition.comment.begin.js
-      set:
-        - meta_include_prototype: false
-        - meta_scope: meta.interpolation.js comment.block.js
-        - match: '(\*/)(})'
-          captures:
-            1: punctuation.definition.comment.end.js
-            2: punctuation.section.interpolation.end.js
-          pop: 1
-        - match: (?=\*/)
-          fail: jsx-interpolation-comment
+      set: jsx-interpolation-comment-body
+
+  jsx-interpolation-comment-body:
+    - meta_include_prototype: false
+    - meta_scope: meta.interpolation.js comment.block.js
+    - match: (\*/)(})
+      captures:
+        1: punctuation.definition.comment.end.js
+        2: punctuation.section.interpolation.end.js
+      pop: 1
+    - match: (?=\*/)
+      fail: jsx-interpolation-comment
 
   jsx-interpolation-plain:
-    - match: '{'
+    - match: \{
       scope: punctuation.section.interpolation.begin.js
-      set:
-        - - meta_scope: meta.interpolation.js
-          - meta_content_scope: source.js.embedded.jsx
-          - match: '}'
-            scope: punctuation.section.interpolation.end.js
-            pop: 1
-        - expression
+      set: jsx-interpolation-plain-body
+
+  jsx-interpolation-plain-body:
+    - meta_scope: meta.interpolation.js
+    - meta_content_scope: source.js.embedded.jsx
+    - match: \}
+      scope: punctuation.section.interpolation.end.js
+      pop: 1
+    - include: expressions
 
   jsx-expect-tag-end:
     - meta_content_scope: meta.tag.js

--- a/JavaScript/tests/syntax_test_jsx.jsx
+++ b/JavaScript/tests/syntax_test_jsx.jsx
@@ -212,18 +212,18 @@
 
     baz={xyzzy}
 //      ^^^^^^^ meta.interpolation
-//      ^ punctuation.definition.interpolation.begin
+//      ^ punctuation.section.interpolation.begin
 //       ^^^^^ source.js.embedded.jsx variable.other.readwrite
-//            ^ punctuation.definition.interpolation.end
+//            ^ punctuation.section.interpolation.end
 
     baz={{ xyzzy:42 }}
 //      ^^^^^^^^^^^^^^ meta.interpolation
-//      ^ punctuation.definition.interpolation.begin
+//      ^ punctuation.section.interpolation.begin
 //       ^^^^^^^^^^^^ source.js.embedded.jsx meta.mapping
 //         ^^^^^ meta.mapping.key
 //              ^ punctuation.separator.key-value
 //               ^^ meta.number.integer.decimal.js constant.numeric.value.js
-//                   ^ punctuation.definition.interpolation.end
+//                   ^ punctuation.section.interpolation.end
 
 
     {...attrs}
@@ -240,7 +240,7 @@
 //        ^^^^^ meta.mapping.key
 //             ^ punctuation.separator.key-value
 //              ^^ meta.number.integer.decimal.js constant.numeric.value.js
-//                  ^ punctuation.definition.interpolation.end
+//                  ^ punctuation.section.interpolation.end
 
     // baz
 //  ^^^^^^ comment.line.double-slash
@@ -278,32 +278,32 @@
 //     ^^^^^ meta.mapping.key
 //          ^ punctuation.separator.key-value
 //           ^^ meta.number.integer.decimal.js constant.numeric.value.js
-//               ^ punctuation.definition.interpolation.end
+//               ^ punctuation.section.interpolation.end
 
     {//}
-//  ^ punctuation.definition.interpolation.begin
+//  ^ punctuation.section.interpolation.begin
 //   ^^^ comment.line.double-slash
 //   ^^ punctuation.definition.comment
 //     ^ - punctuation
     }
-//  ^ punctuation.definition.interpolation.end
+//  ^ punctuation.section.interpolation.end
 
     {/* foo */}
 //  ^^^^^^^^^^^ meta.jsx meta.interpolation comment.block - source.embedded
-//  ^ punctuation.definition.interpolation.begin
+//  ^ punctuation.section.interpolation.begin
 //   ^^ punctuation.definition.comment.begin
 //          ^^ punctuation.definition.comment.end
-//            ^ punctuation.definition.interpolation.end
+//            ^ punctuation.section.interpolation.end
 
     {/* foo */ bar}
 //  ^^^^^^^^^^^^^^^ meta.jsx meta.interpolation
 //   ^^^^^^^^^^^^^ source.js.embedded
-//  ^ punctuation.definition.interpolation.begin - comment
+//  ^ punctuation.section.interpolation.begin - comment
 //   ^^ punctuation.definition.comment.begin
 //          ^^ punctuation.definition.comment.end
 //            ^^^^^ - comment
 //             ^^^ meta.jsx meta.interpolation variable.other.readwrite
-//                ^ punctuation.definition.interpolation.end
+//                ^ punctuation.section.interpolation.end
 
 </foo>;
 


### PR DESCRIPTION
This PR...

1. scopes jsx string interpolation punctuation `punctuation.section.interpolation`.
2. converts jsx interpolation related anonymous into named contexts.