### PR TITLE
[C++] Fix issue 3883

### DIFF
--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -1311,6 +1311,17 @@ contexts:
     - match: ({{macro_identifier}})(?=\s+~?{{identifier}})
       captures:
         1: meta.assumed-macro.c
+    - match: '({{macro_identifier}})\s*(\()(?=[^\)]+\))'
+      captures:
+        1: variable.function.c++
+        2: meta.group.c++ punctuation.section.group.begin.c++
+      push:
+        - meta_scope: meta.function-call.c++
+        - meta_content_scope: meta.group.c++
+        - match: '\)'
+          scope: meta.group.c++ punctuation.section.group.end.c++
+          pop: true
+        - include: expressions
 
   data-structures-class-definition:
     - meta_scope: meta.class.c++

--- a/C++/syntax_test_cpp.cpp
+++ b/C++/syntax_test_cpp.cpp
@@ -3138,3 +3138,46 @@ void test4()
 {
     return;
 }
+
+#define GTY0
+/*      ^^^^ meta.preprocessor.macro.c++ */
+#define GTY1(A)
+/*      ^^^^    entity.name.function.preprocessor */
+/*          ^^^ meta.preprocessor.macro.parameters */
+#define GTY2(A, B)
+/*      ^^^^       entity.name.function.preprocessor */
+/*          ^^^^^^ meta.preprocessor.macro.parameters */
+
+struct GTY0 foo {
+/*<- keyword.declaration.struct.type.c++ */
+/*     ^^^^  meta.assumed-macro */
+/*          ^^^ entity.name.struct.c++ */
+};
+
+struct GTY1(42) bar {
+/*<- keyword.declaration.struct.type.c++ */
+/*     ^^^^ meta.function-call.c++ */
+/*          ^^ constant.numeric.value.c++ */
+/*              ^^^ entity.name.struct.c++ */
+};
+
+enum GTY1("struct") baz {
+/*<- keyword.declaration.enum.type.c++ */
+/*   ^^^^ meta.function-call.c++ */
+/*        ^^^^^^^^ string */
+/*                  ^^^ entity.name.enum.c++ */
+};
+
+union GTY2("union struct", 42) bazz {
+/*<- keyword.declaration.union.type.c++ */
+/*    ^^^^ meta.function-call.c++ */
+/*         ^^^^^^^^^^^^^^ string */
+/*                         ^^ constant.numeric.value.c++ */
+/*                             ^^^^ entity.name.union.c++ */
+};
+
+class GTY2("struct class", 42) bazzz {
+/*<- keyword.declaration.class.c++ */
+/*    ^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call */
+/*                             ^^^^^ entity.name.class.c++ */
+};


### PR DESCRIPTION
Codebases such as Qt or GCC use macros to annotate some class/struct/union.

This patch teaches the C++ syntax highlighter about such constructs, and fixes https://github.com/sublimehq/Packages/issues/3883.