### PR TITLE
[LaTeX] Add support for IEEEarray environments

### DIFF
--- a/LaTeX/LaTeX.sublime-syntax
+++ b/LaTeX/LaTeX.sublime-syntax
@@ -639,7 +639,6 @@ contexts:
         ((\\)begin)
         \s* (\{) \s* ( IEEEeqnarray\*? ) \s* (\})
         \s* (\{) \s* ( {{letter}}+ ) \s* (\})
-      # scope: meta.environment.math.block.latex
       captures:
         1: support.function.begin.latex keyword.control.flow.begin.latex
         2: punctuation.definition.backslash.latex

--- a/LaTeX/LaTeX.sublime-syntax
+++ b/LaTeX/LaTeX.sublime-syntax
@@ -634,16 +634,32 @@ contexts:
         4: variable.parameter.function.latex
         5: punctuation.definition.group.brace.end.tex
       push: block-math-begin-end-command-body
+    - match: |-
+        (?x)
+        ((\\)begin)
+        \s* (\{) \s* ( IEEEeqnarray\*? ) \s* (\})
+        \s* (\{) \s* ( {{letter}}+ ) \s* (\})
+      # scope: meta.environment.math.block.latex
+      captures:
+        1: support.function.begin.latex keyword.control.flow.begin.latex
+        2: punctuation.definition.backslash.latex
+        3: punctuation.definition.group.brace.begin.tex
+        4: variable.parameter.function.latex
+        5: punctuation.definition.group.brace.end.tex
+        6: punctuation.definition.group.brace.begin.tex
+        7: variable.parameter.function.latex
+        8: punctuation.definition.group.brace.end.tex
+      push: block-math-begin-end-command-body
 
   block-math-begin-end-command-body:
-    - meta_content_scope: meta.environment.math.block.be.latex markup.math.block
+    - meta_content_scope: meta.environment.math.block.latex markup.math.block
     - include: block-math-begin-end-command-end
     - include: math-content
 
   block-math-begin-end-command-end:
     - match: ((\\)end)(\{)\s*(\4)\s*(\})
       captures:
-        1: support.function.end.latex keyword.control.flow.begin.latex
+        1: support.function.end.latex keyword.control.flow.end.latex
         2: punctuation.definition.backslash.latex
         3: punctuation.definition.group.brace.begin.tex
         4: variable.parameter.function.latex

--- a/LaTeX/LaTeX.sublime-syntax
+++ b/LaTeX/LaTeX.sublime-syntax
@@ -638,7 +638,7 @@ contexts:
         (?x)
         ((\\)begin)
         \s* (\{) \s* ( IEEEeqnarray\*? ) \s* (\})
-        \s* (\{) \s* ( {{letter}}+ ) \s* (\})
+        (?: \s* (\{) \s* ( {{letter}}+ ) \s* (\}) )?
       captures:
         1: support.function.begin.latex keyword.control.flow.begin.latex
         2: punctuation.definition.backslash.latex

--- a/LaTeX/tests/syntax_test_latex.tex
+++ b/LaTeX/tests/syntax_test_latex.tex
@@ -784,6 +784,13 @@ The \emph{verbatim} environment sets everything in verbatim.
 % ^^^^^^^^^^ markup.math.inline - string
 %           ^ punctuation.definition.string.end.tex - markup.math.inline
 
+ $\verb!$! \alpha$
+%^ meta.environment.math.inline.dollar.tex string.other.math.tex punctuation.definition.string.begin.tex
+% ^^^^^^^^^^^^^^^ meta.environment.math.inline.dollar.tex markup.math.inline
+%       ^ markup.raw.verb.latex
+%          ^^^^^^ keyword.other.math.greek.tex
+%                ^ meta.environment.math.inline.dollar.tex string.other.math.tex punctuation.definition.string.end.tex
+
  $$f(x) = x^2$$
 %^^ string.other.math.tex punctuation.definition.string.begin.tex
 %^^^^^^^^^^^^^^ meta.environment.math.block.dollar.tex
@@ -838,21 +845,47 @@ The \emph{verbatim} environment sets everything in verbatim.
 %      ^^^^^^^^ variable.parameter.function.latex
 %              ^ punctuation.definition.group.brace.end.tex
 f(x) = x^2
-% <- meta.environment.math.block.be.latex variable.other.math.tex
+% <- meta.environment.math.block.latex variable.other.math.tex
 %^^^^^^^^^ meta.environment.math.block
 \end{equation}
-% <- support.function.end.latex keyword.control.flow.begin.latex punctuation.definition.backslash.latex
-%^^^ support.function.end.latex keyword.control.flow.begin.latex
+% <- support.function.end.latex keyword.control.flow.end.latex punctuation.definition.backslash.latex
+%^^^ support.function.end.latex keyword.control.flow.end.latex
 %   ^ punctuation.definition.group.brace.begin.tex
 %    ^^^^^^^^ variable.parameter.function.latex
 %            ^ punctuation.definition.group.brace.end.tex
 
+\begin{equation*}
+% <- support.function.begin.latex keyword.control.flow.begin.latex punctuation.definition.backslash.latex
+%^^^^^ support.function.begin.latex keyword.control.flow.begin.latex
+%     ^ punctuation.definition.group.brace.begin.tex
+%      ^^^^^^^^^ variable.parameter.function.latex
+%               ^ punctuation.definition.group.brace.end.tex
+f(x) = x^2
+% <- meta.environment.math.block.latex variable.other.math.tex
+%^^^^^^^^^ meta.environment.math.block
+\end{equation*}
+% <- support.function.end.latex keyword.control.flow.end.latex punctuation.definition.backslash.latex
+%^^^ support.function.end.latex keyword.control.flow.end.latex
+%   ^ punctuation.definition.group.brace.begin.tex
+%    ^^^^^^^^^ variable.parameter.function.latex
+%             ^ punctuation.definition.group.brace.end.tex
 
-$\verb!$! \alpha$
-%^^^^^^^^^^^^^^^ meta.environment.math.inline.dollar.tex markup.math.inline
-%      ^ markup.raw.verb.latex
-%         ^^^^^^ keyword.other.math.greek.tex
-
+\begin{IEEEeqnarray}{c}
+%^^^^^ support.function.begin.latex keyword.control.flow.begin.latex
+%     ^ punctuation.definition.group.brace.begin.tex
+%      ^^^^^^^^^^^^ variable.parameter.function.latex
+%                  ^ punctuation.definition.group.brace.end.tex
+%                   ^ punctuation.definition.group.brace.begin.tex
+%                    ^ variable.parameter.function.latex
+%                     ^ punctuation.definition.group.brace.end.tex
+f(x) = x^2
+% <- meta.environment.math.block.latex variable.other.math.tex
+%^^^^^^^^^ meta.environment.math.block
+\end{IEEEeqnarray}
+%^^^ support.function.end.latex keyword.control.flow.end.latex
+%   ^ punctuation.definition.group.brace.begin.tex
+%    ^^^^^^^^^^^^ variable.parameter.function.latex
+%                ^ punctuation.definition.group.brace.end.tex
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %                 Boxes

--- a/LaTeX/tests/syntax_test_latex.tex
+++ b/LaTeX/tests/syntax_test_latex.tex
@@ -870,6 +870,20 @@ f(x) = x^2
 %    ^^^^^^^^^ variable.parameter.function.latex
 %             ^ punctuation.definition.group.brace.end.tex
 
+\begin{IEEEeqnarray}
+%^^^^^ support.function.begin.latex keyword.control.flow.begin.latex
+%     ^ punctuation.definition.group.brace.begin.tex
+%      ^^^^^^^^^^^^ variable.parameter.function.latex
+%                  ^ punctuation.definition.group.brace.end.tex
+f(x) = x^2
+% <- meta.environment.math.block.latex variable.other.math.tex
+%^^^^^^^^^ meta.environment.math.block
+\end{IEEEeqnarray}
+%^^^ support.function.end.latex keyword.control.flow.end.latex
+%   ^ punctuation.definition.group.brace.begin.tex
+%    ^^^^^^^^^^^^ variable.parameter.function.latex
+%                ^ punctuation.definition.group.brace.end.tex
+
 \begin{IEEEeqnarray}{c}
 %^^^^^ support.function.begin.latex keyword.control.flow.begin.latex
 %     ^ punctuation.definition.group.brace.begin.tex


### PR DESCRIPTION
This commit

1. adds support for `\begin{IEEEeqnarray}` math environments. 
   specified by: https://moser-isi.ethz.ch/docs/typeset_equations.pdf 
   inspired by: https://github.com/SublimeText/LaTeXTools/issues/1413

2. fixes `meta.environment.math.block` scope by removing incomplete `.be`.
3. fixes `\\end` scope using `keyword.control.flow.end.latex`.