### PR TITLE
[Scala] Tweak string and interpolation scopes

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -1402,7 +1402,7 @@ contexts:
       scope: punctuation.definition.string.begin.scala
       push:
         - meta_include_prototype: false
-        - meta_scope: meta.string.scala string.quoted.double.block.scala
+        - meta_scope: meta.string.scala string.quoted.triple.scala
         - match: '(""")(?!")'
           scope: punctuation.definition.string.end.scala
           pop: true
@@ -1428,7 +1428,7 @@ contexts:
         2: punctuation.definition.string.begin.scala
       push:
         - meta_include_prototype: false
-        - meta_scope: meta.string.interpolated.scala string.quoted.double.block.scala
+        - meta_scope: meta.string.interpolated.scala string.quoted.triple.scala
         - match: '"""'
           scope: punctuation.definition.string.end.scala
           pop: true
@@ -1439,7 +1439,7 @@ contexts:
         2: punctuation.definition.string.begin.scala
       push:
         - meta_include_prototype: false
-        - meta_scope: meta.string.interpolated.scala string.quoted.double.block.scala
+        - meta_scope: meta.string.interpolated.scala string.quoted.triple.scala
         - match: '{{unicode_char}}'
           scope: constant.character.escape.scala
         - match: '(""")(?!")'

--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -1402,17 +1402,17 @@ contexts:
       scope: punctuation.definition.string.begin.scala
       push:
         - meta_include_prototype: false
-        - meta_scope: string.quoted.triple.scala
-        - match: '{{unicode_char}}'
-          scope: constant.character.escape.scala
+        - meta_scope: meta.string.scala string.quoted.double.block.scala
         - match: '(""")(?!")'
           scope: punctuation.definition.string.end.scala
           pop: true
+        - match: '{{unicode_char}}'
+          scope: constant.character.escape.scala
     - match: '"'
       scope: punctuation.definition.string.begin.scala
       push:
         - meta_include_prototype: false
-        - meta_scope: string.quoted.double.scala
+        - meta_scope: meta.string.scala string.quoted.double.scala
         - match: '"'
           scope: punctuation.definition.string.end.scala
           pop: true
@@ -1427,32 +1427,32 @@ contexts:
         1: support.function.scala
         2: punctuation.definition.string.begin.scala
       push:
-        - include: f_string
         - meta_include_prototype: false
-        - meta_scope: string.quoted.interpolated.scala
+        - meta_scope: meta.string.interpolated.scala string.quoted.double.block.scala
         - match: '"""'
           scope: punctuation.definition.string.end.scala
           pop: true
+        - include: f_string
     - match: '({{alphaid}})(""")'
       captures:
         1: support.function.scala
         2: punctuation.definition.string.begin.scala
       push:
         - meta_include_prototype: false
-        - meta_scope: string.quoted.triple.interpolated.scala
+        - meta_scope: meta.string.interpolated.scala string.quoted.double.block.scala
         - match: '{{unicode_char}}'
           scope: constant.character.escape.scala
         - match: '(""")(?!")'
           scope: punctuation.definition.string.end.scala
           pop: true
-        - include: interpolated-vars-expressions
+        - include: interpolations
     - match: '(f)(")'
       captures:
         1: support.function.scala
         2: punctuation.definition.string.begin.scala
       push:
         - meta_include_prototype: false
-        - meta_scope: string.quoted.interpolated.scala
+        - meta_scope: meta.string.interpolated.scala string.quoted.double.scala
         - include: f_string
         - match: '"'
           scope: punctuation.definition.string.end.scala
@@ -1465,27 +1465,27 @@ contexts:
         2: punctuation.definition.string.begin.scala
       push:
         - meta_include_prototype: false
-        - meta_scope: string.quoted.raw.interpolated.scala
+        - meta_scope: meta.string.raw.scala string.quoted.double.scala
         - match: '"'
           scope: punctuation.definition.string.end.scala
           pop: true
         - match: \n
           scope: invalid.string.newline.scala
-        - include: interpolated-vars-expressions
+        - include: interpolations
     - match: '({{alphaid}})(")'
       captures:
         1: support.function.scala
         2: punctuation.definition.string.begin.scala
       push:
         - meta_include_prototype: false
-        - meta_scope: string.quoted.interpolated.scala
+        - meta_scope: meta.string.interpolated.scala string.quoted.double.scala
         - match: '"'
           scope: punctuation.definition.string.end.scala
           pop: true
         - match: \n
           scope: invalid.string.newline.scala
         - include: escaped
-        - include: interpolated-vars-expressions
+        - include: interpolations
 
   escaped:
     - match: '{{escaped_char}}'
@@ -1498,7 +1498,7 @@ contexts:
   # /!\ this implementation may allow incorrect combinations
   f_string:
     - include: escaped
-    - include: interpolated-vars-expressions
+    - include: interpolations
     # constant formatting
     - match: '%[%n]'
       scope: constant.other.formatting.scala
@@ -1518,35 +1518,38 @@ contexts:
     - match: '%[\+\-# 0\(,]*[doxX]'
       scope: constant.other.formatting.scala
 
-  interpolated-vars-expressions:
-    # we duplicate this pattern to encode a greedy ? on the [']
-    - match: '\$(?={{alphaid}})'
-      scope: punctuation.definition.variable.scala variable.other.scala
-      push:
-        - clear_scopes: 1
-        - match: '{{alphaid}}'
-          scope: variable.other.scala
-          pop: true
-    - match: '\$\{'
-      scope: punctuation.definition.expression.scala
-      push:
-        - match: '\}'
-          scope: punctuation.definition.expression.scala
-          pop: true
-        - match: ''
-          push:
-            - clear_scopes: 1
-            - meta_content_scope: source.scala.embedded
-            - match: (?=\})
-              pop: true
-            - include: nest-curly-and-self
-            - include: main
+  interpolations:
+    - match: '(\$)(\{)'
+      captures:
+        1: punctuation.definition.variable.scala
+        2: punctuation.section.interpolation.begin.scala
+      push: interpolation-body
+    - match: '(\$){{alphaid}}'
+      scope: meta.interpolation.scala variable.other.scala
+      captures:
+        1: punctuation.definition.variable.scala
+      push: clear-pop
+
+  clear-pop:
+    - clear_scopes: 1
+    - meta_include_prototype: false
+    - match: ''
+      pop: true
+
+  interpolation-body:
+    - clear_scopes: 1
+    - meta_scope: meta.interpolation.scala
+    - meta_content_scope: source.scala.embedded
+    - match: '\}'
+      scope: punctuation.section.interpolation.end.scala
+      pop: true
+    - include: nest-curly-and-self
 
   xml-literal:
     - match: '<!\[CDATA\['
       scope: punctuation.definition.string.begin.xml
       push:
-        - meta_scope: string.unquoted.cdata.xml
+        - meta_scope: meta.string.scala string.unquoted.cdata.xml
         - match: ']]>'
           scope: punctuation.definition.string.end.xml
           pop: true

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -375,7 +375,7 @@ type Foo = Bar[A] forSome { type A }
 //                                    ^^^ punctuation.definition.string.end.scala
 
    """testing"""
-// ^^^^^^^^^^^^^ meta.string.scala string.quoted.double.block.scala
+// ^^^^^^^^^^^^^ meta.string.scala string.quoted.triple.scala
 
    s"testing $a ${42}"
 // ^^^^^^^^^^ meta.string.interpolated.scala string.quoted.double.scala - meta.interpolation
@@ -393,11 +393,11 @@ type Foo = Bar[A] forSome { type A }
 //                   ^ punctuation.definition.string.end.scala
 
    s"""testing $a ${42}"""
-// ^^^^^^^^^^^^ meta.string.interpolated.scala string.quoted.double.block.scala - meta.interpolation
+// ^^^^^^^^^^^^ meta.string.interpolated.scala string.quoted.triple.scala - meta.interpolation
 //             ^^ meta.string.interpolated.scala meta.interpolation.scala - string
-//               ^ meta.string.interpolated.scala string.quoted.double.block.scala - meta.interpolation
+//               ^ meta.string.interpolated.scala string.quoted.triple.scala - meta.interpolation
 //                ^^^^^ meta.string.interpolated.scala meta.interpolation.scala - string
-//                     ^^^ meta.string.interpolated.scala string.quoted.double.block.scala - meta.interpolation
+//                     ^^^ meta.string.interpolated.scala string.quoted.triple.scala - meta.interpolation
 // ^ support.function
 //             ^^ variable.other
 //                ^ punctuation.definition.variable.scala
@@ -629,12 +629,12 @@ type Foo = Bar[A] forSome { type A }
 //      ^^^^^ meta.string.scala string.quoted.double.scala
 
    case """foo""" =>
-//      ^^^^^^^^^ meta.string.scala string.quoted.double.block.scala
+//      ^^^^^^^^^ meta.string.scala string.quoted.triple.scala
 
    case q"""..$foo""" =>
-//      ^^^^^^ meta.string.interpolated.scala string.quoted.double.block.scala
+//      ^^^^^^ meta.string.interpolated.scala string.quoted.triple.scala
 //            ^^^^ meta.string.interpolated.scala meta.interpolation.scala variable.other.scala - string
-//                ^^^ meta.string.interpolated.scala string.quoted.double.block.scala punctuation.definition.string.end.scala
+//                ^^^ meta.string.interpolated.scala string.quoted.triple.scala punctuation.definition.string.end.scala
 
    case <foo/> =>
 //      ^^^^^^ text.xml

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -356,7 +356,7 @@ type Foo = Bar[A] forSome { type A }
 
    "testing"
 // ^ punctuation.definition.string.begin.scala
-// ^^^^^^^^^ string.quoted.double.scala
+// ^^^^^^^^^ meta.string.scala string.quoted.double.scala
 //         ^ punctuation.definition.string.end.scala
 
   "escaped chars: \u1221 \125 \n"
@@ -375,24 +375,36 @@ type Foo = Bar[A] forSome { type A }
 //                                    ^^^ punctuation.definition.string.end.scala
 
    """testing"""
-// ^^^^^^^^^^^^^ string.quoted.triple.scala
+// ^^^^^^^^^^^^^ meta.string.scala string.quoted.double.block.scala
 
    s"testing $a ${42}"
-// ^^^^^^^^^ string.quoted.interpolated.scala
-// ^ support.function
+// ^^^^^^^^^^ meta.string.interpolated.scala string.quoted.double.scala - meta.interpolation
+//           ^^ meta.string.interpolated.scala meta.interpolation.scala - string
+//             ^ meta.string.interpolated.scala string.quoted.double.scala - meta.interpolation
+//              ^^^^^ meta.string.interpolated.scala meta.interpolation.scala - string
+//                   ^ meta.string.interpolated.scala string.quoted.double.scala - meta.interpolation
+// ^ support.function.scala
+//  ^ punctuation.definition.string.begin.scala
 //           ^^ variable.other
-//              ^^ punctuation.definition.expression
+//              ^ punctuation.definition.variable.scala
+//               ^ punctuation.section.interpolation.begin.scala
 //                ^^ meta.number.integer.decimal.scala
-//                  ^ punctuation.definition.expression
+//                  ^ punctuation.section.interpolation
+//                   ^ punctuation.definition.string.end.scala
 
    s"""testing $a ${42}"""
-// ^^^^^^^^^^^ string.quoted.triple.interpolated.scala
+// ^^^^^^^^^^^^ meta.string.interpolated.scala string.quoted.double.block.scala - meta.interpolation
+//             ^^ meta.string.interpolated.scala meta.interpolation.scala - string
+//               ^ meta.string.interpolated.scala string.quoted.double.block.scala - meta.interpolation
+//                ^^^^^ meta.string.interpolated.scala meta.interpolation.scala - string
+//                     ^^^ meta.string.interpolated.scala string.quoted.double.block.scala - meta.interpolation
 // ^ support.function
 //             ^^ variable.other
-//                ^^ punctuation.definition.expression
+//                ^ punctuation.definition.variable.scala
+//                 ^ punctuation.section.interpolation.begin.scala
 //                  ^^ meta.number.integer.decimal.scala
-//                    ^ punctuation.definition.expression
-//                     ^^^ string.quoted.triple.interpolated.scala
+//                    ^ punctuation.section.interpolation
+//                     ^^^ punctuation.definition.string.end.scala
 
    f"formatted: x: $x%+,.3f ca"
 // ^ support.function
@@ -614,15 +626,15 @@ type Foo = Bar[A] forSome { type A }
 //      ^^^^ constant.other.symbol
 
    case "foo" =>
-//      ^^^^^ string.quoted.double.scala
+//      ^^^^^ meta.string.scala string.quoted.double.scala
 
    case """foo""" =>
-//      ^^^^^^^^^ string.quoted.triple.scala
+//      ^^^^^^^^^ meta.string.scala string.quoted.double.block.scala
 
    case q"""..$foo""" =>
-//      ^^^^^^ string.quoted.triple.interpolated.scala
-//            ^^^^ variable.other
-//                ^^^ string.quoted.triple.interpolated.scala
+//      ^^^^^^ meta.string.interpolated.scala string.quoted.double.block.scala
+//            ^^^^ meta.string.interpolated.scala meta.interpolation.scala variable.other.scala - string
+//                ^^^ meta.string.interpolated.scala string.quoted.double.block.scala punctuation.definition.string.end.scala
 
    case <foo/> =>
 //      ^^^^^^ text.xml
@@ -1032,7 +1044,7 @@ foo(())()
 //    ^^ keyword.declaration.function.arrow
 
 "testing /*comments*/"
-//       ^^^^^^^^^^^^ string.quoted.double
+//       ^^^^^^^^^^^^ meta.string.scala string.quoted.double
 //       ^^^^^^^^^^^^ - comment
 
    (cb: ((Throwable \/ Unit) => Unit)) => 42
@@ -1235,9 +1247,10 @@ xs: Foo with Bar
 // ^^^^^ - storage.type
 
    s"before ${classTag[U] stuff} after"
-//   ^^^^^^ string.quoted.interpolated.scala
+// ^^^^^^^^^ meta.string.interpolated.scala string.quoted.double.scala
+//          ^^^^^^^^^^^^^^^^^^^^ meta.string.interpolated.scala meta.interpolation.scala - string
 //            ^^^^^ - storage.type
-//                               ^^^^^ string.quoted.interpolated.scala
+//                              ^^^^^^^ meta.string.interpolated.scala string.quoted.double.scala
 
 {
   case Stuff(thing, other) =>
@@ -1316,7 +1329,7 @@ def <(a: Int) = 42
        42 + "thing"
 //     ^^^^^^^^^^^^ - text.xml
 //     ^^ source.scala meta.number.integer.decimal.scala
-//          ^^^^^^^ source.scala string.quoted.double.scala
+//          ^^^^^^^ source.scala meta.string.scala string.quoted.double.scala
        // comments!
 //     ^^^^^^^^^^^^ source.scala comment.line.double-slash.scala
 
@@ -1393,7 +1406,7 @@ class Test1
 class Test1
     (val a: String) {
    "string"
-// ^^^^^^^^ string.quoted.double.scala
+// ^^^^^^^^ meta.string.scala string.quoted.double.scala
 }
 
 def test
@@ -1448,7 +1461,7 @@ for (
 
 new {
    "foo"
-// ^^^^^ string.quoted.double.scala
+// ^^^^^ meta.string.scala string.quoted.double.scala
 }
 
 def foo(a: String*, b: (Int => String)*, c: Int*): Negative*
@@ -2026,12 +2039,10 @@ for (_<- fu; _← fu; _= fu)
 //                       ^ punctuation.section.group.end.scala
 
    raw"foo\nbar\rbaz"
-// ^^^ string.quoted.raw.interpolated.scala support.function.scala
-//    ^ string.quoted.raw.interpolated.scala punctuation.definition.string.begin.scala
-//     ^^^^^^^^^^^^^ string.quoted.raw.interpolated.scala
-//        ^^ string.quoted.raw.interpolated.scala
-//             ^^ string.quoted.raw.interpolated.scala
-//                  ^ string.quoted.raw.interpolated.scala punctuation.definition.string.end.scala
+// ^^^^^^^^^^^^^^^^^^ meta.string.raw.scala string.quoted.double.scala - constant.character
+// ^^^ support.function.scala
+//    ^ punctuation.definition.string.begin.scala
+//                  ^ punctuation.definition.string.end.scala
 
 case (foo => } abc
 //             ^^^ - variable
@@ -2061,8 +2072,12 @@ gzis =>// foo
 //     ^^ comment.line.double-slash.scala punctuation.definition.comment.scala
 
 s"testing '$foo' bar"
-//        ^ string.quoted.interpolated.scala - variable
-//             ^ string.quoted.interpolated.scala - variable
+//^^^^^^^^^^^^^^^^^^^ meta.string.interpolated.scala
+//^^^^^^^^^ string.quoted.double.scala - meta.interpolation
+//         ^^^^ meta.interpolation.scala variable.other.scala - string
+//         ^ punctuation.definition.variable.scala
+//             ^^^^^^ string.quoted.double.scala - meta.interpolation
+//                  ^ punctuation.definition.string.end.scala
 
   class Context(var abc: Boolean, val fed: Int)
 //              ^^^ storage.type.volatile.scala

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -367,15 +367,18 @@ type Foo = Bar[A] forSome { type A }
   "bad escaping: \p"
 //               ^ invalid.illegal.lone-escape.scala
 
+   """testing"""
+// ^^^^^^^^^^^^^ meta.string.scala string.quoted.triple.scala
+
   """escaped in triple: \u1221 \125 \n"""
 //^^^ punctuation.definition.string.begin.scala
 //                      ^^^^^^ constant.character.escape.scala
-//                             ^^^ - constant.character.escape.scala
-//                                  ^^ - constant.character.escape.scala
+//                             ^^^^ - constant.character
+//                                  ^^ - constant.character
 //                                    ^^^ punctuation.definition.string.end.scala
 
-   """testing"""
-// ^^^^^^^^^^^^^ meta.string.scala string.quoted.triple.scala
+  """not bad in triple: \p"""
+//                      ^^ - constant.character - invalid
 
    s"testing $a ${42}"
 // ^^^^^^^^^^ meta.string.interpolated.scala string.quoted.double.scala - meta.interpolation

--- a/Scala/syntax_test_scala3.scala
+++ b/Scala/syntax_test_scala3.scala
@@ -494,7 +494,7 @@ val str: "hi" = "hi"
 //       ^^^ string.quoted.double.scala
 
 val str: """hi""" = """hi"""
-//       ^^^^^^^^ string.quoted.triple.scala
+//       ^^^^^^^^ meta.string.scala string.quoted.double.block.scala
 
 val i: 0x01 = 0x01
 //     ^^ constant.numeric.base.scala

--- a/Scala/syntax_test_scala3.scala
+++ b/Scala/syntax_test_scala3.scala
@@ -494,7 +494,7 @@ val str: "hi" = "hi"
 //       ^^^ string.quoted.double.scala
 
 val str: """hi""" = """hi"""
-//       ^^^^^^^^ meta.string.scala string.quoted.double.block.scala
+//       ^^^^^^^^ meta.string.scala string.quoted.triple.scala
 
 val i: 0x01 = 0x01
 //     ^^ constant.numeric.base.scala


### PR DESCRIPTION
This commit tweaks string and interpolation related scopes after the scheme of Python and ShellScript.

1. from python use `meta.string.interpolated` and `string.quoted.double.block`
2. from shell use interpolation scopes.

   Scope guidelines request `punctuation.section.interpolation.[begin|end]`, but `$` variables are historically scoped `punctuation.definition.variable`.

   This commit (as shellscript) attempt to satisfy both.

   Hence `$` in `${}` is scoped punctuation.definition.variable, which may appear odd in the first place.

   Actually `$` is some sort of expansion operator, which adds a variable's or expression's result into containing string. Perl calls it dereferencing operator.

   Most core syntaxes supporting that kind of syntax struggle with it, currently.

   _TL;TR This commit aligns scopes with existing core syntaxes even though there are still some caveats. Solving them is however a bigger task affecting various syntaxes. Good consistent alternatives are required first._