### PR TITLE
[Python] no stray parentheses in regexp patterns

### DIFF
--- a/Python/Embeddings/RegExp (for Python).sublime-syntax
+++ b/Python/Embeddings/RegExp (for Python).sublime-syntax
@@ -58,10 +58,7 @@ contexts:
         3: punctuation.definition.capture-group-name.end.regexp
 
   literals:
-    - include: quantifiers
-    # https://github.com/sublimehq/Packages/issues/314
-    - match: \.
-      scope: keyword.other.any.regexp
+    - meta_prepend: true
     # no illegal parentheses in concatenated patterns
     - match: \]
       scope: punctuation.definition.set.end.regexp

--- a/Python/Embeddings/RegExp (for Python).sublime-syntax
+++ b/Python/Embeddings/RegExp (for Python).sublime-syntax
@@ -56,3 +56,14 @@ contexts:
         1: punctuation.definition.capture-group-name.begin.regexp
         2: variable.other.backref-and-recursion.regexp
         3: punctuation.definition.capture-group-name.end.regexp
+
+  literals:
+    - include: quantifiers
+    # https://github.com/sublimehq/Packages/issues/314
+    - match: \.
+      scope: keyword.other.any.regexp
+    # no illegal parentheses in concatenated patterns
+    - match: \]
+      scope: punctuation.definition.set.end.regexp
+    - match: \)
+      scope: punctuation.section.group.end.regexp

--- a/Python/tests/syntax_test_python_strings.py
+++ b/Python/tests/syntax_test_python_strings.py
@@ -1300,6 +1300,11 @@ match = re.search(r'''(?ix:some text(?-i:hello))(?iLmsux)(?a)foo''', line)
 #                                                        ^^^^ meta.modifier
 #                                                          ^ storage.modifier.mode
 
+match = re.match(r"([^" + charset + r"]*)", line)
+#                  ^ punctuation.section.group.begin.regexp
+#                   ^ punctuation.definition.set.begin.regexp
+#                                     ^ punctuation.definition.set.end.regexp
+#                                       ^ punctuation.section.group.end.regexp
 
 ###############################
 # f-strings


### PR DESCRIPTION
This commit scopes stray brackets normally as those may appear in partial patterns. Correct parentheses matching is not always possible and causes valid closing brackets to be scoped illegal.