### PR TITLE
[LaTeX] Fix case-insensitive comment keyword

### DIFF
--- a/LaTeX/Bibtex.sublime-syntax
+++ b/LaTeX/Bibtex.sublime-syntax
@@ -42,7 +42,7 @@ contexts:
       pop: 1
 
   comments:
-    - match: (@)Comment\b
+    - match: (@)(?i:comment)\b
       scope: keyword.declaration.comment.bibtex
       captures:
         1: punctuation.definition.keyword.bibtex

--- a/LaTeX/tests/syntax_test_bibtex.bib
+++ b/LaTeX/tests/syntax_test_bibtex.bib
@@ -1,5 +1,20 @@
 % SYNTAX TEST "Packages/LaTeX/Bibtex.sublime-syntax"
 
+@comment Ignore content
+% <- comment.line.at-sign.bibtex keyword.declaration.comment.bibtex punctuation.definition.keyword.bibtex
+%^^^^^^^^^^^^^^^^^^^^^^ comment.line.at-sign.bibtex
+%^^^^^^^ keyword.declaration.comment.bibtex
+
+@COMMENT Ignore content
+% <- comment.line.at-sign.bibtex keyword.declaration.comment.bibtex punctuation.definition.keyword.bibtex
+%^^^^^^^^^^^^^^^^^^^^^^ comment.line.at-sign.bibtex
+%^^^^^^^ keyword.declaration.comment.bibtex
+
+@Comment Ignore content
+% <- comment.line.at-sign.bibtex keyword.declaration.comment.bibtex punctuation.definition.keyword.bibtex
+%^^^^^^^^^^^^^^^^^^^^^^ comment.line.at-sign.bibtex
+%^^^^^^^ keyword.declaration.comment.bibtex
+
 @string{mar = "march"}
 % <- meta.declaration.bibtex keyword.declaration.constant.bibtex punctuation.definition.keyword.bibtex
 %^^^^^^ meta.declaration.bibtex keyword.declaration.constant.bibtex


### PR DESCRIPTION
This PR fixes `@comment` keyword pattern to consume it case-insentitive as all other `@`-keywords are.