### PR TITLE
[Rust] Add `+ use<>` syntax

### DIFF
--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -564,7 +564,6 @@ contexts:
   types:
     # matches stray identifiers as a types because a type is expected
     - include: comments
-    - include: impl-types
     - include: return-type
     - match: '&'
       scope: keyword.operator.rust
@@ -590,6 +589,7 @@ contexts:
         - include: pattern-param
     - include: dyn-types
     - include: lifetime
+    - include: impl-trait
     - match: (?={{identifier}}::)
       push: type-path
     - match: (?=::)
@@ -710,15 +710,6 @@ contexts:
     - match: '\b(?:r#)?_*{{type_identifier}}'
       scope: storage.type.rust
 
-  impl-types:
-    - match: '\bimpl\b'
-      scope: storage.type.impl.rust
-      push:
-        - include: comments
-        - include: impl-generic
-        - match: '(?=\S)'
-          pop: true
-
   dyn-types:
     - match: '\bdyn\b(?=\s*(?:\(|{{lifetime}}|{{identifier}}))'
       scope: storage.type.trait.rust
@@ -802,6 +793,31 @@ contexts:
       scope: punctuation.accessor.double-colon.rust
     - match: '[-+%/*]'
       scope: keyword.operator.arithmetic.rust
+
+  impl-trait:
+    - match: '\bimpl\b'
+      scope: storage.type.impl.rust
+      push:
+        - match: '\buse\b'
+          scope: keyword.other.rust
+          push:
+            - match: '<'
+              scope: punctuation.definition.generic.begin.rust
+              set:
+                - match: '>'
+                  scope: punctuation.definition.generic.end.rust
+                  pop: true
+                - include: lifetime
+                - match: ','
+                  scope: punctuation.separator.rust
+                - match: \b(Self)\b
+                  scope: keyword.other.rust
+                - match: '{{identifier}}'
+                - match: '(?=\S)'
+                  pop: true
+        - include: types
+        - match: '(?=\S)'
+          pop: true
 
   ##[ STRUCTS ]###############################################################
 

--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -640,6 +640,7 @@ contexts:
       scope: punctuation.accessor.rust
       set: [type-path-second, path-after-accessor]
     - include: type-names
+    - include: generic-identifier-names
     - include: else-pop
 
   type-path-second:
@@ -813,7 +814,7 @@ contexts:
                   scope: punctuation.separator.rust
                 - match: \b(Self)\b
                   scope: keyword.other.rust
-                - match: '{{identifier}}'
+                - include: all-generic-type-names
                 - match: '(?=\S)'
                   pop: true
         - include: types

--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -823,7 +823,7 @@ contexts:
     - include: lifetime
     - match: ','
       scope: punctuation.separator.rust
-    - match: \b(Self)\b
+    - match: '\bSelf\b'
       scope: keyword.other.rust
     - include: all-generic-type-names
     - match: '(?=\S)'

--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -798,28 +798,36 @@ contexts:
   impl-trait:
     - match: '\bimpl\b'
       scope: storage.type.impl.rust
-      push:
-        - match: '\buse\b'
-          scope: keyword.other.rust
-          push:
-            - match: '<'
-              scope: punctuation.definition.generic.begin.rust
-              set:
-                - meta_scope: meta.generic.rust
-                - match: '>'
-                  scope: punctuation.definition.generic.end.rust
-                  pop: true
-                - include: lifetime
-                - match: ','
-                  scope: punctuation.separator.rust
-                - match: \b(Self)\b
-                  scope: keyword.other.rust
-                - include: all-generic-type-names
-                - match: '(?=\S)'
-                  pop: true
-        - include: types
-        - match: '(?=\S)'
-          pop: true
+      push: impl-trait-types
+
+  impl-trait-types:
+    - match: '\buse\b'
+      scope: keyword.other.rust
+      push: impl-trait-use
+    - include: types
+    - match: '(?=\S)'
+      pop: true
+
+  impl-trait-use:
+    - match: '<'
+      scope: punctuation.definition.generic.begin.rust
+      set: impl-trait-use-generic-body
+    - match: '(?=\S)'
+      pop: true
+
+  impl-trait-use-generic-body:
+    - meta_scope: meta.generic.rust
+    - match: '>'
+      scope: punctuation.definition.generic.end.rust
+      pop: true
+    - include: lifetime
+    - match: ','
+      scope: punctuation.separator.rust
+    - match: \b(Self)\b
+      scope: keyword.other.rust
+    - include: all-generic-type-names
+    - match: '(?=\S)'
+      pop: true
 
   ##[ STRUCTS ]###############################################################
 

--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -804,6 +804,7 @@ contexts:
             - match: '<'
               scope: punctuation.definition.generic.begin.rust
               set:
+                - meta_scope: meta.generic.rust
                 - match: '>'
                   scope: punctuation.definition.generic.end.rust
                   pop: true

--- a/Rust/tests/syntax_test_generics.rs
+++ b/Rust/tests/syntax_test_generics.rs
@@ -545,3 +545,12 @@ fn impl_trait_with_plus() -> impl Iterator<Item = hir::GenericParam<'hir>> + Cap
 //                                                                                                  ^^^^ meta.generic
 //                                                                                                   ^^ storage.modifier.lifetime
 
+fn impl_trait() -> impl Type use < {}
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.rust
+//              ^^^^^^^^^^^^^^^^^^^ meta.function.return-type.rust
+//                 ^^^^ storage.type.impl.rust
+//                      ^^^^ storage.type.rust
+//                           ^^^ keyword.other.rust
+//                               ^^ meta.generic.rust
+//                               ^ punctuation.definition.generic.begin.rust
+//                                 ^^ meta.block.rust

--- a/Rust/tests/syntax_test_generics.rs
+++ b/Rust/tests/syntax_test_generics.rs
@@ -464,7 +464,8 @@ fn impl_trait_return_use_bound<'a>() -> impl for<'b> Trait1<Item = impl Trait2<'
 //                                                                             ^^ storage.modifier.lifetime
 //                                                                               ^ punctuation.definition.generic.end
 //                                                                                 ^ keyword.operator
-//                                                                                      ^^^^ meta.generic meta.generic
+//                                                                                   ^^^ keyword.other
+//                                                                                      ^^^^ meta.generic
 //                                                                                      ^ punctuation.definition.generic.begin
 //                                                                                       ^^ storage.modifier.lifetime
 //                                                                                         ^ punctuation.definition.generic.end
@@ -472,11 +473,12 @@ fn impl_trait_return_use_bound<'a>() -> impl for<'b> Trait1<Item = impl Trait2<'
 
 fn impl_trait_use<'a, foo>() -> impl Trait1 + use<'a, Self, foo> {}
 //                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function meta.function.return-type
-//                                               ^^^^^^^^^^^^^^^ meta.generic
+//                                          ^ keyword.operator
+//                                            ^^^ keyword.other
 //                                               ^ punctuation.definition.generic.begin
 //                                                ^^ storage.modifier.lifetime
 //                                                  ^ punctuation.separator
-//                                                    ^^^^ storage.type
+//                                                    ^^^^ keyword.other
 //                                                        ^ punctuation.separator
 //                                                             ^ punctuation.definition.generic.end
 

--- a/Rust/tests/syntax_test_generics.rs
+++ b/Rust/tests/syntax_test_generics.rs
@@ -442,8 +442,94 @@ fn function<const N: u16>() {
 //              ^^^ storage.type.numeric
     let b: Byte<b'a'>;
 //             ^^^^^^ meta.function meta.block meta.generic
-//              ^^^^ string.quoted.single.rust
+//              ^^^^ string.quoted.single
 //              ^ storage.type.string
 //               ^ punctuation.definition.string.begin
 //                 ^ punctuation.definition.string.end
 }
+
+fn impl_trait_return_use_bound<'a>() -> impl for<'b> Trait1<Item = impl Trait2<'a> + use<'a>> {}
+//                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function meta.function.return-type
+//                                   ^^ punctuation.separator
+//                                      ^^^^ storage.type.impl
+//                                           ^^^ keyword.other
+//                                              ^ meta.generic punctuation.definition.generic.begin
+//                                                 ^ meta.generic punctuation.definition.generic.end
+//                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.generic
+//                                                         ^ meta.generic punctuation.definition.generic.begin
+//                                                               ^ meta.generic keyword.operator
+//                                                                 ^^^^ meta.generic storage.type.impl
+//                                                                            ^^^^ meta.generic meta.generic
+//                                                                            ^ punctuation.definition.generic.begin
+//                                                                             ^^ storage.modifier.lifetime
+//                                                                               ^ punctuation.definition.generic.end
+//                                                                                 ^ keyword.operator
+//                                                                                      ^^^^ meta.generic meta.generic
+//                                                                                      ^ punctuation.definition.generic.begin
+//                                                                                       ^^ storage.modifier.lifetime
+//                                                                                         ^ punctuation.definition.generic.end
+//                                                                                          ^ punctuation.definition.generic.end
+
+fn impl_trait_use<'a, foo>() -> impl Trait1 + use<'a, Self, foo> {}
+//                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function meta.function.return-type
+//                                               ^^^^^^^^^^^^^^^ meta.generic
+//                                               ^ punctuation.definition.generic.begin
+//                                                ^^ storage.modifier.lifetime
+//                                                  ^ punctuation.separator
+//                                                    ^^^^ storage.type
+//                                                        ^ punctuation.separator
+//                                                             ^ punctuation.definition.generic.end
+
+fn impl_trait_return1<'a, 'b>() -> impl Trait<&'a u8, Ty = impl Sized + 'b> {}
+//                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function meta.function.return-type
+//                              ^^ punctuation.separator
+//                                 ^^^^ storage.type.impl
+//                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  meta.generic
+//                                           ^ punctuation.definition.generic.begin
+//                                            ^ keyword.operator
+//                                             ^^ storage.modifier.lifetime
+//                                                ^^ storage.type
+//                                                  ^ punctuation.separator
+//                                                       ^ keyword.operator
+//                                                         ^^^^ storage.type.impl
+//                                                              ^^^^^ support.type
+//                                                                    ^ keyword.operator
+//                                                                      ^^ storage.modifier.lifetime
+//                                                                        ^ punctuation.definition.generic.end
+fn impl_trait_return2() -> impl Debug + 'a {}
+//                      ^^^^^^^^^^^^^^^^^^ meta.function meta.function.return-type
+//                         ^^^^ storage.type.impl
+//                                    ^ keyword.operator
+//                                      ^^ storage.modifier.lifetime
+
+fn impl_trait_param(x: impl FnOnce(&[u8]) -> &[u8])  {}
+//                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function meta.function.parameters
+//                     ^^^^ storage.type.impl
+//                          ^^^^^^ support.type
+//                                ^ meta.group punctuation.section.group.begin
+//                                 ^ meta.group keyword.operator
+//                                  ^ meta.group punctuation.section.group.begin
+//                                   ^^ meta.group storage.type
+//                                     ^^ meta.group punctuation.section.group.end
+//                                        ^^^^^^^^ meta.function meta.function.parameters meta.function.return-type
+//                                        ^^ punctuation.separator
+//                                           ^ meta.function.parameters keyword.operator
+//                                            ^ meta.function.parameters punctuation.section.group.begin
+//                                             ^^ meta.function.parameters storage.type
+//                                               ^ meta.function.parameters punctuation.section.group.end
+
+
+fn impl_trait_with_plus() -> impl Iterator<Item = hir::GenericParam<'hir>> + Captures<'a> + Captures<'s> {}
+//                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function meta.function.return-type
+//                           ^^^^ storage.type.impl
+//                                ^^^^^^^^ support.type
+//                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.generic
+//                                              ^ keyword.operator
+//                                                                  ^^^^ storage.modifier.lifetime
+//                                                                         ^ keyword.operator
+//                                                                                   ^^^^ meta.generic
+//                                                                                    ^^ storage.modifier.lifetime
+//                                                                                        ^ keyword.operator
+//                                                                                                  ^^^^ meta.generic
+//                                                                                                   ^^ storage.modifier.lifetime
+

--- a/Rust/tests/syntax_test_generics.rs
+++ b/Rust/tests/syntax_test_generics.rs
@@ -525,9 +525,11 @@ fn impl_trait_with_plus() -> impl Iterator<Item = hir::GenericParam<'hir>> + Cap
 //                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function meta.function.return-type
 //                           ^^^^ storage.type.impl
 //                                ^^^^^^^^ support.type
-//                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.generic
+//                                        ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.generic - meta.generic meta.generic
 //                                              ^ keyword.operator
+//                                                                 ^^^^^^ meta.generic meta.generic
 //                                                                  ^^^^ storage.modifier.lifetime
+//                                                                       ^ meta.generic - meta.generic meta.generic
 //                                                                         ^ keyword.operator
 //                                                                                   ^^^^ meta.generic
 //                                                                                    ^^ storage.modifier.lifetime

--- a/Rust/tests/syntax_test_generics.rs
+++ b/Rust/tests/syntax_test_generics.rs
@@ -480,6 +480,7 @@ fn impl_trait_use<'a, foo>() -> impl Trait1 + use<'a, Self, foo> {}
 //                                                  ^ punctuation.separator
 //                                                    ^^^^ keyword.other
 //                                                        ^ punctuation.separator
+//                                                          ^^^ storage.type.rust
 //                                                             ^ punctuation.definition.generic.end
 
 fn impl_trait_return1<'a, 'b>() -> impl Trait<&'a u8, Ty = impl Sized + 'b> {}
@@ -501,6 +502,7 @@ fn impl_trait_return1<'a, 'b>() -> impl Trait<&'a u8, Ty = impl Sized + 'b> {}
 fn impl_trait_return2() -> impl Debug + 'a {}
 //                      ^^^^^^^^^^^^^^^^^^ meta.function meta.function.return-type
 //                         ^^^^ storage.type.impl
+//                              ^^^^^ storage.type.rust
 //                                    ^ keyword.operator
 //                                      ^^ storage.modifier.lifetime
 
@@ -526,14 +528,20 @@ fn impl_trait_with_plus() -> impl Iterator<Item = hir::GenericParam<'hir>> + Cap
 //                           ^^^^ storage.type.impl
 //                                ^^^^^^^^ support.type
 //                                        ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.generic - meta.generic meta.generic
+//                                         ^^^^ storage.type.rust
 //                                              ^ keyword.operator
+//                                                ^^^ variable.other.rust
+//                                                   ^^ punctuation.accessor.rust
+//                                                     ^^^^^^^^^^^^ storage.type.rust
 //                                                                 ^^^^^^ meta.generic meta.generic
 //                                                                  ^^^^ storage.modifier.lifetime
 //                                                                       ^ meta.generic - meta.generic meta.generic
 //                                                                         ^ keyword.operator
+//                                                                           ^^^^^^^^ storage.type.rust
 //                                                                                   ^^^^ meta.generic
 //                                                                                    ^^ storage.modifier.lifetime
 //                                                                                        ^ keyword.operator
+//                                                                                          ^^^^^^^^ storage.type.rust
 //                                                                                                  ^^^^ meta.generic
 //                                                                                                   ^^ storage.modifier.lifetime
 


### PR DESCRIPTION
This adds support for the `+ use<>` precise capture syntax to Rust which was introduced in Rust 1.82.
[Documentation](https://doc.rust-lang.org/nightly/reference/trait-bounds.html)
