### PR TITLE
[Lua] Fix block comments after doc comments

### DIFF
--- a/Lua/Lua.sublime-syntax
+++ b/Lua/Lua.sublime-syntax
@@ -152,7 +152,7 @@ contexts:
       set: maybe-line-doc-comment
 
   maybe-line-doc-comment:
-    - match: ^\s*(?=--(?!\[\[))
+    - match: ^\s*(?=--(?!\[(=*)\[))
       set:
         - match: -{2,}
           scope: punctuation.definition.comment.lua

--- a/Lua/tests/syntax_test_lua.lua
+++ b/Lua/tests/syntax_test_lua.lua
@@ -87,6 +87,14 @@
 -- no more doc comment after empty line
 -- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - comment.line.documentation
 
+--- Another doc comment
+    --[=[ block comments after should work with an equals
+--  ^^^^^ comment.block punctuation.definition.comment.begin
+    commented
+--  ^^^^^^^^^ comment.block
+    ]=]
+--  ^^^ comment.block punctuation.definition.comment.end
+
 -----------------
 --^^^^^^^^^^^^^^^ comment.line.documentation.lua punctuation.definition.comment.lua
 -- This will also do.


### PR DESCRIPTION
Test file:

```lua
-- SYNTAX TEST "Packages/Lua/Lua.sublime-syntax"

--- doccomment
--[=[
--^ comment.block punctuation.definition.comment.begin

commented
--^ comment.block

]=]
--<- comment.block punctuation.definition.comment.end

local a
--    ^ variable.other
```