### PR TITLE
[JavaScript] No highlighting in nested tagged template strings

### DIFF
--- a/JavaScript/Embeddings/HTML (for JS template).sublime-syntax
+++ b/JavaScript/Embeddings/HTML (for JS template).sublime-syntax
@@ -72,7 +72,7 @@ contexts:
       scope:
         meta.string.html string.quoted.double.html
         punctuation.definition.string.begin.html
-      embed: scope:source.js.js-template
+      embed: scope:source.js.js-template#expressions
       embed_scope: meta.string.html meta.embedded.html source.js.embedded.html
       escape: \"
       escape_captures:
@@ -82,7 +82,7 @@ contexts:
       scope:
         meta.string.html string.quoted.single.html
         punctuation.definition.string.begin.html
-      embed: scope:source.js.js-template
+      embed: scope:source.js.js-template#expressions
       embed_scope: meta.string.html meta.embedded.html source.js.embedded.html
       escape: \'
       escape_captures:

--- a/JavaScript/Embeddings/HTML (for TS template).sublime-syntax
+++ b/JavaScript/Embeddings/HTML (for TS template).sublime-syntax
@@ -72,7 +72,7 @@ contexts:
       scope:
         meta.string.html string.quoted.double.html
         punctuation.definition.string.begin.html
-      embed: scope:source.js.ts-template
+      embed: scope:source.js.ts-template#expressions
       embed_scope: meta.string.html meta.embedded.html source.js.embedded.html
       escape: \"
       escape_captures:
@@ -82,7 +82,7 @@ contexts:
       scope:
         meta.string.html string.quoted.single.html
         punctuation.definition.string.begin.html
-      embed: scope:source.js.ts-template
+      embed: scope:source.js.ts-template#expressions
       embed_scope: meta.string.html meta.embedded.html source.js.embedded.html
       escape: \'
       escape_captures:

--- a/JavaScript/Embeddings/JavaScript (for JS template).sublime-syntax
+++ b/JavaScript/Embeddings/JavaScript (for JS template).sublime-syntax
@@ -8,7 +8,14 @@ hidden: true
 
 extends: Packages/JavaScript/JavaScript.sublime-syntax
 
+variables:
+    tagged_template_quote_begin: \\\`
+    tagged_template_quote_end: \\\`
+
 contexts:
+
+  main:
+    - include: script
 
   prototype:
     - meta_prepend: true
@@ -17,3 +24,8 @@ contexts:
   string-content:
     - meta_prepend: true
     - include: scope:source.js#string-interpolations
+
+  literal-string-template-begin:
+    - meta_include_prototype: false
+    - include: literal-string-template-raw
+    - include: immediately-pop

--- a/JavaScript/Embeddings/JavaScript (for TS template).sublime-syntax
+++ b/JavaScript/Embeddings/JavaScript (for TS template).sublime-syntax
@@ -8,7 +8,14 @@ hidden: true
 
 extends: Packages/JavaScript/JavaScript.sublime-syntax
 
+variables:
+    tagged_template_quote_begin: \\\`
+    tagged_template_quote_end: \\\`
+
 contexts:
+
+  main:
+    - include: script
 
   prototype:
     - meta_prepend: true
@@ -17,3 +24,8 @@ contexts:
   string-content:
     - meta_prepend: true
     - include: scope:source.ts#string-interpolations
+
+  literal-string-template-begin:
+    - meta_include_prototype: false
+    - include: literal-string-template-raw
+    - include: immediately-pop

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -110,6 +110,11 @@ variables:
   leading_wspace: (?:^\s*)
   trailing_wspace: (?:\s*$\n?)
 
+  tagged_template_quote_begin: \`
+  tagged_template_quote_end: \`
+  tagged_template_quote_escape: '{{no_escape_behind}}{{tagged_template_quote_end}}'
+  no_escape_behind: (?<![^\\]\\)(?<![\\]{3})
+
 contexts:
   main:
     - meta_include_prototype: false # don't match comments before shebang
@@ -1232,11 +1237,11 @@ contexts:
     - include: string-content
 
   literal-string-templates:
-    - match: (?=(?:{{identifier_name}}\s*)?`)
+    - match: (?=(?:{{identifier_name}}\s*)?{{tagged_template_quote_begin}})
       push: literal-string-template-begin
 
   literal-string-template:
-    - match: (?=(?:{{identifier_name}}\s*)?`)
+    - match: (?=(?:{{identifier_name}}\s*)?{{tagged_template_quote_begin}})
       set: literal-string-template-begin
 
   literal-string-template-begin:
@@ -1247,77 +1252,95 @@ contexts:
     #  to maintain JavaScript indentation rules until embedded
     #  code really begins/ends. It's required for embedded code
     #  to be indented using global JavaScript indentation rules.
-    - match: (css)\s*((\`){{trailing_wspace}}?)
+    - include: literal-string-template-css
+    - include: literal-string-template-html
+    - include: literal-string-template-js
+    - include: literal-string-template-json
+    - include: literal-string-template-sql
+    - include: literal-string-template-raw
+    - include: immediately-pop
+
+  literal-string-template-css:
+    - match: (css)\s*(({{tagged_template_quote_begin}}){{trailing_wspace}}?)
       captures:
         1: variable.function.tagged-template.js
         2: meta.string.template.js string.quoted.other.js
         3: punctuation.definition.string.begin.js
       embed: scope:source.css.js-template
       embed_scope: meta.string.template.js source.css.embedded.js
-      escape: '{{leading_wspace}}?(\`)'
+      escape: '{{leading_wspace}}?({{tagged_template_quote_escape}})'
       escape_captures:
         0: meta.string.template.js string.quoted.other.js
         1: punctuation.definition.string.end.js
       pop: 1
-    - match: (html)\s*((\`){{trailing_wspace}}?)
+
+  literal-string-template-html:
+    - match: (html)\s*(({{tagged_template_quote_begin}}){{trailing_wspace}}?)
       captures:
         1: variable.function.tagged-template.js
         2: meta.string.template.js string.quoted.other.js
         3: punctuation.definition.string.begin.js
       embed: scope:text.html.js-template
       embed_scope: meta.string.template.js text.html.embedded.js
-      escape: '{{leading_wspace}}?(\`)'
+      escape: '{{leading_wspace}}?({{tagged_template_quote_escape}})'
       escape_captures:
         0: meta.string.template.js string.quoted.other.js
         1: punctuation.definition.string.end.js
       pop: 1
-    - match: (js)\s*((\`){{trailing_wspace}}?)
+
+  literal-string-template-js:
+    - match: (js)\s*(({{tagged_template_quote_begin}}){{trailing_wspace}}?)
       captures:
         1: variable.function.tagged-template.js
         2: meta.string.template.js string.quoted.other.js
         3: punctuation.definition.string.begin.js
       embed: scope:source.js.js-template
       embed_scope: meta.string.template.js source.js.embedded.js
-      escape: '{{leading_wspace}}?(\`)'
+      escape: '{{leading_wspace}}?({{tagged_template_quote_escape}})'
       escape_captures:
         0: meta.string.template.js string.quoted.other.js
         1: punctuation.definition.string.end.js
       pop: 1
-    - match: (json)\s*((\`){{trailing_wspace}}?)
+
+  literal-string-template-json:
+    - match: (json)\s*(({{tagged_template_quote_begin}}){{trailing_wspace}}?)
       captures:
         1: variable.function.tagged-template.js
         2: meta.string.template.js string.quoted.other.js
         3: punctuation.definition.string.begin.js
       embed: scope:source.json.js-template
       embed_scope: meta.string.template.js source.json.embedded.js
-      escape: '{{leading_wspace}}?(\`)'
+      escape: '{{leading_wspace}}?({{tagged_template_quote_escape}})'
       escape_captures:
         0: meta.string.template.js string.quoted.other.js
         1: punctuation.definition.string.end.js
       pop: 1
-    - match: (sql|SQL)\s*((\`){{trailing_wspace}}?)
+
+  literal-string-template-sql:
+    - match: (sql|SQL)\s*(({{tagged_template_quote_begin}}){{trailing_wspace}}?)
       captures:
         1: variable.function.tagged-template.js
         2: meta.string.template.js string.quoted.other.js
         3: punctuation.definition.string.begin.js
       embed: scope:source.sql.js-template
       embed_scope: meta.string.template.js source.sql.embedded.js
-      escape: '{{leading_wspace}}?(\`)'
+      escape: '{{leading_wspace}}?({{tagged_template_quote_escape}})'
       escape_captures:
         0: meta.string.template.js string.quoted.other.js
         1: punctuation.definition.string.end.js
       pop: 1
-    - match: (?:({{identifier_name}})\s*)?(\`)
+
+  literal-string-template-raw:
+    - match: (?:({{identifier_name}})\s*)?({{tagged_template_quote_begin}})
       captures:
         1: variable.function.tagged-template.js
         2: meta.string.template.js string.quoted.other.js punctuation.definition.string.begin.js
       set: literal-string-template-content
-    - include: immediately-pop
 
   literal-string-template-content:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.template.js string.quoted.other.js
-    - match: \`
+    - match: '{{tagged_template_quote_end}}'
       scope: meta.string.template.js string.quoted.other.js punctuation.definition.string.end.js
       pop: 1
     - include: string-interpolations

--- a/JavaScript/tests/syntax_test_js_template.js
+++ b/JavaScript/tests/syntax_test_js_template.js
@@ -351,3 +351,107 @@ var other = `
 /*^^^ meta.string.template.js string.quoted.other.js */
 /*  ^ punctuation.definition.string.end.js */
 /*   ^ - meta.string */
+
+/*
+ * Nested tagged template strings
+ */
+
+var raw = `
+/*        ^ meta.string.template.js string.quoted.other.js punctuation.definition.string.begin.js */
+    var raw = \`
+/*^^^^^^^^^^^^^^ meta.string.template.js string.quoted.other.js */
+/*            ^^ constant.character.escape.js */
+        var raw = \`
+/*^^^^^^^^^^^^^^^^^^ meta.string.template.js string.quoted.other.js */
+/*                ^^ constant.character.escape.js */
+                any${thing}
+/*^^^^^^^^^^^^^^^^^ meta.string.template.js string.quoted.other.js */
+/*                 ^^^^^^^^ meta.string.template.js meta.interpolation.js */
+/*                 ^^ punctuation.section.interpolation.begin.js */
+/*                   ^^^^^ source.js.embedded variable.other.readwrite.js */
+/*                        ^ punctuation.section.interpolation.end.js */
+            \`;
+/*^^^^^^^^^^^^^ meta.string.template.js string.quoted.other.js */
+/*          ^^ constant.character.escape.js */
+        \`;
+/*^^^^^^^^^ meta.string.template.js string.quoted.other.js */
+/*      ^^ constant.character.escape.js */
+    `;
+/*^^^ meta.string.template.js string.quoted.other.js */
+/*  ^ punctuation.definition.string.end.js */
+/*   ^ punctuation.terminator.statement.js */
+
+var html = html`
+    <style>
+        div { color: ${color}; }
+/*      ^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.template.js text.html.embedded.js source.css.embedded.html */
+/*      ^^^^ meta.selector.css */
+/*      ^^^ entity.name.tag.html.css */
+/*          ^^^^^^^^^^^^^^^^^^^^ meta.property-list.css meta.block.css */
+/*          ^ punctuation.section.block.begin.css */
+/*            ^^^^^ meta.property-name.css support.type.property-name.css */
+/*                 ^ punctuation.separator.key-value.css */
+/*                  ^ meta.property-value.css - meta.interpolation */
+/*                   ^^^^^^^^ meta.property-value.css meta.interpolation.js */
+/*                   ^^ punctuation.section.interpolation.begin.js */
+/*                     ^^^^^ source.js.embedded variable.other.readwrite.js */
+/*                          ^ punctuation.section.interpolation.end.js */
+/*                           ^ punctuation.terminator.rule.css */
+/*                             ^ punctuation.section.block.end.css */
+    </style>
+    <script>
+        let html = html\`
+/*^^^^^^^^^^^^^^^^^^^^^^^ meta.string.template.js text.html.embedded.js source.js.embedded.html */
+/*      ^^^ keyword.declaration */
+/*          ^^^^ variable.other */
+/*               ^ keyword.operator.assignment */
+/*                 ^^^^ variable.function.tagged-template */
+/*                     ^^ meta.string.template string.quoted.other punctuation.definition.string.begin */
+            no more ${html} highlighting
+/*         ^^^^^^^^^ meta.string.template text.html.embedded source.js.embedded.html meta.string.template string.quoted.other */
+/*                  ^^^^^^^ meta.string.template.js text.html.embedded.js source.js.embedded.html meta.string.template.js meta.interpolation.js */
+/*                         ^^^^^^^^^^^^^^ meta.string.template text.html.embedded source.js.embedded.html meta.string.template string.quoted.other */
+            \`;
+/*^^^^^^^^^^^^ meta.string.template text.html.embedded source.js.embedded.html meta.string.template string.quoted.other */
+/*            ^ meta.string.template text.html.embedded source.js.embedded.html punctuation.terminator.statement */
+/*          ^^ punctuation.definition.string.end */
+/*            ^ punctuation.terminator.statement */
+        let css = css\`
+            no more ${css} highlighting
+/*         ^^^^^^^^^ meta.string.template text.html.embedded source.js.embedded.html meta.string.template string.quoted.other */
+/*                  ^^^^^^ meta.string.template.js text.html.embedded.js source.js.embedded.html meta.string.template.js meta.interpolation.js */
+/*                        ^^^^^^^^^^^^^^ meta.string.template text.html.embedded source.js.embedded.html meta.string.template string.quoted.other */
+            \`;
+/*^^^^^^^^^^^^ meta.string.template text.html.embedded source.js.embedded.html meta.string.template string.quoted.other */
+/*            ^ meta.string.template text.html.embedded source.js.embedded.html punctuation.terminator.statement */
+/*          ^^ punctuation.definition.string.end */
+/*            ^ punctuation.terminator.statement */
+        let js = js\`
+            no more ${js} highlighting
+/*         ^^^^^^^^^ meta.string.template text.html.embedded source.js.embedded.html meta.string.template string.quoted.other */
+/*                  ^^^^^ meta.string.template.js text.html.embedded.js source.js.embedded.html meta.string.template.js meta.interpolation.js */
+/*                       ^^^^^^^^^^^^^^ meta.string.template text.html.embedded source.js.embedded.html meta.string.template string.quoted.other */
+            \`;
+/*^^^^^^^^^^^^ meta.string.template text.html.embedded source.js.embedded.html meta.string.template string.quoted.other */
+/*            ^ meta.string.template text.html.embedded source.js.embedded.html punctuation.terminator.statement */
+/*          ^^ punctuation.definition.string.end */
+/*            ^ punctuation.terminator.statement */
+    </script>
+    `
+
+var js = js`
+    var js = js\`
+        var = "no more ${js}";
+/*^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.template.js source.js.embedded.js meta.string.template.js */
+/*^^^^^^^^^^^^^^^^^^^^^ string.quoted.other.js */
+/*                     ^^^^^ meta.interpolation.js */
+/*                          ^^ string.quoted.other.js */
+        \`;
+/*^^^^^^^^^ meta.string.template.js source.js.embedded.js */
+/*^^^^^^^^ meta.string.template.js string.quoted.other.js */
+/*      ^^ punctuation.definition.string.end.js */
+/*        ^ punctuation.terminator.statement.js */
+    `;
+/*^^^ meta.string.template.js string.quoted.other.js */
+/*  ^ punctuation.definition.string.end.js */
+/*   ^ punctuation.terminator.statement.js */


### PR DESCRIPTION
This commit...

1. ensures to terminate syntax highlighted tagged template string only by non-escaped backticks.

2. removes syntax highlighting from nested tagged template strings as it can't be correctly handled using `embed..escape`.

   A "nested tagged template string" is a template string enclosed by escaped backticks.
   
   Note: tagged template strings can't really be nested.

3. Drop shebang from dedicated tagged template JS syntax as it is not needed

4. Restrict inline JS syntax in HTML to "expressions".


Goal is to reduce risk to break syntax highlighting caused by embedded html/js syntax adding tagged template strings.