### PR TITLE
[Lua] Handle multi-global statements

### DIFF
--- a/Lua/Lua.sublime-syntax
+++ b/Lua/Lua.sublime-syntax
@@ -211,7 +211,7 @@ contexts:
       scope: invalid.illegal.unexpected-end.lua
 
     - match: (?=\S)
-      push: expression
+      push: expression-list
 
   block-contents:
     - meta_scope: meta.block.lua

--- a/Lua/tests/syntax_test_lua.lua
+++ b/Lua/tests/syntax_test_lua.lua
@@ -729,6 +729,15 @@
 --                   ^ meta.number.integer.decimal constant.numeric.value
 --                    ^ punctuation.terminator.statement
 
+    a, b = c, d
+--  ^ variable.other
+--   ^ punctuation.separator.comma
+--     ^ variable.other
+--       ^ keyword.operator.assignment
+--         ^ variable.other
+--          ^ punctuation.separator.comma
+--            ^ variable.other
+
     local x <const>, y <  const  > = 1, 2;
 --  ^^^^^ storage.modifier.lua
 --        ^ variable.other.lua


### PR DESCRIPTION
The syntax now handles multi-global statements correctly.

```lua
    a, b = c, d
--   ^ punctuation.separator.comma
--          ^ punctuation.separator.comma
```