### PR TITLE
[Lua] Add more builtins

### DIFF
--- a/Lua/Lua.sublime-syntax
+++ b/Lua/Lua.sublime-syntax
@@ -557,7 +557,7 @@ contexts:
 
   support:
     - match: |-
-        (?x:_G|_VERSION){{identifier_break}}
+        (?x:_G|_VERSION|_ENV){{identifier_break}}
       scope: support.constant.builtin.lua
       pop: 1
 
@@ -566,7 +566,7 @@ contexts:
           assert|collectgarbage|dofile|error|getmetatable|ipairs|load|loadfile
           |next|pairs|pcall|print|rawequal|rawget|rawlen|rawset|select
           |setmetatable|tonumber|tostring|type|xpcall
-          |require|getfenv|module|setfenv|unpack
+          |require|getfenv|module|setfenv|unpack|warn
         ){{function_call_ahead}}
       scope: meta.function-call.lua support.function.builtin.lua
       pop: 1

--- a/Lua/Lua.sublime-syntax
+++ b/Lua/Lua.sublime-syntax
@@ -27,7 +27,7 @@ variables:
   metamethod: |- # http://lua-users.org/wiki/MetatableEvents
     (?x:__(?:
       # special
-      index|newindex|call|tostring|len|i?pairs|gc
+      index|newindex|call|tostring|len|i?pairs|gc|close
       # math operators
       |unm|add|sub|mul|i?div|mod|pow|concat
       # bitwise operators
@@ -36,7 +36,7 @@ variables:
       |eq|lt|le
     ){{identifier_break}})
   # __metatable and __mode don't use functions
-  metaproperty: (?:__(?:metatable|mode){{identifier_break}})
+  metaproperty: (?:__(?:metatable|mode|name){{identifier_break}})
 
   identifier_start: '[A-Za-z_]'
   identifier_char: '[A-Za-z0-9_]'

--- a/Lua/tests/syntax_test_lua_support.lua
+++ b/Lua/tests/syntax_test_lua_support.lua
@@ -3,6 +3,9 @@
     _G;
 --  ^^ support.constant.builtin
 
+    _ENV;
+--  ^^^^ support.constant.builtin
+
     _VERSION;
 --  ^^^^^^^^ support.constant.builtin
 
@@ -17,6 +20,9 @@
 
     error();
 --  ^^^^^ support.function.builtin
+
+    warn();
+--  ^^^^ support.function.builtin
 
     getfenv();
 --  ^^^^^^^ support.function.builtin


### PR DESCRIPTION
`_ENV` was new in Lua 5.2.
`__name` was new in Lua 5.3.
`warn` and `__close` were new in 5.4.