### PR TITLE
[Markdown] Add support for fenced divs

### DIFF
--- a/Markdown/Fold.tmPreferences
+++ b/Markdown/Fold.tmPreferences
@@ -23,6 +23,14 @@
                 <key>excludeTrailingNewlines</key>
                 <true/>
             </dict>
+            <dict>
+                <key>begin</key>
+                <string>punctuation.section.block.begin.markdown</string>
+                <key>end</key>
+                <string>punctuation.section.block.end.markdown</string>
+                <key>excludeTrailingNewlines</key>
+                <false/>
+            </dict>
         </array>
     </dict>
 </dict>

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -172,6 +172,9 @@ variables:
     )
   fenced_code_block_escape: ^{{fenced_code_block_end}}
 
+  # https://pandoc.org/MANUAL.html#divs-and-spans
+  fenced_div_block: :{3,}
+
   # https://spec.commonmark.org/0.30/#email-autolink
   email_domain_commonmark: '[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?'
   email_user_commonmark: '[a-zA-Z0-9.!#$%&''*+/=?^_`{|}~-]+'
@@ -262,6 +265,7 @@ variables:
        |  {{block_quote}}             # a blockquote begins the line
        |  {{atx_heading}}             # an ATX heading begins the line
        |  {{fenced_code_block_start}} # a fenced codeblock begins the line
+       |  {{fenced_div_block}}        # a fenced div block begins the line
        |  {{thematic_break}}          # line is a thematic beak
        |  {{first_list_item}}         # a list item begins the line
        |  {{html_block}}              # a html block begins the line
@@ -275,6 +279,7 @@ variables:
         |   {{block_quote}}             # a blockquote begins the line
         |   {{atx_heading}}             # an ATX heading begins the line
         |   {{fenced_code_block_start}} # a fenced codeblock begins the line
+        |   {{fenced_div_block}}        # a fenced div block begins the line
         |   {{thematic_break}}          # line is a thematic beak
         |   {{list_item}}               # a list item begins the line
         |   {{html_block}}              # a html block begins the line
@@ -347,6 +352,7 @@ contexts:
     - include: list-blocks
     - include: tables
     - include: fenced-code-blocks
+    - include: fenced-div-blocks
     - include: html-blocks
     - include: reference-definitions
     - include: atx-headings
@@ -579,6 +585,7 @@ contexts:
            |   {{reference_definition}}    # a reference definition begins the line
            |   {{atx_heading}}             # an ATX heading begins the line
            |   {{fenced_code_block_start}} # a fenced codeblock begins the line
+           |   {{fenced_div_block}}        # a fenced div block begins the line
            |   {{thematic_break}}          # line is a thematic beak
            |   {{list_item}}               # a list item begins the line
            |   {{html_block}}              # a html block begins the line
@@ -690,6 +697,7 @@ contexts:
            (?: $                           # the line is blank (or only contains whitespace)
            |   {{atx_heading}}             # an ATX heading begins the line
            |   {{fenced_code_block_start}} # a fenced codeblock begins the line
+           |   {{fenced_div_block}}        # a fenced div block begins the line
            |   {{thematic_break}}          # line is a thematic beak
            |   {{list_item}}               # a list item begins the line
            |   {{html_block}}              # a html block begins the line
@@ -717,6 +725,7 @@ contexts:
            (?: \s* $                       # the line is blank (or only contains whitespace)
            |   {{atx_heading}}             # an ATX heading begins the line
            |   {{fenced_code_block_start}} # a fenced codeblock begins the line
+           |   {{fenced_div_block}}        # a fenced div block begins the line
            |   {{thematic_break}}          # line is a thematic beak
            |   {{list_item}}               # a list item begins the line
            |   {{html_block}}              # a html block begins the line
@@ -2249,6 +2258,7 @@ contexts:
            |   {{reference_definition}}    # a reference definition begins the line
            |   {{atx_heading}}             # an ATX heading begins the line
            |   {{fenced_code_block_start}} # a fenced codeblock begins the line
+           |   {{fenced_div_block}}        # a fenced div block begins the line
            |   {{thematic_break}}          # line is a thematic beak
            |   {{list_item}}               # a list item begins the line
            |   {{html_block}}              # a html block begins the line
@@ -2364,6 +2374,7 @@ contexts:
           |   {{atx_heading}}
           |   {{block_quote}}
           |   {{fenced_code_block_start}}
+          |   {{fenced_div_block}}
           |   {{indented_code_block}}
           |   {{thematic_break}}
           )
@@ -3505,6 +3516,46 @@ contexts:
     - include: scope:text.tex.latex#macros
     - include: scope:text.tex.latex#math-content
 
+###[ EXTENSIONS: PANDOC FENCED DIVS ]##########################################
+
+  fenced-div-blocks:
+    # https://pandoc.org/MANUAL.html#divs-and-spans
+    - match: ^[ \t]*({{fenced_div_block}})[ \t]*(?=\S)
+      captures:
+        1: punctuation.section.block.begin.markdown
+      push:
+        - fenced-div-body
+        - fenced-div-puncuation
+        - fenced-div-attr
+
+  fenced-div-attr:
+    - meta_include_prototype: false
+    - match: \{
+      scope: punctuation.definition.attributes.begin.markdown
+      set: link-def-attr-body
+    - match: '{{tag_attribute_name_start}}'
+      set:
+        - tag-attr-meta
+        - tag-attr-equals
+        - tag-attr-name
+    - match: else-pop
+
+  fenced-div-puncuation:
+    - meta_include_prototype: false
+    - match: ':+'
+      scope: punctuation.section.block.markdown
+      pop: 1
+    - include: else-pop
+
+  fenced-div-body:
+    - meta_include_prototype: false
+    - meta_scope: meta.block.div.markdown
+    - match: ^[ \t]*(\1)(\s*\n)
+      captures:
+        1: punctuation.section.block.end.markdown
+      pop: 1
+    - include: markdown
+
 ###[ PROTOTYPES ]#############################################################
 
   else-pop:
@@ -3523,4 +3574,3 @@ contexts:
   immediately-pop:
     - match: ''
       pop: 1
-

--- a/Markdown/tests/syntax_test_markdown.md
+++ b/Markdown/tests/syntax_test_markdown.md
@@ -9037,3 +9037,78 @@ Handle incomplete $\sqrt{b$ expressions well.
    |                       ^^ meta.group.brace
    |                         ^ punctuation.definition.math.end - meta.group
    |                          ^ meta.paragraph.list.markdown - markup.math
+
+# TEST: PANDOC FENCED DIVS ####################################################
+
+| Opening div tags must have attributes
+:::
+| <- - punctuation
+|^^ - punctuation
+
+::: class
+| <- meta.block.div.markdown punctuation.section.block.begin.markdown
+|^^^^^^^^ meta.block.div.markdown - meta.block meta.block
+|^^ punctuation.section.block.begin.markdown
+|   ^^^^^ meta.attribute-with-value.markdown entity.other.attribute-name.markdown
+- list
+|^^^^^ meta.block.div.markdown
+|^^^^^ markup.list.unnumbered.markdown
+| ^^^^ meta.paragraph.list.markdown
+- list
+|^^^^^ meta.block.div.markdown
+|^^^^^ markup.list.unnumbered.markdown
+| ^^^^ meta.paragraph.list.markdown
+:::
+| <- meta.block.div.markdown punctuation.section.block.end.markdown
+|^^ meta.block.div.markdown punctuation.section.block.end.markdown
+
+::: {.class #id} :::
+|^^^^^^^^^^^^^^^^^^^ meta.block.div.markdown
+|^^ punctuation.section.block.begin.markdown
+|   ^^^^^^^^^^^^ meta.attributes.markdown
+|   ^ punctuation.definition.attributes.begin.markdown
+|    ^^^^^^ meta.attribute-with-value.markdown entity.other.attribute-name.markdown
+|           ^^^ meta.attribute-with-value.markdown entity.other.attribute-name.markdown
+|              ^ punctuation.definition.attributes.end.markdown
+|                ^^^ punctuation.section.block.markdown
+::: inner
+|^^^^^^^^ meta.block.div.markdown meta.block.div.markdown
+|^^ punctuation.section.block.begin.markdown
+|   ^^^^^ meta.attribute-with-value.markdown entity.other.attribute-name.markdown
+paragraph
+|^^^^^^^^ meta.block.div.markdown meta.block.div.markdown meta.paragraph.markdown
+:::
+|^^ meta.block.div.markdown meta.block.div.markdown punctuation.section.block.end.markdown
+:::
+|^^ meta.block.div.markdown punctuation.section.block.end.markdown - meta.block meta.block
+
+::: block-quote
+> quoted block
+|^^^^^^^^^^^^^ meta.block.div.markdown markup.quote.markdown
+| ^^^^^^^^^^^^ markup.paragraph.markdown
+> > nested quote
+| <- meta.block.div.markdown markup.quote.markdown markup.paragraph.markdown punctuation.definition.blockquote.markdown
+|^^^^^^^^^^^^^^^ meta.block.div.markdown markup.quote.markdown markup.paragraph.markdown
+| ^ punctuation.definition.blockquote.markdown
+:::
+| <- meta.block.div.markdown punctuation.section.block.end.markdown
+|^^ meta.block.div.markdown punctuation.section.block.end.markdown
+
+::: code-block
+```css
+|^^^^^ meta.block.div.markdown meta.code-fence.definition.begin.css.markdown-gfm
+|^^ punctuation.definition.raw.code-fence.begin.markdown
+|  ^^^ constant.other.language-name.markdown
+```
+:::
+| <- meta.block.div.markdown punctuation.section.block.end.markdown
+|^^ meta.block.div.markdown punctuation.section.block.end.markdown
+
+::: table
+| column | column
+| ---    | ---
+| foo    | bar
+| <- meta.block.div.markdown meta.table.markdown-gfm punctuation.separator.table-cell.markdown
+:::
+| <- meta.block.div.markdown punctuation.section.block.end.markdown
+|^^ meta.block.div.markdown punctuation.section.block.end.markdown


### PR DESCRIPTION
This commit aligns Markdown adds patterns for Pandoc fenced divs.

see: https://pandoc.org/MANUAL.html#divs-and-spans

related with https://github.com/SublimeText-Markdown/MarkdownEditing/commit/fdf86bfc58d199521c7af8b47ed73a4f692082fd