### PR TITLE
[Markdown] Fix Github alert heading indentation

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -363,7 +363,7 @@ contexts:
 
   block-quotes:
     # https://spec.commonmark.org/0.30/#block-quotes
-    - match: '[ \t]{,3}(>)[ ]?((\[)!CAUTION(\]))'
+    - match: '[ \t]{,3}(>)[ ]?[ \t]{,3}((\[)!CAUTION(\]))'
       captures:
         1: punctuation.definition.blockquote.markdown
         2: markup.heading.alert.caution.markdown
@@ -372,7 +372,7 @@ contexts:
       push:
         - block-quote-caution-meta
         - block-quote-body
-    - match: '[ \t]{,3}(>)[ ]?((\[)!WARNING(\]))'
+    - match: '[ \t]{,3}(>)[ ]?[ \t]{,3}((\[)!WARNING(\]))'
       captures:
         1: punctuation.definition.blockquote.markdown
         2: markup.heading.alert.warning.markdown
@@ -381,7 +381,7 @@ contexts:
       push:
         - block-quote-warning-meta
         - block-quote-body
-    - match: '[ \t]{,3}(>)[ ]?((\[)!IMPORTANT(\]))'
+    - match: '[ \t]{,3}(>)[ ]?[ \t]{,3}((\[)!IMPORTANT(\]))'
       captures:
         1: punctuation.definition.blockquote.markdown
         2: markup.heading.alert.important.markdown
@@ -390,7 +390,7 @@ contexts:
       push:
         - block-quote-important-meta
         - block-quote-body
-    - match: '[ \t]{,3}(>)[ ]?((\[)!NOTE(\]))'
+    - match: '[ \t]{,3}(>)[ ]?[ \t]{,3}((\[)!NOTE(\]))'
       captures:
         1: punctuation.definition.blockquote.markdown
         2: markup.heading.alert.note.markdown
@@ -399,7 +399,7 @@ contexts:
       push:
         - block-quote-note-meta
         - block-quote-body
-    - match: '[ \t]{,3}(>)[ ]?((\[)!TIP(\]))'
+    - match: '[ \t]{,3}(>)[ ]?[ \t]{,3}((\[)!TIP(\]))'
       captures:
         1: punctuation.definition.blockquote.markdown
         2: markup.heading.alert.tip.markdown
@@ -788,7 +788,7 @@ contexts:
         4: markup.list.numbered.markdown
 
   list-block-quotes:
-    - match: '[ \t]{,3}(>)[ ]?((\[)!CAUTION(\]))'
+    - match: '[ \t]{,3}(>)[ ]?[ \t]{,3}((\[)!CAUTION(\]))'
       captures:
         1: punctuation.definition.blockquote.markdown
         2: markup.heading.alert.caution.markdown
@@ -797,7 +797,7 @@ contexts:
       push:
         - block-quote-caution-meta
         - list-block-quote-body
-    - match: '[ \t]{,3}(>)[ ]?((\[)!WARNING(\]))'
+    - match: '[ \t]{,3}(>)[ ]?[ \t]{,3}((\[)!WARNING(\]))'
       captures:
         1: punctuation.definition.blockquote.markdown
         2: markup.heading.alert.warning.markdown
@@ -806,7 +806,7 @@ contexts:
       push:
         - block-quote-warning-meta
         - list-block-quote-body
-    - match: '[ \t]{,3}(>)[ ]?((\[)!IMPORTANT(\]))'
+    - match: '[ \t]{,3}(>)[ ]?[ \t]{,3}((\[)!IMPORTANT(\]))'
       captures:
         1: punctuation.definition.blockquote.markdown
         2: markup.heading.alert.important.markdown
@@ -815,7 +815,7 @@ contexts:
       push:
         - block-quote-important-meta
         - list-block-quote-body
-    - match: '[ \t]{,3}(>)[ ]?((\[)!NOTE(\]))'
+    - match: '[ \t]{,3}(>)[ ]?[ \t]{,3}((\[)!NOTE(\]))'
       captures:
         1: punctuation.definition.blockquote.markdown
         2: markup.heading.alert.note.markdown
@@ -824,7 +824,7 @@ contexts:
       push:
         - block-quote-note-meta
         - list-block-quote-body
-    - match: '[ \t]{,3}(>)[ ]?((\[)!TIP(\]))'
+    - match: '[ \t]{,3}(>)[ ]?[ \t]{,3}((\[)!TIP(\]))'
       captures:
         1: punctuation.definition.blockquote.markdown
         2: markup.heading.alert.tip.markdown

--- a/Markdown/tests/syntax_test_markdown.md
+++ b/Markdown/tests/syntax_test_markdown.md
@@ -8464,12 +8464,77 @@ This is a [[wiki link]].
 
 # TEST: GITHUB ALERTS #########################################################
 
+>[!CAUTION]
+| <- markup.quote.alert.caution.markdown punctuation.definition.blockquote.markdown
+|^^^^^^^^^^^ markup.quote.alert.caution.markdown
+|^^^^^^^^^^ markup.heading.alert.caution.markdown
+|^ punctuation.definition.heading.begin.markdown
+|         ^ punctuation.definition.heading.end.markdown
+
 > [!CAUTION]
 | <- markup.quote.alert.caution.markdown punctuation.definition.blockquote.markdown
 |^^^^^^^^^^^^ markup.quote.alert.caution.markdown
 | ^^^^^^^^^^ markup.heading.alert.caution.markdown
 | ^ punctuation.definition.heading.begin.markdown
 |          ^ punctuation.definition.heading.end.markdown
+
+>  [!CAUTION]
+| <- markup.quote.alert.caution.markdown punctuation.definition.blockquote.markdown
+|^^^^^^^^^^^^^ markup.quote.alert.caution.markdown
+|  ^^^^^^^^^^ markup.heading.alert.caution.markdown
+|  ^ punctuation.definition.heading.begin.markdown
+|           ^ punctuation.definition.heading.end.markdown
+
+>   [!CAUTION]
+| <- markup.quote.alert.caution.markdown punctuation.definition.blockquote.markdown
+|^^^^^^^^^^^^^^ markup.quote.alert.caution.markdown
+|   ^^^^^^^^^^ markup.heading.alert.caution.markdown
+|   ^ punctuation.definition.heading.begin.markdown
+|            ^ punctuation.definition.heading.end.markdown
+
+>    [!CAUTION]
+| <- markup.quote.alert.caution.markdown punctuation.definition.blockquote.markdown
+|^^^^^^^^^^^^^^^ markup.quote.alert.caution.markdown
+|    ^^^^^^^^^^ markup.heading.alert.caution.markdown
+|    ^ punctuation.definition.heading.begin.markdown
+|             ^ punctuation.definition.heading.end.markdown
+
+>     [!CAUTION]
+| <- markup.quote.markdown punctuation.definition.blockquote.markdown
+|^^^^^^^^^^^^^^^^ markup.quote.markdown
+| ^^^^^^^^^^^^^^^ markup.raw.block.markdown
+
+---
+
+>	[!CAUTION]
+| <- markup.quote.alert.caution.markdown punctuation.definition.blockquote.markdown
+|^^^^^^^^^^^^ markup.quote.alert.caution.markdown
+| ^^^^^^^^^^ markup.heading.alert.caution.markdown
+| ^ punctuation.definition.heading.begin.markdown
+|          ^ punctuation.definition.heading.end.markdown
+
+> 	[!CAUTION]
+| <- markup.quote.alert.caution.markdown punctuation.definition.blockquote.markdown
+|^^^^^^^^^^^^^ markup.quote.alert.caution.markdown
+|  ^^^^^^^^^^ markup.heading.alert.caution.markdown
+|  ^ punctuation.definition.heading.begin.markdown
+|           ^ punctuation.definition.heading.end.markdown
+
+> 		[!CAUTION]
+| <- markup.quote.alert.caution.markdown punctuation.definition.blockquote.markdown
+|^^^^^^^^^^^^^^ markup.quote.alert.caution.markdown
+|   ^^^^^^^^^^ markup.heading.alert.caution.markdown
+|   ^ punctuation.definition.heading.begin.markdown
+|            ^ punctuation.definition.heading.end.markdown
+
+> 			[!CAUTION]
+| <- markup.quote.alert.caution.markdown punctuation.definition.blockquote.markdown
+|^^^^^^^^^^^^^^^ markup.quote.alert.caution.markdown
+|    ^^^^^^^^^^ markup.heading.alert.caution.markdown
+|    ^ punctuation.definition.heading.begin.markdown
+|             ^ punctuation.definition.heading.end.markdown
+
+---
 
 > [!CAUTION]
 > 


### PR DESCRIPTION
This commit fixes github alerts not being scoped as such, if heading is indented by more than one space.

Heading may be indented by up to _1 + 3 spaces_ or _1 space + 3 tabs_.