### PR TITLE
[CSS] Fix attribute selectors with quoted values

### DIFF
--- a/CSS/CSS.sublime-syntax
+++ b/CSS/CSS.sublime-syntax
@@ -3298,6 +3298,7 @@ contexts:
     - meta_scope: meta.line-names.css meta.brackets.css
     - include: brackets-end
     - include: line-names
+    - include: quoted-strings
     - include: terminator-pop
 
   line-names:

--- a/CSS/syntax_test_css.css
+++ b/CSS/syntax_test_css.css
@@ -2766,6 +2766,18 @@
 /*                                                 ^^ meta.selector.css meta.function-call.arguments.css meta.group.css - meta.brackets */
 /*                                                   ^ meta.selector.css - meta.group */
 
+ul:has(> li), a[ng-click='post()'] { ul:has(> li), a[ng-click='post()'] { color: color(w(var()) s(var()) () )); } }
+/* <- meta.selector.css entity.name.tag.html.css */
+/*^^^^^^^^^^^^^ meta.selector.css - meta.attribute-selector */
+/*             ^^^^^^^^^^^^^^^^^^^ meta.selector.css meta.attribute-selector.css meta.brackets.css */
+/*                                ^ meta.selector.css - meta.attribute-selector - meta.property-list */
+/*                                 ^^ meta.property-list.css meta.block.css - meta.selector */
+/*                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.css meta.block.css meta.selector.css */
+/*                                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-list.css meta.block.css meta.property-list.css meta.block.css */
+/*                                                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-value.css */
+/*                                                                                                               ^^ meta.property-list.css meta.block.css - meta.property-list meta.property-list - meta.block meta.block */
+/*                                                                                                                 ^ - meta.property-list - meta.block */
+
    *.test-universal-selector {}
 /* ^ constant.other.wildcard.asterisk.css */
 


### PR DESCRIPTION
Resolves https://github.com/SublimeText/Sass/issues/113

This commit adds quoted strings to `line-name-list-body` to prevent premature bailout due to parentheses or semicolons in quoted strings.

That's required for `maybe-property` to correctly fail and switch to `selector-body`.