### PR TITLE
[SQL] improve MySQL syntax

### DIFF
--- a/SQL/MySQL.sublime-syntax
+++ b/SQL/MySQL.sublime-syntax
@@ -677,9 +677,9 @@ contexts:
     - include: pop-on-top-level-reserved-word
 
   variable-member:
+    - meta_include_prototype: false
     - meta_content_scope: variable.other.member.mysql
-    - match: ''
-      pop: 1
+    - include: immediately-pop          
 
 ###[ GRANT STATEMENTS ]########################################################
 

--- a/SQL/MySQL.sublime-syntax
+++ b/SQL/MySQL.sublime-syntax
@@ -679,7 +679,7 @@ contexts:
   variable-member:
     - meta_include_prototype: false
     - meta_content_scope: variable.other.member.mysql
-    - include: immediately-pop          
+    - include: immediately-pop
 
 ###[ GRANT STATEMENTS ]########################################################
 

--- a/SQL/MySQL.sublime-syntax
+++ b/SQL/MySQL.sublime-syntax
@@ -18,7 +18,7 @@ variables:
     (?xi: continue | exit | return )
 
   loop_keywords: |-
-    (?xi: loop | end\s+(?: loop | repeat | while ) | repeat | while )
+    (?xi: loop | end\s+(?: loop | repeat | while ) | repeat | while | do )
 
   other_keywords: |-
     (?xi: close | cursor | declare | deallocate | delimiter | execute | fetch
@@ -628,6 +628,15 @@ contexts:
     - meta_prepend: true
     - include: set-password
     - include: set-role
+    - match: \b(?i:global|session|local|persist|persist_only)\b
+      scope: storage.modifier.mysql
+      set: set-other-assignment
+    - match: ((@@)(?i:global|session|local|persist|persist_only))(\.)
+      captures:
+        1: variable.language.mysql
+        2: punctuation.definition.variable.mysql
+        3: punctuation.accessor.dot.mysql
+      set: set-other-assignment
 
   set-password:
     # https://mariadb.com/kb/en/set-password
@@ -653,6 +662,11 @@ contexts:
     - include: expect-user-name
 
   set-other-assignment:
+    - match: (?=\b\w+\s*:?=)
+      scope: punctuation.accessor.dot.mysql
+      push:
+        - variable-member
+        - single-identifier
     - match: =
       scope: keyword.operator.assignment.sql
       set: set-other-value
@@ -661,6 +675,11 @@ contexts:
   set-other-value:
     - include: expressions
     - include: pop-on-top-level-reserved-word
+
+  variable-member:
+    - meta_content_scope: variable.other.member.mysql
+    - match: ''
+      pop: 1
 
 ###[ GRANT STATEMENTS ]########################################################
 
@@ -886,9 +905,22 @@ contexts:
       scope: keyword.other.dml.sql
     - include: like-expressions
 
+
+###[ OPERATORS ]###############################################################
+
+  statement-terminators:
+    - meta_append: true
+    - match: '\$\$'
+      scope: punctuation.terminator.mysql
+
+  assignment-operators:
+    - meta_append: true
+    - match: ':='
+      scope: keyword.operator.assignment.mysql
+
   assignment-operators-constants:
     - include: assignment-operators
-    - match: \b(?i:utf8|utf8mb3|tree|traditional|json)\b
+    - match: \b(?i:utf8|utf8mb\d|tree|traditional|json)\b
       scope: string.unquoted.mysql
 
 ###[ ALGORITHM EXPRESSIONS ]###################################################
@@ -1492,6 +1524,16 @@ contexts:
     - match: \b(?i:with(?:out)?\s+time\s+zone)\b
       scope: storage.modifier.sql
       pop: 1
+    - match: \b(?i:charset)\b
+      scope: storage.modifier.mysql
+      push: charset
+
+  charset:
+    - match: \w+
+      scope: constant.language.mysql
+      pop: 1
+    - match: (?=\S)
+      pop: 1
 
 ###[ IDENTIFIERS ]#############################################################
 
@@ -1597,6 +1639,9 @@ contexts:
       scope: variable.language.sql
       captures:
         1: punctuation.definition.variable.sql
+      push:
+        - variable-member
+        - maybe-identifier-accessor
     - match: (@){{simple_identifier}}\b
       scope: variable.other.sql
       captures:

--- a/SQL/SQL (basic).sublime-syntax
+++ b/SQL/SQL (basic).sublime-syntax
@@ -1619,6 +1619,7 @@ contexts:
     - match: \b(?i:and|or|having|exists|between|in|not|is)\b
       scope: keyword.operator.logical.sql
       pop: 1
+    - include: assignment-operators
     - include: else-pop
 
   operators:

--- a/SQL/tests/syntax/syntax_test_mysql.sql
+++ b/SQL/tests/syntax/syntax_test_mysql.sql
@@ -4683,3 +4683,131 @@ INSERT IGNORE INTO users_partners (uid,pid) VALUES (1,1);
 INSERT IGNORE users_partners (uid,pid) VALUES (1,1);
 -- ^^^^^^^^^^ keyword.other.dml
 --            ^^^^^^^^^^^^^^ meta.table-name
+
+DELIMITER $$
+-- ^^^^^^ keyword.other.sql
+--        ^^ punctuation.terminator.mysql
+
+CREATE DEFINER=`root`@`%` FUNCTION `RandString`(length SMALLINT(3), initial_seed INT)
+-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.create.sql
+-- ^^^ keyword.other.ddl.sql
+--     ^^^^^^^ variable.parameter.definer.sql
+--            ^ keyword.operator.assignment.sql
+--             ^^^^^^^^^^ meta.username.sql
+--             ^ punctuation.definition.identifier.begin.sql
+--                  ^ punctuation.definition.identifier.end.sql
+--                   ^ punctuation.accessor.at.sql
+--                    ^ punctuation.definition.identifier.begin.sql
+--                     ^ constant.other.wildcard.percent.sql
+--                      ^ punctuation.definition.identifier.end.sql
+--                        ^^^^^^^^^^^^^^^^^^^^^ meta.function.sql
+--                        ^^^^^^^^ keyword.other.ddl.sql
+--                                 ^^^^^^^^^^^^ entity.name.function.sql
+--                                 ^ punctuation.definition.identifier.begin.sql
+--                                            ^ punctuation.definition.identifier.end.sql
+--                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.parameters.sql meta.group.sql
+--                                             ^ punctuation.section.group.begin.sql
+--                                              ^^^^^^ variable.parameter.sql
+--                                                     ^^^^^^^^^^^ storage.type.sql
+--                                                             ^^^ meta.parens.sql
+--                                                             ^ punctuation.definition.parens.begin.sql
+--                                                              ^ meta.number.integer.decimal.sql constant.numeric.value.sql
+--                                                               ^ punctuation.definition.parens.end.sql
+--                                                                ^ punctuation.separator.sequence.sql
+--                                                                  ^^^^^^^^^^^^ variable.parameter.sql
+--                                                                               ^^^ storage.type.sql
+--                                                                                  ^ punctuation.section.group.end.sql
+    RETURNS varchar(100) CHARSET UTF8MB4
+-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.create.sql meta.function.sql
+--  ^^^^^^^ keyword.other.ddl.sql
+--          ^^^^^^^^^^^^ storage.type.sql
+--                 ^^^^^ meta.parens.sql
+--                 ^ punctuation.definition.parens.begin.sql
+--                  ^^^ meta.number.integer.decimal.sql constant.numeric.value.sql
+--                     ^ punctuation.definition.parens.end.sql
+--                       ^^^^^^^ storage.modifier.mysql
+--                               ^^^^^^^ constant.language.mysql
+    CONTAINS SQL
+--  ^^^^^^^^^^^^ storage.modifier.sql
+    DETERMINISTIC
+--  ^^^^^^^^^^^^^ storage.modifier.sql
+BEGIN
+    SET @returnStr = '';
+    SET @allowedChars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyz';
+    SET @i = 0;
+    
+    SET @seed := initial_seed;
+--  ^^^^ meta.statement.set.sql
+--  ^^^ keyword.other.dml.sql
+--      ^^^^^ variable.other.sql
+--      ^ punctuation.definition.variable.sql
+--            ^^ keyword.operator.assignment.mysql
+--                           ^ punctuation.terminator.statement.sql
+
+    WHILE (@i < length) DO
+--  ^^^^^ keyword.control.loop.sql
+--        ^^^^^^^^^^^^^ meta.group.sql
+--        ^ punctuation.section.group.begin.sql
+--         ^^ variable.other.sql
+--         ^ punctuation.definition.variable.sql
+--            ^ keyword.operator.comparison.sql
+--                    ^ punctuation.section.group.end.sql
+--                      ^^ keyword.control.loop.sql
+        SET @returnStr = CONCAT(@returnStr, substring(@allowedChars, FLOOR(RAND(@seed) * LENGTH(@allowedChars) + 1), 1));
+        SET @i = @i + 1;
+        SET @seed = round(rand(@seed)*4294967296);
+    END WHILE;
+
+    RETURN @returnStr;
+END
+$$
+-- <- punctuation.terminator.mysql
+DELIMITER ;
+
+
+-- https://dev.mysql.com/doc/refman/8.4/en/set-variable.html
+SET GLOBAL max_connections = 1000;
+-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.set.sql
+-- <- keyword.other.dml.sql
+--  ^^^^^^ storage.modifier.mysql
+--         ^^^^^^^^^^^^^^^ variable.other
+--                         ^ keyword.operator.assignment
+--                           ^^^^ meta.number.integer.decimal.sql constant.numeric.value.sql
+--                               ^ punctuation.terminator.statement.sql
+SET @@GLOBAL.max_connections = 1000;
+--  ^^^^^^^^ variable.language
+--  ^^ punctuation.definition.variable
+--          ^^^^^^^^^^^^^^^^ - meta.column-name
+--          ^ punctuation.accessor.dot
+--           ^^^^^^^^^^^^^^^ variable.other
+--                           ^ keyword.operator.assignment
+--                             ^^^^ meta.number.integer.decimal.sql constant.numeric.value.sql
+--                                 ^ punctuation.terminator.statement.sql
+
+SET SESSION sql_mode = 'TRADITIONAL';
+SET LOCAL sql_mode = 'TRADITIONAL';
+SET @@SESSION.sql_mode = 'TRADITIONAL';
+SET @@LOCAL.sql_mode = 'TRADITIONAL';
+SET @@sql_mode = 'TRADITIONAL';
+SET sql_mode = 'TRADITIONAL';
+
+SET PERSIST max_connections = 1000;
+SET @@PERSIST.max_connections = 1000;
+
+SET PERSIST_ONLY back_log = 100;
+SET @@PERSIST_ONLY.back_log = 100;
+
+SET @@SESSION.max_join_size = DEFAULT;
+SET @@SESSION.max_join_size = @@GLOBAL.max_join_size;
+-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.set.sql
+-- <- keyword.other.dml.sql
+--  ^^^^^^^^^ variable.language.mysql
+--  ^^ punctuation.definition.variable.mysql
+--           ^ punctuation.accessor.dot.mysql
+--            ^^^^^^^^^^^^^ variable.other
+--                          ^ keyword.operator.assignment.sql
+--                            ^^^^^^^^ variable.language.sql
+--                            ^^ punctuation.definition.variable.sql
+--                                    ^ punctuation.accessor.dot.sql
+--                                     ^^^^^^^^^^^^^ variable.other.member.mysql
+--                                                  ^ punctuation.terminator.statement.sql


### PR DESCRIPTION
- support charset in return types
- support $$ as a statement terminator
- support `SET` ... `:=` syntax
- support `SET` with system variable assignment