### PR TITLE
[HTML] Use variable for tag name lookaheads

### DIFF
--- a/HTML/HTML (Plain).sublime-syntax
+++ b/HTML/HTML (Plain).sublime-syntax
@@ -258,7 +258,7 @@ contexts:
 ###[ HTML TAGS ]##############################################################
 
   tag-html:
-    - match: </?(?=[A-Za-z])
+    - match: </?(?={{tag_name_start}})
       scope: punctuation.definition.tag.begin.html
       push:
         - tag-html-content


### PR DESCRIPTION
This PR uses `{{tag_name_start}}` variable in _HTML (Plain)_ in favor of hard coded patterns to enable extending syntaxes to override it.