### PR TITLE
[JavaScript] Enable snippets for all dialects

### DIFF
--- a/JavaScript/Snippets/Get-Elements.sublime-snippet
+++ b/JavaScript/Snippets/Get-Elements.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[getElement${1/(T)|.*/(?1:s)/}By${1:T}${1/(T)|(I)|.*/(?1:agName)(?2:d)/}('$2')]]></content>
 	<tabTrigger>get</tabTrigger>
-	<scope>source.js</scope>
+	<scope>source.js, source.ts, source.jsx, source.tsx</scope>
 	<description>Get Elements</description>
 </snippet>

--- a/JavaScript/Snippets/Object-Method.sublime-snippet
+++ b/JavaScript/Snippets/Object-Method.sublime-snippet
@@ -3,6 +3,6 @@
 	$0
 }${10:,}]]></content>
 	<tabTrigger>o:f</tabTrigger>
-	<scope>source.js</scope>
+	<scope>source.js, source.ts, source.jsx, source.tsx</scope>
 	<description>Object Method</description>
 </snippet>

--- a/JavaScript/Snippets/Object-Value-JS.sublime-snippet
+++ b/JavaScript/Snippets/Object-Value-JS.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[${1:value_name}: ${0:value},]]></content>
 	<tabTrigger>:,</tabTrigger>
-	<scope>source.js</scope>
+	<scope>source.js, source.ts, source.jsx, source.tsx</scope>
 	<description>Object Value JS</description>
 </snippet>

--- a/JavaScript/Snippets/Object-key-key-value.sublime-snippet
+++ b/JavaScript/Snippets/Object-key-key-value.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[${1:key}: ${2:"${3:value}"}${4:, }]]></content>
 	<tabTrigger>:</tabTrigger>
-	<scope>source.js</scope>
+	<scope>source.js, source.ts, source.jsx, source.tsx</scope>
 	<description>Object key — key: "value"</description>
 </snippet>

--- a/JavaScript/Snippets/Prototype-(proto).sublime-snippet
+++ b/JavaScript/Snippets/Prototype-(proto).sublime-snippet
@@ -4,6 +4,6 @@
 };
 ]]></content>
 	<tabTrigger>proto</tabTrigger>
-	<scope>source.js</scope>
+	<scope>source.js, source.ts, source.jsx, source.tsx</scope>
 	<description>Prototype</description>
 </snippet>

--- a/JavaScript/Snippets/for-()-{}-(faster).sublime-snippet
+++ b/JavaScript/Snippets/for-()-{}-(faster).sublime-snippet
@@ -3,6 +3,6 @@
 	${100:${1:Things}[${20:i}]}$0
 }]]></content>
 	<tabTrigger>for</tabTrigger>
-	<scope>source.js</scope>
+	<scope>source.js, source.ts, source.jsx, source.tsx</scope>
 	<description>for (…) {…} (Improved Native For-Loop)</description>
 </snippet>

--- a/JavaScript/Snippets/for-()-{}.sublime-snippet
+++ b/JavaScript/Snippets/for-()-{}.sublime-snippet
@@ -3,6 +3,6 @@
 	${100:${1:Things}[${20:i}]}$0
 }]]></content>
 	<tabTrigger>for</tabTrigger>
-	<scope>source.js</scope>
+	<scope>source.js, source.ts, source.jsx, source.tsx</scope>
 	<description>for (…) {…}</description>
 </snippet>

--- a/JavaScript/Snippets/function-(fun).sublime-snippet
+++ b/JavaScript/Snippets/function-(fun).sublime-snippet
@@ -3,6 +3,6 @@
 	${0:// body...}
 }]]></content>
 	<tabTrigger>fun</tabTrigger>
-	<scope>source.js</scope>
+	<scope>source.js, source.ts, source.jsx, source.tsx</scope>
 	<description>Function</description>
 </snippet>

--- a/JavaScript/Snippets/function.sublime-snippet
+++ b/JavaScript/Snippets/function.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[function($1) {${0:$TM_SELECTED_TEXT}}]]></content>
 	<tabTrigger>f</tabTrigger>
-	<scope>source.js</scope>
+	<scope>source.js, source.ts, source.jsx, source.tsx</scope>
 	<description>Anonymous Function</description>
 </snippet>

--- a/JavaScript/Snippets/if-else.sublime-snippet
+++ b/JavaScript/Snippets/if-else.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[if (${1:true}) {${0:$TM_SELECTED_TEXT}} else {}]]></content>
 	<tabTrigger>ife</tabTrigger>
-	<scope>source.js</scope>
+	<scope>source.js, source.ts, source.jsx, source.tsx</scope>
 	<description>if … else</description>
 </snippet>

--- a/JavaScript/Snippets/if.sublime-snippet
+++ b/JavaScript/Snippets/if.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[if (${1:true}) {${0:$TM_SELECTED_TEXT}}]]></content>
 	<tabTrigger>if</tabTrigger>
-	<scope>source.js</scope>
+	<scope>source.js, source.ts, source.jsx, source.tsx</scope>
 	<description>if</description>
 </snippet>

--- a/JavaScript/Snippets/setTimeout-function.sublime-snippet
+++ b/JavaScript/Snippets/setTimeout-function.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[setTimeout(function() {$0}${2:}, ${1:10});]]></content>
 	<tabTrigger>timeout</tabTrigger>
-	<scope>source.js</scope>
+	<scope>source.js, source.ts, source.jsx, source.tsx</scope>
 	<description>setTimeout function</description>
 </snippet>


### PR DESCRIPTION
Fixes #4157

This commit...

1. enables JS snippets for TypeScript and JSX/TSX.
2. renames if-else snippet file to remove long underscores