### PR TITLE
[Java] Restrict contextual keyword `record`

### DIFF
--- a/Java/Java.sublime-syntax
+++ b/Java/Java.sublime-syntax
@@ -37,7 +37,7 @@ variables:
     | {{illegal_keywords}}
     )
   declaration_keywords: |-
-    (?x: class | enum | @?interface | record | var | void | extends | implements | import | package )
+    (?x: class | enum | @?interface | var | void | extends | implements | import | package )
   control_keywords: |-
     (?x: assert | break | case | catch | continue | do | else | finally | for
     | if | return | switch | throw | throws | try | while | yield )
@@ -843,12 +843,29 @@ contexts:
 
 ###[ RECORD DECLARATIONS ]#####################################################
 
+  member-record-keyword:
+    # https://docs.oracle.com/javase/specs/jls/se16/html/jls-8.html#jls-8.10
+    - match: record{{break}}
+      scope: keyword.declaration.record.java
+      set:
+        - member-record-block
+        - record-extends
+        - record-parameters
+        - maybe-type-parameter
+        - class-name
+
+  member-record-block:
+    - match: \{
+      scope: punctuation.section.block.begin.java
+      set: class-block-body
+    - include: member-else-fail
+
   record-keyword:
     # https://docs.oracle.com/javase/specs/jls/se16/html/jls-8.html#jls-8.10
     - match: record{{break}}
       scope: keyword.declaration.record.java
       set:
-        - class-block
+        - record-block
         - record-extends
         - record-parameters
         - maybe-type-parameter
@@ -893,6 +910,12 @@ contexts:
         - inherited-object-type
     - include: else-pop
 
+  record-block:
+    - match: \{
+      scope: punctuation.section.block.begin.java
+      set: class-block-body
+    - include: declaration-else-fail
+
 ###[ MEMBER DECLARATIONS ]#####################################################
 
   member-declarations:
@@ -900,11 +923,11 @@ contexts:
       branch_point: class-members
       branch:
         - member-maybe-constructor
-        - member-maybe-method
-        - member-maybe-field
         - member-maybe-class
         - member-maybe-enum
         - member-maybe-interface
+        - member-maybe-method
+        - member-maybe-field
 
   member-else-fail:
     - match: (?=\S)
@@ -918,7 +941,7 @@ contexts:
     # https://docs.oracle.com/javase/specs/jls/se13/html/jls-8.html#jls-8.1
     - meta_scope: meta.class.java
     - include: class-keyword
-    - include: record-keyword
+    - include: member-record-keyword
     - include: class-modifiers
     - include: member-else-fail
 

--- a/Java/tests/syntax_test_java.java
+++ b/Java/tests/syntax_test_java.java
@@ -2449,37 +2449,33 @@ Bar             // comment
  * https://docs.oracle.com/javase/specs/jls/se16/html/jls-8.html#jls-8.10
  *****************************************************************************/
 
-record
-// <- meta.class.java keyword.declaration.record.java
-//^^^^ meta.class.java keyword.declaration.record.java
-//    ^ meta.class.identifier.java
+record ;
+// <- - keyword.declaration
+//^^^^ - keyword.declaration
 
-record RecordTest
+record RecordTest ;
+// <- support.class.java
+//^^^^ support.class.java
+//     ^^^^^^^^^^ variable.other.java
+
+record RecordTest<> ;
+// <- support.class.java
+//^^^^ support.class.java
+//     ^^^^^^^^^^ variable.other.java
+
+record RecordTest<T> ;
+// <- support.class.java
+//^^^^ support.class.java
+//     ^^^^^^^^^^ variable.other.java
+
+record RecordTest {  }
 // <- meta.class.java keyword.declaration.record.java
 //^^^^ meta.class.java keyword.declaration.record.java
 //    ^^^^^^^^^^^^ meta.class.identifier.java
+//                ^^^^ meta.class.java meta.block.java
 //     ^^^^^^^^^^ entity.name.class.java
-
-record RecordTest<>
-// <- meta.class.java keyword.declaration.record.java
-//^^^^ meta.class.java keyword.declaration.record.java
-//    ^^^^^^^^^^^ meta.class.identifier.java - meta.generic
-//               ^^ meta.class.identifier.java meta.generic.declaration.java
-//                 ^ meta.class.identifier.java - meta.generic
-//     ^^^^^^^^^^ entity.name.class.java
-//               ^ punctuation.definition.generic.begin.java
-//                ^ punctuation.definition.generic.end.java
-
-record RecordTest<T>
-// <- meta.class.java keyword.declaration.record.java
-//^^^^ meta.class.java keyword.declaration.record.java
-//    ^^^^^^^^^^^ meta.class.identifier.java - meta.generic
-//               ^^^ meta.class.identifier.java meta.generic.declaration.java
-//                  ^ meta.class.identifier.java - meta.generic
-//     ^^^^^^^^^^ entity.name.class.java
-//               ^ punctuation.definition.generic.begin.java
-//                ^ variable.parameter.type.java
-//                 ^ punctuation.definition.generic.end.java
+//                ^ punctuation.section.block.begin.java
+//                   ^ punctuation.section.block.end.java
 
 record RecordTest( {  }
 // <- meta.class.java keyword.declaration.record.java
@@ -2569,6 +2565,76 @@ record CompactConstructorTests(int foo) {
 // ^ meta.class.java meta.block.java meta.function.java meta.block.java punctuation.section.block.end.java
 }
 // <- meta.class.java meta.block.java punctuation.section.block.end.java
+
+/*
+ * Record is a `contextual keyword` valid only in record declaration statements.
+ * see: https://docs.oracle.com/javase/specs/jls/se23/html/jls-3.html#jls-3.9
+ */
+
+record record(record record) { record record(record record) { record record = 10 } }
+//^^^^ meta.class.java keyword.declaration.record.java
+//    ^^^^^^^ meta.class.identifier.java
+//           ^^^^^^^^^^^^^^^ meta.class.parameters.java meta.group.java
+//                          ^ meta.class.java - meta.block
+//                           ^^ meta.class.java meta.block.java
+//                             ^^^^^^ meta.class.java meta.block.java meta.class.java
+//                                   ^^^^^^^ meta.class.java meta.block.java meta.class.identifier.java
+//                                          ^^^^^^^^^^^^^^^ meta.class.java meta.block.java meta.class.parameters.java meta.group.java
+//                                                         ^ meta.class.java meta.block.java meta.class.java - meta.block meta.block
+//                                                          ^^^^^^^^^^^^^^^^^^^^^^ meta.class.java meta.block.java meta.class.java meta.block.java
+//                                                                                ^^ meta.class.java meta.block.java - meta.block meta.block
+//                                                                                  ^ - meta.class
+//^^^^ keyword.declaration.record.java
+//     ^^^^^^ entity.name.class.java
+//            ^^^^^^ support.class.java
+//                   ^^^^^^ variable.parameter.java
+//                             ^^^^^^ keyword.declaration.record.java
+//                                    ^^^^^^ entity.name.class.java
+//                                           ^^^^^^ support.class.java
+//                                                  ^^^^^^ variable.parameter.java
+//                                                            ^^^^^^ support.class.java
+//                                                                   ^^^^^^ variable.other.member.java
+
+object.record(20000, Units.MILLISECONDS);
+//^^^^ meta.variable.identifier.java variable.other.java
+//    ^ punctuation.accessor.dot.java
+//     ^^^^^^ meta.function-call.identifier.java variable.function.java - keyword.declaration
+//           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.java meta.group.java
+//           ^ punctuation.section.group.begin.java
+//            ^^^^^ meta.number.integer.decimal.java constant.numeric.value.java
+//                 ^ punctuation.separator.comma.java
+//                   ^^^^^ support.class.java
+//                        ^ punctuation.accessor.dot.java
+//                         ^^^^^^^^^^^^ constant.other.java
+//                                     ^ punctuation.section.group.end.java
+//                                      ^ punctuation.terminator.java
+
+class Clazz {
+   void fn() {
+      object.record(20000, Units.MILLISECONDS);
+//    ^^^^^^ meta.variable.identifier.java variable.other.java
+//          ^ punctuation.accessor.dot.java
+//           ^^^^^^ meta.function-call.identifier.java variable.function.java - keyword.declaration
+//                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.java meta.group.java
+//                 ^ punctuation.section.group.begin.java
+//                  ^^^^^ meta.number.integer.decimal.java constant.numeric.value.java
+//                       ^ punctuation.separator.comma.java
+//                         ^^^^^ support.class.java
+//                              ^ punctuation.accessor.dot.java
+//                               ^^^^^^^^^^^^ constant.other.java
+//                                           ^ punctuation.section.group.end.java
+//                                            ^ punctuation.terminator.java
+
+      record = 10;
+//    ^^^^^^ variable.other.java
+
+      record.record = record;
+//    ^^^^^^ variable.other.java
+//           ^^^^^^ variable.other.java
+//                  ^ keyword.operator.assignment.java
+//                    ^^^^^^ variable.other.java
+   }
+}
 
 /******************************************************************************
  * Field Declaration Tests


### PR DESCRIPTION
Fixes #4162

This commit avoids contextual keyword `record` being matched in unappropriated context. It is a valid keyword only in record declarations.

A record declaration is treated as valid if it starts with `record ident`, terminated by a `{..}` block. Anything in between is treated optional.

see: https://docs.oracle.com/javase/specs/jls/se23/html/jls-3.html#jls-3.9