### PR TITLE
[TOML] Add Syntax

### DIFF
--- a/TOML/Comments.tmPreferences
+++ b/TOML/Comments.tmPreferences
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>scope</key>
+	<string>source.toml</string>
+	<key>settings</key>
+	<dict>
+		<key>shellVariables</key>
+		<array>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START</string>
+				<key>value</key>
+				<string># </string>
+			</dict>
+		</array>
+	</dict>
+</dict>
+</plist>

--- a/TOML/Fold.tmPreferences
+++ b/TOML/Fold.tmPreferences
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>scope</key>
+	<string>source.toml</string>
+	<key>settings</key>
+	<dict>
+		<key>foldScopes</key>
+		<array>
+			<dict>
+				<key>begin</key>
+				<string>punctuation.definition.section.end</string>
+				<key>end</key>
+				<string>punctuation.definition.section.begin</string>
+				<key>excludeTrailingNewlines</key>
+				<true/>
+			</dict>
+			<dict>
+				<key>begin</key>
+				<string>string.quoted.double.block punctuation.definition.string.begin</string>
+				<key>end</key>
+				<string>string.quoted.double.block punctuation.definition.string.end</string>
+				<key>excludeTrailingNewlines</key>
+				<false/>
+			</dict>
+			<dict>
+				<key>begin</key>
+				<string>string.quoted.single.block punctuation.definition.string.begin</string>
+				<key>end</key>
+				<string>string.quoted.single.block punctuation.definition.string.end</string>
+				<key>excludeTrailingNewlines</key>
+				<false/>
+			</dict>
+		</array>
+	</dict>
+</dict>
+</plist>

--- a/TOML/Symbol List.tmPreferences
+++ b/TOML/Symbol List.tmPreferences
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+    <key>scope</key>
+    <string>entity.name.section</string>
+    <key>settings</key>
+    <dict>
+        <key>showInSymbolList</key>
+        <integer>1</integer>
+        <key>symbolTransformation</key>
+        <string>
+            s/^[ \t]+|[ \t]+$//g;   # trim leading and trailing whitespace
+            s/[ \t]*\.[ \t]*/\./g;  # trim whitespace between name parts
+        </string>
+    </dict>
+</dict>
+</plist>

--- a/TOML/TOML.sublime-syntax
+++ b/TOML/TOML.sublime-syntax
@@ -1,0 +1,405 @@
+%YAML 1.2
+---
+# https://toml.io/en/
+# http://www.sublimetext.com/docs/3/syntax.html
+name: TOML
+scope: source.toml
+version: 2
+
+file_extensions:
+  - toml
+  - tml
+  - Cargo.lock
+  - Gopkg.lock
+  - Pipfile
+  - pdm.lock
+  - poetry.lock
+  - uv.lock
+
+contexts:
+  main:
+    - include: comments
+    - include: sections
+    - include: keys
+    - include: values
+
+###[ COMMENTS ]################################################################
+
+  comments:
+    # https://toml.io/en/v1.0.0#comment
+    - match: \#
+      scope: punctuation.definition.comment.toml
+      push: comment-body
+
+  comment-body:
+    - meta_scope: comment.line.number-sign.toml
+    - match: $\n?
+      pop: 1
+
+###[ SECTIONS ]################################################################
+
+  sections:
+    # https://toml.io/en/v1.0.0#array-of-tables
+    - match: \[\[
+      scope: meta.section.toml punctuation.definition.section.begin.toml
+      push: array-section-name-body
+    # https://toml.io/en/v1.0.0#table
+    - match: \[
+      scope: meta.section.toml punctuation.definition.section.begin.toml
+      push: single-section-name-body
+
+  array-section-name-body:
+    - meta_content_scope: meta.section.toml entity.name.section.toml
+    - match: \]\]
+      scope: meta.section.toml punctuation.definition.section.end.toml
+      set: expect-eol
+    - include: name-content
+    - include: illegal-eol-pop
+
+  single-section-name-body:
+    - meta_content_scope: meta.section.toml entity.name.section.toml
+    - match: \]
+      scope: meta.section.toml punctuation.definition.section.end.toml
+      set: expect-eol
+    - include: name-content
+    - include: illegal-eol-pop
+
+###[ KEYS ]####################################################################
+
+  keys:
+    # https://toml.io/en/v1.0.0#keys
+    - match: '{{key_begin}}'
+      push: key-body
+
+  key-body:
+    - meta_scope: meta.mapping.key.toml entity.name.key.toml
+    - match: (?=[ \t]*(?:$|[#=]))
+      pop: 1
+    - include: name-content
+
+  name-content:
+    - match: \.
+      scope: punctuation.accessor.toml
+    - match: \"
+      scope: punctuation.definition.quoted.begin.toml
+      push: double-quoted-name-body
+    - match: \'
+      scope: punctuation.definition.quoted.begin.toml
+      push: single-quoted-name-body
+    - include: name-prototype
+    - match: '[^ \t0-9A-Za-z_-]'
+      scope: invalid.illegal.toml
+
+  double-quoted-name-body:
+    - match: \"
+      scope: punctuation.definition.quoted.end.toml
+      pop: 1
+    - include: illegal-eol-pop
+    - include: string-escapes
+    - include: name-prototype
+
+  single-quoted-name-body:
+    - match: \'
+      scope: punctuation.definition.quoted.end.toml
+      pop: 1
+    - include: illegal-eol-pop
+    - include: name-prototype
+
+  name-prototype: []
+
+###[ VALUES ]##################################################################
+
+  values:
+    - match: '[ \t]*(=)[ \t]*'
+      scope: meta.mapping.toml
+      captures:
+         1: punctuation.separator.key-value.toml
+      push: [value-meta, value]
+    - match: (?=\S)
+      push: [value-meta, value]
+
+  value-meta:
+    - meta_content_scope: meta.mapping.value.toml
+    - include: expect-eol
+
+  value:
+    - include: array
+    - include: mapping
+    - include: boolean
+    - include: datetime
+    - include: numbers
+    - include: basic-multiline-string
+    - include: basic-string
+    - include: literal-multiline-string
+    - include: literal-string
+    - include: immediately-pop
+
+###[ ARRAYS ]##################################################################
+
+  array:
+    # https://toml.io/en/v1.0.0#array
+    - match: \[
+      scope: punctuation.section.sequence.begin.toml
+      push: array-body
+
+  array-body:
+    - meta_scope: meta.sequence.array.toml
+    - match: \]
+      scope: punctuation.section.sequence.end.toml
+      pop: 2
+    - match: ','
+      scope: punctuation.separator.sequence.toml
+    - include: comments
+    - match: (?=\S)
+      push: value
+
+###[ INLINE TABLES ]###########################################################
+
+  mapping:
+    # https://toml.io/en/v1.0.0#inline-table
+    - match: \{
+      scope: punctuation.section.mapping.begin.toml
+      push: mapping-body
+
+  mapping-body:
+    - meta_scope: meta.mapping.toml
+    - match: \}
+      scope: punctuation.section.mapping.end.toml
+      pop: 2
+    - match: ','
+      scope: punctuation.separator.sequence.toml
+    - match: '='
+      scope: punctuation.separator.key-value.toml
+      push:
+        # value can start on next line
+        - match: (?=\S)
+          set: mapping-value-body
+    - match: '{{key_begin}}'
+      push: mapping-key-body
+    - include: comments
+    - match: (?=\S)
+      push: mapping-value-body
+
+  mapping-key-body:
+    - clear_scopes: 1
+    - meta_scope: meta.mapping.key.toml entity.name.key.toml
+    - match: (?=[ \t]*[#=}])
+      pop: 1
+    - include: name-content
+
+  mapping-value-body:
+    - clear_scopes: 1
+    - meta_scope: meta.mapping.value.toml
+    - include: value
+
+###[ CONSTANT VALUES ]#########################################################
+
+  boolean:
+    # https://toml.io/en/v1.0.0#boolean
+    - match: false{{ident_break}}
+      scope: constant.language.boolean.false.toml
+      pop: 1
+    - match: true{{ident_break}}
+      scope: constant.language.boolean.true.toml
+      pop: 1
+
+  datetime:
+    # https://toml.io/en/v1.0.0#offset-date-time
+    # https://datatracker.ietf.org/doc/html/rfc3339
+    - match: '{{date_time}}'
+      scope: constant.other.datetime.toml
+      captures:
+        1: punctuation.separator.date.toml
+        2: punctuation.separator.date.toml
+        3: punctuation.separator.datetime.toml
+        4: punctuation.separator.time.toml
+        5: punctuation.separator.time.toml
+        6: punctuation.separator.decimal.toml
+        7: storage.modifier.timezone.toml
+        8: keyword.operator.arithmetic.toml
+        9: punctuation.separator.time.toml
+      pop: 1
+    - match: '{{date}}'
+      scope: constant.other.date.toml
+      captures:
+        1: punctuation.separator.date.toml
+        2: punctuation.separator.date.toml
+      pop: 1
+    - match: '{{time}}'
+      scope: constant.other.time.toml
+      captures:
+        1: punctuation.separator.time.toml
+        2: punctuation.separator.time.toml
+        3: punctuation.separator.decimal.toml
+      pop: 1
+
+  numbers:
+    # https://toml.io/en/v1.0.0#float
+    - match: ([-+])?(inf|nan){{ident_break}}
+      scope: meta.number.float.other.toml
+      captures:
+        1: keyword.operator.arithmetic.toml
+        2: constant.numeric.value.toml
+      pop: 1
+    - match: ([-+]?)({{dec_digits}}(?:(\.){{zero_dec_digits}}{{exponent}}?|{{exponent}})){{ident_break}}
+      scope: meta.number.float.decimal.toml
+      captures:
+        1: keyword.operator.arithmetic.toml
+        2: constant.numeric.value.toml
+        3: punctuation.separator.decimal.toml
+      pop: 1
+    # https://toml.io/en/v1.0.0#integer
+    - match: (0b)([01][01_]*)?{{ident_break}}
+      scope: meta.number.integer.binary.toml
+      captures:
+        1: constant.numeric.base.toml
+        2: constant.numeric.value.toml
+      pop: 1
+    - match: (0o)([0-7][0-7_]*)?{{ident_break}}
+      scope: meta.number.integer.octal.toml
+      captures:
+        1: constant.numeric.base.toml
+        2: constant.numeric.value.toml
+      pop: 1
+    - match: (0x)(\h[\h_]*)?{{ident_break}}
+      scope: meta.number.integer.hexadecimal.toml
+      captures:
+        1: constant.numeric.base.toml
+        2: constant.numeric.value.toml
+      pop: 1
+    - match: ([-+]?)({{dec_digits}}){{ident_break}}
+      scope: meta.number.integer.decimal.toml
+      captures:
+        1: keyword.operator.arithmetic.toml
+        2: constant.numeric.value.toml
+      pop: 1
+
+###[ STRING VALUES ]###########################################################
+
+  basic-multiline-string:
+    - match: '"""'
+      scope: punctuation.definition.string.begin.toml
+      push: basic-multiline-string-body
+
+  basic-multiline-string-body:
+    - meta_scope: meta.string.toml string.quoted.double.block.toml
+    - match: '"""'
+      scope: punctuation.definition.string.end.toml
+      pop: 2
+    - include: string-escapes
+    - include: string-prototype
+
+  basic-string:
+    - match: \"
+      scope: punctuation.definition.string.begin.toml
+      push: basic-string-body
+
+  basic-string-body:
+    - meta_scope: meta.string.toml string.quoted.double.toml
+    - match: \"
+      scope: punctuation.definition.string.end.toml
+      pop: 2
+    - include: illegal-eol-pop
+    - include: string-escapes
+    - include: string-prototype
+
+  literal-multiline-string:
+    - match: "'''"
+      scope: punctuation.definition.string.begin.toml
+      push: literal-multiline-string-body
+
+  literal-multiline-string-body:
+    - meta_scope: meta.string.toml string.quoted.single.block.toml
+    - match: "'''"
+      scope: punctuation.definition.string.end.toml
+      pop: 2
+    - include: string-prototype
+
+  literal-string:
+    - match: \'
+      scope: punctuation.definition.string.begin.toml
+      push: literal-string-body
+
+  literal-string-body:
+    - meta_scope: meta.string.toml string.quoted.single.toml
+    - match: \'
+      scope: punctuation.definition.string.end.toml
+      pop: 2
+    - include: illegal-eol-pop
+    - include: string-prototype
+
+  string-escapes:
+    # https://toml.io/en/v1.0.0#string
+    - match: \\[btnfr"\\]
+      scope: constant.character.escape.toml
+    - match: \\u\h{4}
+      scope: constant.character.escape.unicode.16bit.toml
+    - match: \\U\h{8}
+      scope: constant.character.escape.unicode.32bit.toml
+    - match: \\.
+      scope: invalid.illegal.string.escape.toml
+
+  string-prototype: []
+
+###[ PROTOTYPES ]##############################################################
+
+  immediately-pop:
+    - match: ''
+      pop: 1
+
+  eol-pop:
+    - match: $|(?=\s+#)
+      pop: 1
+
+  expect-eol:
+    - include: eol-pop
+    - match: '[^#\s]+'
+      scope: invalid.illegal.unexpected-token.toml
+
+  illegal-eol-pop:
+    - match: $\n?
+      scope: invalid.illegal.unexpected-eol.toml
+      pop: 1
+
+###############################################################################
+
+variables:
+  # maybe quoted identifiers
+  key_begin: (?=["'0-9A-Za-z_-])
+
+  # identifier
+  ident_begin: (?={{ident_char}})
+  ident_break: (?!{{ident_char}})
+  ident_char: '[0-9A-Za-z_-]'
+
+  # numbers
+  dec_digits: (?:[1-9][0-9_]+|[0-9])
+  zero_dec_digits: (?:[0-9][0-9_]*)
+  exponent: (?:[eE][-+]?{{zero_dec_digits}})
+
+  # rfc3339 / ISO8601 datetime
+  # local-date / offset-date-time / local-date-time
+  date_time: '(?x: {{date}} ([ tT]) {{time}} {{time_offset}}? )'
+
+  # rfc3339 / ISO8601 date
+  date: '(?x: {{date_year}} (-) {{date_month}} (-) {{date_mday}})'
+  # date-fullyear = 4DIGIT
+  date_year: '[0-9]{4}'
+  # date-month = 2DIGIT   ; 01-12
+  date_month: '(?:0[0-9]|1[0-2])'
+  # date-mday = 2DIGIT    ; 01-28, 01-29, 01-30, 01-31 based on month/year
+  date_mday: '(?:[0-2][0-9]|3[0-1])'
+
+  # rfc3339 / ISO8601 time
+  time: '(?x: {{time_hour}} (:) {{time_minute}} (:) {{time_second}} {{time_secfrac}}?)'
+  # time-hour = 2DIGIT    ; 00-23
+  time_hour: '(?:[01][0-9]|2[0-4])'
+  # time-minute = 2DIGIT  ; 00-59
+  time_minute: '[0-5][0-9]'
+  # time-second = 2DIGIT  ; 00-58, 00-59, 00-60 based on leap second rules
+  time_second: '(?:[0-6][0-9])'
+  # time-secfrac = "." 1*DIGIT
+  time_secfrac: '(?:(\.)[0-9]+)'
+  # time-offset = "Z" / time-numoffset
+  # time-numoffset = ("+" / "-") time-hour ":" time-minute
+  time_offset: '(?: ([zZ]) | ([-+]) {{time_hour}} (:) {{time_minute}})'

--- a/TOML/tests/syntax_test_scopes.toml
+++ b/TOML/tests/syntax_test_scopes.toml
@@ -1,0 +1,673 @@
+# SYNTAX TEST "Packages/TOML/TOML.sublime-syntax"
+
+### [ TABLES ]#################################################################
+
+[table-name] illegal # comment
+# <- meta.section.toml punctuation.definition.section.begin.toml
+#^^^^^^^^^^^ meta.section.toml
+#^^^^^^^^^^ entity.name.section.toml
+#          ^ punctuation.definition.section.end.toml
+#           ^ - invalid
+#            ^^^^^^^ invalid.illegal.unexpected-token.toml
+#                    ^^^^^^^^^ comment.line.number-sign.toml
+#                    ^ punctuation.definition.comment.toml
+
+[table.name] illegal # comment
+# <- meta.section.toml punctuation.definition.section.begin.toml
+#^^^^^^^^^^^ meta.section.toml
+#^^^^^^^^^^ entity.name.section.toml
+#     ^ punctuation.accessor.toml
+#          ^ punctuation.definition.section.end.toml
+#           ^ - invalid
+#            ^^^^^^^ invalid.illegal.unexpected-token.toml
+#                    ^^^^^^^^^ comment.line.number-sign.toml
+#                    ^ punctuation.definition.comment.toml
+
+[table."doted.name"] illegal # comment
+#^^^^^^^^^^^^^^^^^^^ meta.section.toml
+#^^^^^^^^^^^^^^^^^^ entity.name.section.toml
+#     ^ punctuation.accessor.toml
+#      ^ punctuation.definition.quoted.begin.toml
+#            ^ - punctuation
+#                 ^ punctuation.definition.quoted.end.toml
+#                  ^ punctuation.definition.section.end.toml
+#                   ^ - invalid
+#                    ^^^^^^^ invalid.illegal.unexpected-token.toml
+#                            ^^^^^^^^^ comment.line.number-sign.toml
+#                            ^ punctuation.definition.comment.toml
+
+[ key . subkey . "sub.subkey" ]
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.section.toml
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ entity.name.section.toml - string
+#     ^ punctuation.accessor.toml
+#              ^ punctuation.accessor.toml
+#                ^ punctuation.definition.quoted.begin.toml
+#                           ^ punctuation.definition.quoted.end.toml
+#                             ^ punctuation.definition.section.end.toml
+
+[[array.section.name]] illegal # comment
+#^^^^^^^^^^^^^^^^^^^^^ meta.section.toml
+#^ punctuation.definition.section.begin.toml
+# ^^^^^^^^^^^^^^^^^^ entity.name.section.toml
+#      ^ punctuation.accessor.toml
+#              ^ punctuation.accessor.toml
+#                   ^^ punctuation.definition.section.end.toml
+#                     ^ - invalid
+#                      ^^^^^^^ invalid.illegal.unexpected-token.toml
+#                              ^^^^^^^^^ comment.line.number-sign.toml
+#                              ^ punctuation.definition.comment.toml
+
+### [ BARE KEYS ]##############################################################
+
+  key
+# ^^^ meta.mapping.key entity.name.key.toml
+
+  bare_key
+# ^^^^^^^^ meta.mapping.key entity.name.key.toml
+
+  bare-key
+# ^^^^^^^^ meta.mapping.key entity.name.key.toml
+
+  1234 # comment
+# ^^^^ meta.mapping.key entity.name.key.toml
+
+  key\b\t\n\f\r\\\u1234\U12345678
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.key.toml entity.name.key.toml
+#    ^ invalid.illegal.toml
+#      ^ invalid.illegal.toml
+#        ^ invalid.illegal.toml
+#          ^ invalid.illegal.toml
+#            ^ invalid.illegal.toml
+#              ^^^ invalid.illegal.toml
+#                      ^ invalid.illegal.toml
+
+### [ QUOTED KEYS ]############################################################
+
+  "127.0.0.1"
+# ^^^^^^^^^^^ meta.mapping.key.toml entity.name.key.toml
+# ^ punctuation.definition.quoted.begin.toml
+#           ^ punctuation.definition.quoted.end.toml
+
+  "character encoding"
+# ^^^^^^^^^^^^^^^^^^^^ meta.mapping.key.toml entity.name.key.toml
+# ^ punctuation.definition.quoted.begin.toml
+#                    ^ punctuation.definition.quoted.end.toml
+
+  "ʎǝʞ"
+# ^^^^^ meta.mapping.key.toml entity.name.key.toml
+# ^ punctuation.definition.quoted.begin.toml
+#     ^ punctuation.definition.quoted.end.toml
+
+  'key2'
+# ^^^^^^ entity.name.key.toml
+# ^ punctuation.definition.quoted.begin.toml
+#      ^ punctuation.definition.quoted.end.toml
+
+  'quoted "value"'
+# ^^^^^^^^^^^^^^^^ entity.name.key.toml
+# ^ punctuation.definition.quoted.begin.toml
+#                ^ punctuation.definition.quoted.end.toml
+
+  "key\b\t\n\f\r\"\\\u1234\U12345678"
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.key entity.name.key.toml
+# ^ punctuation.definition.quoted.begin.toml
+#     ^^^^^^^^^^^^^^ constant.character.escape.toml
+#                   ^^^^^^ constant.character.escape.unicode.16bit.toml
+#                         ^^^^^^^^^^ constant.character.escape.unicode.32bit.toml
+#                                   ^ punctuation.definition.quoted.end.toml
+#                                    ^^^ - meta.mapping
+
+  'key\b\t\n\f\r\"\\\u1234\U12345678'
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.key entity.name.key.toml
+# ^ punctuation.definition.quoted.begin.toml
+#     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - constant.character
+#                                   ^ punctuation.definition.quoted.end.toml
+#                                    ^^^ - meta.mapping
+
+  "" = "blank"     # VALID but discouraged
+# ^^ meta.mapping.key.toml entity.name.key.toml
+# ^ punctuation.definition.quoted.begin.toml
+#  ^ punctuation.definition.quoted.end.toml
+
+  '' = 'blank'     # VALID but discouraged
+# ^^ meta.mapping.key.toml entity.name.key.toml
+# ^ punctuation.definition.quoted.begin.toml
+#  ^ punctuation.definition.quoted.end.toml
+
+### [ DOTTED KEYS ]############################################################
+
+  dotted.key = { dotted.key }
+# ^^^^^^^^^^ meta.mapping.key.toml entity.name.key.toml
+#       ^ punctuation.accessor.toml
+#           ^^^ meta.mapping.toml
+#              ^^^^^^^^^^^^^^ meta.mapping.value.toml
+#                ^^^^^^^^^^ meta.mapping.key.toml entity.name.key.toml
+#                      ^ punctuation.accessor.toml
+
+site."google.com" = { site."google.com" }
+#^^^^^^^^^^^^^^^^ meta.mapping.key.toml entity.name.key.toml
+#   ^ punctuation.accessor.toml
+#    ^ punctuation.definition.quoted.begin.toml
+#           ^ - punctuation
+#               ^ punctuation.definition.quoted.end.toml
+#                ^^^ meta.mapping.toml
+#                   ^^^^^^^^^^^^^^^^^^^^^ meta.mapping.value.toml
+#                     ^^^^^^^^^^^^^^^^^ meta.mapping.key.toml
+#                         ^ punctuation.accessor.toml
+#                          ^ punctuation.definition.quoted.begin.toml
+#                                 ^ - punctuation
+#                                     ^ punctuation.definition.quoted.end.toml
+
+site . "google.com" = { site . "google.com" }
+#^^^^^^^^^^^^^^^^^^ meta.mapping.key.toml entity.name.key.toml
+#    ^ punctuation.accessor.toml
+#      ^ punctuation.definition.quoted.begin.toml
+#             ^ - punctuation
+#                 ^ punctuation.definition.quoted.end.toml
+#                  ^^^ meta.mapping.toml
+#                     ^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.value.toml
+#                       ^^^^^^^^^^^^^^^^^^^ meta.mapping.key.toml
+#                            ^ punctuation.accessor.toml
+#                              ^ punctuation.definition.quoted.begin.toml
+#                                     ^ - punctuation
+#                                         ^ punctuation.definition.quoted.end.toml
+
+### [ ARRAYS ]#################################################################
+
+array = []
+#       ^^ meta.mapping.value.toml meta.sequence.array.toml
+#       ^ punctuation.section.sequence.begin.toml
+#        ^ punctuation.section.sequence.end.toml
+
+array = [[]]
+#       ^ meta.mapping.value.toml meta.sequence.array.toml punctuation.section.sequence.begin.toml
+#        ^ meta.mapping.value.toml meta.sequence.array.toml meta.sequence.array.toml punctuation.section.sequence.begin.toml
+#         ^ meta.mapping.value.toml meta.sequence.array.toml meta.sequence.array.toml punctuation.section.sequence.end.toml
+#          ^ meta.mapping.value.toml meta.sequence.array.toml punctuation.section.sequence.end.toml
+#           ^ - meta.mapping - meta.sequence
+
+array = [ 10,, true, "str", [0, 0b1, ["a", 'b']] ]
+#       ^^^^^^^^^^^^^^^^^^^^ meta.mapping.value.toml meta.sequence.array.toml
+#                           ^^^^^^^^^ meta.mapping.value.toml meta.sequence.array.toml meta.sequence.array.toml
+#                                    ^^^^^^^^^^ meta.mapping.value.toml meta.sequence.array.toml meta.sequence.array.toml meta.sequence.array.toml
+#                                              ^ meta.mapping.value.toml meta.sequence.array.toml meta.sequence.array.toml
+#                                               ^^ meta.mapping.value.toml meta.sequence.array.toml
+#                                                 ^ - meta.mapping - meta.sequence
+
+### [ INLINE TABLES ]##########################################################
+
+table = {}
+#       ^^ meta.mapping.value.toml meta.mapping.toml
+#       ^ punctuation.section.mapping.begin.toml
+#        ^ punctuation.section.mapping.end.toml
+#         ^ - meta.mapping
+
+table = {{}}
+#       ^ meta.mapping.value.toml meta.mapping.toml punctuation.section.mapping.begin.toml
+#        ^ meta.mapping.value.toml meta.mapping.value.toml meta.mapping.toml punctuation.section.mapping.begin.toml
+#         ^ meta.mapping.value.toml meta.mapping.value.toml meta.mapping.toml punctuation.section.mapping.end.toml
+#          ^ meta.mapping.value.toml meta.mapping.toml punctuation.section.mapping.end.toml
+#           ^ - meta.mapping
+
+table = {[]}
+#       ^ meta.mapping.value.toml meta.mapping.toml punctuation.section.mapping.begin.toml
+#        ^ meta.mapping.value.toml meta.mapping.value.toml meta.sequence.array.toml punctuation.section.sequence.begin.toml
+#         ^ meta.mapping.value.toml meta.mapping.value.toml meta.sequence.array.toml punctuation.section.sequence.end.toml
+#          ^ meta.mapping.value.toml meta.mapping.toml punctuation.section.mapping.end.toml
+#           ^ - meta.mapping
+
+table = { 0 }   # not a number, but an unquoted key
+#       ^^ meta.mapping.value.toml meta.mapping.toml
+#         ^ meta.mapping.value.toml meta.mapping.key.toml entity.name.key.toml
+#          ^^ meta.mapping.value.toml meta.mapping.toml
+#            ^ - meta.mapping
+
+table = { -0 }  # not a number, but an unquoted key
+#       ^^ meta.mapping.value.toml meta.mapping.toml
+#         ^^ meta.mapping.value.toml meta.mapping.key.toml entity.name.key.toml
+#           ^^ meta.mapping.value.toml meta.mapping.toml
+#             ^ - meta.mapping
+
+table = { +0 }  # + is no valid char in identifiers, so treat it as value
+#       ^^ meta.mapping.value.toml meta.mapping.toml
+#         ^^ meta.mapping.value.toml meta.mapping.value.toml meta.number.integer.decimal.toml
+#           ^^ meta.mapping.value.toml meta.mapping.toml
+#             ^ - meta.mapping
+
+table = { "+10" }
+#       ^^ meta.mapping.value.toml meta.mapping.toml
+#         ^^^^^ meta.mapping.value.toml meta.mapping.key.toml entity.name.key.toml
+#              ^^ meta.mapping.value.toml meta.mapping.toml
+#                ^ - meta.mapping
+
+table = { '+10' }
+#       ^^ meta.mapping.value.toml meta.mapping.toml
+#         ^^^^^ meta.mapping.value.toml entity.name.key.toml
+#              ^^ meta.mapping.value.toml meta.mapping.toml
+#                ^ - meta.mapping
+
+table = { = -0 }
+#       ^^^^ meta.mapping.value.toml meta.mapping.toml
+#           ^^ meta.mapping.value.toml meta.mapping.value.toml meta.number.integer.decimal.toml
+#             ^^ meta.mapping.value.toml meta.mapping.toml
+#               ^ - meta.mapping
+
+table = { key = { key = "value", key = 5 } }
+#^^^^ meta.mapping.key entity.name.key.toml
+#    ^^^ meta.mapping.toml
+#       ^^ meta.mapping.value.toml meta.mapping.toml - meta.mapping meta.mapping meta.mapping
+#         ^^^ meta.mapping.value.toml meta.mapping.key - meta.mapping meta.mapping meta.mapping
+#            ^^^ meta.mapping.value.toml meta.mapping.toml - meta.mapping meta.mapping meta.mapping
+#               ^^ meta.mapping.value.toml meta.mapping.value.toml meta.mapping.toml
+#                 ^^^ meta.mapping.value.toml meta.mapping.value.toml meta.mapping.key
+#                    ^^^ meta.mapping.value.toml meta.mapping.value.toml meta.mapping.toml
+#                       ^^^^^^^ meta.mapping.value.toml meta.mapping.value.toml meta.mapping.value.toml
+#                              ^^ meta.mapping.value.toml meta.mapping.value.toml meta.mapping.toml
+#                                ^^^ meta.mapping.value.toml meta.mapping.value.toml meta.mapping.key.toml
+#                                   ^^^ meta.mapping.value.toml meta.mapping.value.toml meta.mapping.toml
+#                                      ^ meta.mapping.value.toml meta.mapping.value.toml meta.mapping.value.toml
+#                                       ^^ meta.mapping.value.toml meta.mapping.value.toml meta.mapping.toml
+#                                         ^^ meta.mapping.value.toml meta.mapping.toml - meta.mapping meta.mapping meta.mapping
+#                                           ^ - meta.mapping
+
+table = {
+#       ^^ meta.mapping.value.toml meta.mapping.toml
+#       ^ meta.mapping.value.toml meta.mapping.toml punctuation.section.mapping.begin.toml
+  key = {
+#^^^^^^^^ meta.mapping.value.toml
+#^ meta.mapping.toml
+# ^^^ meta.mapping.value.toml meta.mapping.key.toml entity.name.key.toml
+#    ^^^ meta.mapping.toml
+#     ^ punctuation.separator.key-value.toml
+#       ^ meta.mapping.value.toml meta.mapping.toml punctuation.section.mapping.begin.toml
+    array
+#^^^ meta.mapping.value.toml meta.mapping.value.toml meta.mapping.toml
+#   ^^^^^^ meta.mapping.value.toml meta.mapping.value.toml meta.mapping.key.toml entity.name.key.toml
+    =
+#^^^^^ meta.mapping.value.toml meta.mapping.value.toml meta.mapping.toml
+#   ^ punctuation.separator.key-value.toml
+    [
+#^^^ meta.mapping.value.toml meta.mapping.value.toml meta.mapping.toml
+#   ^^ meta.mapping.value.toml meta.mapping.value.toml meta.mapping.value.toml meta.sequence.array.toml
+#   ^ punctuation.section.sequence.begin.toml
+      "foo"
+#     ^^^^^ meta.mapping.value.toml meta.mapping.value.toml meta.mapping.value.toml meta.sequence.array.toml meta.string.toml string.quoted.double.toml
+      ,
+#     ^ meta.mapping.value.toml meta.mapping.value.toml meta.mapping.value.toml meta.sequence.array.toml punctuation.separator.sequence.toml
+      'bar'
+#     ^^^^^ meta.mapping.value.toml meta.mapping.value.toml meta.mapping.value.toml meta.sequence.array.toml meta.string.toml string.quoted.single.toml
+      ,
+#     ^ meta.mapping.value.toml meta.mapping.value.toml meta.mapping.value.toml meta.sequence.array.toml punctuation.separator.sequence.toml
+      '''
+#     ^^^ meta.mapping.value.toml meta.mapping.value.toml meta.mapping.value.toml meta.sequence.array.toml meta.string.toml string.quoted.single.block.toml punctuation.definition.string.begin.toml
+      baz
+#     ^^^^ meta.mapping.value.toml meta.mapping.value.toml meta.mapping.value.toml meta.sequence.array.toml meta.string.toml string.quoted.single.block.toml
+      '''
+#     ^^^ meta.mapping.value.toml meta.mapping.value.toml meta.mapping.value.toml meta.sequence.array.toml meta.string.toml string.quoted.single.block.toml punctuation.definition.string.end.toml
+    ]
+#^^^^ meta.mapping.value.toml meta.mapping.value.toml meta.mapping.value.toml meta.sequence.array.toml
+#   ^ punctuation.section.sequence.end.toml
+  }
+#^^ meta.mapping.value.toml meta.mapping.value.toml meta.mapping.toml
+# ^ punctuation.section.mapping.end.toml
+#  ^ meta.mapping.value.toml meta.mapping.toml
+}
+# <- meta.mapping.value.toml meta.mapping.toml punctuation.section.mapping.end.toml
+#^ - meta.mapping
+
+points = [ { x = 1, y = 2, z = 3 },
+           { x = 2, y = 4, z = 8 } ]
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.value.toml meta.sequence.array.toml
+#          ^^ meta.mapping.toml
+#          ^ punctuation.section.mapping.begin.toml
+#            ^ meta.mapping.key.toml entity.name.key.toml
+#             ^^^ meta.mapping.toml
+#              ^ punctuation.separator.key-value.toml
+#                ^ meta.mapping.value.toml meta.number.integer.decimal.toml constant.numeric.value.toml
+#                 ^^ meta.mapping.toml
+#                 ^ punctuation.separator.sequence.toml
+#                   ^ meta.mapping.key.toml entity.name.key.toml
+#                    ^^^ meta.mapping.toml
+#                     ^ punctuation.separator.key-value.toml
+#                       ^ meta.mapping.value.toml meta.number.integer.decimal.toml constant.numeric.value.toml
+#                        ^^ meta.mapping.toml
+#                        ^ punctuation.separator.sequence.toml
+#                          ^ meta.mapping.key.toml entity.name.key.toml
+#                           ^^^ meta.mapping.toml
+#                            ^ punctuation.separator.key-value.toml
+#                              ^ meta.mapping.value.toml meta.number.integer.decimal.toml constant.numeric.value.toml
+#                               ^^ meta.mapping.toml
+#                                ^ punctuation.section.mapping.end.toml
+#                                  ^ punctuation.section.sequence.end.toml
+
+### [ BOOLEANS ]###############################################################
+
+key = true
+#     ^^^^ meta.mapping.value.toml constant.language.boolean.true.toml
+#         ^ - meta.mapping
+
+key = false
+#     ^^^^^ meta.mapping.value.toml constant.language.boolean.false.toml
+#          ^ - meta.mapping
+
+key = true_illegal
+#     ^^^^^^^^^^^^ invalid.illegal.unexpected-token.toml
+
+key = False
+#     ^^^^^ invalid.illegal.unexpected-token.toml
+
+### [ BINARY INTEGERS ]########################################################
+
+bin = 0b1_001
+#     ^^^^^^^ meta.mapping.value.toml meta.number.integer.binary.toml
+#     ^^ constant.numeric.base.toml
+#       ^^^^^ constant.numeric.value.toml
+
+bin = 0b
+#     ^^ meta.mapping.value.toml meta.number.integer.binary.toml constant.numeric.base.toml
+
+bin = 0b_
+#     ^^^ invalid.illegal.unexpected-token.toml
+
+bin = 0b12
+#     ^^^^ invalid.illegal.unexpected-token.toml
+
+### [ OCTAL INTEGERS ]#########################################################
+
+oct = 0o12_34_56_7
+#     ^^^^^^^^^^^^ meta.mapping.value.toml meta.number.integer.octal.toml
+#     ^^ constant.numeric.base.toml
+#       ^^^^^^^^^^ constant.numeric.value.toml
+
+oct = 0o
+#     ^^ meta.mapping.value.toml meta.number.integer.octal.toml constant.numeric.base.toml
+#       ^ - meta.mapping
+
+oct = 0o_
+#     ^^^ invalid.illegal.unexpected-token.toml
+
+oct = 0o18
+#     ^^^^ invalid.illegal.unexpected-token.toml
+
+### [ HEXADECIMAL INTEGERS ]###################################################
+
+hex = 0x12_34_56_78_9A_BC_DE_EF
+#     ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.value.toml meta.number.integer.hexadecimal.toml
+#     ^^ constant.numeric.base.toml
+#       ^^^^^^^^^^^^^^^^^^^^^^^ constant.numeric.value.toml
+#                              ^ - meta.mapping
+
+hex = 0x
+#     ^^ meta.mapping.value.toml meta.number.integer.hexadecimal.toml constant.numeric.base.toml
+#       ^ - meta.mapping
+
+hex = 0x_
+#     ^^^ invalid.illegal.unexpected-token.toml
+
+hex = 0x1G
+#     ^^^^ invalid.illegal.unexpected-token.toml
+
+### [ DECIMAL INTEGERS ]#######################################################
+
+dec = 0
+#     ^ meta.mapping.value.toml meta.number.integer.decimal.toml constant.numeric.value.toml
+#      ^ - meta.mapping
+
+dec = -0
+#     ^^ meta.mapping.value.toml meta.number.integer.decimal.toml
+#     ^ keyword.operator.arithmetic.toml
+#      ^ constant.numeric.value.toml
+#       ^ - meta.mapping
+
+dec = +0
+#     ^^ meta.mapping.value.toml meta.number.integer.decimal.toml
+#     ^ keyword.operator.arithmetic.toml
+#      ^ constant.numeric.value.toml
+#       ^ - meta.mapping
+
+dec = 10
+#     ^^ meta.mapping.value.toml meta.number.integer.decimal.toml constant.numeric.value.toml
+
+dec = 01
+#     ^^ invalid.illegal.unexpected-token.toml
+
+dec = 1234567890
+#     ^^^^^^^^^^ meta.mapping.value.toml meta.number.integer.decimal.toml constant.numeric.value.toml
+
+dec = 1234567890A
+#     ^^^^^^^^^^^ invalid.illegal.unexpected-token.toml
+
+### [ FLOATS ]#################################################################
+
+float = inf
+#       ^^^ meta.mapping.value.toml meta.number.float.other.toml constant.numeric.value.toml
+
+float = -inf
+#       ^^^^ meta.mapping.value.toml meta.number.float.other.toml
+#       ^ keyword.operator.arithmetic.toml
+#        ^^^ constant.numeric.value.toml
+
+float = +inf
+#       ^^^^ meta.mapping.value.toml meta.number.float.other.toml
+#       ^ keyword.operator.arithmetic.toml
+#        ^^^ constant.numeric.value.toml
+
+float = nan
+#       ^^^ meta.mapping.value.toml meta.number.float.other.toml constant.numeric.value.toml
+
+float = -nan
+#       ^^^^ meta.mapping.value.toml meta.number.float.other.toml
+#       ^ keyword.operator.arithmetic.toml
+#        ^^^ constant.numeric.value.toml
+
+float = +nan
+#       ^^^^ meta.mapping.value.toml meta.number.float.other.toml
+#       ^ keyword.operator.arithmetic.toml
+#        ^^^ constant.numeric.value.toml
+
+float = 0.1
+#       ^^^ meta.mapping.value.toml meta.number.float.decimal.toml constant.numeric.value.toml
+#        ^ punctuation.separator.decimal.toml
+
+float = -0.1
+#       ^^^^ meta.mapping.value.toml meta.number.float.decimal.toml
+#       ^ keyword.operator.arithmetic.toml
+#        ^^^ constant.numeric.value.toml
+#         ^ punctuation.separator.decimal.toml
+
+float = +0.1
+#       ^^^^ meta.mapping.value.toml meta.number.float.decimal.toml
+#       ^ keyword.operator.arithmetic.toml
+#        ^^^ constant.numeric.value.toml
+#         ^ punctuation.separator.decimal.toml
+
+float = 0.
+#       ^ meta.mapping.value.toml meta.number.integer.decimal.toml constant.numeric.value.toml
+#        ^ invalid.illegal.unexpected-token.toml
+
+float = .1
+#       ^^ invalid.illegal.unexpected-token.toml
+
+float = 00.1
+#       ^^^^ invalid.illegal.unexpected-token.toml
+
+float = 1e1
+#       ^^^ meta.mapping.value.toml meta.number.float.decimal.toml constant.numeric.value.toml
+
+float = 1e+1
+#       ^^^^ meta.mapping.value.toml meta.number.float.decimal.toml constant.numeric.value.toml
+
+float = 1e-1
+#       ^^^^ meta.mapping.value.toml meta.number.float.decimal.toml constant.numeric.value.toml
+
+float = -1e+1
+#       ^^^^^ meta.mapping.value.toml meta.number.float.decimal.toml
+#       ^ keyword.operator.arithmetic.toml
+#        ^^^^constant.numeric.value.toml
+
+float = +1e-1
+#       ^^^^^ meta.mapping.value.toml meta.number.float.decimal.toml
+#       ^ keyword.operator.arithmetic.toml
+#        ^^^^constant.numeric.value.toml
+
+### [ DATE AND TIME ]##########################################################
+
+odt1 = 1979-05-27T07:32:00Z
+#      ^^^^^^^^^^^^^^^^^^^^ meta.mapping.value.toml constant.other.datetime.toml
+#          ^ punctuation.separator.date.toml
+#             ^ punctuation.separator.date.toml
+#                ^ punctuation.separator.datetime.toml
+#                   ^ punctuation.separator.time.toml
+#                      ^ punctuation.separator.time.toml
+#                         ^ storage.modifier.timezone.toml
+
+odt2 = 1979-05-27T00:32:00-07:00
+#      ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.value.toml constant.other.datetime.toml
+#          ^ punctuation.separator.date.toml
+#             ^ punctuation.separator.date.toml
+#                ^ punctuation.separator.datetime.toml
+#                   ^ punctuation.separator.time.toml
+#                      ^ punctuation.separator.time.toml
+#                         ^ keyword.operator.arithmetic.toml
+#                            ^ punctuation.separator.time.toml
+
+odt3 = 1979-05-27T00:32:00.999999-07:00
+#      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.value.toml constant.other.datetime.toml
+#          ^ punctuation.separator.date.toml
+#             ^ punctuation.separator.date.toml
+#                ^ punctuation.separator.datetime.toml
+#                   ^ punctuation.separator.time.toml
+#                      ^ punctuation.separator.time.toml
+#                         ^ punctuation.separator.decimal.toml
+#                                ^ keyword.operator.arithmetic.toml
+#                                   ^ punctuation.separator.time.toml
+
+odt4 = 1979-05-27 07:32:00Z
+#      ^^^^^^^^^^^^^^^^^^^^ meta.mapping.value.toml constant.other.datetime.toml
+#          ^ punctuation.separator.date.toml
+#             ^ punctuation.separator.date.toml
+#                ^ punctuation.separator.datetime.toml
+#                   ^ punctuation.separator.time.toml
+#                      ^ punctuation.separator.time.toml
+#                         ^ storage.modifier.timezone.toml
+
+ldt1 = 1979-05-27T07:32:00
+#      ^^^^^^^^^^^^^^^^^^^ meta.mapping.value.toml constant.other.datetime.toml
+#          ^ punctuation.separator.date.toml
+#             ^ punctuation.separator.date.toml
+#                ^ punctuation.separator.datetime.toml
+#                   ^ punctuation.separator.time.toml
+#                      ^ punctuation.separator.time.toml
+
+ldt2 = 1979-05-27T00:32:00.999999
+#      ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.value.toml constant.other.datetime.toml
+#          ^ punctuation.separator.date.toml
+#             ^ punctuation.separator.date.toml
+#                ^ punctuation.separator.datetime.toml
+#                   ^ punctuation.separator.time.toml
+#                      ^ punctuation.separator.time.toml
+#                         ^ punctuation.separator.decimal.toml
+
+ld1 = 1979-05-27
+#     ^^^^^^^^^^ meta.mapping.value.toml constant.other.date.toml
+#         ^ punctuation.separator.date.toml
+#            ^ punctuation.separator.date.toml
+
+lt1 = 07:32:00
+#     ^^^^^^^^ meta.mapping.value.toml constant.other.time.toml
+#       ^ punctuation.separator.time.toml
+#          ^ punctuation.separator.time.toml
+
+lt2 = 00:32:00.999999
+#     ^^^^^^^^^^^^^^^ meta.mapping.value.toml constant.other.time.toml
+#       ^ punctuation.separator.time.toml
+#          ^ punctuation.separator.time.toml
+#             ^ punctuation.separator.decimal.toml
+
+ldt = 199-05-27T07:32:00
+#     ^^^^^^^^^^^^^^^^^^ invalid.illegal.unexpected-token.toml
+
+ldt = 1979-05-7T07:32:00
+#     ^^^^^^^^^^^^^^^^^^ invalid.illegal.unexpected-token.toml
+
+### [ STRINGS ]################################################################
+
+key = "value"
+#^^^^^^^^^^^^ - meta.mapping meta.mapping
+#^^ meta.mapping.key entity.name.key.toml
+#  ^^^ meta.mapping.toml
+#   ^ punctuation.separator.key-value.toml
+#     ^ meta.mapping.value.toml meta.string.toml string.quoted.double.toml punctuation.definition.string.begin.toml
+#      ^^^^^^ meta.mapping.value.toml meta.string.toml string.quoted.double.toml
+#           ^ punctuation.definition.string.end.toml
+
+key = "value
+#^^^^^^^^^^^^ - meta.mapping meta.mapping
+#^^ meta.mapping.key entity.name.key.toml
+#  ^^^ meta.mapping.toml
+#   ^ punctuation.separator.key-value.toml
+#     ^ meta.mapping.value.toml meta.string.toml string.quoted.double.toml punctuation.definition.string.begin.toml
+#      ^^^^^^ meta.mapping.value.toml meta.string.toml string.quoted.double.toml
+#           ^ invalid.illegal.unexpected-eol.toml
+
+key = 'value'
+#^^^^^^^^^^^^ - meta.mapping meta.mapping
+#^^ meta.mapping.key entity.name.key.toml
+#  ^^^ meta.mapping.toml
+#   ^ punctuation.separator.key-value.toml
+#     ^ meta.mapping.value.toml meta.string.toml string.quoted.single.toml punctuation.definition.string.begin.toml
+#      ^^^^^^ meta.mapping.value.toml meta.string.toml string.quoted.single.toml
+#           ^ punctuation.definition.string.end.toml
+
+key = 'value
+#^^^^^^^^^^^^ - meta.mapping meta.mapping
+#^^ meta.mapping.key entity.name.key.toml
+#  ^^^ meta.mapping.toml
+#   ^ punctuation.separator.key-value.toml
+#     ^ meta.mapping.value.toml meta.string.toml string.quoted.single.toml punctuation.definition.string.begin.toml
+#      ^^^^^^ meta.mapping.value.toml meta.string.toml string.quoted.single.toml
+#           ^ invalid.illegal.unexpected-eol.toml
+
+key = """
+#^^^^^^^^^ - meta.mapping meta.mapping
+#^^ meta.mapping.key entity.name.key.toml
+#  ^^^ meta.mapping.toml
+#   ^ punctuation.separator.key-value.toml
+#     ^^^ meta.mapping.value.toml meta.string.toml string.quoted.double.block.toml punctuation.definition.string.begin.toml
+
+      "This \n \u2ff4"
+#^^^^^^^^^^^^^^^^^^^^^ meta.mapping.value.toml meta.string.toml string.quoted.double.block.toml
+#     ^ - punctuation
+#           ^^ constant.character.escape.toml
+#              ^^^^^^ constant.character.escape.unicode.16bit.toml
+#                    ^ - punctuation
+
+      """ illegal # comment
+#^^^^^^^^ meta.mapping.value.toml meta.string.toml string.quoted.double.block.toml
+#     ^^^ punctuation.definition.string.end.toml
+#        ^ - string - invalid
+#         ^^^^^^^ invalid.illegal.unexpected-token.toml
+#                ^ - invalid - comment
+#                 ^^^^^^^^^^ comment.line.number-sign.toml
+
+key = '''
+#^^^^^^^^^ - meta.mapping meta.mapping
+#^^ meta.mapping.key entity.name.key.toml
+#  ^^^ meta.mapping.toml
+#   ^ punctuation.separator.key-value.toml
+#     ^^^ meta.mapping.value.toml meta.string.toml string.quoted.single.block.toml punctuation.definition.string.begin.toml
+
+      "This \n \u2ff4"
+#^^^^^^^^^^^^^^^^^^^^^ meta.mapping.value.toml meta.string.toml string.quoted.single.block.toml
+#     ^ - punctuation
+#           ^^ - constant.character
+#              ^^^^^^ - constant.character
+#                    ^ - punctuation
+
+      ''' illegal # comment
+#^^^^^^^^ meta.mapping.value.toml meta.string.toml string.quoted.single.block.toml
+#     ^^^ punctuation.definition.string.end.toml
+#        ^ - string - invalid
+#         ^^^^^^^ invalid.illegal.unexpected-token.toml
+#                ^ - invalid - comment
+#                 ^^^^^^^^^^ comment.line.number-sign.toml


### PR DESCRIPTION
Resolves #4167 

This PR adds new TOML default package.

Syntax takes some inspiration from https://packagecontrol.io/packages/TOML but has finally been re-written from scratch using specs from https://toml.io/en/

Reasons:

1. version 2 syntax definition

2. be less strict with regards to incomplete statements to avoid overeager illegal highlighting.
   _It is arguable if current state of illegal value highlighting is already too much._

3. design syntax primarily using named contexts with possible inheritance in mind

4. this implementation is about 30% faster (in its initial state)

Remarks:

4. both, tables (aka. sections) and keys can consist of fully qualified identifiers specifying a path of hash table keys to final value.

   ```toml
   [foo . "bar" . 'baz']
   buuz = "value"
   ```

   is the same as

   ```toml
   [foo]
   bar . "baz" . 'buuz' = "value"
   ```
   
   Both represent following JSON:

   ```json
   {
       "foo": {
           "bar": {
               "baz": {
                   "buuz": "value"
               }
           }
       }
   }
   ```

   As discussed in #4167 it probably doesn't make sense to map section name and key name scopes to those of JSON representation as it would cause both being scoped `meta.mapping.key string`, which results in unexpected highlighting compared to GitConfig and INI syntax.

   As keys can consist of multiple elements, it is questionable whether `meta.mapping.key string` convention is the appropriate choise at all, because using different scoping schemas for sections and keys doesn't feel right and scoping individual elements `string.unquoted` or `string.quoted` separated by period, doesn't add any value, too.

   Hence this PR starts with scoping whole...

   1. `[section.name]` => `meta.section entity.name.section` (known from INI and GitConfig)
   2. `key.name` => `meta.mapping.key entity.name.key` (which was used earlier)

   Only quotation punctuation and `.` spearator is scoped on top of those `entity` scopes.
