### PR TITLE
[Diff] Fix conflict markers

### DIFF
--- a/Diff/Diff.sublime-syntax
+++ b/Diff/Diff.sublime-syntax
@@ -307,10 +307,11 @@ contexts:
 ###############################################################################
 
 variables:
-  conflict_begin: <{7}
-  conflict_end: '>{7}'
-  conflict_split: ={7}
-  conflict_base: \|{7}
+  conflict_marker_size: '{7}'
+  conflict_begin: <{{conflict_marker_size}}
+  conflict_end: '>{{conflict_marker_size}}'
+  conflict_split: ={{conflict_marker_size}}
+  conflict_base: \|{{conflict_marker_size}}
   conflict_any: |-
     (?x:
       {{conflict_begin}}

--- a/Diff/Diff.sublime-syntax
+++ b/Diff/Diff.sublime-syntax
@@ -244,24 +244,24 @@ contexts:
 
   # Utility context for other files to use
   conflict-markers:
-    - match: '{{bol}}({{conflict_begin}})(?:\s*({{conflict_identifier}}))?{{eol}}'
+    - match: '{{bol}}({{conflict_begin}})(?:\s+({{conflict_identifier}}))?{{eol}}'
       scope: meta.block.conflict.begin.diff
       captures:
         1: punctuation.section.block.begin.diff
         2: entity.name.section.diff
-    - match: '{{bol}}({{conflict_end}})(?:\s*({{conflict_identifier}}))?{{eol}}'
+    - match: '{{bol}}({{conflict_end}})(?:\s+({{conflict_identifier}}))?{{eol}}'
       scope: meta.block.conflict.end.diff
       captures:
         1: punctuation.section.block.end.diff
         2: entity.name.section.diff
-    - match: '{{bol}}({{conflict_base}}|{{conflict_split}})(?:\s*({{conflict_identifier}}))?{{eol}}'
+    - match: '{{bol}}({{conflict_base}}|{{conflict_split}})(?:\s+({{conflict_identifier}}))?{{eol}}'
       scope: meta.block.conflict.separator.diff
       captures:
         1: punctuation.section.block.diff
         2: entity.name.section.diff
 
   conflicts:
-    - match: '{{bol}}({{conflict_begin}})(?:\s*({{conflict_identifier}}))?{{eol}}'
+    - match: '{{bol}}({{conflict_begin}})(?:\s+({{conflict_identifier}}))?{{eol}}'
       scope: meta.block.conflict.begin.diff
       captures:
         1: punctuation.section.block.begin.diff
@@ -270,7 +270,7 @@ contexts:
 
   conflict-deleted-lines:
     - meta_content_scope: meta.block.conflict.diff markup.deleted.diff
-    - match: '{{bol}}({{conflict_base}})(?:\s*({{conflict_identifier}}))?{{eol}}'
+    - match: '{{bol}}({{conflict_base}})(?:\s+({{conflict_identifier}}))?{{eol}}'
       scope: meta.block.conflict.separator.diff
       captures:
         1: punctuation.section.block.diff
@@ -280,7 +280,7 @@ contexts:
 
   conflict-base-lines:
     - meta_content_scope: meta.block.conflict.diff comment.block.diff
-    - match: '{{bol}}({{conflict_split}})(?:\s*({{conflict_identifier}}))?{{eol}}'
+    - match: '{{bol}}({{conflict_split}})(?:\s+({{conflict_identifier}}))?{{eol}}'
       scope: meta.block.conflict.separator.diff
       captures:
         1: punctuation.section.block.diff
@@ -290,7 +290,7 @@ contexts:
 
   conflict-new-lines:
     - meta_content_scope: meta.block.conflict.diff markup.inserted.diff
-    - match: '{{bol}}({{conflict_end}})(?:\s*({{conflict_identifier}}))?{{eol}}'
+    - match: '{{bol}}({{conflict_end}})(?:\s+({{conflict_identifier}}))?{{eol}}'
       scope: meta.block.conflict.end.diff
       captures:
         1: punctuation.section.block.end.diff
@@ -307,10 +307,10 @@ contexts:
 ###############################################################################
 
 variables:
-  conflict_begin: <{5,}
-  conflict_end: '>{5,}'
-  conflict_split: ={5,}
-  conflict_base: \|{5,}
+  conflict_begin: <{7}
+  conflict_end: '>{7}'
+  conflict_split: ={7}
+  conflict_base: \|{7}
   conflict_any: |-
     (?x:
       {{conflict_begin}}

--- a/Diff/tests/syntax_test_diff.diff
+++ b/Diff/tests/syntax_test_diff.diff
@@ -452,7 +452,7 @@ lines from B
 <
 \ <- meta.block.conflict.diff markup.inserted.diff - punctuation - invalid
 |||||
-\^^^^ meta.block.conflict.diff markup.inserted.diff invalid.illegal.conflict.diff
+\^^^^ meta.block.conflict.diff markup.inserted.diff - punctuation.section
 lines from C
 \^^^^^^^^^^^^ meta.block.conflict.diff markup.inserted.diff
 >>>>>>> C
@@ -580,6 +580,63 @@ hello()
 \^^^^^^ punctuation.section.block.end.diff
 \       ^^^^^^^^^ entity.name.section.diff
 
+\ illegal separators due to positions \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+<<<<<<< theirs
+>>>>>>> ours
+\ <- meta.block.conflict.diff markup.deleted.diff invalid.illegal.conflict.diff
+\^^^^^^ meta.block.conflict.diff markup.deleted.diff invalid.illegal.conflict.diff
+======= 
+\ <- meta.block.conflict.diff markup.deleted.diff invalid.illegal.conflict.diff
+\^^^^^^ meta.block.conflict.diff markup.deleted.diff invalid.illegal.conflict.diff
+=======a
+\ <- meta.block.conflict.diff markup.deleted.diff invalid.illegal.conflict.diff
+\^^^^^^ meta.block.conflict.diff markup.deleted.diff invalid.illegal.conflict.diff
+=======
+\ <- meta.block.conflict.separator.diff punctuation.section.block.diff
+\^^^^^^ meta.block.conflict.separator.diff punctuation.section.block.diff
+=======
+\ <- meta.block.conflict.diff markup.inserted.diff invalid.illegal.conflict.diff
+\^^^^^^ meta.block.conflict.diff markup.inserted.diff invalid.illegal.conflict.diff
+>>>>>>> ours
+\<- meta.block.conflict.end.diff punctuation.section.block.end.diff
+\^^^^^^^^^^^^ meta.block.conflict.end.diff
+
+\ not a conflict marker \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+<<<<<<<deleted
+\ <- markup.deleted.diff punctuation.definition.deleted.diff
+\^^^^^^^^^^^^^^ markup.deleted.diff
+
+>>>>>>>added
+\ <- markup.inserted.diff punctuation.definition.inserted.diff
+\^^^^^^^^^^^^ markup.inserted.diff
+
+<<<<<< deleted
+\ <- markup.deleted.diff punctuation.definition.deleted.diff
+\^^^^^^^^^^^^^^ markup.deleted.diff
+
+|||||
+\ <- - meta.block.conflict - punctuation
+\^^^^ - meta.block.conflict - punctuation
+
+>>>>>> added
+\ <- markup.inserted.diff punctuation.definition.inserted.diff
+\^^^^^^^^^^^^ markup.inserted.diff
+
+<<<<<<<< deleted
+\ <- markup.deleted.diff punctuation.definition.deleted.diff
+\^^^^^^^^^^^^^^^^ markup.deleted.diff
+
+|||||||||
+\ <- - meta.block.conflict - punctuation
+\^^^^^^^^ - meta.block.conflict - punctuation
+
+>>>>>>>> added
+\ <- markup.inserted.diff punctuation.definition.inserted.diff
+\^^^^^^^^^^^^^^ markup.inserted.diff
+
+\ side-by-side diffs \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 
 \ https://www.gnu.org/software/diffutils/manual/diffutils.html#Example-Side-by-Side
 The Way that can be told of is n   <


### PR DESCRIPTION
This PR...

1. restricts merge conflict markers to exactly 7 consecutive chars (e.g. `<<<<<<<` or `>>>>>>>`) according to https://www.gnu.org/software/diffutils/manual/diffutils.html#Generating-the-Merged-Output-Directly

   If less chars, it's not invalid, but just no conflict marker.

2. ensure reference names are separated from markers by at least one whitespace

These changes are required to reduce risk of ambiguities with headings in Markdown and Restructured Text.

This is an attempt to avoid existing syntax tests failing, when merging current master into #4047.