### PR TITLE
[Git Config] Some scope tweaks

### DIFF
--- a/Git Formats/Git Config - Fold.tmPreferences
+++ b/Git Formats/Git Config - Fold.tmPreferences
@@ -9,9 +9,9 @@
         <array>
             <dict>
                 <key>begin</key>
-                <string>meta.section meta.brackets punctuation.definition.brackets.end</string>
+                <string>meta.section meta.brackets punctuation.section.brackets.end</string>
                 <key>end</key>
-                <string>meta.section meta.brackets punctuation.definition.brackets.begin</string>
+                <string>meta.section meta.brackets punctuation.section.brackets.begin</string>
                 <key>excludeTrailingNewlines</key>
                 <true/>
             </dict>

--- a/Git Formats/Git Config - Symbol List.tmPreferences
+++ b/Git Formats/Git Config - Symbol List.tmPreferences
@@ -4,7 +4,7 @@
 	<key>name</key>
 	<string>Symbol List</string>
 	<key>scope</key>
-	<string>meta.section.header.git.config meta.brackets.git.config</string>
+	<string>meta.section.git.config meta.brackets.git.config</string>
 	<key>settings</key>
 	<dict>
 		<key>showInSymbolList</key>

--- a/Git Formats/Git Config.sublime-syntax
+++ b/Git Formats/Git Config.sublime-syntax
@@ -33,17 +33,17 @@ contexts:
     # Note that this does not match [color] (without the subsection). This is
     # because [color] doesn't actually take color values.
     - match: ^\s*(?=\[\s*color\s+\")
-      push: [key-color-pair, section-header]
+      push: [key-color-pair, section-header-meta, section-header]
     # section-other matches all sections except [color "subsection"].
     - match: ^\s*(?=\[)
-      push: [key-value-pair, section-header]
+      push: [key-value-pair, section-header-meta, section-header]
 
 ###[ SECTION HEADERS ]#########################################################
 
   section-header:
     - match: \[
       scope: punctuation.definition.brackets.begin.git.config
-      set: [section-header-meta, section-header-end, section-name]
+      set: [section-header-end, section-name]
 
   section-header-meta:
     - meta_scope: meta.section.git.config

--- a/Git Formats/Git Config.sublime-syntax
+++ b/Git Formats/Git Config.sublime-syntax
@@ -17,7 +17,7 @@ hidden_file_extensions:
 first_line_match: ^\[core\]  # .git/config files always start with [core]
 
 variables:
-  variable_name: '[a-zA-Z][\w-]*'
+  key_name: '[a-zA-Z][\w-]*'
   zero_to_255: 25[0-5]|2[0-4][0-9]|1\d\d|[1-9][0-9]|[0-9]
 
 contexts:
@@ -115,10 +115,10 @@ contexts:
   # changed = red
   # untracked = bold green
   key-color-pair:
-    - match: ^(\s*)({{variable_name}})(\s*(\=)\s*)
+    - match: ^(\s*)({{key_name}})(\s*(=)\s*)
       captures:
         1: meta.mapping.git.config
-        2: meta.mapping.key.git.config variable.other.readwrite.git.config
+        2: meta.mapping.key.git.config string.unquoted.git.config
         3: meta.mapping.git.config
         4: punctuation.separator.key-value.git.config
       push:
@@ -129,10 +129,10 @@ contexts:
 
   # key = val
   key-value-pair:
-    - match: ^(\s*)({{variable_name}})(\s*(\=)\s*)
+    - match: ^(\s*)({{key_name}})(\s*(=)\s*)
       captures:
         1: meta.mapping.git.config
-        2: meta.mapping.key.git.config variable.other.readwrite.git.config
+        2: meta.mapping.key.git.config string.unquoted.git.config
         3: meta.mapping.git.config
         4: punctuation.separator.key-value.git.config
       push:

--- a/Git Formats/Git Config.sublime-syntax
+++ b/Git Formats/Git Config.sublime-syntax
@@ -46,7 +46,7 @@ contexts:
       set: [section-header-meta, section-header-end, section-name]
 
   section-header-meta:
-    - meta_scope: meta.section.header.git.config
+    - meta_scope: meta.section.git.config
     - match: $\n?
       pop: 1
     - match: \S
@@ -115,7 +115,6 @@ contexts:
   # changed = red
   # untracked = bold green
   key-color-pair:
-    - meta_scope: meta.section.body.git.config
     - match: ^(\s*)({{variable_name}})(\s*(\=)\s*)
       captures:
         1: meta.mapping.git.config
@@ -130,7 +129,6 @@ contexts:
 
   # key = val
   key-value-pair:
-    - meta_scope: meta.section.body.git.config
     - match: ^(\s*)({{variable_name}})(\s*(\=)\s*)
       captures:
         1: meta.mapping.git.config

--- a/Git Formats/Git Config.sublime-syntax
+++ b/Git Formats/Git Config.sublime-syntax
@@ -42,7 +42,7 @@ contexts:
 
   section-header:
     - match: \[
-      scope: punctuation.definition.brackets.begin.git.config
+      scope: punctuation.section.brackets.begin.git.config
       set: [section-header-end, section-name]
 
   section-header-meta:
@@ -55,7 +55,7 @@ contexts:
   section-header-end:
     - meta_scope: meta.brackets.git.config
     - match: \]
-      scope: punctuation.definition.brackets.end.git.config
+      scope: punctuation.section.brackets.end.git.config
       pop: 1
     - include: illegal-line-end-pop
     - match: \S

--- a/Git Formats/tests/syntax_test_git_config
+++ b/Git Formats/tests/syntax_test_git_config
@@ -101,29 +101,32 @@
 #            ^ punctuation.definition.brackets.end
 #             ^ meta.section - meta.brackets
     old = red
-# <- meta.mapping
-#^^^^^^^^^^^^ meta.mapping
-#   ^^^ variable.other.readwrite
-#      ^ -variable.other.readwrite
+# <- meta.mapping.git.config
+#^^^ meta.mapping.git.config
+#   ^^^ meta.mapping.key.git.config
+#      ^^^ meta.mapping.git.config
+#         ^^^ meta.mapping.value.git.config support.constant.color.git.config
+#   ^^^ string.unquoted
+#      ^ - string.unquoted
 #       ^ punctuation.separator.key-value
-#        ^ -punctuation.separator.key-value
-#         ^^^ meta.mapping.value support.constant.color
+#        ^ - punctuation.separator.key-value
+#         ^^^ support.constant.color
     new = #00aa00 # this should be a comment
 # <- meta.mapping
 #^^^^^^^^^^^^^^^^ meta.mapping
-#   ^^^ variable.other.readwrite
-#      ^ -variable.other.readwrite
+#   ^^^ string.unquoted
+#      ^ - string.unquoted
 #       ^ punctuation.separator.key-value
-#        ^ -punctuation.separator.key-value
+#        ^ - punctuation.separator.key-value
 #         ^ comment.line punctuation.definition.comment
 #          ^^^^^^^ comment.line
     commit = bold yellow
 # <- meta.mapping
 #^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping
-#   ^^^^^^ variable.other.readwrite
-#         ^ -variable.other.readwrite
+#   ^^^^^^ string.unquoted
+#         ^ - string.unquoted
 #          ^ punctuation.separator.key-value
-#           ^ -punctuation.separator.key-value
+#           ^ - punctuation.separator.key-value
 #            ^^^^^^^^^^^ meta.mapping.value
 #            ^^^^ support.constant.color-attribute
 #                 ^^^^^^ support.constant.color
@@ -163,7 +166,7 @@
 [escapes]
     quoted = "\\ \" \b \n \t"
 #^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping
-#   ^^^^^^ variable.other.readwrite
+#   ^^^^^^ string.unquoted
 #          ^ punctuation.separator.key-value
 #            ^^^^^^^^^^^^^^^^ meta.mapping.value string.quoted.double
 #             ^^ constant.character.escape
@@ -185,32 +188,32 @@
 [bools]
     foo = true
 #^^^^^^^^^^^^^ meta.mapping
-#   ^^^ variable.other.readwrite
+#   ^^^ string.unquoted
 #       ^ punctuation.separator.key-value
 #         ^^^^ meta.mapping.value constant.language
     foo = false
 #^^^^^^^^^^^^^^ meta.mapping
-#   ^^^ variable.other.readwrite
+#   ^^^ string.unquoted
 #       ^ punctuation.separator.key-value
 #         ^^^^^ meta.mapping.value constant.language
     foo = on
 #^^^^^^^^^^^ meta.mapping
-#   ^^^ variable.other.readwrite
+#   ^^^ string.unquoted
 #       ^ punctuation.separator.key-value
 #         ^^ meta.mapping.value constant.language
     foo = off
 #^^^^^^^^^^^^ meta.mapping
-#   ^^^ variable.other.readwrite
+#   ^^^ string.unquoted
 #       ^ punctuation.separator.key-value
 #         ^^^ meta.mapping.value constant.language
     foo = no
 #^^^^^^^^^^^ meta.mapping
-#   ^^^ variable.other.readwrite
+#   ^^^ string.unquoted
 #       ^ punctuation.separator.key-value
 #         ^^ meta.mapping.value constant.language
     foo = yes
 #^^^^^^^^^^^^ meta.mapping
-#   ^^^ variable.other.readwrite
+#   ^^^ string.unquoted
 #       ^ punctuation.separator.key-value
 #         ^^^ meta.mapping.value constant.language
 
@@ -466,20 +469,20 @@ stray-bracket]
     branch-author = for-each-ref --format='%(committerdate) %09 %(authorname) %09 %(refname)'
 # <- meta.mapping
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping
-#   ^^^^^^^^^^^^^ variable.other.readwrite
-#                ^ -variable.other.readwrite
+#   ^^^^^^^^^^^^^ string.unquoted
+#                ^ - string.unquoted
 #                 ^ punctuation.separator.key-value
-#                  ^ -punctuation.separator.key-value
+#                  ^ - punctuation.separator.key-value
 #                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.value
 #                   ^^^^^^^^^^^^ string.unquoted.value
 
     fatch = fetch --all --prune --tags
 # <- meta.mapping
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping
-#   ^^^^^ variable.other.readwrite
-#        ^ -variable.other.readwrite
+#   ^^^^^ string.unquoted
+#        ^ - string.unquoted
 #         ^ punctuation.separator.key-value
-#          ^ -punctuation.separator.key-value
+#          ^ - punctuation.separator.key-value
 #           ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.value
 #           ^^^^^ string.unquoted.value
 #                 ^^^^^ string.unquoted.value
@@ -488,10 +491,10 @@ stray-bracket]
     lgrep = log -1 -E -i --grep
 # <- meta.mapping
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping
-#   ^^^^^ variable.other.readwrite
-#        ^ -variable.other.readwrite
+#   ^^^^^ string.unquoted
+#        ^ - string.unquoted
 #         ^ punctuation.separator.key-value
-#          ^ -punctuation.separator.key-value
+#          ^ - punctuation.separator.key-value
 #           ^^^^^^^^^^^^^^^^^^^ meta.mapping.value
 #           ^^^ string.unquoted.value
 #               ^^ string.unquoted.value
@@ -502,10 +505,10 @@ stray-bracket]
     pushf = push --force-with-lease
 # <- meta.mapping
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping
-#   ^^^^^ variable.other.readwrite
-#        ^ -variable.other.readwrite
+#   ^^^^^ string.unquoted
+#        ^ - string.unquoted
 #         ^ punctuation.separator.key-value
-#          ^ -punctuation.separator.key-value
+#          ^ - punctuation.separator.key-value
 #           ^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.value
 #           ^^^^ string.unquoted.value
 #                ^^^^^^^^^^^^^^^^^^ string.unquoted.value
@@ -513,10 +516,10 @@ stray-bracket]
     sla = log --oneline --decorate --graph --all
 # <- meta.mapping
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping
-#   ^^^ variable.other.readwrite
-#      ^ -variable.other.readwrite
+#   ^^^ string.unquoted
+#      ^ - string.unquoted
 #       ^ punctuation.separator.key-value
-#        ^ -punctuation.separator.key-value
+#        ^ - punctuation.separator.key-value
 #         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.value
 #         ^^^ string.unquoted.value
 #             ^^^^^^^^^
@@ -530,7 +533,7 @@ stray-bracket]
 #  ^^^^^ meta.mapping.key
 #       ^^^ meta.mapping
 #          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.value
-#  ^^^^^ variable.other.readwrite
+#  ^^^^^ string.unquoted
 #        ^ punctuation.separator.key-value
 #          ^ keyword.control.import.shell
 #           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.shell
@@ -540,7 +543,7 @@ stray-bracket]
 #  ^^^^^ meta.mapping.key
 #       ^^^ meta.mapping
 #          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.value
-#  ^^^^^ variable.other.readwrite
+#  ^^^^^ string.unquoted
 #        ^ punctuation.separator.key-value
 #          ^ string.quoted.double punctuation.definition.string.begin
 #           ^ keyword.control.import.shell
@@ -565,7 +568,7 @@ stray-bracket]
 #             ^^^ meta.mapping - meta.mapping.key - meta.mapping.value
 #                ^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.value
 #                                       ^ - meta.mapping
-# ^^^^^^^^^^^^ variable.other.readwrite
+# ^^^^^^^^^^^^ string.unquoted
 #              ^ punctuation.separator.key-value
 #                ^ string.quoted.double punctuation.definition.string.begin
 #                 ^ keyword.control.import.shell
@@ -578,7 +581,7 @@ stray-bracket]
 #             ^^^ meta.mapping - meta.mapping.key - meta.mapping.value
 #                ^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.value
 #                                       ^ - meta.mapping
-# ^^^^^^^^^^^^ variable.other.readwrite
+# ^^^^^^^^^^^^ string.unquoted
 #              ^ punctuation.separator.key-value
 #                ^ string.quoted.double punctuation.definition.string.begin
 #                 ^ keyword.control.import.shell
@@ -591,7 +594,7 @@ stray-bracket]
 # ^^^^^^^^^^^^ meta.mapping.key
 #             ^^^ meta.mapping - meta.mapping.key - meta.mapping.value
 #                ^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.value
-# ^^^^^^^^^^^^ variable.other.readwrite
+# ^^^^^^^^^^^^ string.unquoted
 #              ^ punctuation.separator.key-value
 #                ^ string.quoted.double punctuation.definition.string.begin
 #                 ^ keyword.control.import.shell
@@ -606,7 +609,7 @@ stray-bracket]
 # ^^^^^^^^^^^^ meta.mapping.key
 #             ^^^ meta.mapping - meta.mapping.key - meta.mapping.value
 #                ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.value
-# ^^^^^^^^^^^^ variable.other.readwrite
+# ^^^^^^^^^^^^ string.unquoted
 #              ^ punctuation.separator.key-value
 #                ^ string.quoted.double punctuation.definition.string.begin
 #                 ^ keyword.control.import.shell
@@ -619,7 +622,7 @@ stray-bracket]
 # ^^^^^^^^^^^^ meta.mapping.key
 #             ^^^ meta.mapping - meta.mapping.key - meta.mapping.value
 #                ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.value
-# ^^^^^^^^^^^^ variable.other.readwrite
+# ^^^^^^^^^^^^ string.unquoted
 #              ^ punctuation.separator.key-value
 #                ^ string.quoted.double punctuation.definition.string.begin
 #                 ^ keyword.control.import.shell
@@ -633,7 +636,7 @@ stray-bracket]
 # ^^^^^^^^^^^^ meta.mapping.key
 #             ^^^ meta.mapping - meta.mapping.key - meta.mapping.value
 #                ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.value
-# ^^^^^^^^^^^^ variable.other.readwrite
+# ^^^^^^^^^^^^ string.unquoted
 #              ^ punctuation.separator.key-value
 #                ^ string.quoted.double punctuation.definition.string.begin
 #                 ^ keyword.control.import.shell
@@ -652,7 +655,7 @@ stray-bracket]
 # ^^^^^^^^^^^^ meta.mapping.key
 #             ^^^ meta.mapping - meta.mapping.key - meta.mapping.value
 #                ^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.value
-# ^^^^^^^^^^^^ variable.other.readwrite
+# ^^^^^^^^^^^^ string.unquoted
 #              ^ punctuation.separator.key-value
 #                ^ string.quoted.double punctuation.definition.string.begin
 #                 ^ keyword.control.import.shell

--- a/Git Formats/tests/syntax_test_git_config
+++ b/Git Formats/tests/syntax_test_git_config
@@ -10,25 +10,25 @@
 
 # SECTION HEADER TESTS
 [section]  # color section
-# <- meta.section.header meta.brackets punctuation.definition.brackets.begin
-#^^^^^^^ meta.section.header meta.brackets entity.name.section - punctuation
-#       ^ meta.section.header meta.brackets punctuation.definition.brackets.end
-#        ^^^^^^^^^^^^^^^^^^ meta.section.header - meta.brackets
+# <- meta.section meta.brackets punctuation.definition.brackets.begin
+#^^^^^^^ meta.section meta.brackets entity.name.section - punctuation
+#       ^ meta.section meta.brackets punctuation.definition.brackets.end
+#        ^^^^^^^^^^^^^^^^^^ meta.section - meta.brackets
 #          ^ punctuation.definition.comment
 #          ^^^^^^^^^^^^^^^^ comment.line
 [section "subsection"]
-# <- meta.section.header meta.brackets punctuation.definition.brackets.begin
-#^^^^^^^^^^^^^^^^^^^^^ meta.section.header meta.brackets
-#                     ^ meta.section.header - meta.brackets
+# <- meta.section meta.brackets punctuation.definition.brackets.begin
+#^^^^^^^^^^^^^^^^^^^^^ meta.section meta.brackets
+#                     ^ meta.section - meta.brackets
 #^^^^^^^ entity.name
 #        ^^^^^^^^^^^^ string.quoted.double
 #        ^ punctuation.definition.string.begin
 #                   ^ punctuation.definition.string.end
 #                    ^ punctuation.definition.brackets.end
 [section \"subsection"]
-# <- meta.section.header meta.brackets punctuation.definition.brackets.begin
-#^^^^^^^^^^^^^^^^^^^^^^ meta.section.header meta.brackets
-#                      ^ meta.section.header - meta.brackets
+# <- meta.section meta.brackets punctuation.definition.brackets.begin
+#^^^^^^^^^^^^^^^^^^^^^^ meta.section meta.brackets
+#                      ^ meta.section - meta.brackets
 #^^^^^^^ entity.name
 #        ^ invalid.illegal
 [section "\slashes\are\legal"]
@@ -56,9 +56,9 @@
 
 # LEGACY SECTION HEADER SYNTAX
 [section.subsection.subsubsection]
-# <- meta.section.header
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.section.header meta.brackets
-#                                 ^ meta.section.header - meta.brackets
+# <- meta.section
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.section meta.brackets
+#                                 ^ meta.section - meta.brackets
 # <- punctuation.definition.brackets.begin
 #^^^^^^^ entity.name.section
 #       ^ punctuation.accessor.dot
@@ -69,9 +69,9 @@
 
 # LEGACY SECTION HEADER SYNTAX
 [se\ct\\ion.s"ub\se\\ct\"ion
-# <- meta.section.header
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.section.header meta.brackets
-#                            ^ - meta.section.header
+# <- meta.section
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.section meta.brackets
+#                            ^ - meta.section
 # <- punctuation.definition.brackets.begin
 #^^ entity.name.section
 #  ^ invalid.illegal.section-name
@@ -92,14 +92,14 @@
 
 # COLOR TESTS
 [color "diff"]
-# <- meta.section.header meta.brackets punctuation.definition.brackets.begin
-#^^^^^^^^^^^^^ meta.section.header meta.brackets
+# <- meta.section meta.brackets punctuation.definition.brackets.begin
+#^^^^^^^^^^^^^ meta.section meta.brackets
 #^^^^^ entity.name
 #      ^^^^^^ string.quoted.double
 #      ^ punctuation.definition.string.begin
 #           ^ punctuation.definition.string.end
 #            ^ punctuation.definition.brackets.end
-#             ^ meta.section.header - meta.brackets
+#             ^ meta.section - meta.brackets
     old = red
 # <- meta.mapping
 #^^^^^^^^^^^^ meta.mapping
@@ -216,7 +216,7 @@
 
 # ILLEGAL NEWLINE IN SECTION TEST
 [section
-#^^^^^^^^ meta.section.header
+#^^^^^^^^ meta.section
 #^^^^^^^ entity.name
 #       ^ invalid.illegal.unexpected.eol
 ]
@@ -458,11 +458,11 @@ stray-bracket]
 
 # REAL WORLD SAMPLE TESTS
 [alias]
-# <- meta.section.header meta.brackets punctuation.definition.brackets.begin
-#^^^^^^ meta.section.header meta.brackets
+# <- meta.section meta.brackets punctuation.definition.brackets.begin
+#^^^^^^ meta.section meta.brackets
 #^^^^^ entity.name
 #     ^ punctuation.definition.brackets.end
-#      ^ meta.section.header - meta.brackets
+#      ^ meta.section - meta.brackets
     branch-author = for-each-ref --format='%(committerdate) %09 %(authorname) %09 %(refname)'
 # <- meta.mapping
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping

--- a/Git Formats/tests/syntax_test_git_config
+++ b/Git Formats/tests/syntax_test_git_config
@@ -16,15 +16,16 @@
 #        ^^^^^^^^^^^^^^^^^^ meta.section - meta.brackets
 #          ^ punctuation.definition.comment
 #          ^^^^^^^^^^^^^^^^ comment.line
-[section "subsection"]
-# <- meta.section meta.brackets punctuation.definition.brackets.begin
-#^^^^^^^^^^^^^^^^^^^^^ meta.section meta.brackets
-#                     ^ meta.section - meta.brackets
-#^^^^^^^ entity.name
-#        ^^^^^^^^^^^^ string.quoted.double
-#        ^ punctuation.definition.string.begin
-#                   ^ punctuation.definition.string.end
-#                    ^ punctuation.definition.brackets.end
+    [section "subsection"]
+# <- meta.section - meta.brackets
+#^^^ meta.section - meta.brackets
+#   ^^^^^^^^^^^^^^^^^^^^^^ meta.section meta.brackets
+#                         ^ meta.section - meta.brackets
+#    ^^^^^^^ entity.name
+#            ^^^^^^^^^^^^ string.quoted.double
+#            ^ punctuation.definition.string.begin
+#                       ^ punctuation.definition.string.end
+#                        ^ punctuation.definition.brackets.end
 [section \"subsection"]
 # <- meta.section meta.brackets punctuation.definition.brackets.begin
 #^^^^^^^^^^^^^^^^^^^^^^ meta.section meta.brackets

--- a/Git Formats/tests/syntax_test_git_config
+++ b/Git Formats/tests/syntax_test_git_config
@@ -10,9 +10,9 @@
 
 # SECTION HEADER TESTS
 [section]  # color section
-# <- meta.section meta.brackets punctuation.definition.brackets.begin
+# <- meta.section meta.brackets punctuation.section.brackets.begin
 #^^^^^^^ meta.section meta.brackets entity.name.section - punctuation
-#       ^ meta.section meta.brackets punctuation.definition.brackets.end
+#       ^ meta.section meta.brackets punctuation.section.brackets.end
 #        ^^^^^^^^^^^^^^^^^^ meta.section - meta.brackets
 #          ^ punctuation.definition.comment
 #          ^^^^^^^^^^^^^^^^ comment.line
@@ -25,9 +25,9 @@
 #            ^^^^^^^^^^^^ string.quoted.double
 #            ^ punctuation.definition.string.begin
 #                       ^ punctuation.definition.string.end
-#                        ^ punctuation.definition.brackets.end
+#                        ^ punctuation.section.brackets.end
 [section \"subsection"]
-# <- meta.section meta.brackets punctuation.definition.brackets.begin
+# <- meta.section meta.brackets punctuation.section.brackets.begin
 #^^^^^^^^^^^^^^^^^^^^^^ meta.section meta.brackets
 #                      ^ meta.section - meta.brackets
 #^^^^^^^ entity.name
@@ -60,20 +60,20 @@
 # <- meta.section
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.section meta.brackets
 #                                 ^ meta.section - meta.brackets
-# <- punctuation.definition.brackets.begin
+# <- punctuation.section.brackets.begin
 #^^^^^^^ entity.name.section
 #       ^ punctuation.accessor.dot
 #        ^^^^^^^^^^ string.unquoted
 #                  ^ punctuation.accessor.dot
 #                   ^^^^^^^^^^^^^ string.unquoted
-#                                ^ punctuation.definition.brackets.end
+#                                ^ punctuation.section.brackets.end
 
 # LEGACY SECTION HEADER SYNTAX
 [se\ct\\ion.s"ub\se\\ct\"ion
 # <- meta.section
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.section meta.brackets
 #                            ^ - meta.section
-# <- punctuation.definition.brackets.begin
+# <- punctuation.section.brackets.begin
 #^^ entity.name.section
 #  ^ invalid.illegal.section-name
 #   ^^ entity.name.section
@@ -93,13 +93,13 @@
 
 # COLOR TESTS
 [color "diff"]
-# <- meta.section meta.brackets punctuation.definition.brackets.begin
+# <- meta.section meta.brackets punctuation.section.brackets.begin
 #^^^^^^^^^^^^^ meta.section meta.brackets
 #^^^^^ entity.name
 #      ^^^^^^ string.quoted.double
 #      ^ punctuation.definition.string.begin
 #           ^ punctuation.definition.string.end
-#            ^ punctuation.definition.brackets.end
+#            ^ punctuation.section.brackets.end
 #             ^ meta.section - meta.brackets
     old = red
 # <- meta.mapping.git.config
@@ -462,10 +462,10 @@ stray-bracket]
 
 # REAL WORLD SAMPLE TESTS
 [alias]
-# <- meta.section meta.brackets punctuation.definition.brackets.begin
+# <- meta.section meta.brackets punctuation.section.brackets.begin
 #^^^^^^ meta.section meta.brackets
 #^^^^^ entity.name
-#     ^ punctuation.definition.brackets.end
+#     ^ punctuation.section.brackets.end
 #      ^ meta.section - meta.brackets
     branch-author = for-each-ref --format='%(committerdate) %09 %(authorname) %09 %(refname)'
 # <- meta.mapping


### PR DESCRIPTION
This PR...

1. simplifies `meta.section` scope, by only applying it to `[...]` lines
2. changes section bracket scopes to `punctuation.section.brackets` to comply with scope naming guidelines
3. changes key scopes to `meta.mapping.key string.unquoted`

Note: Sub-sections are also scoped `entity.name.section string`, which is something we are facing with TOML as well. Luckily `key` question is easier here as only unqualified unquoted keys are allowed.