### PR TITLE
[Git Commit] Fix verbose diff highlighting

### DIFF
--- a/Git Formats/Git Commit.sublime-syntax
+++ b/Git Formats/Git Commit.sublime-syntax
@@ -130,8 +130,10 @@ contexts:
     # ------------------------ >8 ------------------------
     - match: '{{comment_char}} -{24} >8 -{24}\s*\n'
       scope: comment.line.git.commit markup.bold.commit
-      set:
-        - meta_content_scope: meta.dropped.git.commit
-        - include: comments
-        - match: ^(?=diff --git)
-          set: [Packages/Diff/Diff.sublime-syntax]
+      set: dropped-content-body
+
+  dropped-content-body:
+    - meta_content_scope: meta.dropped.git.commit
+    - include: comments
+    - match: ^(?=diff --git)
+      set: Git Diff.sublime-syntax

--- a/Git Formats/Git Diff.sublime-syntax
+++ b/Git Formats/Git Diff.sublime-syntax
@@ -307,7 +307,7 @@ contexts:
 
   diff-file-header-path-start:
     # TODO: Quoted file names https://git-scm.com/docs/git-config#Documentation/git-config.txt-corequotePath
-    - match: (?:a|b|ours|theirs)(?=/)
+    - match: (?:a|b|c|i|w|ours|theirs)(?=/)
       scope: variable.parameter.source.diff
       push: diff-file-header-path
 

--- a/Git Formats/tests/syntax_test_git_commit
+++ b/Git Formats/tests/syntax_test_git_commit
@@ -322,16 +322,22 @@ This commit applies all changes required to satisfy the JSON format unittest.
 # ------------------------ >8 ------------------------
 # Do not touch the line above.
 # Everything below will be removed.
-diff --git a/modules/compare.py b/modules/compare.py
+diff --git i/modules/compare.py b/modules/compare.py
 index 5610357..b9b47f3 100644
---- a/modules/compare.py
-+++ b/modules/compare.py
+--- c/modules/compare.py
++++ w/modules/compare.py
+# <- source.diff.git meta.block.header.diff meta.diff.header.to-file meta.header.to-file.diff punctuation.definition.to-file.diff
+#^^^^^^^^^^^^^^^^^^^^^^^^ source.diff.git meta.block.header.diff meta.diff.header.to-file meta.header.to-file.diff
+#^^ punctuation.definition.to-file.diff
+#   ^ variable.parameter.source.diff
+#    ^^^^^^^^^^^^^^^^^^^ meta.path.diff string.unquoted.git
 @@ -97,7 +97,7 @@ def set_against_branch(git_gutter, **kwargs):
              message = pieces[0]
              branch = pieces[1][11:]   # skip 'refs/heads/'
              commit = pieces[2][0:7]   # 7-digit commit hash
 -            return [branch, '%s %s' % (commit, message)]
 +            return [branch, '%s | %s' % (commit, message)]
-
+# <- source.diff.git meta.block.delta.diff markup.inserted.diff punctuation.definition.inserted.diff
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.diff.git meta.block.delta.diff markup.inserted.diff
          # Create the list of branches to show in the quick panel
          items = [parse_result(r) for r in output.split('\n')]


### PR DESCRIPTION
This commit...

1. uses _Git Diff.sublime-syntax_ to highlight verbose diffs at the end of commit messages (fixes #4172)
2. adds support for c/ i/ and w/ path prefixes (fixes #4173)