### PR TITLE
[Python] Fix function-calls in inherited class definitions

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -797,8 +797,13 @@ contexts:
       pop: 1
     - match: ','
       scope: punctuation.separator.inheritance.python
+    # expression-in-a-group (without qualified-name)
+    - include: line-continuations
+    - include: illegal-assignment-expressions
+    - include: lambda-in-groups
+    - include: expressions-common
     - include: illegal-name
-    - include: constants
+    # specific "qualified-name" patterns
     - match: ({{identifier}})\s*({{assignment_operator}})
       captures:
         1: variable.parameter.class-inheritance.python
@@ -807,7 +812,6 @@ contexts:
       push: qualified-base-class-name
     - match: '{{identifier}}'
       scope: entity.other.inherited-class.python
-    - include: expression-in-a-group
 
   qualified-base-class-name:
     - meta_scope: meta.path.python

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -2188,6 +2188,39 @@ class DataClass(TypedDict, None, total=False, True=False):
 #                                                 ^ invalid.illegal.assignment.python
 #                                                  ^^^^^ constant.language.boolean.false.python
 
+class MyClass(func(var, arg=var), module.func(var, arg=var)):
+#     ^^^^^^^ meta.class.python
+#            ^ meta.class.inheritance.python - meta.function-call
+#             ^^^^ meta.class.inheritance.python meta.function-call.identifier.python
+#                 ^^^^^^^^^^^^^^ meta.class.inheritance.python meta.function-call.arguments.python
+#                               ^^^^^^^^^ meta.class.inheritance.python - meta.function-call
+#                                        ^^^^ meta.class.inheritance.python meta.function-call.identifier.python
+#                                            ^^^^^^^^^^^^^^ meta.class.inheritance.python meta.function-call.arguments.python
+#                                                          ^ meta.class.inheritance.python
+#                                                           ^ meta.class.python
+#     ^^^^^^^ entity.name.class.python
+#            ^ punctuation.section.inheritance.begin.python
+#             ^^^^ variable.function.python
+#                 ^ punctuation.section.arguments.begin.python
+#                  ^^^ meta.generic-name.python
+#                     ^ punctuation.separator.arguments.python
+#                       ^^^ variable.parameter.python
+#                          ^ keyword.operator.assignment.python
+#                           ^^^ meta.generic-name.python
+#                              ^ punctuation.section.arguments.end.python
+#                               ^ punctuation.separator.inheritance.python
+#                                 ^^^^^^ meta.path.python meta.generic-name.python
+#                                       ^ meta.path.python punctuation.accessor.dot.python
+#                                        ^^^^ meta.path.python variable.function.python
+#                                            ^ punctuation.section.arguments.begin.python
+#                                             ^^^ meta.generic-name.python
+#                                                ^ punctuation.separator.arguments.python
+#                                                  ^^^ variable.parameter.python
+#                                                     ^ keyword.operator.assignment.python
+#                                                      ^^^ meta.generic-name.python
+#                                                         ^ punctuation.section.arguments.end.python
+#                                                          ^ punctuation.section.inheritance.end.python
+#                                                           ^ punctuation.section.class.begin.python
 
 class MyClass:
     def foo():


### PR DESCRIPTION
Fixes #4177

This commit replaces `expression-in-a-group` by the contexts it consists of into `class-definition-base-list-body` to ensure function calls are scoped as expected.

Only the `qualified-name` part is replaced by inheritance specific patterns.

It also removes a duplicate include of `illegal-names`.