### PR TITLE
CSS comments should follow indentation

### DIFF
--- a/CSS/Comments.tmPreferences
+++ b/CSS/Comments.tmPreferences
@@ -19,12 +19,6 @@
 				<key>value</key>
 				<string>*/</string>
 			</dict>
-			<dict>
-				<key>name</key>
-				<string>TM_COMMENT_DISABLE_INDENT</string>
-				<key>value</key>
-				<string>yes</string>
-			</dict>
 		</array>
 	</dict>
 </dict>


### PR DESCRIPTION
Especially relevant since css now has nesting.

Before:

https://github.com/user-attachments/assets/835691b9-21a3-42d2-a823-f443ea91c091

After:

https://github.com/user-attachments/assets/5e5bf511-4ec1-40c3-8fbc-a201b5a62a40

