### PR TITLE
[Go] Fix %w format string

### DIFF
--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -785,7 +785,7 @@ contexts:
         # precision
         (?: \. (?: \d+ | (?:\[\d+\])? \* )? )?
         # maybe indexed verb
-        (?:\[\d+\])? [bcdeEfFgGoOpqsTtUvxX]
+        (?:\[\d+\])? [bcdeEfFgGoOpqsTtUvwxX]
       scope: constant.other.placeholder.go
 
   match-block-string-templates:

--- a/Go/tests/syntax_test_go.go
+++ b/Go/tests/syntax_test_go.go
@@ -4567,12 +4567,13 @@ by accident, but if necessary, such support could be sacrificed.
 //  ^^^^^^^^^^^^^^^^ meta.string.go string.quoted.double.go
 //   ^^^^^^^^^^^^^^ constant.other.placeholder.go
 
-    "%d %d %#[1]x %#x"
-//  ^^^^^^^^^^^^^^^^^^ meta.string.go string.quoted.double.go
+    "%d %d %#[1]x %#x %w"
+//  ^^^^^^^^^^^^^^^^^^^^^ meta.string.go string.quoted.double.go
 //   ^^ constant.other.placeholder.go
 //      ^^ constant.other.placeholder.go
 //         ^^^^^^ constant.other.placeholder.go
 //                ^^^ constant.other.placeholder.go
+//                    ^^ constant.other.placeholder.go
 
     "%"
 //  ^^^ meta.string.go string.quoted.double.go
@@ -4695,12 +4696,13 @@ by accident, but if necessary, such support could be sacrificed.
 //  ^^^^^^^^^^^^^^^^ meta.string.go string.quoted.backtick.go
 //   ^^^^^^^^^^^^^^ constant.other.placeholder.go
 
-    `%d %d %#[1]x %#x`
+    `%d %d %#[1]x %#x %w`
 //  ^^^^^^^^^^^^^^^^^^ meta.string.go string.quoted.backtick.go
 //   ^^ constant.other.placeholder.go
 //      ^^ constant.other.placeholder.go
 //         ^^^^^^ constant.other.placeholder.go
 //                ^^^ constant.other.placeholder.go
+//                    ^^ constant.other.placeholder.go
 
     `%`
 //  ^^^ meta.string.go string.quoted.backtick.go


### PR DESCRIPTION
Fixes #4188

This commit adds back `%w` placeholder, which is a special kind of `%v` and pretty well hidden in official syntax specs.