### PR TITLE
[Lua] Highlight strings used by string.{format,gsub,pack,etc}

### DIFF
--- a/Lua/Lua.sublime-syntax
+++ b/Lua/Lua.sublime-syntax
@@ -465,7 +465,11 @@ contexts:
       push: expression-begin
 
   accessor:
-    - match: '[.:]'
+    - match: ':'
+      scope: punctuation.accessor.lua
+      push: property-method
+
+    - match: '\.'
       scope: punctuation.accessor.lua
       push: property
 
@@ -498,6 +502,18 @@ contexts:
       pop: 1
     - include: reserved-word-pop
     - include: else-pop
+
+  property-method:
+    - match: '(?:find|gmatch|gsub|match){{identifier_break}}'
+      scope: meta.property.lua meta.function-call.lua variable.function.lua
+      set:
+        - match: (?={{function_args_begin}})
+          pop: 1
+          push:
+            - function-arguments-meta
+            - function-arguments-pattern-at1
+        - include: else-pop
+    - include: property
 
   function-arguments-meta:
     - meta_scope: meta.function-call.arguments.lua
@@ -757,6 +773,142 @@ contexts:
     - meta_scope: meta.function.lua
     - include: immediately-pop
 
+  function-arguments-pattern-at2:
+    - include: string
+    - include: table-constructor
+
+    - match: \(
+      scope: punctuation.section.group.begin.lua
+      set:
+        - meta_scope: meta.group.lua
+        - match: \)
+          scope: punctuation.section.group.end.lua
+          pop: 1
+        - include: reserved-word-expression-pop
+        - match: (?=\S)
+          push:
+            - expression-list-end-pattern-next
+            - expression-begin
+
+  function-arguments-pattern-at1:
+    - include: pattern-string
+    - include: table-constructor
+
+    - match: \(
+      scope: punctuation.section.group.begin.lua
+      set:
+        - meta_scope: meta.group.lua
+        - match: \)
+          scope: punctuation.section.group.end.lua
+          pop: 1
+        - include: reserved-word-expression-pop
+        - match: (?=\S)
+          push:
+            - expression-list-end
+            - pattern-expression
+
+  pattern-expression:
+    - include: pattern-string
+    - include: expression-begin
+
+  expression-list-end-pattern-next:
+    - match: ','
+      scope: punctuation.separator.comma.lua
+      set:
+        - expression-list-end
+        - pattern-expression
+    - include: expression-end
+
+  pattern-nonnested:
+    - match: '\('
+      scope: punctuation.section.group.begin.lua
+    - match: '\)'
+      scope: punctuation.section.group.end.lua
+    - match: '(\[)(\^)?\]?'
+      captures:
+        1: punctuation.definition.set.begin.lua
+        2: keyword.operator.logical.lua
+    - match: '\]'
+      scope: punctuation.definition.set.end.lua
+    - match: '\(\)'
+      scope: punctuation.section.brackets.lua
+    - match: '[+*?\-]'
+      scope: keyword.operator.quantifier.lua
+    - match: \.
+      scope: keyword.other.any.lua
+
+  pattern-string:
+    - match: \[(=*)\[
+      scope: punctuation.definition.string.begin.lua
+      set:
+        - pattern-multiline-string-body
+        - pattern-test-first-caret
+    - match: \'
+      scope: punctuation.definition.string.begin.lua
+      set:
+        - pattern-single-quoted-string-body
+        - pattern-test-first-caret
+    - match: \"
+      scope: punctuation.definition.string.begin.lua
+      set:
+        - pattern-double-quoted-string-body
+        - pattern-test-first-caret
+
+  pattern-test-first-caret:
+    - match: '\^'
+      scope: keyword.control.anchor.lua
+      pop: 1
+    - include: immediately-pop
+
+  pattern-single-quoted-string-body:
+    - meta_include_prototype: false
+    - meta_scope: meta.string.lua string.quoted.single.lua
+    - include: single-quoted-string-body
+    - match: \$(?=\')
+      scope: keyword.control.anchor.lua
+    - match: '%'
+      scope: constant.character.escape.lua
+      push:
+        - match: (?=[\\\'])
+          pop: 1
+        - match: .
+          scope: constant.character.escape.lua
+          pop: 1
+    - include: pattern-nonnested
+
+  pattern-double-quoted-string-body:
+    - meta_include_prototype: false
+    - meta_scope: meta.string.lua string.quoted.double.lua
+    - include: double-quoted-string-body
+    - match: \$(?=\")
+      scope: keyword.control.anchor.lua
+    - match: '%'
+      scope: constant.character.escape.lua
+      push:
+        - match: (?=[\\\"])
+          pop: 1
+        - match: .
+          scope: constant.character.escape.lua
+          pop: 1
+    - include: pattern-nonnested
+
+  pattern-multiline-string-body:
+    - meta_include_prototype: false
+    - meta_scope: meta.string.lua string.quoted.multiline.lua
+    - match: (?:(\$)|(%)|)(\]\1\])
+      captures:
+        1: keyword.control.anchor.lua
+        2: constant.character.escape.lua
+        3: punctuation.definition.string.end.lua
+      pop: 1
+    - match: '%'
+      scope: constant.character.escape.lua
+      push:
+        - match: .
+          scope: constant.character.escape.lua
+          pop: 1
+    - include: pattern-nonnested
+
   builtin-modules:
     - match: coroutine{{identifier_break}}
       scope: support.constant.builtin.lua
@@ -800,9 +952,18 @@ contexts:
         - match: \.
           scope: punctuation.accessor.lua
           set:
+            - match: (?:find|gmatch|gsub|match){{identifier_break}}
+              scope: meta.property.lua support.function.builtin.lua
+              set:
+                - match: (?={{function_args_begin}})
+                  pop: 1
+                  push:
+                    - function-arguments-meta
+                    - function-arguments-pattern-at2
+                - include: else-pop
             - match: |-
                 (?x:
-                  byte|char|dump|find|format|gmatch|gsub|len|lower|match|pack
+                  byte|char|dump|format|len|lower|pack
                   |packsize|rep|reverse|sub|unpack|upper
                 ){{identifier_break}}
               scope: meta.property.lua support.function.builtin.lua

--- a/Lua/Lua.sublime-syntax
+++ b/Lua/Lua.sublime-syntax
@@ -824,6 +824,23 @@ contexts:
             - expression-list-end
             - fmtstr-expression
 
+  function-arguments-packstr-at1:
+    - include: packstr-string
+    - include: table-constructor
+
+    - match: \(
+      scope: punctuation.section.group.begin.lua
+      set:
+        - meta_scope: meta.group.lua
+        - match: \)
+          scope: punctuation.section.group.end.lua
+          pop: 1
+        - include: reserved-word-expression-pop
+        - match: (?=\S)
+          push:
+            - expression-list-end
+            - packstr-expression
+
   pattern-expression:
     - include: pattern-string
     - include: expression-begin
@@ -967,6 +984,42 @@ contexts:
       scope: invalid.illegal.invalid-format.lua
       pop: 1
 
+  packstr-expression:
+    - include: packstr-string
+    - include: expression-begin
+
+  packstr-string:
+    - match: \[(=*)\[
+      scope: punctuation.definition.string.begin.lua
+      set: multiline-string-body
+      with_prototype:
+        - include: packstr-pattern
+
+    - match: \'
+      scope: punctuation.definition.string.begin.lua
+      set: single-quoted-string-body
+      with_prototype:
+        - include: packstr-pattern
+
+    - match: \"
+      scope: punctuation.definition.string.begin.lua
+      set: double-quoted-string-body
+      with_prototype:
+        - include: packstr-pattern
+
+  packstr-pattern:
+    - match: '[=<>]|![0-9]*'
+      scope: storage.modifier.lua
+
+    - match: '[bBhHlLjJTfdnz]|[Iis][0-9]*|c[0-9]+'
+      scope: storage.type.lua
+
+    - match: '[xX]'
+      scope: punctuation.separator.padding.lua
+
+    - match: (?:[^\\\"\'\]\s])
+      scope: invalid.illegal.invalid-storage.lua
+
   builtin-modules:
     - match: coroutine{{identifier_break}}
       scope: support.constant.builtin.lua
@@ -1028,10 +1081,19 @@ contexts:
                     - function-arguments-meta
                     - function-arguments-fmtstr-at1
                 - include: else-pop
+            - match: (?:pack|unpack|packsize){{identifier_break}}
+              scope: meta.property.lua support.function.builtin.stringy.lua
+              set:
+                - match: (?={{function_args_begin}})
+                  pop: 1
+                  push:
+                    - function-arguments-meta
+                    - function-arguments-packstr-at1
+                - include: else-pop
             - match: |-
                 (?x:
-                  byte|char|dump|len|lower|pack
-                  |packsize|rep|reverse|sub|unpack|upper
+                  byte|char|dump|len|lower
+                  |rep|reverse|sub|upper
                 ){{identifier_break}}
               scope: meta.property.lua support.function.builtin.lua
               pop: 1

--- a/Lua/Lua.sublime-syntax
+++ b/Lua/Lua.sublime-syntax
@@ -807,6 +807,23 @@ contexts:
             - expression-list-end
             - pattern-expression
 
+  function-arguments-fmtstr-at1:
+    - include: fmtstr-string
+    - include: table-constructor
+
+    - match: \(
+      scope: punctuation.section.group.begin.lua
+      set:
+        - meta_scope: meta.group.lua
+        - match: \)
+          scope: punctuation.section.group.end.lua
+          pop: 1
+        - include: reserved-word-expression-pop
+        - match: (?=\S)
+          push:
+            - expression-list-end
+            - fmtstr-expression
+
   pattern-expression:
     - include: pattern-string
     - include: expression-begin
@@ -909,6 +926,47 @@ contexts:
           pop: 1
     - include: pattern-nonnested
 
+  fmtstr-expression:
+    - include: fmtstr-string
+    - include: expression-begin
+
+  fmtstr-string:
+    - match: \[(=*)\[
+      scope: punctuation.definition.string.begin.lua
+      set: multiline-string-body
+      with_prototype:
+        - include: fmtstr-embed
+
+    - match: \'
+      scope: punctuation.definition.string.begin.lua
+      set: single-quoted-string-body
+      with_prototype:
+        - include: fmtstr-embed
+
+    - match: \"
+      scope: punctuation.definition.string.begin.lua
+      set: double-quoted-string-body
+      with_prototype:
+        - include: fmtstr-embed
+
+  fmtstr-embed:
+    - match: '%'
+      scope: constant.other.placeholder.lua
+      push: fmtstr-pattern
+
+  fmtstr-pattern:
+    # these characters never appear in a format pattern so it can be simpler
+    - match: (?=[\\\"\'\]])
+      pop: 1
+    - match: '[-+#0-9. ]'
+      scope: constant.other.placeholder.lua
+    - match: '[cdiuoxXaAfeEgGpqs%]'
+      scope: constant.other.placeholder.lua
+      pop: 1
+    - match: '.'
+      scope: invalid.illegal.invalid-format.lua
+      pop: 1
+
   builtin-modules:
     - match: coroutine{{identifier_break}}
       scope: support.constant.builtin.lua
@@ -961,9 +1019,18 @@ contexts:
                     - function-arguments-meta
                     - function-arguments-pattern-at2
                 - include: else-pop
+            - match: (?:format){{identifier_break}}
+              scope: meta.property.lua support.function.builtin.stringy.lua
+              set:
+                - match: (?={{function_args_begin}})
+                  pop: 1
+                  push:
+                    - function-arguments-meta
+                    - function-arguments-fmtstr-at1
+                - include: else-pop
             - match: |-
                 (?x:
-                  byte|char|dump|format|len|lower|pack
+                  byte|char|dump|len|lower|pack
                   |packsize|rep|reverse|sub|unpack|upper
                 ){{identifier_break}}
               scope: meta.property.lua support.function.builtin.lua

--- a/Lua/tests/syntax_test_lua.lua
+++ b/Lua/tests/syntax_test_lua.lua
@@ -789,3 +789,17 @@
 --                            ^^^^^^^^^^^^ meta.string string.quoted.double.lua
 --                                        ^ punctuation.separator.comma.lua
 --                                             ^ punctuation.section.group.end.lua
+
+-- basic tests for patterns
+    local a = ('test'):match('^()t?$-e*s+()$')
+--                            ^ keyword.control.anchor
+--                             ^ punctuation.section.group.begin
+--                              ^ punctuation.section.group.end
+--                                ^ keyword.operator.quantifier
+--                                  ^ keyword.operator.quantifier
+--                                    ^ keyword.operator.quantifier
+--                                      ^ keyword.operator.quantifier
+--                                         ^ keyword.control.anchor
+
+    local b = string.format('%0.9f', 15.4)
+--                           ^^^^^ constant.other.placeholder.lua


### PR DESCRIPTION
This PR adds highlighting to the strings that are passed to `string.{format,find,match,gsub,gmatch,pack,unpack,packsize}`.

They are split into three categories:

- Format strings [1].
  These are done similarly to C's `sprintf` and friends, except that Lua only supports some specifiers and adds `q` as an option.

- Patterns [2].
  They are passed as the second argument to the four functions that take patterns, meaning that I can also match on `(whatever_value):match 'this%s*that'`. For scopes, I have roughly followed what the builtin regular expressions package does.
  I haven't worked on nested groups as that got quite hard with handling it inside the three different types of strings that Lua provides.
  The special capture `()` returns a position. I'm not sure what scope this should be. I've set it to `punctuation.section.brackets.lua` for the moment.

- Pack format strings [3].
  The alignment and endian specifiers I have scoped as `storage.modifier` and I have scoped the actual type designations as `storage.type`
  For the padding that can be specified with `x` or `X`, I've scoped it to `punctuation.separator.padding` as I didn't see any better one, and that helped differentiate it from ones that have values.

Since format strings are always the first argument, I did not find a way of handling them when the function is called as a method. (e.g. `('%3.5f'):format(3)`).

[1]\: https://www.lua.org/manual/5.4/manual.html#pdf-string.format
[2]\: https://www.lua.org/manual/5.4/manual.html#6.4.1
[3]\: https://www.lua.org/manual/5.4/manual.html#6.4.2
