### PR TITLE
[Git Formats] Diff TOC components for renames

### DIFF
--- a/Git Formats/Git Diff.sublime-syntax
+++ b/Git Formats/Git Diff.sublime-syntax
@@ -552,10 +552,10 @@ contexts:
 
   path-shortcuts:
     - match: \.{3}
-      scope: keyword.operator.diff
+      scope: keyword.operator.truncation.diff
     - match: ' (=>) '
       captures:
-        1: keyword.operator.diff
+        1: keyword.operator.transformation.diff
     - match: \{
       scope: punctuation.section.braces.begin.git
     - match: \}

--- a/Git Formats/tests/syntax_test_git_diff.patch
+++ b/Git Formats/tests/syntax_test_git_diff.patch
@@ -82,9 +82,9 @@ Much better, no?
 \                                   ^ markup.inserted.diff
  ....tmPreferences => DOT - Comments.tmPreferences} |   10 +-
 \^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.toc-list.filename.diff meta.path.git string.unquoted.git
-\^^^ keyword.operator.diff
+\^^^ keyword.operator.truncation.diff
 \   ^ - keyword.operator
-\                  ^^ keyword.operator.diff
+\                  ^^ keyword.operator.transformation.diff
 \                                                 ^ punctuation.section.braces.end.git
 \                                                   ^ punctuation.separator.sequence.diff
 \                                                       ^^ meta.number.integer.decimal.diff constant.numeric.value.diff


### PR DESCRIPTION
Adds scopes to some additional sections of the rename/move/copy format.

If the community determines that it's worth it to forward-lookahead open/close brace pairs, I can do that. But sometimes they are not matched, as in the example test.