### PR TITLE
Add "set_unsaved_view_name_for_syntax" setting

### DIFF
--- a/Markdown/Markdown.sublime-settings
+++ b/Markdown/Markdown.sublime-settings
@@ -1,0 +1,3 @@
+{
+    "set_unsaved_view_name_for_syntax": true,
+}

--- a/Markdown/MultiMarkdown.sublime-settings
+++ b/Markdown/MultiMarkdown.sublime-settings
@@ -1,0 +1,3 @@
+{
+    "set_unsaved_view_name_for_syntax": true,
+}

--- a/RestructuredText/reStructuredText.sublime-settings
+++ b/RestructuredText/reStructuredText.sublime-settings
@@ -1,0 +1,3 @@
+{
+    "set_unsaved_view_name_for_syntax": true,
+}

--- a/Text/Plain text.sublime-settings
+++ b/Text/Plain text.sublime-settings
@@ -1,0 +1,3 @@
+{
+    "set_unsaved_view_name_for_syntax": true,
+}


### PR DESCRIPTION
This will be shipping in a future build of Sublime Text to control which syntaxes the `set_unsaved_view_name.py` plugin applies to, replacing a hardcoded check for the "Plain text" syntax.