### PR TITLE
[Python] Recognize shebangs with `uv`

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -33,6 +33,7 @@ hidden_file_extensions:
 first_line_match: |-
   (?xi:
     ^ \#! .* \bpython(?:\d(?:\.\d+)?)?\b                        # shebang
+  | ^ \#! .* \buv\b                                             # shebang (uv)
   | ^ \s* \# .*? -\*- .*? \bpython(?:\d(?:\.\d+)?)?\b .*? -\*-  # editorconfig
   )
 


### PR DESCRIPTION
This will work for the mostly UNIX-compatible way of specifying multiple arguments via `env -S` and then using the new inline script metadata PEP that uv implements.

Most widely used variant:

    #!/usr/bin/env -S uv run --script

See also https://docs.astral.sh/uv/reference/cli/#uv-run

Note that apparently Windows users can also use this with the `py` launcher and a slightly different shebang, or at least I have seen examples of this online. All examples I've seen include `\buv\b` though.