### PR TITLE
[C++] Add support for Arduino `.ino` files

### DIFF
--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -20,6 +20,7 @@ file_extensions:
   - ipp
   - ixx
   - cppm
+  - ino
 
 first_line_match: |-
   (?xi:


### PR DESCRIPTION
This adds support for Arduino `.ino` files which share the same syntax definition as `C++`.