### PR TITLE
[Perl] Add postfix dereference syntax

### DIFF
--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -1639,8 +1639,17 @@ contexts:
         - match: '{{identifier}}(?!::)'
           scope: meta.function-call.perl variable.function.member.perl
           pop: true
-        # item access like $array->[0]
-        - match: (?=[{\[])
+        # item access like $array->[0] or postfix dereferce slicing $array->@[0]
+        # https://perldoc.perl.org/perlref#Postfix-Reference-Slicing
+        - match: (?:[$@%&*]\#?)?(?=[{\[])
+          scope: keyword.operator.dereference.perl
+          set: maybe-item-access
+        # postfix dereferencing
+        # https://perldoc.perl.org/perlref#Postfix-Dereference-Syntax
+        - match: ([$@%&*]\#?)(\*)(?!=)
+          captures:
+            1: keyword.operator.dereference.perl
+            2: variable.language.perl
           set: maybe-item-access
         - include: comment-line
         - include: else-pop

--- a/Perl/syntax_test_perl.pl
+++ b/Perl/syntax_test_perl.pl
@@ -2613,6 +2613,99 @@ EOT-EOT-EOT
 # ^^ variable.language.deprecated.perl
 # ^ punctuation.definition.variable.perl
 
+# Postfix Dereference Syntax
+# https://perldoc.perl.org/perlref#Postfix-Dereference-Syntax
+
+$sref->$*;  # same as  ${ $sref }
+#      ^ keyword.operator.dereference.perl
+#       ^ variable.language.perl
+
+$aref->@*;  # same as  @{ $aref }
+#      ^ keyword.operator.dereference.perl
+#       ^ variable.language.perl
+
+$aref->$#*; # same as $#{ $aref }
+#      ^^ keyword.operator.dereference.perl
+#        ^ variable.language.perl
+
+$href->%*;  # same as  %{ $href }
+#      ^ keyword.operator.dereference.perl
+#       ^ variable.language.perl
+
+$cref->&*;  # same as  &{ $cref }
+#      ^ keyword.operator.dereference.perl
+#       ^ variable.language.perl
+
+$gref->**;  # same as  *{ $gref }
+#      ^ keyword.operator.dereference.perl
+#       ^ variable.language.perl
+
+$gref->*{SCALAR}; # same as *{ $gref }{SCALAR}
+#      ^ keyword.operator.dereference.perl
+#       ^^^^^^^^ meta.item-access.perl
+#       ^ punctuation.section.item-access.begin.perl
+#        ^^^^^^ constant.other.key.perl
+#              ^ punctuation.section.item-access.end.perl
+
+# Postfix Reference Slicing
+# https://perldoc.perl.org/perlref#Postfix-Reference-Slicing
+
+$aref->$[ 0 ];  # same as $$aref[ 0 ]
+#      ^ keyword.operator.dereference.perl
+#       ^^^^^ meta.item-access.perl
+#       ^ punctuation.section.item-access.begin.perl
+#         ^ constant.numeric.value.perl
+#           ^ punctuation.section.item-access.end.perl
+
+$href->${ key };  # same as $$href{ key }
+#      ^ keyword.operator.dereference.perl
+#       ^^^^^^^ meta.item-access.perl
+#       ^ punctuation.section.item-access.begin.perl
+#         ^^^ constant.other.key.perl
+#             ^ punctuation.section.item-access.end.perl
+
+$aref->@[ 0 ];  # same as @$aref[ 0 ]
+#      ^ keyword.operator.dereference.perl
+#       ^^^^^ meta.item-access.perl
+#       ^ punctuation.section.item-access.begin.perl
+#         ^ constant.numeric.value.perl
+#           ^ punctuation.section.item-access.end.perl
+
+$href->@{ key };  # same as @$href{ key }
+#      ^ keyword.operator.dereference.perl
+#       ^^^^^^^ meta.item-access.perl
+#       ^ punctuation.section.item-access.begin.perl
+#         ^^^ constant.other.key.perl
+#             ^ punctuation.section.item-access.end.perl
+
+$aref->%[ 0 ];  # same as %$aref[ 0 ]
+#      ^ keyword.operator.dereference.perl
+#       ^^^^^ meta.item-access.perl
+#       ^ punctuation.section.item-access.begin.perl
+#         ^ constant.numeric.value.perl
+#           ^ punctuation.section.item-access.end.perl
+
+$href->%{ key };  # same as %$href{ key }
+#      ^ keyword.operator.dereference.perl
+#       ^^^^^^^ meta.item-access.perl
+#       ^ punctuation.section.item-access.begin.perl
+#         ^^^ constant.other.key.perl
+#             ^ punctuation.section.item-access.end.perl
+
+$aref->&[ 0 ];  # same as &$aref[ 0 ]
+#      ^ keyword.operator.dereference.perl
+#       ^^^^^ meta.item-access.perl
+#       ^ punctuation.section.item-access.begin.perl
+#         ^ constant.numeric.value.perl
+#           ^ punctuation.section.item-access.end.perl
+
+$href->&{ key };  # same as &$href{ key }
+#      ^ keyword.operator.dereference.perl
+#       ^^^^^^^ meta.item-access.perl
+#       ^ punctuation.section.item-access.begin.perl
+#         ^^^ constant.other.key.perl
+#             ^ punctuation.section.item-access.end.perl
+
 ###[ UNQUALIFIED VARIABLES ]##################################################
 
   $_foo = "bar";


### PR DESCRIPTION
Fixes #4204

This commit implements:

1. https://perldoc.perl.org/perlref#Postfix-Dereference-Syntax
2. https://perldoc.perl.org/perlref#Postfix-Reference-Slicing