### PR TITLE
[JavaScript] Add support for commented tagged template strings

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -190,8 +190,10 @@ contexts:
       push:
         - jsdoc-comment-body
         - jsdoc-block-tag
-    # normal block comments
-    - match: /\*
+    # normal block comments (not looking like tagged template string "decorator")
+    # note: required as comments are included via `prototype` and we don't want
+    # to exclude prototypes from `expression-begin` context as it might break inherited syntaxes.
+    - match: /\*(?!\s*{{identifier_name}}\s*\*/\s*`)
       scope: punctuation.definition.comment.begin.js
       push: block-comment-body
 
@@ -1169,9 +1171,9 @@ contexts:
     - include: yield-expression
     - include: await-expression
 
-    - include: regexp-complete
-    - include: literal-string
     - include: literal-string-template
+    - include: literal-string
+    - include: regexp-complete
     - include: constructor
     - include: literal-number
     - include: prefix-operators
@@ -1282,11 +1284,11 @@ contexts:
     - include: string-content
 
   literal-string-templates:
-    - match: (?=(?:{{identifier_name}}\s*)?{{tagged_template_quote_begin}})
+    - match: (?=(?:(?:/\*\s*{{identifier_name}}\s*\*/|{{identifier_name}})\s*)?{{tagged_template_quote_begin}})
       push: literal-string-template-begin
 
   literal-string-template:
-    - match: (?=(?:{{identifier_name}}\s*)?{{tagged_template_quote_begin}})
+    - match: (?=(?:(?:/\*\s*{{identifier_name}}\s*\*/|{{identifier_name}})\s*)?{{tagged_template_quote_begin}})
       set: literal-string-template-begin
 
   literal-string-template-begin:
@@ -1306,11 +1308,14 @@ contexts:
     - include: immediately-pop
 
   literal-string-template-css:
-    - match: (css)\s*(({{tagged_template_quote_begin}}){{trailing_wspace}}?)
+    - match: (?i:((/\*)\s*css\s*(\*/))|(css))\s*(({{tagged_template_quote_begin}}){{trailing_wspace}}?)
       captures:
-        1: variable.function.tagged-template.js
-        2: meta.string.template.js string.quoted.other.js
-        3: punctuation.definition.string.begin.js
+        1: comment.block.js
+        2: punctuation.definition.comment.begin.js
+        3: punctuation.definition.comment.end.js
+        4: variable.function.tagged-template.js
+        5: meta.string.template.js string.quoted.other.js
+        6: punctuation.definition.string.begin.js
       embed: scope:source.css.js-template
       embed_scope: meta.string.template.js source.css.embedded.js
       escape: '{{leading_wspace}}?({{tagged_template_quote_escape}})'
@@ -1320,11 +1325,14 @@ contexts:
       pop: 1
 
   literal-string-template-html:
-    - match: (html)\s*(({{tagged_template_quote_begin}}){{trailing_wspace}}?)
+    - match: (?i:((/\*)\s*html\s*(\*/))|(html))\s*(({{tagged_template_quote_begin}}){{trailing_wspace}}?)
       captures:
-        1: variable.function.tagged-template.js
-        2: meta.string.template.js string.quoted.other.js
-        3: punctuation.definition.string.begin.js
+        1: comment.block.js
+        2: punctuation.definition.comment.begin.js
+        3: punctuation.definition.comment.end.js
+        4: variable.function.tagged-template.js
+        5: meta.string.template.js string.quoted.other.js
+        6: punctuation.definition.string.begin.js
       embed: scope:text.html.js-template
       embed_scope: meta.string.template.js text.html.embedded.js
       escape: '{{leading_wspace}}?({{tagged_template_quote_escape}})'
@@ -1334,11 +1342,14 @@ contexts:
       pop: 1
 
   literal-string-template-js:
-    - match: (js)\s*(({{tagged_template_quote_begin}}){{trailing_wspace}}?)
+    - match: (?i:((/\*)\s*js\s*(\*/))|(js))\s*(({{tagged_template_quote_begin}}){{trailing_wspace}}?)
       captures:
-        1: variable.function.tagged-template.js
-        2: meta.string.template.js string.quoted.other.js
-        3: punctuation.definition.string.begin.js
+        1: comment.block.js
+        2: punctuation.definition.comment.begin.js
+        3: punctuation.definition.comment.end.js
+        4: variable.function.tagged-template.js
+        5: meta.string.template.js string.quoted.other.js
+        6: punctuation.definition.string.begin.js
       embed: scope:source.js.js-template
       embed_scope: meta.string.template.js source.js.embedded.js
       escape: '{{leading_wspace}}?({{tagged_template_quote_escape}})'
@@ -1348,11 +1359,14 @@ contexts:
       pop: 1
 
   literal-string-template-json:
-    - match: (json)\s*(({{tagged_template_quote_begin}}){{trailing_wspace}}?)
+    - match: (?i:((/\*)\s*json\s*(\*/))|(json))\s*(({{tagged_template_quote_begin}}){{trailing_wspace}}?)
       captures:
-        1: variable.function.tagged-template.js
-        2: meta.string.template.js string.quoted.other.js
-        3: punctuation.definition.string.begin.js
+        1: comment.block.js
+        2: punctuation.definition.comment.begin.js
+        3: punctuation.definition.comment.end.js
+        4: variable.function.tagged-template.js
+        5: meta.string.template.js string.quoted.other.js
+        6: punctuation.definition.string.begin.js
       embed: scope:source.json.js-template
       embed_scope: meta.string.template.js source.json.embedded.js
       escape: '{{leading_wspace}}?({{tagged_template_quote_escape}})'
@@ -1362,11 +1376,14 @@ contexts:
       pop: 1
 
   literal-string-template-sql:
-    - match: (sql|SQL)\s*(({{tagged_template_quote_begin}}){{trailing_wspace}}?)
+    - match: (?i:((/\*)\s*sql\s*(\*/))|(sql))\s*(({{tagged_template_quote_begin}}){{trailing_wspace}}?)
       captures:
-        1: variable.function.tagged-template.js
-        2: meta.string.template.js string.quoted.other.js
-        3: punctuation.definition.string.begin.js
+        1: comment.block.js
+        2: punctuation.definition.comment.begin.js
+        3: punctuation.definition.comment.end.js
+        4: variable.function.tagged-template.js
+        5: meta.string.template.js string.quoted.other.js
+        6: punctuation.definition.string.begin.js
       embed: scope:source.sql.js-template
       embed_scope: meta.string.template.js source.sql.embedded.js
       escape: '{{leading_wspace}}?({{tagged_template_quote_escape}})'
@@ -1376,6 +1393,10 @@ contexts:
       pop: 1
 
   literal-string-template-raw:
+    # Consume block comments as patterns of `block-comments` context don't match if followed by backtick.
+    - match: /\*
+      scope: punctuation.definition.comment.begin.js
+      push: block-comment-body
     - match: (?:({{identifier_name}})\s*)?({{tagged_template_quote_begin}})
       captures:
         1: variable.function.tagged-template.js

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -1227,76 +1227,87 @@ contexts:
     - meta_prepend: true
     - include: ts-non-null-assertion
 
-  literal-string-template-begin:
-    # Notes:
-    #  Consume trailing whitespace after opening punctuation
-    #  and leading whitespace in front of closing punctuation
-    #  to maintain JavaScript indentation rules until embedded
-    #  code really begins/ends. It's required for embedded code
-    #  to be indented using global JavaScript indentation rules.
-    - match: (css)\s*((\`){{trailing_wspace}}?)
+  literal-string-template-css:
+    - match: (?i:((/\*)\s*css\s*(\*/))|(css))\s*(({{tagged_template_quote_begin}}){{trailing_wspace}}?)
       captures:
-        1: variable.function.tagged-template.js
-        2: meta.string.template.js string.quoted.other.js
-        3: punctuation.definition.string.begin.js
+        1: comment.block.js
+        2: punctuation.definition.comment.begin.js
+        3: punctuation.definition.comment.end.js
+        4: variable.function.tagged-template.js
+        5: meta.string.template.js string.quoted.other.js
+        6: punctuation.definition.string.begin.js
       embed: scope:source.css.ts-template
       embed_scope: meta.string.template.js source.css.embedded.js
-      escape: '{{leading_wspace}}?(\`)'
+      escape: '{{leading_wspace}}?({{tagged_template_quote_escape}})'
       escape_captures:
         0: meta.string.template.js string.quoted.other.js
         1: punctuation.definition.string.end.js
       pop: 1
-    - match: (html)\s*((\`){{trailing_wspace}}?)
+
+  literal-string-template-html:
+    - match: (?i:((/\*)\s*html\s*(\*/))|(html))\s*(({{tagged_template_quote_begin}}){{trailing_wspace}}?)
       captures:
-        1: variable.function.tagged-template.js
-        2: meta.string.template.js string.quoted.other.js
-        3: punctuation.definition.string.begin.js
+        1: comment.block.js
+        2: punctuation.definition.comment.begin.js
+        3: punctuation.definition.comment.end.js
+        4: variable.function.tagged-template.js
+        5: meta.string.template.js string.quoted.other.js
+        6: punctuation.definition.string.begin.js
       embed: scope:text.html.ts-template
       embed_scope: meta.string.template.js text.html.embedded.js
-      escape: '{{leading_wspace}}?(\`)'
+      escape: '{{leading_wspace}}?({{tagged_template_quote_escape}})'
       escape_captures:
         0: meta.string.template.js string.quoted.other.js
         1: punctuation.definition.string.end.js
       pop: 1
-    - match: (js)\s*((\`){{trailing_wspace}}?)
+
+  literal-string-template-js:
+    - match: (?i:((/\*)\s*js\s*(\*/))|(js))\s*(({{tagged_template_quote_begin}}){{trailing_wspace}}?)
       captures:
-        1: variable.function.tagged-template.js
-        2: meta.string.template.js string.quoted.other.js
-        3: punctuation.definition.string.begin.js
+        1: comment.block.js
+        2: punctuation.definition.comment.begin.js
+        3: punctuation.definition.comment.end.js
+        4: variable.function.tagged-template.js
+        5: meta.string.template.js string.quoted.other.js
+        6: punctuation.definition.string.begin.js
       embed: scope:source.js.ts-template
       embed_scope: meta.string.template.js source.js.embedded.js
-      escape: '{{leading_wspace}}?(\`)'
+      escape: '{{leading_wspace}}?({{tagged_template_quote_escape}})'
       escape_captures:
         0: meta.string.template.js string.quoted.other.js
         1: punctuation.definition.string.end.js
       pop: 1
-    - match: (json)\s*((\`){{trailing_wspace}}?)
+
+  literal-string-template-json:
+    - match: (?i:((/\*)\s*json\s*(\*/))|(json))\s*(({{tagged_template_quote_begin}}){{trailing_wspace}}?)
       captures:
-        1: variable.function.tagged-template.js
-        2: meta.string.template.js string.quoted.other.js
-        3: punctuation.definition.string.begin.js
+        1: comment.block.js
+        2: punctuation.definition.comment.begin.js
+        3: punctuation.definition.comment.end.js
+        4: variable.function.tagged-template.js
+        5: meta.string.template.js string.quoted.other.js
+        6: punctuation.definition.string.begin.js
       embed: scope:source.json.ts-template
       embed_scope: meta.string.template.js source.json.embedded.js
-      escape: '{{leading_wspace}}?(\`)'
+      escape: '{{leading_wspace}}?({{tagged_template_quote_escape}})'
       escape_captures:
         0: meta.string.template.js string.quoted.other.js
         1: punctuation.definition.string.end.js
       pop: 1
-    - match: (sql|SQL)\s*((\`){{trailing_wspace}}?)
+
+  literal-string-template-sql:
+    - match: (?i:((/\*)\s*sql\s*(\*/))|(sql))\s*(({{tagged_template_quote_begin}}){{trailing_wspace}}?)
       captures:
-        1: variable.function.tagged-template.js
-        2: meta.string.template.js string.quoted.other.js
-        3: punctuation.definition.string.begin.js
+        1: comment.block.js
+        2: punctuation.definition.comment.begin.js
+        3: punctuation.definition.comment.end.js
+        4: variable.function.tagged-template.js
+        5: meta.string.template.js string.quoted.other.js
+        6: punctuation.definition.string.begin.js
       embed: scope:source.sql.ts-template
       embed_scope: meta.string.template.js source.sql.embedded.js
-      escape: '{{leading_wspace}}?(\`)'
+      escape: '{{leading_wspace}}?({{tagged_template_quote_escape}})'
       escape_captures:
         0: meta.string.template.js string.quoted.other.js
         1: punctuation.definition.string.end.js
       pop: 1
-    - match: (?:({{identifier_name}})\s*)?(\`)
-      captures:
-        1: variable.function.tagged-template.js
-        2: meta.string.template.js string.quoted.other.js punctuation.definition.string.begin.js
-      set: literal-string-template-content
-    - include: immediately-pop

--- a/JavaScript/tests/syntax_test_js_template.js
+++ b/JavaScript/tests/syntax_test_js_template.js
@@ -4,6 +4,12 @@
  * HTML Templates
  */
 
+var html = /* html */ ` <p>${content}</p> `
+/*                    ^^^^^^^^^^^^^^^^^^^^^ meta.string.template.js */
+/*                    ^ string.quoted.other.js punctuation.definition.string.begin.js - text.html.embedded */
+/*                     ^^^^^^^^^^^^^^^^^^^ text.html.embedded.js - string */
+/*                                        ^ string.quoted.other.js punctuation.definition.string.end.js - text.html.embedded */
+
 var html = html` <p>${content}</p> `
 /*             ^^^^^^^^^^^^^^^^^^^^^ meta.string.template.js */
 /*             ^ string.quoted.other.js punctuation.definition.string.begin.js - text.html.embedded */
@@ -96,6 +102,12 @@ var html = html`
  * JSON Templates
  */
 
+var json = /* json */ ` { "key": "value" } `
+/*                    ^^^^^^^^^^^^^^^^^^^^^^ meta.string.template.js */
+/*                    ^ string.quoted.other.js punctuation.definition.string.begin.js - source.json.embedded */
+/*                     ^^^^^^^^^^^^^^^^^^^^ source.json.embedded.js */
+/*                                         ^ string.quoted.other.js punctuation.definition.string.end.js - source.json.embedded */
+
 var json = json` { "key": "value" } `
 /*             ^^^^^^^^^^^^^^^^^^^^^^ meta.string.template.js */
 /*             ^ string.quoted.other.js punctuation.definition.string.begin.js - source.json.embedded */
@@ -148,6 +160,12 @@ var json = json`
  * JavaScript Templates
  */
 
+var script = /* js */ ` var = 0 `
+/*                    ^^^^^^^^^^^ meta.string.template.js */
+/*                    ^ string.quoted.other.js punctuation.definition.string.begin.js - source.js.embedded */
+/*                     ^^^^^^^^^ source.js.embedded.js */
+/*                              ^ string.quoted.other.js punctuation.definition.string.end.js - source.js.embedded */
+
 var script = js` var = 0 `
 /*             ^^^^^^^^^^^ meta.string.template.js */
 /*             ^ string.quoted.other.js punctuation.definition.string.begin.js - source.js.embedded */
@@ -175,6 +193,11 @@ var script = js`
  * CSS Templates
  */
 
+var style = /* css */ ` tr {  } `
+/*                    ^^^^^^^^^^^ meta.string.template.js */
+/*                    ^ string.quoted.other.js punctuation.definition.string.begin.js - source.css.embedded */
+/*                     ^^^^^^^^^ source.css.embedded.js */
+/*                              ^ string.quoted.other.js punctuation.definition.string.end.js - source.css.embedded */
 
 var style = css` tr {  } `
 /*             ^^^^^^^^^^^ meta.string.template.js */
@@ -271,12 +294,17 @@ var style = css`color:${color}`;
  * SQL Templates
  */
 
+var sql = /* sql */ `SELECT * FROM "foo";`
+/*                  ^^^^^^^^^^^^^^^^^^^^^^ meta.string.template.js */
+/*                  ^ string.quoted.other.js punctuation.definition.string.begin.js - source.sql.embedded */
+/*                   ^^^^^^^^^^^^^^^^^^^^ source.sql.embedded.js */
+/*                                       ^ string.quoted.other.js punctuation.definition.string.end.js - source.sql.embedded */
+
 var sql = sql`SELECT * FROM "foo";`
 /*           ^^^^^^^^^^^^^^^^^^^^^^ meta.string.template.js */
 /*           ^ string.quoted.other.js punctuation.definition.string.begin.js - source.sql.embedded */
 /*            ^^^^^^^^^^^^^^^^^^^^ source.sql.embedded.js */
 /*                                ^ string.quoted.other.js punctuation.definition.string.end.js - source.sql.embedded */
-
 
 var sql = SQL`SELECT * FROM "foo";`
 /*           ^^^^^^^^^^^^^^^^^^^^^^ meta.string.template.js */
@@ -324,6 +352,14 @@ var sql = sql`SELECT * FROM ${users};`
 /*
  * Unknown Template
  */
+
+var other = /* any */ `tagged`
+/*          ^^^^^^^^^ comment.block.js */
+/*          ^^ punctuation.definition.comment.begin.js */
+/*                 ^^ punctuation.definition.comment.end.js */
+/*                    ^^^^^^^^ meta.string.template.js string.quoted.other.js */
+/*                    ^ punctuation.definition.string.begin.js */
+/*                           ^ punctuation.definition.string.end.js */
 
 var other = other`
 /*          ^^^^^ variable.function.tagged-template */

--- a/JavaScript/tests/syntax_test_typescript_template.ts
+++ b/JavaScript/tests/syntax_test_typescript_template.ts
@@ -4,6 +4,12 @@
  * HTML Templates
  */
 
+var html = /* html */ ` <p>${content}</p> `
+/*                    ^^^^^^^^^^^^^^^^^^^^^ meta.string.template.js */
+/*                    ^ string.quoted.other.js punctuation.definition.string.begin.js - text.html.embedded */
+/*                     ^^^^^^^^^^^^^^^^^^^ text.html.embedded.js - string */
+/*                                        ^ string.quoted.other.js punctuation.definition.string.end.js - text.html.embedded */
+
 var html = html` <p>${content}</p> `
 /*             ^^^^^^^^^^^^^^^^^^^^^ meta.string.template.js */
 /*             ^ string.quoted.other.js punctuation.definition.string.begin.js - text.html.embedded */
@@ -96,6 +102,13 @@ var html = html`
  * JSON Templates
  */
 
+var json = /* json */ ` { "key": "value" } `
+/*                    ^^^^^^^^^^^^^^^^^^^^^^ meta.string.template.js */
+/*                    ^ string.quoted.other.js punctuation.definition.string.begin.js - source.json.embedded */
+/*                     ^^^^^^^^^^^^^^^^^^^^ source.json.embedded.js */
+/*                                         ^ string.quoted.other.js punctuation.definition.string.end.js - source.json.embedded */
+
+
 var json = json` { "key": "value" } `
 /*             ^^^^^^^^^^^^^^^^^^^^^^ meta.string.template.js */
 /*             ^ string.quoted.other.js punctuation.definition.string.begin.js - source.json.embedded */
@@ -148,6 +161,12 @@ var json = json`
  * JavaScript Templates
  */
 
+var script = /* js */ ` var = 0 `
+/*                    ^^^^^^^^^^^ meta.string.template.js */
+/*                    ^ string.quoted.other.js punctuation.definition.string.begin.js - source.js.embedded */
+/*                     ^^^^^^^^^ source.js.embedded.js */
+/*                              ^ string.quoted.other.js punctuation.definition.string.end.js - source.js.embedded */
+
 var script = js` var = 0 `
 /*             ^^^^^^^^^^^ meta.string.template.js */
 /*             ^ string.quoted.other.js punctuation.definition.string.begin.js - source.js.embedded */
@@ -175,6 +194,11 @@ var script = js`
  * CSS Templates
  */
 
+var style = /* css */ ` tr {  } `
+/*                    ^^^^^^^^^^^ meta.string.template.js */
+/*                    ^ string.quoted.other.js punctuation.definition.string.begin.js - source.css.embedded */
+/*                     ^^^^^^^^^ source.css.embedded.js */
+/*                              ^ string.quoted.other.js punctuation.definition.string.end.js - source.css.embedded */
 
 var style = css` tr {  } `
 /*             ^^^^^^^^^^^ meta.string.template.js */
@@ -270,6 +294,12 @@ var style = css`color:${color}`;
  * SQL Templates
  */
 
+var sql = /* sql */ `SELECT * FROM "foo";`
+/*                  ^^^^^^^^^^^^^^^^^^^^^^ meta.string.template.js */
+/*                  ^ string.quoted.other.js punctuation.definition.string.begin.js - source.sql.embedded */
+/*                   ^^^^^^^^^^^^^^^^^^^^ source.sql.embedded.js */
+/*                                       ^ string.quoted.other.js punctuation.definition.string.end.js - source.sql.embedded */
+
 var sql = sql`SELECT * FROM "foo";`
 /*           ^^^^^^^^^^^^^^^^^^^^^^ meta.string.template.js */
 /*           ^ string.quoted.other.js punctuation.definition.string.begin.js - source.sql.embedded */
@@ -323,6 +353,14 @@ var sql = sql`SELECT * FROM ${users};`
 /*
  * Unknown Template
  */
+
+var other = /* any */ `tagged`
+/*          ^^^^^^^^^ comment.block.js */
+/*          ^^ punctuation.definition.comment.begin.js */
+/*                 ^^ punctuation.definition.comment.end.js */
+/*                    ^^^^^^^^ meta.string.template.js string.quoted.other.js */
+/*                    ^ punctuation.definition.string.begin.js */
+/*                           ^ punctuation.definition.string.end.js */
 
 var other = other`
 /*          ^^^^^ variable.function.tagged-template */


### PR DESCRIPTION
Resolves #4213


This PR...

1. adds support for syntax highlighted tagged templates prefixed with comments:

   ```
   /* html */ `<p>highlighted</p>`
   ```

2. adjusts tagged template related context structure in TypeScript, which did not yet make use of dedicated per-language contexts.

Notes:

1. Need to change include order of contexts in expression-begin to give literal string templates precedence over regular expressions.

   reason: `` /* ident */ ` `` is more detailed then `/`.

2. A bit of song and dance is required to prevent normal block comment patterns to apply as those are included via `prototype` and would always take precedence if no special action was taken.

   A negative lookahead was chosen as otherwise all contexts, including `literal-string-template` contexts would need to exclude `prototype` and possibly manually include it after `literal-string-template`.

   That's possibly more error prone with regards to future changes.