### PR TITLE
[Perl] Fix POD comments

### DIFF
--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -194,96 +194,96 @@ contexts:
       push: comment-line-body
 
   comment-line-body:
-    - meta_scope: meta.comment.perl comment.line.number-sign.perl
+    - meta_scope: comment.line.number-sign.perl
     - match: \n
       pop: true
 
   comment-pod:
     # SEE: https://perldoc.perl.org/perlpod.html
-    - match: ^{{pod}}
-      scope: entity.name.tag.pod.perl
+    # pod end tags
+    - match: ^=(?:cut|end)\b
+      scope: comment.block.documentation.perl entity.name.tag.pod.perl
+    # pod heading
+    - match: ^(=head[1-6])\s+
+      captures:
+        1: entity.name.tag.pod.perl
       push:
-        - comment-pod-body
-        - comment-pod-begin
-
-  comment-pod-begin:
-    - meta_content_scope: meta.string.perl string.unquoted.perl
-    - match: \n
-      pop: true
-    - include: comment-pod-formatting
-
-  comment-pod-body:
-    - meta_scope: meta.comment.perl comment.block.documentation.perl
-    - match: ^=cut\b
-      scope: entity.name.tag.pod.perl
-      pop: true
-    - include: comment-pod-embedded
-    - include: comment-pod-keyword
-    - include: comment-pod-formatting
-
-  comment-pod-embedded:
+        - comment-pod-paragraph-body
+        - comment-pod-heading-body
+    # verbatim paragraph
     - match: ^=begin\b
       scope: entity.name.tag.pod.perl
-      push: comment-pod-embedded-body
+      push: comment-pod-verbatim-body
+    # other/unknown pod tags
+    - match: ^({{pod}})\s+
+      captures:
+        1: entity.name.tag.pod.perl
+      push:
+        - comment-pod-paragraph-body
+        - comment-pod-command-body
 
-  comment-pod-embedded-body:
-    - clear_scopes: 1 # remove `comment`
-    - meta_scope: meta.interpolation.perl
+  comment-pod-heading-body:
+    - meta_scope: meta.heading.perl
+    - meta_content_scope: entity.name.section.perl
+    - match: $\n?
+      pop: true
+    - include: comment-pod-formatting
+
+  comment-pod-command-body:
+    - meta_content_scope: meta.string.perl string.unquoted.perl
+    - match: $\n?
+      pop: true
+    - include: comment-pod-formatting
+
+  comment-pod-paragraph-body:
+    - meta_scope: comment.block.documentation.perl
+    - match: ^(?={{pod}})
+      pop: true
+    - include: comment-pod-formatting
+
+  comment-pod-verbatim-body:
+    - meta_scope: comment.block.documentation.perl
     # end embedded section
     - match: ^=end\b
       scope: entity.name.tag.pod.perl
       pop: true
     # embedded css
     - match: \bcss\b
-      scope: constant.other.language-name.css.perl
+      scope: constant.other.language-name.perl
       embed: scope:source.css
       embed_scope: source.css.embedded.perl
       escape: (?=^{{pod}})
     # embedded html
     - match: \bhtml\b
-      scope: constant.other.language-name.html.perl
+      scope: constant.other.language-name.perl
       embed: scope:text.html.basic
       embed_scope: text.html.embedded.perl
       escape: (?=^{{pod}})
     # embedded javascript
     - match: \b(?:js|javascript)\b
-      scope: constant.other.language-name.js.perl
+      scope: constant.other.language-name.perl
       embed: scope:source.js
       embed_scope: source.js.embedded.perl
       escape: (?=^{{pod}})
     # embedded json
     - match: \bjson\b
-      scope: constant.other.language-name.json.perl
+      scope: constant.other.language-name.perl
       embed: scope:source.json
       embed_scope: source.json.embedded.perl
       escape: (?=^{{pod}})
     # embedded sql
     - match: \bsql\b
-      scope: constant.other.language-name.sql.perl
+      scope: constant.other.language-name.perl
       embed: scope:source.sql
       embed_scope: source.sql.embedded.perl
       escape: (?=^{{pod}})
     # embedded xml
     - match: \bxml\b
-      scope: constant.other.language-name.xml.perl
+      scope: constant.other.language-name.perl
       embed: scope:text.xml
       embed_scope: text.xml.embedded.perl
       escape: (?=^{{pod}})
-    # unexpected pod command
-    - match: ^{{pod}}
-      scope: invalid.illegal.end-expected.perl
-      pop: true
     - include: else-pop
-
-  comment-pod-keyword:
-    - match: ^{{pod}}
-      scope: entity.name.tag.pod.perl
-      push: comment-pod-keyword-body
-
-  comment-pod-keyword-body:
-    - meta_content_scope: markup.heading.perl
-    - include: eol-pop
-    - include: comment-pod-formatting
 
   comment-pod-formatting:
     # bold text : B<content>

--- a/Perl/syntax_test_perl.pl
+++ b/Perl/syntax_test_perl.pl
@@ -6,62 +6,95 @@
 
 ###[ POD TESTS ] #############################################################
 
-=pod
-# <- meta.comment.perl comment.block.documentation.perl entity.name.tag.pod.perl
-#^^^ meta.comment.perl comment.block.documentation.perl entity.name.tag.pod.perl
-=encoding utf8
-# <- meta.comment.perl comment.block.documentation.perl entity.name.tag.pod.perl
-#^^^^^^^^^^^^^ meta.comment.perl comment.block.documentation.perl
-#^^^^^^^^ entity.name.tag.pod.perl
-#         ^^^^ markup.heading.perl
-=head1 B<--param>
-# <- meta.comment.perl comment.block.documentation.perl entity.name.tag.pod.perl
-#^^^^^^^^^^^^^^^^ meta.comment.perl comment.block.documentation.perl
+=head1 Section 1
+# <- comment.block.documentation.perl meta.heading.perl entity.name.tag.pod.perl
+#^^^^^^^^^^^^^^^^ comment.block.documentation.perl meta.heading.perl
 #^^^^^ entity.name.tag.pod.perl
-#      ^^^^^^^^^^ markup.heading.perl
+#     ^ - entity
+#      ^^^^^^^^^ entity.name.section.perl
+Paragraph
+# <- comment.block.documentation.perl
+#^^^^^^^^^ comment.block.documentation.perl
+=head2 Section 1.1
+# <- comment.block.documentation.perl meta.heading.perl entity.name.tag.pod.perl
+#^^^^^^^^^^^^^^^^^^ comment.block.documentation.perl meta.heading.perl
+#^^^^^ entity.name.tag.pod.perl
+#     ^ - entity
+#      ^^^^^^^^^^^ entity.name.section.perl
+Paragraph
+# <- comment.block.documentation.perl
+#^^^^^^^^^ comment.block.documentation.perl
+=item Using C<$|> to Control Buffering
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.perl
+#^^^^ entity.name.tag.pod.perl
+#    ^ - entity - string
+#     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.perl string.unquoted.perl
+#           ^ entity.name.tag.code.perl
+#            ^ punctuation.definition.tag.begin.perl
+#             ^^ markup.quote.perl
+#               ^ punctuation.definition.tag.end.perl
+=cut
+# <- comment.block.documentation.perl entity.name.tag.pod.perl
+#^^^ comment.block.documentation.perl entity.name.tag.pod.perl
+
+=pod
+# <- comment.block.documentation.perl entity.name.tag.pod.perl
+#^^^ comment.block.documentation.perl entity.name.tag.pod.perl
+=encoding utf8
+# <- comment.block.documentation.perl entity.name.tag.pod.perl
+#^^^^^^^^^^^^^ comment.block.documentation.perl
+#^^^^^^^^ entity.name.tag.pod.perl
+#        ^ - entity - string
+#         ^^^^ meta.string.perl string.unquoted.perl
+=head1 B<--param>
+# <- comment.block.documentation.perl meta.heading.perl entity.name.tag.pod.perl
+#^^^^^^^^^^^^^^^^^ comment.block.documentation.perl meta.heading.perl
+#^^^^^ entity.name.tag.pod.perl
+#     ^ - entity - string
+#      ^^^^^^^^^^ entity.name.section.perl
 #      ^ entity.name.tag.bold.perl
 #       ^ punctuation.definition.tag.begin.perl
 #        ^^^^^^^ markup.bold.perl
 #               ^ punctuation.definition.tag.end.perl
    B<bold>
-#  ^^^^^^^ meta.comment.perl comment.block.documentation.perl
+#  ^^^^^^^ comment.block.documentation.perl
 #  ^ entity.name.tag.bold.perl
 #   ^ punctuation.definition.tag.begin.perl
 #    ^^^^ markup.bold.perl
 #        ^ punctuation.definition.tag.end.perl
    C<code>
-#  ^^^^^^^ meta.comment.perl comment.block.documentation.perl
+#  ^^^^^^^ comment.block.documentation.perl
 #  ^ entity.name.tag.code.perl
 #   ^ punctuation.definition.tag.begin.perl
 #    ^^^^ markup.quote.perl
 #        ^ punctuation.definition.tag.end.perl
    E<lt>
-#  ^^^^^ meta.comment.perl comment.block.documentation.perl
+#  ^^^^^ comment.block.documentation.perl
 #  ^ entity.name.tag.escaped.perl
 #   ^ punctuation.definition.tag.begin.perl
 #    ^^ constant.character.escape.perl
 #      ^ punctuation.definition.tag.end.perl
    F<file.ext>
-#  ^^^^^^^^^^^ meta.comment.perl comment.block.documentation.perl
+#  ^^^^^^^^^^^ comment.block.documentation.perl
 #  ^ entity.name.tag.filename.perl
 #   ^ punctuation.definition.tag.begin.perl
 #    ^^^^^^^^ meta.string.perl string.unquoted.perl
 #            ^ punctuation.definition.tag.end.perl
    I<italic>
-#  ^^^^^^^^^ meta.comment.perl comment.block.documentation.perl
+#  ^^^^^^^^^ comment.block.documentation.perl
 #  ^ entity.name.tag.italic.perl
 #   ^ punctuation.definition.tag.begin.perl
 #    ^^^^^^ markup.italic.perl
 #          ^ punctuation.definition.tag.end.perl
 
    L<http://www.perl.org/>
-#  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.comment.perl comment.block.documentation.perl
+#  ^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.perl
 #  ^ entity.name.tag.link.perl
 #   ^ punctuation.definition.tag.begin.perl
 #    ^^^^^^^^^^^^^^^^^^^^ markup.underline.link.perl
 #                        ^ punctuation.definition.tag.end.perl
    L<The Perl Home Page|http://www.perl.org/>
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.comment.perl comment.block.documentation.perl
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.perl
 #  ^ entity.name.tag.link.perl
 #   ^ punctuation.definition.tag.begin.perl
 #    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.perl
@@ -75,7 +108,7 @@
 #         ^ punctuation.definition.tag.end.perl
 #            ^ punctuation.definition.tag.end.perl
    X<index entry>
-#  ^^^^^^^^^^^^^^ meta.comment.perl comment.block.documentation.perl
+#  ^^^^^^^^^^^^^^ comment.block.documentation.perl
 #  ^ entity.name.tag.index.perl
 #   ^ punctuation.definition.tag.begin.perl
 #    ^^^^^^^^^^^ entity.name.label.perl
@@ -85,64 +118,66 @@
 #                                         ^ entity.name.tag.escaped.perl
 
 =begin css
-# <- meta.comment.perl meta.interpolation.perl entity.name.tag.pod.perl
-#^^^^^^^^^^ meta.comment.perl meta.interpolation.perl
+# <- comment.block.documentation.perl entity.name.tag.pod.perl
+#^^^^^^^^^^ comment.block.documentation.perl
 #^^^^^ entity.name.tag.pod.perl
 #     ^ - constant - entity
-#      ^^^ constant.other.language-name.css.perl
+#      ^^^ constant.other.language-name.perl
   a {  };
-# ^^^^^^^ meta.comment.perl meta.interpolation.perl source.css.embedded.perl source.css
+# ^^^^^^^^ comment.block.documentation.perl source.css.embedded.perl
 =end
-# <- meta.comment.perl meta.interpolation.perl entity.name.tag.pod.perl
-#^^^ meta.comment.perl meta.interpolation.perl entity.name.tag.pod.perl
+# <- comment.block.documentation.perl entity.name.tag.pod.perl
+#^^^ comment.block.documentation.perl entity.name.tag.pod.perl
 
 =begin html
-# <- meta.comment.perl meta.interpolation.perl entity.name.tag.pod.perl
-#^^^^^^^^^^ meta.comment.perl meta.interpolation.perl
+# <- comment.block.documentation.perl entity.name.tag.pod.perl
+#^^^^^^^^^^^ comment.block.documentation.perl
 #^^^^^ entity.name.tag.pod.perl
 #     ^ - constant - entity
-#      ^^^^ constant.other.language-name.html.perl
+#      ^^^^ constant.other.language-name.perl
     <html>
-# <- meta.comment.perl meta.interpolation.perl text.html.embedded.perl
-#^^^^^^^^^ meta.comment.perl meta.interpolation.perl text.html.embedded.perl
+# <- comment.block.documentation.perl text.html.embedded.perl
+#^^^^^^^^^^ comment.block.documentation.perl text.html.embedded.perl
     </html>
-# <- meta.comment.perl meta.interpolation.perl text.html.embedded.perl
-#^^^^^^^^^ meta.comment.perl meta.interpolation.perl text.html.embedded.perl
+# <- comment.block.documentation.perl text.html.embedded.perl
+#^^^^^^^^^^ comment.block.documentation.perl text.html.embedded.perl
 =end
-# <- meta.comment.perl meta.interpolation.perl entity.name.tag.pod.perl
-#^^^ meta.comment.perl meta.interpolation.perl entity.name.tag.pod.perl
+# <- comment.block.documentation.perl entity.name.tag.pod.perl
+#^^^ comment.block.documentation.perl entity.name.tag.pod.perl
 
 =begin json
-# <- meta.comment.perl meta.interpolation.perl entity.name.tag.pod.perl
-#^^^^^^^^^^ meta.comment.perl meta.interpolation.perl
+# <- comment.block.documentation.perl entity.name.tag.pod.perl
+#^^^^^^^^^^^ comment.block.documentation.perl
 #^^^^^ entity.name.tag.pod.perl
 #     ^ - constant - entity
-#      ^^^^ constant.other.language-name.json.perl
+#      ^^^^ constant.other.language-name.perl
   {
-# ^ meta.comment.perl meta.interpolation.perl source.json.embedded.perl source.json
+# ^ comment.block.documentation.perl source.json.embedded.perl meta.mapping.json punctuation.section.mapping.begin.json
     "key": "value",
-#   ^^^^^^^^^^^^^^^ meta.comment.perl meta.interpolation.perl source.json.embedded.perl source.json
+#   ^^^^^^^^^^^^^^^^ comment.block.documentation.perl source.json.embedded.perl
   }
-# ^ meta.comment.perl meta.interpolation.perl source.json.embedded.perl source.json
+# ^ comment.block.documentation.perl source.json.embedded.perl meta.mapping.json punctuation.section.mapping.end.json
 =end
-# <- meta.comment.perl meta.interpolation.perl entity.name.tag.pod.perl
-#^^^ meta.comment.perl meta.interpolation.perl entity.name.tag.pod.perl
+# <- comment.block.documentation.perl entity.name.tag.pod.perl
+#^^^ comment.block.documentation.perl entity.name.tag.pod.perl
 
 =begin sql
-# <- meta.comment.perl meta.interpolation.perl entity.name.tag.pod.perl
-#^^^^^^^^^^ meta.comment.perl meta.interpolation.perl
+# <- comment.block.documentation.perl entity.name.tag.pod.perl
+#^^^^^^^^^^ comment.block.documentation.perl
 #^^^^^ entity.name.tag.pod.perl
 #     ^ - constant - entity
-#      ^^^ constant.other.language-name.sql.perl
+#      ^^^ constant.other.language-name.perl
   SELECT * FROM `table`
-# ^^^^^^^^^^^^^^^^^^^^^ meta.comment.perl meta.interpolation.perl source.sql.embedded.perl source.sql
+#^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.perl source.sql.embedded.perl
 =end
-# <- meta.comment.perl meta.interpolation.perl entity.name.tag.pod.perl
-#^^^ meta.comment.perl meta.interpolation.perl entity.name.tag.pod.perl
+# <- comment.block.documentation.perl entity.name.tag.pod.perl
+#^^^ comment.block.documentation.perl entity.name.tag.pod.perl
+
+# stray =cut tag
 
 =cut
-# <- meta.comment.perl comment.block.documentation.perl entity.name.tag.pod.perl
-#^^^ meta.comment.perl comment.block.documentation.perl entity.name.tag.pod.perl
+# <- comment.block.documentation.perl entity.name.tag.pod.perl
+#^^^ comment.block.documentation.perl entity.name.tag.pod.perl
 
 ###[ FORMAT ]#################################################################
 
@@ -869,7 +904,7 @@ HTML
 # <- meta.string.heredoc.perl text.html.embedded.perl
 #^^^^^^^^^ meta.string.heredoc.perl text.html.embedded.perl
    HTML
-#  ^^^^ meta.string.heredoc.perl text.html.embedded.perl - constant.other.language-name.html.perl
+#  ^^^^ meta.string.heredoc.perl text.html.embedded.perl - constant.other.language-name.perl
 HTML
 # <- meta.string.heredoc.perl entity.name.tag.heredoc.html.perl
 #^^^ meta.string.heredoc.perl entity.name.tag.heredoc.html.perl


### PR DESCRIPTION
Fixes #4211 

This commit...

1. restructures POD related contexts and patterns to fix a wrong assumption of them needing to be wrapped into =pod and =cut tags.

   Instead any =<name> tag starts a new paragraph.

2. removes `meta.comment` scope

3. removes `meta.interpolation` scope for highlighted code blocks, as this is just not what they are.