### PR TITLE
[Markdown] Add TOML to fenced code block

### DIFF
--- a/Markdown/Code Block Syntaxes.sublime-completions
+++ b/Markdown/Code Block Syntaxes.sublime-completions
@@ -656,6 +656,14 @@
 			"details": "Specifies <code>SQL</code> code highlighting"
 		},
 
+		// TOML
+		{
+			"trigger": "toml",
+			"annotation": "TOML",
+			"kind": ["markup", "s", "Syntax"],
+			"details": "Specifies <code>TOML</code> code highlighting"
+		},
+
 		// XML
 		{
 			"trigger": "atom",

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -1142,6 +1142,7 @@ contexts:
     - include: fenced-scala
     - include: fenced-shell
     - include: fenced-sql
+    - include: fenced-toml
     - include: fenced-tsx
     - include: fenced-typescript
     - include: fenced-xml
@@ -2000,6 +2001,28 @@ contexts:
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.sql.markdown-gfm
+        1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
+
+  fenced-toml:
+    - match: |-
+         (?x)
+          {{fenced_code_block_start}}
+          (?i:\s*(toml))
+          {{fenced_code_block_trailing_infostring_characters}}
+      captures:
+        0: meta.code-fence.definition.begin.toml.markdown-gfm
+        2: punctuation.definition.raw.code-fence.begin.markdown
+        5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
+      embed: scope:source.toml
+      embed_scope:
+        markup.raw.code-fence.toml.markdown-gfm
+        source.toml
+      escape: '{{fenced_code_block_escape}}'
+      escape_captures:
+        0: meta.code-fence.definition.end.toml.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 

--- a/Markdown/tests/syntax_test_markdown.md
+++ b/Markdown/tests/syntax_test_markdown.md
@@ -2153,6 +2153,20 @@ FROM TableName
 |^^ meta.code-fence.definition.end.sql.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 |  ^ meta.code-fence.definition.end.sql.markdown-gfm meta.fold.code-fence.end - punctuation
 
+```toml
+| <- meta.code-fence.definition.begin.toml.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^^^^^^ meta.code-fence.definition.begin.toml.markdown-gfm
+|^^ punctuation.definition.raw.code-fence.begin.markdown
+|  ^^^^ constant.other.language-name.markdown
+[section.name]
+|^^^^^^^^^^^^^ markup.raw.code-fence.toml.markdown-gfm source.toml meta.section.toml meta.brackets.toml
+|^^^^^^^^^^^^ entity.name.section.toml
+|       ^ punctuation.accessor.dot.toml
+|            ^ punctuation.section.brackets.end.toml
+```
+| <- meta.code-fence.definition.end.toml.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.toml.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
 ```ts
 declare type foo = 'bar'
 | <- markup.raw.code-fence.typescript.markdown-gfm source.ts


### PR DESCRIPTION
This commit adds syntax highlighting support for TOML within Markdown fenced code blocks.