### PR TITLE
[Markdown] Add support for TOML frontmatter

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -344,6 +344,16 @@ contexts:
       escape_captures:
         0: meta.frontmatter.markdown
         1: punctuation.section.frontmatter.end.markdown
+    - match: (\+{3})\s*\n
+      captures:
+        0: meta.frontmatter.markdown
+        1: punctuation.section.block.begin.frontmatter.markdown
+      embed: scope:source.toml
+      embed_scope: meta.frontmatter.markdown source.toml.embedded.markdown
+      escape: ^(\+{3})\s*\n
+      escape_captures:
+        0: meta.frontmatter.markdown
+        1: punctuation.section.block.end.frontmatter.markdown
 
   markdown:
     - include: indented-code-blocks


### PR DESCRIPTION
This commit adds support for TOML highlighted markdown frontmatter.

caused by: https://github.com/SublimeText-Markdown/MarkdownEditing/issues/736