### PR TITLE
[Python] Multi-line string extended regexp mode

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -2714,7 +2714,7 @@ contexts:
     - meta_content_scope: meta.string.python string.quoted.double.block.python source.regexp.python
     - include: triple-double-quoted-string-end
     - match: ''
-      push: scope:source.regexp.python#base-literal
+      push: scope:source.regexp.python#base-literal-extended
       with_prototype:
         - include: triple-double-quoted-string-pop
         - include: triple-double-quoted-raw-b-string-content
@@ -2754,7 +2754,7 @@ contexts:
     - meta_content_scope: meta.string.python string.quoted.double.block.python source.regexp.python
     - include: triple-double-quoted-string-end
     - match: ''
-      push: scope:source.regexp.python#base-literal
+      push: scope:source.regexp.python#base-literal-extended
       with_prototype:
         - include: triple-double-quoted-string-pop
         - include: triple-double-quoted-raw-f-string-content
@@ -2807,7 +2807,7 @@ contexts:
     - meta_content_scope: meta.string.python string.quoted.double.block.python source.regexp.python
     - include: triple-double-quoted-string-end
     - match: ''
-      push: scope:source.regexp.python#base-literal
+      push: scope:source.regexp.python#base-literal-extended
       with_prototype:
         - include: triple-double-quoted-string-pop
         - include: triple-double-quoted-regexp-raw-u-string-content
@@ -3398,7 +3398,7 @@ contexts:
     - meta_content_scope: meta.string.python string.quoted.single.block.python source.regexp.python
     - include: triple-single-quoted-string-end
     - match: ''
-      push: scope:source.regexp.python#base-literal
+      push: scope:source.regexp.python#base-literal-extended
       with_prototype:
         - include: triple-single-quoted-string-pop
         - include: triple-single-quoted-raw-b-string-content
@@ -3438,7 +3438,7 @@ contexts:
     - meta_content_scope: meta.string.python string.quoted.single.block.python source.regexp.python
     - include: triple-single-quoted-string-end
     - match: ''
-      push: scope:source.regexp.python#base-literal
+      push: scope:source.regexp.python#base-literal-extended
       with_prototype:
         - include: triple-single-quoted-string-pop
         - include: triple-single-quoted-raw-f-string-content
@@ -3490,7 +3490,7 @@ contexts:
     - meta_content_scope: meta.string.python string.quoted.single.block.python source.regexp.python
     - include: triple-single-quoted-string-end
     - match: ''
-      push: scope:source.regexp.python#base-literal
+      push: scope:source.regexp.python#base-literal-extended
       with_prototype:
         - include: triple-single-quoted-string-pop
         - include: triple-single-quoted-regexp-raw-u-string-content

--- a/Python/tests/syntax_test_python_strings.py
+++ b/Python/tests/syntax_test_python_strings.py
@@ -153,12 +153,32 @@ regex = r'(?P<Quote>[\'"]).*?\g<Quote>'
 #                               ^^^^^ variable.other.backref-and-recursion.regexp - invalid
 
 regex = r'''\b ([fobar]*){1}(?:a|b)?'''
-#           ^ keyword.control.anchor.regexp
-#                         ^ keyword.operator.quantifier.regexp
+#           ^^^^^^^^^^^^^^^^^^^^^^^^ meta.mode.extended.regexp
+#           ^^ keyword.control.anchor.regexp
+#                        ^^^ keyword.operator.quantifier.regexp
+#                                  ^ keyword.operator.quantifier.regexp
+
+regex = r'''
+    \b ([fobar]*){1} (?: a | b )?
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mode.extended.regexp
+#   ^^ keyword.control.anchor.regexp
+#                ^^^ keyword.operator.quantifier.regexp
+#                               ^ keyword.operator.quantifier.regexp
+'''
 
 regex = r"""\b ([fobar]*){1}(?:a|b)?"""
-#           ^ keyword.control.anchor.regexp
-#                         ^ keyword.operator.quantifier.regexp
+#           ^^^^^^^^^^^^^^^^^^^^^^^^ meta.mode.extended.regexp
+#           ^^ keyword.control.anchor.regexp
+#                        ^^^ keyword.operator.quantifier.regexp
+#                                  ^ keyword.operator.quantifier.regexp
+
+regex = r"""
+    \b ([fobar]*){1} (?: a | b )?
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mode.extended.regexp
+#   ^^ keyword.control.anchor.regexp
+#                ^^^ keyword.operator.quantifier.regexp
+#                               ^ keyword.operator.quantifier.regexp
+"""
 
 # Capital R prevents all syntax embedding
 regex = R'\b ([fobar]*){1}(?:a|b)?'
@@ -1732,8 +1752,10 @@ fr"""
 # ^^^^ meta.string.python string.quoted.double.block.python
 # ^^^ punctuation.definition.string.begin.python
 #    ^ - punctuation - invalid
+#     ^ meta.mode.extended.regexp
 
     {var}? {var}* {var}{2,3} [{foo}-{bar}]+
+# <- meta.mode.extended.regexp
 # ^^ meta.string.python string.quoted
 #   ^^^^^ meta.string.python meta.interpolation.python - string
 #        ^^ meta.string.python string.quoted
@@ -1760,8 +1782,10 @@ fr'''
 # ^^^^ meta.string.python string.quoted.single.block.python
 # ^^^ punctuation.definition.string.begin.python
 #    ^ - punctuation - invalid
+#     ^ meta.mode.extended.regexp
 
     {var}? {var}* {var}{2,3} [{foo}-{bar}]+
+# <- meta.mode.extended.regexp
 # ^^ meta.string.python string.quoted
 #   ^^^^^ meta.string.python meta.interpolation.python - string
 #        ^^ meta.string.python string.quoted


### PR DESCRIPTION
This PR modifies raw triple-quoted string related contexts to automatically use/include regular expressions with extended mode enabled.

It assumes triple-quoted (multi-line) strings mainly containing sophisticated patterns used in conjunction with `re.X` flag.

_Notes:_

This PR follows a simpler proposal to handle all triple-quoted strings the same to avoid adding too much complexity.

Another smart proposal to only enable extended mode, if patterns start at the line after opening triple quotes, adds a reasonable amount of extra complexity, while probably not increasing chance to guess right mode enough. Patterns could still start right after opening quotes but still span multiple lines, being targeted for use with `re.X` as well. It would require another lookahead to check for closing quotes on same line, but that's finally a bit too much.

fixes https://discord.com/channels/280102180189634562/280157083356233728/1363092527925690451