### PR TITLE
[Common] Scope `in` iteration

### DIFF
--- a/ASP/ASP.sublime-syntax
+++ b/ASP/ASP.sublime-syntax
@@ -663,7 +663,7 @@ contexts:
   control_flow_foreach_in:
     - meta_scope: meta.for.block.asp
     - match: '\b(?i:In){{whitespace_or_end_of_statement}}'
-      scope: keyword.control.flow.asp
+      scope: keyword.operator.iteration.in.asp
       set: [inside_control_flow_for, expression_until_end_of_statement]
 
   control_flow_forto:

--- a/ASP/syntax_test_asp.asp
+++ b/ASP/syntax_test_asp.asp
@@ -878,7 +878,7 @@
    '<- - meta.between-if-and-then.asp
    '^^^^^^^^ keyword.control.flow.asp
    '         ^^^^^^ variable.other.asp
-   '                ^^ keyword.control.flow.asp
+   '                ^^ keyword.operator.iteration.in.asp
    '                                  ^ meta.for.block.asp
         Response.Write(vbCrLf & cookie)
        '^^^^^^^^ support.class.asp
@@ -1231,7 +1231,7 @@ test = "hello%>
 <%
         for each item in list
        '^^^^^^^^ text.html.asp source.asp.embedded.html meta.method.asp meta.method.body.asp meta.for.block.asp keyword.control.flow.asp
-       '              ^^ text.html.asp source.asp.embedded.html meta.method.asp meta.method.body.asp meta.for.block.asp keyword.control.flow.asp
+       '              ^^ text.html.asp source.asp.embedded.html meta.method.asp meta.method.body.asp meta.for.block.asp keyword.operator.iteration.in.asp
             %><li><%= item %></li><%
                     '^^^^^^ text.html.asp source.asp.embedded.html meta.method.asp meta.method.body.asp meta.for.block.asp
            '  ^ punctuation.definition.tag.begin.html

--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -474,7 +474,7 @@ contexts:
 
   ctl-for-in:
     - match: (?i:in){{keyword_break}}
-      scope: keyword.operator.logical.dosbatch
+      scope: keyword.operator.iteration.in.dosbatch
       pop: 1
     - include: else-pop
 

--- a/Batch File/tests/syntax_test_batch_file.bat
+++ b/Batch File/tests/syntax_test_batch_file.bat
@@ -1946,7 +1946,7 @@ is a #@$虎" strange label
 :: ^^^ keyword.control.loop.for.dosbatch
 ::     ^^ punctuation.definition.variable.dosbatch
 ::     ^^^ variable.other.readwrite.dosbatch
-::         ^^ keyword.operator.logical.dosbatch
+::         ^^ keyword.operator.iteration.in.dosbatch
 ::            ^ punctuation.section.set.begin.dosbatch
 ::             ^ meta.number.integer.decimal.dosbatch constant.numeric.value.dosbatch
 ::              ^ punctuation.separator.comma.dosbatch
@@ -1962,7 +1962,7 @@ is a #@$虎" strange label
 ::        ^^ variable.parameter.option.recursive.dosbatch
 ::           ^^ punctuation.definition.variable.dosbatch
 ::           ^^^ variable.other.readwrite.dosbatch
-::               ^^ keyword.operator.logical.dosbatch
+::               ^^ keyword.operator.iteration.in.dosbatch
 ::                  ^ punctuation.section.set.begin.dosbatch
 ::                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.set.dosbatch
 ::                          ^ punctuation.separator.comma.dosbatch
@@ -1982,7 +1982,7 @@ is a #@$虎" strange label
 ::    ^^ variable.parameter.option.recursive.dosbatch
 ::       ^^ punctuation.definition.variable.dosbatch
 ::       ^^^ variable.other.readwrite.dosbatch
-::           ^^ keyword.operator.logical.dosbatch
+::           ^^ keyword.operator.iteration.in.dosbatch
 ::              ^ punctuation.section.set.begin.dosbatch
 ::              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.set.dosbatch
 ::                      ^ punctuation.separator.comma.dosbatch
@@ -1996,7 +1996,7 @@ is a #@$虎" strange label
    %%f IN (folder1, ..\folder2, C:\folder) DO command
 :: ^^ punctuation.definition.variable.dosbatch
 :: ^^^ variable.other.readwrite.dosbatch
-::     ^^ keyword.operator.logical.dosbatch
+::     ^^ keyword.operator.iteration.in.dosbatch
 ::        ^ punctuation.section.set.begin.dosbatch
 ::        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.set.dosbatch
 ::                ^ punctuation.separator.comma.dosbatch
@@ -2009,7 +2009,7 @@ is a #@$虎" strange label
    /D /r ^
    %%f ^
    IN (folder1, ..\folder2, C:\folder) DO command
-:: ^^ keyword.operator.logical.dosbatch
+:: ^^ keyword.operator.iteration.in.dosbatch
 ::    ^ punctuation.section.set.begin.dosbatch
 ::    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.set.dosbatch
 ::            ^ punctuation.separator.comma.dosbatch
@@ -2062,7 +2062,7 @@ is a #@$虎" strange label
 ::                 ^ punctuation.definition.string.end.dosbatch
 ::                   ^^ punctuation.definition.variable.dosbatch
 ::                   ^^^ variable.other.readwrite.dosbatch
-::                       ^^ keyword.operator.logical.dosbatch
+::                       ^^ keyword.operator.iteration.in.dosbatch
 ::                          ^ punctuation.section.set.begin.dosbatch
 ::                          ^ meta.set.dosbatch punctuation.section.set.begin.dosbatch - meta.embedded
 ::                           ^ punctuation.section.embedded.begin.dosbatch
@@ -2089,7 +2089,7 @@ is a #@$虎" strange label
 ::     ^ punctuation.definition.variable.dosbatch
 ::     ^^ variable.parameter.option.range.dosbatch
 ::        ^^ invalid.illegal.variable.dosbatch
-::           ^^ keyword.operator.logical.dosbatch
+::           ^^ keyword.operator.iteration.in.dosbatch
 ::              ^ punctuation.section.set.begin.dosbatch
 ::              ^^^^^^^^^ meta.set.dosbatch
 ::               ^ meta.number.integer.decimal.dosbatch constant.numeric.value.dosbatch
@@ -2107,7 +2107,7 @@ is a #@$虎" strange label
 ::     ^^ variable.parameter.option.recursive.dosbatch
 ::        ^^^^^^^^^^^^^^^^^^^^ string.unquoted.dosbatch
 ::                             ^^^^^ invalid.illegal.variable.dosbatch
-::                                   ^^ keyword.operator.logical.dosbatch
+::                                   ^^ keyword.operator.iteration.in.dosbatch
 
    FOR /R C:\dir name\file name.ext %%f IN (.) DO command
 :: ^^^ keyword.control.loop.for.dosbatch
@@ -2118,7 +2118,7 @@ is a #@$虎" strange label
 ::                         ^^^^^^^^ invalid.illegal.variable.dosbatch
 ::                                  ^^ punctuation.definition.variable.dosbatch
 ::                                  ^^^ variable.other.readwrite.dosbatch
-::                                      ^^ keyword.operator.logical.dosbatch
+::                                      ^^ keyword.operator.iteration.in.dosbatch
 
    FOR /R 'C:\dir name\file name.ext' %%f IN (*.ext) DO command
 :: ^^^ keyword.control.loop.for.dosbatch
@@ -2129,7 +2129,7 @@ is a #@$虎" strange label
 ::                          ^^^^^^^^^ invalid.illegal.variable.dosbatch
 ::                                    ^^ punctuation.definition.variable.dosbatch
 ::                                    ^^^ variable.other.readwrite.dosbatch
-::                                        ^^ keyword.operator.logical.dosbatch
+::                                        ^^ keyword.operator.iteration.in.dosbatch
 
    FOR /R "C:\dir name\file-name.ext" %%f IN (set) DO command
 :: ^^^ keyword.control.loop.for.dosbatch
@@ -2140,12 +2140,12 @@ is a #@$虎" strange label
 ::                                  ^ punctuation.definition.string.end.dosbatch
 ::                                    ^^ punctuation.definition.variable.dosbatch
 ::                                    ^^^ variable.other.readwrite.dosbatch
-::                                        ^^ keyword.operator.logical.dosbatch
+::                                        ^^ keyword.operator.iteration.in.dosbatch
 
    FOR /Z %%f IN (foo & bar | < baz > && no || false) DO command
 ::     ^^ invalid.illegal.parameter.dosbatch
 ::        ^^^ variable.other.readwrite.dosbatch
-::            ^^ keyword.operator.logical.dosbatch
+::            ^^ keyword.operator.iteration.in.dosbatch
 ::                    ^ invalid.illegal.operator.dosbatch
 ::                          ^ invalid.illegal.operator.dosbatch
 ::                            ^ invalid.illegal.operator.dosbatch
@@ -2156,7 +2156,7 @@ is a #@$虎" strange label
    for %%i in (1, 2,  3) do (
       for %%j in (%%i) do (
 ::        ^^^ variable.other.readwrite.dosbatch
-::            ^^ keyword.operator.logical.dosbatch
+::            ^^ keyword.operator.iteration.in.dosbatch
 ::               ^ punctuation.section.set.begin.dosbatch
 ::                ^^^  string.unquoted.dosbatch
 ::                ^^ constant.character.escape.dosbatch

--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -2295,8 +2295,8 @@ contexts:
       pop: true
 
   foreach_var_assignment:
-    - match: '\b(in)\b'
-      scope: keyword.control.flow.cs
+    - match: \bin\b
+      scope: keyword.operator.iteration.in.cs
       set: line_of_code_in
     - match: (?=\)|\})
       pop: true

--- a/C#/tests/syntax_test_C#7.cs
+++ b/C#/tests/syntax_test_C#7.cs
@@ -494,7 +494,7 @@ class Foo {
 ///                       ^ punctuation.separator.sequence
 ///                         ^^^ variable.other
 ///                            ^ punctuation.section.sequence.end
-///                              ^^ keyword.control.flow
+///                              ^^ keyword.operator.iteration.in.cs
         {
             Console.WriteLine($"{name} is {age} years old.");
         }
@@ -509,7 +509,7 @@ class Foo {
 ///                   ^ punctuation.separator.sequence
 ///                     ^ variable.other
 ///                      ^ punctuation.section.sequence.end
-///                        ^^ keyword.control.flow
+///                        ^^ keyword.operator.iteration.in.cs
 ///                           ^^^^^^^^^ variable.other
 ///                                    ^ punctuation.section.group.end
         {
@@ -527,7 +527,7 @@ class Foo {
 ///                      ^^^ support.type
 ///                          ^ variable.other
 ///                           ^ punctuation.section.sequence.end
-///                             ^^ keyword.control.flow
+///                             ^^ keyword.operator.iteration.in.cs
 ///                                ^^^^^^^^^ variable.other
 ///                                         ^ punctuation.section.group.end
         ; // empty statement

--- a/C#/tests/syntax_test_GeneralStructure.cs
+++ b/C#/tests/syntax_test_GeneralStructure.cs
@@ -291,7 +291,7 @@ namespace TestNamespace . Test
 ///                 ^ punctuation.section.group.begin
 ///                  ^^^ storage.type
 ///                      ^^^^ variable.other
-///                           ^^ keyword.control.flow
+///                           ^^ keyword.operator.iteration.in.cs
 ///                              ^^^^^^^^^^ variable.other
 ///                                        ^ punctuation.section.group.end
             {}

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1540,7 +1540,7 @@ contexts:
       scope: invalid.illegal.missing-in.python
       pop: 1
     - match: in\b
-      scope: keyword.control.loop.for.in.python
+      scope: keyword.operator.iteration.in.python
       set: for-statement-in
     - include: line-continuation-or-pop
     - include: expression-in-a-statement
@@ -1772,7 +1772,7 @@ contexts:
   for-expression-target-list:
     - meta_scope: meta.expression.generator.python
     - match: in\b
-      scope: keyword.control.loop.for.in.python
+      scope: keyword.operator.iteration.in.python
       pop: 1
     - match: (?=[)\]}])
       pop: 1

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -911,7 +911,7 @@ def _():
     for
 #   ^^^ keyword.control.loop.for
     b = c in d
-#         ^^ keyword.operator.logical - keyword.control.loop.for.in
+#         ^^ keyword.operator.logical - keyword.operator.iteration.in
 
     for \
         a \
@@ -924,7 +924,7 @@ def _():
 #   ^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.loop.for
 #   ^^^^^ storage.modifier.async
 #         ^^^ keyword.control.loop.for
-#               ^^ keyword.control.loop.for.in
+#               ^^ keyword.operator.iteration.in
 #                          ^ punctuation.section.block.loop.for
         pass
 
@@ -2536,7 +2536,7 @@ class Class():
 #     ^ meta.generic-name.python
 #       ^^^ keyword.control.loop.for.generator.python
 #           ^ meta.generic-name.python
-#             ^^ keyword.control.loop.for.in.python
+#             ^^ keyword.operator.iteration.in.python
 #                ^^^^^^^ meta.function-call.identifier.python variable.function.python
 #                       ^^ meta.function-call.arguments.python
 #                         ^ punctuation.section.sequence.end.python
@@ -2552,7 +2552,7 @@ class Class():
 #     ^ meta.generic-name.python
 #       ^^^ keyword.control.loop.for.generator.python
 #           ^ meta.generic-name.python
-#             ^^ keyword.control.loop.for.in.python
+#             ^^ keyword.operator.iteration.in.python
 #                ^^^^^^^ meta.function-call.identifier.python variable.function.python
 #                       ^^ meta.function-call.arguments.python
 #                         ^ punctuation.section.sequence.end.python
@@ -2730,24 +2730,24 @@ generator = (i for i in range(100))
 #           ^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence.generator.python
 #              ^^^^^^^^ meta.expression.generator
 #              ^^^ keyword.control.loop.for.generator
-#                    ^^ keyword.control.loop.for.in
+#                    ^^ keyword.operator.iteration.in
 list_ = [i for i in range(100)]
 #       ^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence
 #          ^^^^^^^^ meta.expression.generator
 #          ^^^ keyword.control.loop.for.generator
-#                ^^ keyword.control.loop.for.in
+#                ^^ keyword.operator.iteration.in
 set_ = {i for i in range(100)}
 #      ^^^^^^^^^^^^^^^^^^^^^^^ meta.set
 #         ^^^^^^^^ meta.expression.generator
 #         ^^^ keyword.control.loop.for.generator
-#               ^^ keyword.control.loop.for.in
+#               ^^ keyword.operator.iteration.in
 set_ = {x * x for x in y}
 #      ^^^^^^^^^^^^^^^^^^ meta.set
 #             ^^^^^^^^ meta.expression.generator
 #      ^ punctuation.section.set.begin
 #         ^ keyword.operator.arithmetic
 #             ^^^ keyword.control.loop.for.generator
-#                   ^^ keyword.control.loop.for.in
+#                   ^^ keyword.operator.iteration.in
 #                       ^ punctuation.section.set.end
 set_ = {x ** 2 for x in y}
 #      ^^^^^^^^^^^^^^^^^^ meta.set
@@ -2755,7 +2755,7 @@ set_ = {x ** 2 for x in y}
 #      ^ punctuation.section.set.begin
 #         ^^ keyword.operator.arithmetic
 #              ^^^ keyword.control.loop.for.generator
-#                    ^^ keyword.control.loop.for.in
+#                    ^^ keyword.operator.iteration.in
 #                        ^ punctuation.section.set.end
 dict_ = {i: i for i in range(100)}
 #       ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping - meta.mapping meta.mapping
@@ -2766,7 +2766,7 @@ dict_ = {i: i for i in range(100)}
 #            ^^^^^^^^^^^^^^^^^^^^^ meta.mapping.python
 #             ^^^^^^^^ meta.expression.generator
 #             ^^^ keyword.control.loop.for.generator
-#                   ^^ keyword.control.loop.for.in
+#                   ^^ keyword.operator.iteration.in
 dict_ = {x * x: 1 for x in y}
 #       ^ meta.mapping.python
 #        ^^^^^ meta.mapping.key.python
@@ -2777,7 +2777,7 @@ dict_ = {x * x: 1 for x in y}
 #          ^ keyword.operator.arithmetic
 #             ^ punctuation.separator.key-value
 #                 ^^^ keyword.control.loop.for.generator
-#                       ^^ keyword.control.loop.for.in
+#                       ^^ keyword.operator.iteration.in
 #                           ^ punctuation.section.mapping.end
 dict_ = {x ** 2: 1 for x in y}
 #       ^ meta.mapping.python
@@ -2789,7 +2789,7 @@ dict_ = {x ** 2: 1 for x in y}
 #          ^^ keyword.operator.arithmetic
 #              ^ punctuation.separator.key-value
 #                  ^^^ keyword.control.loop.for.generator
-#                        ^^ keyword.control.loop.for.in
+#                        ^^ keyword.operator.iteration.in
 #                            ^ punctuation.section.mapping.end
 list_ = [i for i in range(100) if i > 0 else -1]
 #       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence
@@ -2799,7 +2799,7 @@ list_ = [i for i in range(100) if i > 0 else -1]
 
 list2_ = [i in range(10) for i in range(100) if i in range(5, 15)]
 #           ^^ keyword.operator.logical
-#                              ^^ keyword.control.loop.for.in
+#                              ^^ keyword.operator.iteration.in
 #                                                 ^^ keyword.operator.logical
 
 generator = ((k1, k2, v) for ((k1, k2), v) in xs)
@@ -2863,7 +2863,7 @@ unpack_ = [*(_ for [[][:], *_] in [((1, 2), "woops")])]
 #                          ^ keyword.operator.unpacking.sequence.python
 #                           ^ meta.path.python variable.language.anonymous.python
 #                            ^ punctuation.section.sequence.end.python
-#                              ^^ keyword.control.loop.for.in.python
+#                              ^^ keyword.operator.iteration.in.python
 #                                 ^ punctuation.section.sequence.begin.python
 #                                  ^ punctuation.section.sequence.begin.python
 #                                   ^ punctuation.section.sequence.begin.python
@@ -2891,7 +2891,7 @@ list_ = [lambda: 1 for i in range(10)]
 #                ^ constant.numeric.value.python
 #                  ^^^ keyword.control.loop.for.generator.python
 #                      ^ meta.generic-name.python
-#                        ^^ keyword.control.loop.for.in.python
+#                        ^^ keyword.operator.iteration.in.python
 #                           ^^^^^ support.function.builtin.python
 #                                ^ punctuation.section.arguments.begin.python
 #                                 ^^ constant.numeric.value.python
@@ -2911,7 +2911,7 @@ generator_ = (lambda: 1 for i in range(10))
 #                     ^ constant.numeric.value.python
 #                       ^^^ keyword.control.loop.for.generator.python
 #                           ^ meta.generic-name.python
-#                             ^^ keyword.control.loop.for.in.python
+#                             ^^ keyword.operator.iteration.in.python
 #                                ^^^^^ support.function.builtin.python
 #                                     ^ punctuation.section.arguments.begin.python
 #                                      ^^ constant.numeric.value.python
@@ -2931,7 +2931,7 @@ set_ = {lambda: 1 for i in range(10)}
 #               ^ constant.numeric.value.python
 #                 ^^^ keyword.control.loop.for.generator.python
 #                     ^ meta.generic-name.python
-#                       ^^ keyword.control.loop.for.in.python
+#                       ^^ keyword.operator.iteration.in.python
 #                          ^^^^^ support.function.builtin.python
 #                               ^ punctuation.section.arguments.begin.python
 #                                ^^ constant.numeric.value.python
@@ -2951,10 +2951,10 @@ list((i for i in generator), 123)
 _ = [m
      for cls in self.__class__.mro()
 #    ^^^ keyword.control.loop.for.generator
-#            ^^ keyword.control.loop.for.in
+#            ^^ keyword.operator.iteration.in
      for m in cls.__dict__]
 #    ^^^ keyword.control.loop.for.generator
-#          ^^ keyword.control.loop.for.in
+#          ^^ keyword.operator.iteration.in
 
 result = [i async for i in aiter() if i % 2]
 #           ^^^^^ storage.modifier.async
@@ -3031,7 +3031,7 @@ generator = (
 #   ^^^ keyword.control.loop.for.generator
     i
     in
-#   ^^ keyword.control.loop.for.in
+#   ^^ keyword.operator.iteration.in
     range(100)
 )
 

--- a/R/R.sublime-syntax
+++ b/R/R.sublime-syntax
@@ -208,7 +208,7 @@ contexts:
     - match: \bwhile\b(?=\s*\()
       scope: keyword.control.loop.while.r
     - match: \bin\b
-      scope: keyword.operator.word.r
+      scope: keyword.operator.interation.in.r
 
   accessor:
     - meta_include_prototype: false

--- a/R/syntax_test_r.R
+++ b/R/syntax_test_r.R
@@ -398,7 +398,7 @@ if (1) {} else {return()}
 for (i in 1:10) {
 # <- keyword.control.loop.for.r
 #   ^ punctuation.section.parens.begin.r
-#      ^^ keyword.operator.word.r
+#      ^^ keyword.operator.interation.in.r
 #             ^ punctuation.section.parens.end.r
 #               ^ punctuation.section.braces.begin.r
 }

--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -561,7 +561,7 @@ contexts:
       scope: keyword.operator.logical.ruby
       push: after-keyword
     - match: \bin\b(?![?!])
-      scope: keyword.operator.logical.ruby
+      scope: keyword.operator.iteration.in.ruby
       push: after-keyword
     # other functions
     - match: \b(?:BEGIN|END)\b(?![?!])

--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -529,7 +529,7 @@ contexts:
     # loop
     - match: \bfor\b(?![?!])
       scope: keyword.control.loop.for.ruby
-      push: after-keyword
+      push: for-variable
     - match: \buntil\b(?![?!])
       scope: keyword.control.loop.until.ruby
       push: after-keyword
@@ -561,7 +561,7 @@ contexts:
       scope: keyword.operator.logical.ruby
       push: after-keyword
     - match: \bin\b(?![?!])
-      scope: keyword.operator.iteration.in.ruby
+      scope: keyword.operator.logical.ruby
       push: after-keyword
     # other functions
     - match: \b(?:BEGIN|END)\b(?![?!])
@@ -572,6 +572,14 @@ contexts:
     - match: \bsuper\b(?![?!])
       scope: support.function.builtin.ruby
       push: after-keyword
+
+  for-variable:
+    # note: variables are not scoped, currently
+    - match: \bin\b
+      scope: keyword.operator.iteration.in.ruby
+      set: after-keyword
+    - match: (?=(?:end|do)\b(?![?!]))|$
+      pop: true
 
   operators:
     - match: '>>'

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -1579,6 +1579,39 @@ rule /`/ do
 #        ^^ keyword.control.block.do
 end
 
+case 1
+#^^^ keyword.control.conditional.case.ruby
+#    ^ meta.number.integer.decimal.ruby constant.numeric.value.ruby
+  in 0..10
+# ^^ keyword.operator.iteration.in.ruby
+#    ^ meta.number.integer.decimal.ruby constant.numeric.value.ruby
+#     ^^ keyword.operator.range.ruby
+#       ^^ meta.number.integer.decimal.ruby constant.numeric.value.ruby
+    true
+  else
+# ^^^^ keyword.control.conditional.if.ruby
+    false
+end
+#^^ keyword.control.block.end.ruby
+
+for i in 0..10 do
+#^^ keyword.control.loop.for.ruby
+#     ^^ keyword.operator.iteration.in.ruby
+#        ^ meta.number.integer.decimal.ruby constant.numeric.value.ruby
+#         ^^ keyword.operator.range.ruby
+#           ^^ meta.number.integer.decimal.ruby constant.numeric.value.ruby
+#              ^^ keyword.control.block.do.ruby
+end
+#^^ keyword.control.block.end.ruby
+
+while item in items do
+#^^^^ keyword.control.loop.while.ruby
+#          ^^ keyword.operator.iteration.in.ruby
+#                   ^^ keyword.control.block.do.ruby
+end
+#^^ keyword.control.block.end.ruby
+
+
 ##################
 # Crazy Stuff Found Online™
 ##################

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -1583,7 +1583,7 @@ case 1
 #^^^ keyword.control.conditional.case.ruby
 #    ^ meta.number.integer.decimal.ruby constant.numeric.value.ruby
   in 0..10
-# ^^ keyword.operator.iteration.in.ruby
+# ^^ keyword.operator.logical.ruby
 #    ^ meta.number.integer.decimal.ruby constant.numeric.value.ruby
 #     ^^ keyword.operator.range.ruby
 #       ^^ meta.number.integer.decimal.ruby constant.numeric.value.ruby
@@ -1594,23 +1594,39 @@ case 1
 end
 #^^ keyword.control.block.end.ruby
 
-for i in 0..10 do
+for do
 #^^ keyword.control.loop.for.ruby
-#     ^^ keyword.operator.iteration.in.ruby
-#        ^ meta.number.integer.decimal.ruby constant.numeric.value.ruby
-#         ^^ keyword.operator.range.ruby
-#           ^^ meta.number.integer.decimal.ruby constant.numeric.value.ruby
-#              ^^ keyword.control.block.do.ruby
+#   ^^ keyword.control.block.do.ruby
+end
+#^^ keyword.control.block.end.ruby
+
+for item in items do
+#^^ keyword.control.loop.for.ruby
+#        ^^ keyword.operator.iteration.in.ruby
+#                 ^^ keyword.control.block.do.ruby
+end
+#^^ keyword.control.block.end.ruby
+
+unless item in items do
+#^^^^^ keyword.control.conditional.unless.ruby
+#           ^^ keyword.operator.logical.ruby
+#                    ^^ keyword.control.block.do.ruby
+end
+#^^ keyword.control.block.end.ruby
+
+until item in items do
+#^^^^ keyword.control.loop.until.ruby
+#          ^^ keyword.operator.logical.ruby
+#                   ^^ keyword.control.block.do.ruby
 end
 #^^ keyword.control.block.end.ruby
 
 while item in items do
 #^^^^ keyword.control.loop.while.ruby
-#          ^^ keyword.operator.iteration.in.ruby
+#          ^^ keyword.operator.logical.ruby
 #                   ^^ keyword.control.block.do.ruby
 end
 #^^ keyword.control.block.end.ruby
-
 
 ##################
 # Crazy Stuff Found Online™

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -1275,7 +1275,7 @@ contexts:
 
   loop-iterator-wordlist:
     - match: in{{cmd_break}}
-      scope: keyword.operator.iterator.in.shell
+      scope: keyword.operator.iteration.in.shell
       set: loop-iterator-wordlist-body
     - include: cmd-args-end
     - include: else-pop

--- a/ShellScript/Bash/tests/syntax_test_scope.bash
+++ b/ShellScript/Bash/tests/syntax_test_scope.bash
@@ -1058,7 +1058,7 @@ for in in in in
 #^^^^^^^^^^^^^^ meta.statement.loop.for.shell
 #^^ keyword.control.loop.for.shell
 #   ^^ variable.other.readwrite.shell - keyword
-#      ^^ keyword.operator.iterator.in.shell
+#      ^^ keyword.operator.iteration.in.shell
 #         ^^ meta.string.glob.shell string.unquoted.shell
 #            ^^ meta.string.glob.shell string.unquoted.shell
 
@@ -1095,7 +1095,7 @@ for x; do echo "${!x}"; done
 for i in for in do echo done; do echo $i; done;
 # <- meta.statement.loop.for.shell keyword.control.loop.for.shell
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.loop.for.shell
-#     ^^ keyword.operator.iterator.in.shell
+#     ^^ keyword.operator.iteration.in.shell
 #       ^ - meta.string
 #        ^^^ meta.string.glob.shell string.unquoted.shell
 #           ^ - meta.string
@@ -1118,7 +1118,7 @@ for i in { [ \( ; do echo $i; done;
 # <- meta.statement.loop.for.shell keyword.control.loop.for.shell
 #^^^^^^^^^^^^^^ meta.statement.loop.for.shell
 #   ^ variable.other.readwrite.shell
-#     ^^ keyword.operator.iterator.in.shell
+#     ^^ keyword.operator.iteration.in.shell
 #       ^ - meta.string
 #        ^ meta.string.glob.shell string.unquoted.shell
 #         ^ - meta.string
@@ -1138,7 +1138,7 @@ for i in str1 $str2 "str3" 'str4' st$r5; do echo $i; done;
 # <- meta.statement.loop.for.shell keyword.control.loop.for.shell
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.loop.for.shell
 #   ^ variable.other.readwrite.shell
-#     ^^ keyword.operator.iterator.in.shell
+#     ^^ keyword.operator.iteration.in.shell
 #        ^^^^ meta.string.glob.shell string.unquoted.shell
 #             ^^^^^ meta.interpolation.parameter.shell variable.other.readwrite.shell
 #                   ^^^^^^ meta.string.glob.shell string.quoted.double.shell
@@ -1157,7 +1157,7 @@ for i in <files.txt; do echo $i; done;
 # <- meta.statement.loop.for.shell keyword.control.loop.for.shell
 #^^^^^^^^^^^^^^^^^^ meta.statement.loop.for.shell
 #   ^ variable.other.readwrite.shell
-#     ^^ keyword.operator.iterator.in.shell
+#     ^^ keyword.operator.iteration.in.shell
 #        ^ keyword.operator.assignment.redirection.shell
 #                  ^ punctuation.terminator.statement.shell
 #                    ^^ keyword.control.loop.do.shell
@@ -1173,7 +1173,7 @@ for i in {foo,bar,baz}; do echo $i; done;
 # <- meta.statement.loop.for.shell keyword.control.loop.for.shell
 #^^^^^^^^^^^^^^^^^^^^^ meta.statement.loop.for.shell
 #   ^ variable.other.readwrite.shell
-#     ^^ keyword.operator.iterator.in.shell
+#     ^^ keyword.operator.iteration.in.shell
 #        ^ meta.string.glob.shell meta.interpolation.brace.shell punctuation.section.interpolation.begin.shell - string
 #         ^^^ meta.string.glob.shell meta.interpolation.brace.shell meta.string.shell string.unquoted.shell
 #            ^ meta.string.glob.shell meta.interpolation.brace.shell punctuation.separator.sequence.shell - string
@@ -1187,7 +1187,7 @@ for i in for pre{foo,bar,baz}suf; do echo $i; done;
 # <- meta.statement.loop.for.shell keyword.control.loop.for.shell
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.loop.for.shell
 #   ^ variable.other.readwrite.shell
-#     ^^ keyword.operator.iterator.in.shell
+#     ^^ keyword.operator.iteration.in.shell
 #        ^^^ meta.string.glob.shell string.unquoted.shell
 #           ^ - meta.string
 #            ^^^ meta.string.glob.shell string.unquoted.shell - meta.interpolation
@@ -1205,7 +1205,7 @@ for i in {1..10}; do echo $i; done;
 # <- meta.statement.loop.for.shell keyword.control.loop.for.shell
 #^^^^^^^^^^^^^^^ meta.statement.loop.for.shell
 #   ^ variable.other.readwrite.shell
-#     ^^ keyword.operator.iterator.in.shell
+#     ^^ keyword.operator.iteration.in.shell
 #        ^^^^^^^ meta.interpolation.brace.shell
 #        ^ punctuation.section.interpolation.begin.shell
 #         ^ meta.number.integer.decimal.shell constant.numeric.value.shell
@@ -1225,7 +1225,7 @@ for i in {-10..+20}; do echo $i; done;
 # <- meta.statement.loop.for.shell keyword.control.loop.for.shell
 #^^^^^^^^^^^^^^^^^^ meta.statement.loop.for.shell
 #   ^ variable.other.readwrite.shell
-#     ^^ keyword.operator.iterator.in.shell
+#     ^^ keyword.operator.iteration.in.shell
 #        ^^^^^^^^^^ meta.interpolation.brace.shell
 #        ^ punctuation.section.interpolation.begin.shell
 #         ^ meta.number.integer.decimal.shell keyword.operator.arithmetic.shell
@@ -1247,7 +1247,7 @@ for i in {-10..+20..-4}; do echo $i; done;
 # <- meta.statement.loop.for.shell keyword.control.loop.for.shell
 #^^^^^^^^^^^^^^^^^^^^^^ meta.statement.loop.for.shell
 #   ^ variable.other.readwrite.shell
-#     ^^ keyword.operator.iterator.in.shell
+#     ^^ keyword.operator.iteration.in.shell
 #        ^^^^^^^^^^^^^^ meta.interpolation.brace.shell
 #        ^ punctuation.section.interpolation.begin.shell
 #         ^ meta.number.integer.decimal.shell keyword.operator.arithmetic.shell
@@ -1272,7 +1272,7 @@ for i in (foo bar baz); do echo $i; done;
 # <- meta.statement.loop.for.shell keyword.control.loop.for.shell
 #^^^^^^^^^^^^^^^^^^^^ meta.statement.loop.for.shell
 #   ^ variable.other.readwrite.shell
-#     ^^ keyword.operator.iterator.in.shell
+#     ^^ keyword.operator.iteration.in.shell
 #        ^ meta.statement.loop.for.shell invalid.illegal.unexpected-token.shell
 #         ^^^ meta.statement.loop.for.shell meta.string.glob.shell string.unquoted.shell
 #            ^ - meta.string
@@ -1291,7 +1291,7 @@ for domain in $domains; do echo $domain; done
 #^^^^^^^^^^^^^^^^^^^^^ meta.statement.loop.for.shell
 #^^ keyword.control.loop.for.shell
 #   ^^^^^^ variable.other.readwrite.shell - keyword
-#          ^^ keyword.operator.iterator.in.shell
+#          ^^ keyword.operator.iteration.in.shell
 #             ^^^^^^^^ variable.other.readwrite.shell
 #                     ^ punctuation.terminator.statement.shell
 #                       ^^ keyword.control.loop.do.shell
@@ -1306,7 +1306,7 @@ for i in $(seq 100); do
 #^^^^^^^^^^^^^^^^^^ meta.statement.loop.for.shell
 #^^ keyword.control.loop.for.shell
 #        ^^^^^^^^^^ meta.interpolation.command.shell
-#     ^^ keyword.operator.iterator.in.shell
+#     ^^ keyword.operator.iteration.in.shell
 #        ^ punctuation.definition.variable.shell
 #         ^ punctuation.section.interpolation.begin.shell
 #          ^^^ meta.function-call variable.function.shell
@@ -1329,7 +1329,7 @@ for \
 #<- meta.statement.loop.for.shell
 #^^^^^^^^^^^^^^^^^^^ meta.statement.loop.for.shell
 # ^^^ variable.other.readwrite.shell
-#     ^^ keyword.operator.iterator.in.shell
+#     ^^ keyword.operator.iteration.in.shell
 #        ^^^ meta.string.glob.shell string.unquoted.shell
 #            ^^^ meta.string.glob.shell string.unquoted.shell
 #                ^^^ meta.string.glob.shell string.unquoted.shell
@@ -1338,9 +1338,9 @@ for \
 for \
   var \
 in foo bar baz;
-#<- meta.statement.loop.for.shell keyword.operator.iterator.in.shell
+#<- meta.statement.loop.for.shell keyword.operator.iteration.in.shell
 #^^^^^^^^^^^^^ meta.statement.loop.for.shell
-#^ meta.statement.loop.for.shell keyword.operator.iterator.in.shell
+#^ meta.statement.loop.for.shell keyword.operator.iteration.in.shell
 #  ^^^ meta.string.glob.shell string.unquoted.shell
 #      ^^^ meta.string.glob.shell string.unquoted.shell
 #          ^^^ meta.string.glob.shell string.unquoted.shell
@@ -1354,7 +1354,7 @@ in foo bar baz;
 #                             ^^ meta.interpolation.command.shell meta.interpolation.parameter.shell variable.other.readwrite.shell - meta.statement.loop
 #                               ^^^^^^ meta.interpolation.command.shell - meta.statement.loop - meta.interpolation meta.interpolation
 #^^^ keyword.control.loop.for.shell
-#      ^^ keyword.operator.iterator.in.shell
+#      ^^ keyword.operator.iteration.in.shell
 #         ^ punctuation.definition.variable.shell
 #          ^ punctuation.section.interpolation.begin.shell
 #           ^^^ meta.function-call.identifier.shell variable.function.shell
@@ -1429,7 +1429,7 @@ select in in in select do done; do echo $in; done;
 #                             ^^ - meta.statement.loop - meta.sequence
 #^^^^^ keyword.control.loop.select.shell
 #      ^^ variable.other.readwrite.shell
-#         ^^ keyword.operator.iterator.in.shell
+#         ^^ keyword.operator.iteration.in.shell
 #           ^ - meta.string - string
 #            ^^ meta.string.glob.shell string.unquoted.shell
 #              ^ - meta.string - string
@@ -1454,7 +1454,7 @@ select \
 #          ^^^^^^^^^^^^^ meta.statement.loop.select.shell meta.sequence.list.shell meta.string.glob.shell
 #                       ^^ - meta.statement.loop - meta.sequence
 # ^^^^^ variable.other.readwrite.shell
-#       ^^ keyword.operator.iterator.in.shell
+#       ^^ keyword.operator.iteration.in.shell
 #          ^ meta.interpolation.tilde.shell variable.language.tilde.shell - string
 #           ^^^^^^^^^^^^ string.unquoted.shell
 #            ^^ constant.other.wildcard.asterisk.shell
@@ -1469,7 +1469,7 @@ select \
 #   ^ meta.statement.loop.select.shell meta.sequence.list.shell - meta.string
 #    ^^^^^^^^^^^^^ meta.statement.loop.select.shell meta.sequence.list.shell meta.string.glob.shell
 #                 ^^ - meta.statement.loop - meta.sequence
-# ^^ keyword.operator.iterator.in.shell
+# ^^ keyword.operator.iteration.in.shell
 #    ^ meta.interpolation.tilde.shell variable.language.tilde.shell - string
 #     ^^^^^^^^^^^^ string.unquoted.shell
 #      ^^ constant.other.wildcard.asterisk.shell
@@ -1493,7 +1493,7 @@ select \
 select fname in *;
 # <- keyword.control.loop.select.shell
 #^^^^^ keyword.control.loop.select.shell
-#            ^^ keyword.operator.iterator.in.shell
+#            ^^ keyword.operator.iteration.in.shell
 #               ^ meta.string.glob.shell string.unquoted.shell
 #                ^ punctuation.terminator.statement.shell
 do

--- a/ShellScript/Zsh/tests/syntax_test_scope.zsh
+++ b/ShellScript/Zsh/tests/syntax_test_scope.zsh
@@ -90,7 +90,7 @@ for name in word1 word2; do echo me; done
 # <- keyword.control.loop.for.shell
 #^^ keyword.control.loop.for.shell
 #   ^^^^ variable.other.readwrite.shell
-#        ^^ keyword.operator.iterator.in.shell
+#        ^^ keyword.operator.iteration.in.shell
 #           ^^^^^ meta.string.glob.shell string.unquoted.shell
 #                 ^^^^^ meta.string.glob.shell string.unquoted.shell
 #                      ^ punctuation.terminator.statement.shell
@@ -167,7 +167,7 @@ select name in word1 word2; do echo $name; done
 # <- keyword.control.loop.select.shell
 #^^^^^ keyword.control.loop.select.shell
 #      ^^^^ variable.other.readwrite.shell
-#           ^^ keyword.operator.iterator.in.shell
+#           ^^ keyword.operator.iteration.in.shell
 #              ^^^^^ meta.string.glob.shell string.unquoted.shell
 #                    ^^^^^ meta.string.glob.shell string.unquoted.shell
 #                         ^ punctuation.terminator.statement.shell
@@ -358,7 +358,7 @@ for name in word1 word2; echo me;
 # <- keyword.control.loop.for.shell
 #^^ keyword.control.loop.for.shell
 #   ^^^^ variable.other.readwrite.shell
-#        ^^ keyword.operator.iterator.in.shell
+#        ^^ keyword.operator.iteration.in.shell
 #           ^^^^^ meta.string.glob.shell string.unquoted.shell
 #                 ^^^^^ meta.string.glob.shell string.unquoted.shell
 #                      ^ punctuation.terminator.statement.shell
@@ -493,7 +493,7 @@ select name in word1 word2; do echo $name; done;
 # <- keyword.control.loop.select.shell
 #^^^^^ keyword.control.loop.select.shell
 #      ^^^^ variable.other.readwrite.shell
-#           ^^ keyword.operator.iterator.in.shell
+#           ^^ keyword.operator.iteration.in.shell
 #              ^^^^^ meta.string.glob.shell string.unquoted.shell
 #                    ^^^^^ meta.string.glob.shell string.unquoted.shell
 #                         ^ punctuation.terminator.statement.shell
@@ -6494,7 +6494,7 @@ for a in ./**/*\ *(Dod); do mv $a ${a:h}/${a:t:gs/ /_}; done   # Remove spaces f
 #^^^^^^^^^^^^^^^^^^^^^^ meta.statement.loop.for.shell
 #^^ keyword.control.loop.for.shell
 #   ^ variable.other.readwrite.shell
-#     ^^ keyword.operator.iterator.in.shell
+#     ^^ keyword.operator.iteration.in.shell
 #       ^^^^^^^^^^^^^^^ meta.sequence.list.shell
 #        ^^^^^^^^^^^^^^ meta.string.glob.shell
 #        ^^^^^^^^^ string.unquoted.shell


### PR DESCRIPTION
This PR scopes `in` keywords in loop statements `keyword.operator.iteration`.

Uses "iteration" rather than "iterator" as it is more aligned with "assignment" or "comparison".

This commit is part of an attempt to introduce a single scope for that keyword as various (3rd-party) packages use different ones, like:

-  `keyword.control.flow`
-  `keyword.control.loop.for.in`
-  `keyword.operator`
-  `keyword.operator.logical`
-  `keyword.operator.in`
-  `keyword.operator.iterator`
-  `keyword.operator.iteration`
-  `keyword.other.in`

3rd-party packages known to already use proposed scope:

- CoffeeScript
- Jinja2
- Liquid
- Ngx HTML
- PostCSS
- Sass
- Twig
- XSL
