### PR TITLE
[Markdown] Fix frontmatter punctuation scope

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -347,13 +347,13 @@ contexts:
     - match: (\+{3})\s*\n
       captures:
         0: meta.frontmatter.markdown
-        1: punctuation.section.block.begin.frontmatter.markdown
+        1: punctuation.section.frontmatter.begin.markdown
       embed: scope:source.toml
       embed_scope: meta.frontmatter.markdown source.toml.embedded.markdown
       escape: ^(\+{3})\s*\n
       escape_captures:
         0: meta.frontmatter.markdown
-        1: punctuation.section.block.end.frontmatter.markdown
+        1: punctuation.section.frontmatter.end.markdown
 
   markdown:
     - include: indented-code-blocks


### PR DESCRIPTION
This commit renames TOML frontmatter punctuation scopes to align them with the other types.

_Note: This was a copy & paste error when transferring patterns from MarkdownEditing._