### PR TITLE
[Markdown] Reduce unique fenced codeblock scopes

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -524,7 +524,7 @@ contexts:
           {{fenced_code_block_language}}?
           .*?(\s*$\n?)   # all characters until EOL
       captures:
-        0: meta.code-fence.definition.begin.text.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: meta.fold.code-fence.begin.markdown
@@ -543,7 +543,7 @@ contexts:
     - include: block-quote-end
     - match: '{{fenced_code_block_end}}'
       captures:
-        0: meta.code-fence.definition.end.text.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
       pop: 1
@@ -1165,18 +1165,19 @@ contexts:
           (?i:\s*(actionscript|as))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.actionscript.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.actionscript.2
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.actionscript.markdown-gfm
         source.actionscript.2
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.actionscript.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1187,18 +1188,19 @@ contexts:
           (?i:\s*(applescript|osascript|scpt))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.applescript.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.applescript
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.applescript.markdown-gfm
         source.applescript
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.applescript.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1209,18 +1211,19 @@ contexts:
           (?i:\s*(clojure|clj))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.clojure.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.clojure
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.clojure.markdown-gfm
         source.clojure
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.clojure.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1231,18 +1234,19 @@ contexts:
           (?i:\s*(c|h))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.c.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.c
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.c.markdown-gfm
         source.c
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.c.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1253,18 +1257,19 @@ contexts:
           (?i:\s*(c\+\+|cc|cpp|cxx|h\+\+|hpp|hxx))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.c++.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.c++
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.c++.markdown-gfm
         source.c++
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.c++.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1275,18 +1280,19 @@ contexts:
           (?i:\s*(csharp|c\#|cs))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.csharp.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.cs
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.csharp.markdown-gfm
         source.cs
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.csharp.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1297,18 +1303,19 @@ contexts:
           (?i:\s*(css))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.css.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.css
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.css.markdown-gfm
         source.css
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.css.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1319,18 +1326,19 @@ contexts:
           (?i:\s*(u?diff|patch))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.diff.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.diff.embedded.markdown
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.diff.markdown-gfm
         source.diff
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.diff.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1341,18 +1349,19 @@ contexts:
           (?i:\s*(bat(?:ch(?:file)?)?|cmd|(?:dos|win)batch))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.dosbatch.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.dosbatch
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.dosbatch.markdown-gfm
         source.dosbatch
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.dosbatch.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1363,18 +1372,19 @@ contexts:
           (?i:\s*(erl(?:ang)?|escript))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.erlang.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.erlang
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.erlang.markdown-gfm
         source.erlang
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.erlang.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1385,18 +1395,19 @@ contexts:
           (?i:\s*(dot|graphviz|gv))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.graphviz.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.dot
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.graphviz.markdown-gfm
         source.dot
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.graphviz.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1407,18 +1418,19 @@ contexts:
           (?i:\s*(go(?:lang)?))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.go.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.go
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.go.markdown-gfm
         source.go
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.go.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1429,18 +1441,19 @@ contexts:
           (?i:\s*(haskell|hsc?))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.haskell.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.haskell
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.haskell.markdown-gfm
         source.haskell
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.haskell.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1451,18 +1464,19 @@ contexts:
           (?i:\s*(html\+php|phtml))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.html-php.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:embedding.php
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.html-php.markdown-gfm
         embedding.php
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.html-php.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1473,18 +1487,19 @@ contexts:
           (?i:\s*(x?html))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.html.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:text.html.basic
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.html.markdown-gfm
         text.html.basic
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.html.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1495,18 +1510,19 @@ contexts:
           (?i:\s*(java))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.java.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.java
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.java.markdown-gfm
         source.java
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.java.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1517,18 +1533,19 @@ contexts:
           (?i:\s*(javascript|js|node))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.javascript.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.js
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.javascript.markdown-gfm
         source.js
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.javascript.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1539,18 +1556,19 @@ contexts:
           (?i:\s*(jsonc?))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.json.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.json
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.json.markdown-gfm
         source.json
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.json.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1561,18 +1579,19 @@ contexts:
           (?i:\s*(jspx?))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.jsp.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:text.html.jsp
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.jsp.markdown-gfm
         text.html.jsp
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.jsp.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1583,18 +1602,19 @@ contexts:
           (?i:\s*(jsx))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.jsx.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.jsx
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.jsx.markdown-gfm
         source.jsx
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.jsx.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1605,18 +1625,19 @@ contexts:
           (?i:\s*(latex|tex))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.latex.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:text.tex.latex
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.latex.markdown-gfm
         text.tex.latex
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.latex.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1627,18 +1648,19 @@ contexts:
           (?i:\s*(lisp))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.lisp.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.lisp
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.lisp.markdown-gfm
         source.lisp
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.lisp.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1649,18 +1671,19 @@ contexts:
           (?i:\s*(lua))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.lua.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.lua
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.lua.markdown-gfm
         source.lua
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.lua.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1671,18 +1694,19 @@ contexts:
           (?i:\s*(make(?:file)?|mf))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.makefile.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.makefile
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.makefile.markdown-gfm
         source.makefile
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.makefile.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1693,18 +1717,19 @@ contexts:
           (?i:\s*(matlab))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.matlab.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.matlab
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.matlab.markdown-gfm
         source.matlab
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.matlab.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1715,18 +1740,19 @@ contexts:
           (?i:\s*(objc|obj-c|objectivec|objective-c))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.objc.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.objc
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.objc.markdown-gfm
         source.objc
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.objc.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1737,18 +1763,19 @@ contexts:
           (?i:\s*(objc\+\+|obj-c\+\+|objectivec\+\+|objective-c\+\+))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.objc++.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.objc++
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.objc++.markdown-gfm
         source.objc++
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.objc++.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1759,18 +1786,19 @@ contexts:
           (?i:\s*(ocaml))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.ocaml.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.ocaml
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.ocaml.markdown-gfm
         source.ocaml
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.ocaml.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1781,18 +1809,19 @@ contexts:
           (?i:\s*(perl5?))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.perl.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.perl
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.perl.markdown-gfm
         source.perl
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.perl.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1803,18 +1832,19 @@ contexts:
           (?i:\s*(php|inc))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.php.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.php
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.php.markdown-gfm
         source.php
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.php.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1825,18 +1855,19 @@ contexts:
           (?i:\s*(python3?|py))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.python.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.python
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.python.markdown-gfm
         source.python
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.python.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1847,18 +1878,19 @@ contexts:
           (?i:\s*(regexp?))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.regexp.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.regexp
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.regexp.markdown-gfm
         source.regexp
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.regexp.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1869,18 +1901,19 @@ contexts:
           (?i:\s*(rscript|r|splus))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.r.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.r
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.r.markdown-gfm
         source.r
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.r.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1891,18 +1924,19 @@ contexts:
           (?i:\s*(ruby|rb|rbx))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.ruby.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.ruby
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.ruby.markdown-gfm
         source.ruby
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.ruby.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1913,18 +1947,19 @@ contexts:
           (?i:\s*(rust|rs))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.rust.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.rust
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.rust.markdown-gfm
         source.rust
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.rust.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1935,18 +1970,19 @@ contexts:
           (?i:\s*(scala))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.scala.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.scala
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.scala.markdown-gfm
         source.scala
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.scala.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1957,18 +1993,19 @@ contexts:
           (?i:\s*(console|bash|shell(?:-script)?|sh))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.shell.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.shell.bash.embedded.markdown
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.shell.markdown-gfm
         source.shell.bash.embedded.markdown
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.shell.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
     - match: |-
@@ -1977,18 +2014,19 @@ contexts:
           (?i:\s*(zsh))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.shell.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.shell.zsh.embedded.markdown
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.shell.markdown-gfm
         source.shell.zsh.embedded.markdown
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.shell.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1999,18 +2037,19 @@ contexts:
           (?i:\s*(sql))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.sql.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.sql
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.sql.markdown-gfm
         source.sql
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.sql.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2021,18 +2060,19 @@ contexts:
           (?i:\s*(toml))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.toml.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.toml
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.toml.markdown-gfm
         source.toml
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.toml.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2043,18 +2083,19 @@ contexts:
           (?i:\s*(tsx))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.tsx.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.tsx
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.tsx.markdown-gfm
         source.tsx
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.tsx.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2065,18 +2106,19 @@ contexts:
           (?i:\s*(typescript|ts(?:node)?))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.typescript.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.ts
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.typescript.markdown-gfm
         source.ts
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.typescript.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2087,18 +2129,19 @@ contexts:
           (?i:\s*(atom|plist|svg|xjb|xml|xsd|xsl))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.xml.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:text.xml
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.xml.markdown-gfm
         text.xml
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.xml.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2109,18 +2152,19 @@ contexts:
           (?i:\s*(yaml|yml))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.yaml.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.yaml
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.yaml.markdown-gfm
         source.yaml
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.yaml.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2131,17 +2175,17 @@ contexts:
           {{fenced_code_block_language}}?
           .*?(\s*$\n?)   # all characters until EOL
       captures:
-        0: meta.code-fence.definition.begin.text.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: meta.fold.code-fence.begin.markdown
       push: fenced-raw-content
 
   fenced-raw-content:
-    - meta_content_scope: markup.raw.code-fence.markdown-gfm
+    - meta_content_scope: meta.code-fence.body.markdown-gfm markup.raw.code-fence.markdown-gfm
     - match: '{{fenced_code_block_escape}}'
       captures:
-        0: meta.code-fence.definition.end.text.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
       pop: 1

--- a/Markdown/tests/syntax_test_markdown.md
+++ b/Markdown/tests/syntax_test_markdown.md
@@ -1350,32 +1350,32 @@ paragraph
 ## https://spec.commonmark.org/0.30/#example-119
 
 ```
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|  ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^ meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|  ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin - punctuation
 <
-| <- markup.raw.code-fence.markdown-gfm - punctuation
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.markdown-gfm - punctuation
  >
 |^^ markup.raw.code-fence.markdown-gfm - punctuation
 ```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-120
 
 ~~~
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|  ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^ meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|  ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin - punctuation
 <
-| <- markup.raw.code-fence.markdown-gfm - punctuation
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.markdown-gfm - punctuation
  >
 |^^ markup.raw.code-fence.markdown-gfm - punctuation
 ~~~
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-121
 
@@ -1388,30 +1388,30 @@ foo
 ## https://spec.commonmark.org/0.30/#example-122
 
 ```
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|  ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^ meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|  ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin - punctuation
 aaa
 ~~~
-| <- markup.raw.code-fence.markdown-gfm - punctuation
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.markdown-gfm - punctuation
 ```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-123
 
 ~~~
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|  ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^ meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|  ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin - punctuation
 aaa
 ```
-| <- markup.raw.code-fence.markdown-gfm - punctuation
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.markdown-gfm - punctuation
 ~~~
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ~~~~ 
 | <- punctuation.definition.raw.code-fence.begin
@@ -1421,31 +1421,31 @@ aaa
 ## https://spec.commonmark.org/0.30/#example-124
 
 ````
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|^^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|   ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^^ meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|   ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin - punctuation
 aaa
 ```
-| <- markup.raw.code-fence.markdown-gfm - punctuation
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.markdown-gfm - punctuation
 ``````
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^^^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|     ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^^^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|     ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-125
 
 ~~~~
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|^^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|   ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^^ meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|   ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin - punctuation
 |
 aaa
 ~~~
-| <- markup.raw.code-fence.markdown-gfm - punctuation
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.markdown-gfm - punctuation
 ~~~~
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|   ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|   ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-128
 
@@ -1461,23 +1461,23 @@ bbb
 ## https://spec.commonmark.org/0.30/#example-129
 
 ```
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|  ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^ meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|  ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin - punctuation
 
   
 ```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-130
 
 ```
 ```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-131
 
@@ -1485,9 +1485,9 @@ bbb
  aaa
 aaa
 ```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-132
 
@@ -1496,10 +1496,10 @@ aaa
   aaa
 aaa
   ```
-| <- meta.code-fence.definition.end.text.markdown-gfm - punctuation
-|^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
-| ^^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|    ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm - punctuation
+|^ meta.code-fence.definition.end.markdown-gfm - punctuation
+| ^^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|    ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-133
 
@@ -1508,10 +1508,10 @@ aaa
     aaa
   aaa
    ```
-| <- meta.code-fence.definition.end.text.markdown-gfm - punctuation
-|^^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
-|  ^^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|     ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm - punctuation
+|^^ meta.code-fence.definition.end.markdown-gfm - punctuation
+|  ^^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|     ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-134
 
@@ -1524,45 +1524,45 @@ aaa
 ## https://spec.commonmark.org/0.30/#example-135
 
 ```
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|  ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^ meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|  ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin - punctuation
 aaa
-| <- markup.raw.code-fence.markdown-gfm
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.markdown-gfm
   ```
-| <- meta.code-fence.definition.end.text.markdown-gfm - punctuation
-|^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
-| ^^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|    ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm - punctuation
+|^ meta.code-fence.definition.end.markdown-gfm - punctuation
+| ^^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|    ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-136
 
    ```
-| <- meta.code-fence.definition.begin.text.markdown-gfm - punctuation
-|^^ meta.code-fence.definition.begin.text.markdown-gfm - punctuation
-|  ^^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|     ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
+| <- meta.code-fence.definition.begin.markdown-gfm - punctuation
+|^^ meta.code-fence.definition.begin.markdown-gfm - punctuation
+|  ^^^ meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|     ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin - punctuation
 aaa
-| <- markup.raw.code-fence.markdown-gfm
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.markdown-gfm
   ```
-| <- meta.code-fence.definition.end.text.markdown-gfm - punctuation
-|^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
-| ^^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|    ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm - punctuation
+|^ meta.code-fence.definition.end.markdown-gfm - punctuation
+| ^^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|    ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-137
 
 ```
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|  ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^ meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|  ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin - punctuation
 aaa
-| <- markup.raw.code-fence.markdown-gfm
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.markdown-gfm
     ```
-| <- meta.code-fence.definition.end.text.markdown-gfm - punctuation
-|^^^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
-|   ^^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|      ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm - punctuation
+|^^^ meta.code-fence.definition.end.markdown-gfm - punctuation
+|   ^^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|      ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-138
 
@@ -1580,21 +1580,21 @@ aaa
 ~~~~~~
 aaa
 ~~~ ~~
-| <- markup.raw.code-fence.markdown-gfm - punctuation
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.markdown-gfm - punctuation
 |^^^^^^ markup.raw.code-fence.markdown-gfm - punctuation
 
 ~~~~~~
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^^^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|     ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^^^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|     ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-140
 
 foo
 ```
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|  ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^ meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|  ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin - punctuation
 bar
 ```
 baz
@@ -1605,69 +1605,69 @@ baz
 
 Paragraph is terminated by fenced code blocks.
 ```
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
 ```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 
 Code blocks terminate **bold text
 ```
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
 ```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 this must not be bold**
 | <- - meta.bold
 |^^^^^^^^^^^^^^^^^^^^^^^ - meta.bold
 
 Code blocks terminate __bold text
 ```
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
 ```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 this must not be bold__
 | <- - meta.bold
 |^^^^^^^^^^^^^^^^^^^^^^^ - meta.bold
 
 Code blocks terminate *italic text
 ```
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
 ```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 this must not be italic*
 | <- - meta.italic
 |^^^^^^^^^^^^^^^^^^^^^^^ - meta.italic
 
 Code blocks terminate _italic text
 ```
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
 ```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 this must not be italic_
 | <- - meta.italic
 |^^^^^^^^^^^^^^^^^^^^^^^ - meta.bold - meta.italic
 
 Code blocks terminate ***bold italic text
 ```
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
 ```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 this must not be bold italic***
 | <- - meta.bold - meta.italic
 |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.bold - meta.italic
 
 Code blocks terminate ___bold italic text
 ```
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
 ```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 this must not be bold italic___
 | <- - meta.bold - meta.italic
 |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.bold - meta.italic
 
 Code blocks terminate **_bold italic text
 ```
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
 ```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 this must not be bold italic_**
 | <- - meta.bold - meta.italic
 |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.bold - meta.italic
@@ -1677,9 +1677,9 @@ this must not be bold italic_**
 foo
 ---
 ~~~
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|  ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^ meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|  ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin - punctuation
 bar
 |^^^ markup.raw.code-fence.markdown-gfm
 ~~~
@@ -1690,49 +1690,49 @@ bar
 ## https://spec.commonmark.org/0.30/#example-142
 
 ```ruby
-| <- meta.code-fence.definition.begin.ruby.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|^^ meta.code-fence.definition.begin.ruby.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|  ^^^^ meta.code-fence.definition.begin.ruby.markdown-gfm constant.other.language-name.markdown
-|      ^ meta.code-fence.definition.begin.ruby.markdown-gfm meta.fold.code-fence.begin - constant
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^ meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|  ^^^^ meta.code-fence.definition.begin.markdown-gfm constant.other.language-name.markdown
+|      ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin - constant
 def foo(x)
-| <- markup.raw.code-fence.ruby.markdown-gfm source.ruby meta.function
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.ruby.markdown-gfm source.ruby meta.function
   return 3
 end
-| <- markup.raw.code-fence.ruby.markdown-gfm source.ruby keyword
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.ruby.markdown-gfm source.ruby keyword
 ```
-| <- meta.code-fence.definition.end.ruby.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.ruby.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.ruby.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-143
 
 ~~~~    ruby startline=3 $%@#$
-| <- meta.code-fence.definition.begin.ruby.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|^^^ meta.code-fence.definition.begin.ruby.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|   ^^^^ meta.code-fence.definition.begin.ruby.markdown-gfm - punctuation - constant
-|       ^^^^ meta.code-fence.definition.begin.ruby.markdown-gfm constant.other.language-name.markdown
-|           ^^^^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.ruby.markdown-gfm - meta.fold - constant
-|                             ^ meta.code-fence.definition.begin.ruby.markdown-gfm meta.fold.code-fence.begin - constant
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^^ meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|   ^^^^ meta.code-fence.definition.begin.markdown-gfm - punctuation - constant
+|       ^^^^ meta.code-fence.definition.begin.markdown-gfm constant.other.language-name.markdown
+|           ^^^^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.markdown-gfm - meta.fold - constant
+|                             ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin - constant
 def foo(x)
-| <- markup.raw.code-fence.ruby.markdown-gfm source.ruby meta.function
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.ruby.markdown-gfm source.ruby meta.function
   return 3
 end
-| <- markup.raw.code-fence.ruby.markdown-gfm source.ruby keyword
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.ruby.markdown-gfm source.ruby keyword
 ~~~~~~~
-| <- meta.code-fence.definition.end.ruby.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^^^^^ meta.code-fence.definition.end.ruby.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^^^^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 
 ## https://spec.commonmark.org/0.30/#example-144
 
 ````;
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|^^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|   ^ meta.code-fence.definition.begin.text.markdown-gfm - meta.fold
-|    ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^^ meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|   ^ meta.code-fence.definition.begin.markdown-gfm - meta.fold
+|    ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin - punctuation
 ````
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|   ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|   ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-145
 
@@ -1747,48 +1747,48 @@ foo
 ## https://spec.commonmark.org/0.30/#example-146
 
 ~~~ aa ``` ~~~
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|   ^^ meta.code-fence.definition.begin.text.markdown-gfm constant.other.language-name.markdown
-|     ^^^^^^^^ meta.code-fence.definition.begin.text.markdown-gfm - meta.fold - punctuation
-|             ^ meta.code-fence.definition.begin.text.markdown-gfm - punctuation meta.fold.code-fence.begin.markdown
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^ meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|   ^^ meta.code-fence.definition.begin.markdown-gfm constant.other.language-name.markdown
+|     ^^^^^^^^ meta.code-fence.definition.begin.markdown-gfm - meta.fold - punctuation
+|             ^ meta.code-fence.definition.begin.markdown-gfm - punctuation meta.fold.code-fence.begin.markdown
 foo
 ~~~
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ~~~~~foo~
-|^^^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|    ^^^^ meta.code-fence.definition.begin.text.markdown-gfm constant.other.language-name.markdown
-|        ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
+|^^^^ meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|    ^^^^ meta.code-fence.definition.begin.markdown-gfm constant.other.language-name.markdown
+|        ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin - punctuation
 
 ~~~~~
-|^^^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|    ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+|^^^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|    ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-147
 
 ```
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|  ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^ meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|  ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin - punctuation
 ``` aaa
-| <- markup.raw.code-fence.markdown-gfm - punctuation
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.markdown-gfm - punctuation
 ```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://fenced-code-block-embedded-syntaxes-tests
 
 ```bash
-| <- meta.code-fence.definition.begin.shell.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|^^ meta.code-fence.definition.begin.shell.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|  ^^^^ meta.code-fence.definition.begin.shell.markdown-gfm constant.other.language-name.markdown
-|      ^ meta.code-fence.definition.begin.shell.markdown-gfm meta.fold.code-fence.begin
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^ meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|  ^^^^ meta.code-fence.definition.begin.markdown-gfm constant.other.language-name.markdown
+|      ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin
 # test
-| <- markup.raw.code-fence.shell.markdown-gfm source.shell.bash.embedded.markdown comment.line.number-sign.shell punctuation.definition.comment.shell
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.shell.markdown-gfm source.shell.bash.embedded.markdown comment.line.number-sign.shell punctuation.definition.comment.shell
 |^^^^^^ markup.raw.code-fence.shell.markdown-gfm source.shell.bash.embedded.markdown comment.line.number-sign.shell
 echo hello, \
 |           ^ punctuation.separator.continuation.line
@@ -1799,14 +1799,14 @@ heredoc=<<EOF
 | ^^^^^^^^^^ markup.raw.code-fence.shell.markdown-gfm source.shell.bash.embedded.markdown meta.string.heredoc.shell string.unquoted.heredoc.shell
 |           ^^^^^^^^ markup.raw.code-fence.shell.markdown-gfm source.shell.bash.embedded.markdown meta.string.heredoc.shell meta.interpolation.parameter.shell 
 EOF
-| <- markup.raw.code-fence.shell.markdown-gfm source.shell.bash.embedded.markdown meta.tag.heredoc.end.shell entity.name.tag.heredoc.shell
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.shell.markdown-gfm source.shell.bash.embedded.markdown meta.tag.heredoc.end.shell entity.name.tag.heredoc.shell
 |^^ markup.raw.code-fence.shell.markdown-gfm source.shell.bash.embedded.markdown meta.tag.heredoc.end.shell entity.name.tag.heredoc.shell
 $ cmd  # no interactive shell marker
-| <- markup.raw.code-fence.shell.markdown-gfm source.shell.bash.embedded.markdown meta.function-call.identifier.shell variable.function.shell
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.shell.markdown-gfm source.shell.bash.embedded.markdown meta.function-call.identifier.shell variable.function.shell
 |^^^^ markup.raw.code-fence.shell.markdown-gfm source.shell.bash.embedded.markdown meta.function-call.arguments.shell
 ```
-| <- meta.code-fence.definition.end.shell punctuation.definition.raw.code-fence.end
-|^^ meta.code-fence.definition.end.shell.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+| <- meta.code-fence.definition.end punctuation.definition.raw.code-fence.end
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 
    ```bash
    #!/usr/bin/env bash
@@ -1822,7 +1822,7 @@ $ cmd  # no interactive shell marker
 |  ^ markup.raw.code-fence.shell.markdown-gfm source.shell.bash.embedded.markdown meta.function-call.identifier.shell variable.function.shell
 |   ^^^^ markup.raw.code-fence.shell.markdown-gfm source.shell.bash.embedded.markdown meta.function-call.arguments.shell
    ```
-|  ^^^ meta.code-fence.definition.end.shell.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 
    ```bash
    $ ls
@@ -1830,8 +1830,8 @@ $ cmd  # no interactive shell marker
 |  ^ comment.other.shell
 |    ^^ meta.function-call.identifier.shell variable.function.shell
    ```
-|  ^^^ meta.code-fence.definition.end.shell.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|     ^ meta.code-fence.definition.end.shell.markdown-gfm meta.fold.code-fence.end - punctuation
+|  ^^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|     ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```clojure
 |^^^^^^^^^ meta.code-fence.definition.begin - meta.fold
@@ -1841,29 +1841,29 @@ $ cmd  # no interactive shell marker
 | <- source.clojure
 |^^^^^^^^^^ source.clojure
 ```
-| <- meta.code-fence.definition.end.clojure.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.clojure.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.clojure.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```cmd
 |^^^^^ meta.code-fence.definition.begin - meta.fold
 |     ^ meta.code-fence.definition.begin meta.fold.code-fence.begin
 
-| <- markup.raw.code-fence.dosbatch.markdown-gfm source.dosbatch
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.dosbatch.markdown-gfm source.dosbatch
 ```
-| <- meta.code-fence.definition.end.dosbatch.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.dosbatch.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.dosbatch.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```css
 |^^^^^ meta.code-fence.definition.begin - meta.fold
 |     ^ meta.code-fence.definition.begin meta.fold.code-fence.begin
 
-| <- markup.raw.code-fence.css.markdown-gfm source.css
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.css.markdown-gfm source.css
 ```
-| <- meta.code-fence.definition.end.css.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.css.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.css.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```diff
 |^^^^^^ meta.code-fence.definition.begin - meta.fold
@@ -1874,9 +1874,9 @@ $ cmd  # no interactive shell marker
 - deleted
 | <- source.diff markup.deleted.diff punctuation.definition.deleted.diff
 ```
-| <- meta.code-fence.definition.end.diff.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.diff.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.diff.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 1. list item with diff fenced code block
 
@@ -1909,30 +1909,30 @@ $ cmd  # no interactive shell marker
 graph n {}
 | ^^^ storage.type.dot
 ```
-| <- meta.code-fence.definition.end.graphviz.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.graphviz.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.graphviz.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```haskell
 |^^^^^^^^^ meta.code-fence.definition.begin - meta.fold
 |         ^ meta.code-fence.definition.begin meta.fold.code-fence.begin
 
-| <- markup.raw.code-fence.haskell.markdown-gfm source.haskell
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.haskell.markdown-gfm source.haskell
 ```
-| <- meta.code-fence.definition.end.haskell.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.haskell.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.haskell.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```html
 |^^^^^^ meta.code-fence.definition.begin - meta.fold
 |      ^ meta.code-fence.definition.begin meta.fold.code-fence.begin
   <html>
-| <- markup.raw.code-fence.html.markdown-gfm text.html
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.html.markdown-gfm text.html
 | ^^^^^^ text.html meta.tag
 ```
-| <- meta.code-fence.definition.end.html.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.html.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.html.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```html+php
 |^^^^^^^^^^ meta.code-fence.definition.begin - meta.fold
@@ -1940,12 +1940,12 @@ graph n {}
 <div></div>
 |^^^ entity.name.tag.block
 <?php
-| <- markup.raw.code-fence.html-php.markdown-gfm embedding.php text.html meta.embedded punctuation.section.embedded.begin.php
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.html-php.markdown-gfm embedding.php text.html meta.embedded punctuation.section.embedded.begin.php
 var_dump(expression);
-| <- markup.raw.code-fence.html-php.markdown-gfm embedding.php text.html meta.embedded source.php meta.function-call
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.html-php.markdown-gfm embedding.php text.html meta.embedded source.php meta.function-call
 ```
-| <- meta.code-fence.definition.end.html-php.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.html-php.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 
 ```js
 |^^^^ meta.code-fence.definition.begin - meta.fold
@@ -1957,91 +1957,91 @@ for (var i = 0; i < 10; i++) {
     console.log(i);
 }
 ```
-| <- meta.code-fence.definition.end.javascript.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.javascript.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.javascript.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```jsx
 |^^^^^ meta.code-fence.definition.begin - meta.fold
 |     ^ meta.code-fence.definition.begin meta.fold.code-fence.begin
 
-| <- markup.raw.code-fence.jsx.markdown-gfm
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.jsx.markdown-gfm
 ```
-| <- meta.code-fence.definition.end.jsx.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.jsx.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.jsx.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```latex
-| <- meta.code-fence.definition.begin.latex.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|^^ meta.code-fence.definition.begin.latex.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|  ^^^^^ meta.code-fence.definition.begin.latex.markdown-gfm constant.other.language-name.markdown
-|       ^ meta.code-fence.definition.begin.latex.markdown-gfm meta.fold.code-fence.begin.markdown - punctuation
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^ meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|  ^^^^^ meta.code-fence.definition.begin.markdown-gfm constant.other.language-name.markdown
+|       ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin.markdown - punctuation
 
-| <- markup.raw.code-fence.latex.markdown-gfm text.tex.latex
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.latex.markdown-gfm text.tex.latex
 ```
-| <- meta.code-fence.definition.end.latex.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.latex.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.latex.markdown-gfm meta.fold.code-fence.end.markdown - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end.markdown - punctuation
 
 ```lisp
 |^^^^^^ meta.code-fence.definition.begin - meta.fold
 |      ^ meta.code-fence.definition.begin meta.fold.code-fence.begin
 
-| <- markup.raw.code-fence.lisp.markdown-gfm source.lisp
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.lisp.markdown-gfm source.lisp
 ```
-| <- meta.code-fence.definition.end.lisp.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.lisp.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.lisp.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```lua
 |^^^^^ meta.code-fence.definition.begin - meta.fold
 |     ^ meta.code-fence.definition.begin meta.fold.code-fence.begin
 
-| <- markup.raw.code-fence.lua.markdown-gfm source.lua
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.lua.markdown-gfm source.lua
 ```
-| <- meta.code-fence.definition.end.lua.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.lua.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.lua.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```makefile
 |^^^^^^^^^^ meta.code-fence.definition.begin - meta.fold
 |          ^ meta.code-fence.definition.begin meta.fold.code-fence.begin
 
-| <- markup.raw.code-fence.makefile.markdown-gfm source.makefile
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.makefile.markdown-gfm source.makefile
 ```
-| <- meta.code-fence.definition.end.makefile.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.makefile.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.makefile.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```matlab
 |^^^^^^^^ meta.code-fence.definition.begin - meta.fold
 |        ^ meta.code-fence.definition.begin meta.fold.code-fence.begin
 
-| <- markup.raw.code-fence.matlab.markdown-gfm source.matlab
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.matlab.markdown-gfm source.matlab
 ```
-| <- meta.code-fence.definition.end.matlab.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.matlab.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.matlab.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```ocaml
 |^^^^^^^ meta.code-fence.definition.begin - meta.fold
 |       ^ meta.code-fence.definition.begin meta.fold.code-fence.begin
 
-| <- markup.raw.code-fence.ocaml.markdown-gfm source.ocaml
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.ocaml.markdown-gfm source.ocaml
 ```
-| <- meta.code-fence.definition.end.ocaml.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.ocaml.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.ocaml.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```php
 |^^^^^ meta.code-fence.definition.begin - meta.fold
 |     ^ meta.code-fence.definition.begin meta.fold.code-fence.begin
 var_dump(expression);
-| <- markup.raw.code-fence.php.markdown-gfm source.php meta.function-call
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.php.markdown-gfm source.php meta.function-call
 ```
-| <- meta.code-fence.definition.end.php.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.php.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.php.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```python
 |^^^^^^^^ meta.code-fence.definition.begin - meta.fold - markup
@@ -2054,82 +2054,82 @@ def function():
 unclosed_paren = (
 |                ^ meta.group.python punctuation.section.group.begin.python
 ```
-| <- meta.code-fence.definition.end.python.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.python.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.python.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```regex
 |^^^^^^^ meta.code-fence.definition.begin - meta.fold - markup
 |       ^ meta.code-fence.definition.begin meta.fold.code-fence.begin - markup
 (?x)
 \s+
-| <- markup.raw.code-fence.regexp.markdown-gfm source.regexp
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.regexp.markdown-gfm source.regexp
 ```
-| <- meta.code-fence.definition.end.regexp.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.regexp.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.regexp.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```scala
 |^^^^^^^ meta.code-fence.definition.begin - meta.fold - markup
 |       ^ meta.code-fence.definition.begin meta.fold.code-fence.begin - markup
 
-| <- markup.raw.code-fence.scala.markdown-gfm source.scala
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.scala.markdown-gfm source.scala
 ```
-| <- meta.code-fence.definition.end.scala.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.scala.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.scala.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```sh
 |^^^^ meta.code-fence.definition.begin - meta.fold - markup
 |    ^ meta.code-fence.definition.begin meta.fold.code-fence.begin - markup
 
-| <- markup.raw.code-fence.shell.markdown-gfm source.shell.bash.embedded.markdown
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.shell.markdown-gfm source.shell.bash.embedded.markdown
 ```
-| <- meta.code-fence.definition.end.shell.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.shell.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 
 ```shell
 |^^^^^^^ meta.code-fence.definition.begin - meta.fold - markup
 |       ^ meta.code-fence.definition.begin meta.fold.code-fence.begin - markup
 
-| <- markup.raw.code-fence.shell.markdown-gfm source.shell.bash.embedded.markdown
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.shell.markdown-gfm source.shell.bash.embedded.markdown
 ```
-| <- meta.code-fence.definition.end.shell.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.shell.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 
 ```shell-script
 
-| <- markup.raw.code-fence.shell.markdown-gfm source.shell.bash.embedded.markdown
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.shell.markdown-gfm source.shell.bash.embedded.markdown
 ```
-| <- meta.code-fence.definition.end.shell.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.shell.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 
 === Generic Interactive Shell ===
 
 ```sh
 $ ls ~
-| <- markup.raw.code-fence.shell.markdown-gfm source.shell.bash.embedded.markdown comment.other.shell
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.shell.markdown-gfm source.shell.bash.embedded.markdown comment.other.shell
 | ^^ meta.function-call.identifier.shell variable.function.shell
 |   ^^ meta.function-call.arguments.shell
 
 output.txt
-| <- markup.raw.code-fence.shell.markdown-gfm source.shell.bash.embedded.markdown - meta.function-call - variable
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.shell.markdown-gfm source.shell.bash.embedded.markdown - meta.function-call - variable
 |^^^^^^^^^ markup.raw.code-fence.shell.markdown-gfm source.shell.bash.embedded.markdown - meta.function-call - variable
 
 $ ls \
 > /foo/
-| <- markup.raw.code-fence.shell.markdown-gfm source.shell.bash.embedded.markdown comment.other.shell
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.shell.markdown-gfm source.shell.bash.embedded.markdown comment.other.shell
 |^^^^^^^ markup.raw.code-fence.shell.markdown-gfm source.shell.bash.embedded.markdown
 
 $ ls \
 > /foo/
 bar
-| <- markup.raw.code-fence.shell.markdown-gfm source.shell.bash.embedded.markdown - meta.function-call
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.shell.markdown-gfm source.shell.bash.embedded.markdown - meta.function-call
 |^^^ markup.raw.code-fence.shell.markdown-gfm source.shell.bash.embedded.markdown - meta.function-call
 ```
-| <- meta.code-fence.definition.end.shell.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.shell.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.shell.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
    ```shell
    $ ls
@@ -2137,8 +2137,8 @@ bar
 |  ^ comment.other.shell
 |    ^^ meta.function-call.identifier.shell variable.function.shell
    ```
-|  ^^^ meta.code-fence.definition.end.shell.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|     ^ meta.code-fence.definition.end.shell.markdown-gfm meta.fold.code-fence.end - punctuation
+|  ^^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|     ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```sql
 |^^^^^ meta.code-fence.definition.begin - meta.fold - markup
@@ -2149,13 +2149,13 @@ SELECT TOP 10 *
 |^^^^^^^^^^^^^^^ markup.raw.code-fence.sql source.sql
 FROM TableName
 ```
-| <- meta.code-fence.definition.end.sql.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.sql.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.sql.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```toml
-| <- meta.code-fence.definition.begin.toml.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|^^^^^^^ meta.code-fence.definition.begin.toml.markdown-gfm
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^^^^^^ meta.code-fence.definition.begin.markdown-gfm
 |^^ punctuation.definition.raw.code-fence.begin.markdown
 |  ^^^^ constant.other.language-name.markdown
 [section.name]
@@ -2164,22 +2164,22 @@ FROM TableName
 |       ^ punctuation.accessor.dot.toml
 |            ^ punctuation.section.brackets.end.toml
 ```
-| <- meta.code-fence.definition.end.toml.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.toml.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 
 ```ts
 declare type foo = 'bar'
-| <- markup.raw.code-fence.typescript.markdown-gfm source.ts
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.typescript.markdown-gfm source.ts
 ```
-| <- meta.code-fence.definition.end.typescript.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.typescript.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 
 ```tsx
 
-| <- markup.raw.code-fence.tsx.markdown-gfm
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.tsx.markdown-gfm
 ```
-| <- meta.code-fence.definition.end.tsx.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.tsx.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 
 ```xml
 |^^^^^ meta.code-fence.definition.begin - meta.fold - markup
@@ -2193,9 +2193,9 @@ declare type foo = 'bar'
     <foobar />
 </example>
 ```
-| <- meta.code-fence.definition.end.xml.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.xml.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.xml.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```jsx:file.jsx
 |^^^^^^^^^^^^^^ meta.code-fence.definition.begin - meta.fold - markup
@@ -2204,61 +2204,61 @@ declare type foo = 'bar'
 |  ^^^ constant.other.language-name.markdown
 |     ^^^^^^^^^ comment.line.infostring.markdown
 
-| <- markup.raw.code-fence.jsx.markdown-gfm source.jsx
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.jsx.markdown-gfm source.jsx
 ```
-| <- meta.code-fence.definition.end.jsx.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.jsx.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.jsx.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```jldoctest; filter = r"Stacktrace:(\n \[[0-9]+\].*)*"
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.text.markdown-gfm - meta.fold
-|                                                      ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin.markdown - punctuation
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.markdown-gfm - meta.fold
+|                                                      ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin.markdown - punctuation
 |^^ punctuation.definition.raw.code-fence.begin.markdown
 |  ^^^^^^^^^ constant.other.language-name.markdown
 |           ^ - constant
 ```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```R%&?! weird language name
-|^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.text.markdown-gfm - meta.fold
-|                           ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.markdown-gfm - meta.fold
+|                           ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin
 |^^ punctuation.definition.raw.code-fence.begin.markdown
 |  ^^^^^ constant.other.language-name.markdown
 |        ^^^^^^^^^^^^^^^^^^^^^ - constant
 ```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```{key: value}
-|^^^^^^^^^^^^^^ meta.code-fence.definition.begin.text.markdown-gfm - meta.fold
-|              ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin
+|^^^^^^^^^^^^^^ meta.code-fence.definition.begin.markdown-gfm - meta.fold
+|              ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin
 |^^ punctuation.definition.raw.code-fence.begin.markdown
 |  ^^^^^^^^^^^^ - constant
 ```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ``` {key: value}
-|^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.text.markdown-gfm - meta.fold
-|               ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin
+|^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.markdown-gfm - meta.fold
+|               ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin
 |^^ punctuation.definition.raw.code-fence.begin.markdown
 |   ^^^^^^^^^^^^ - constant
 ```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```zsh
-|^^ meta.code-fence.definition.begin.shell.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|  ^^^ meta.code-fence.definition.begin.shell.markdown-gfm constant.other.language-name.markdown
+|^^ meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|  ^^^ meta.code-fence.definition.begin.markdown-gfm constant.other.language-name.markdown
 |     ^ meta.code-fence.definition.begin meta.fold.code-fence.begin - markup
 # test
-| <- markup.raw.code-fence.shell.markdown-gfm source.shell.zsh.embedded.markdown comment.line.number-sign.shell punctuation.definition.comment.shell
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.shell.markdown-gfm source.shell.zsh.embedded.markdown comment.line.number-sign.shell punctuation.definition.comment.shell
 |^^^^^^ markup.raw.code-fence.shell.markdown-gfm source.shell.zsh.embedded.markdown comment.line.number-sign.shell
 echo hello, \
 |           ^ punctuation.separator.continuation.line
@@ -2269,16 +2269,16 @@ heredoc=<<EOF
 | ^^^^^^^^^^ markup.raw.code-fence.shell.markdown-gfm source.shell.zsh.embedded.markdown meta.string.heredoc.shell string.unquoted.heredoc.shell
 |           ^^^^^^^^ markup.raw.code-fence.shell.markdown-gfm source.shell.zsh.embedded.markdown meta.string.heredoc.shell meta.interpolation.parameter.shell 
 EOF
-| <- markup.raw.code-fence.shell.markdown-gfm source.shell.zsh.embedded.markdown meta.tag.heredoc.end.shell entity.name.tag.heredoc.shell
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.shell.markdown-gfm source.shell.zsh.embedded.markdown meta.tag.heredoc.end.shell entity.name.tag.heredoc.shell
 |^^ markup.raw.code-fence.shell.markdown-gfm source.shell.zsh.embedded.markdown meta.tag.heredoc.end.shell entity.name.tag.heredoc.shell
 
 $ cmd  # no interactive shell marker
-| <- markup.raw.code-fence.shell.markdown-gfm source.shell.zsh.embedded.markdown meta.function-call.identifier.shell variable.function.shell
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.shell.markdown-gfm source.shell.zsh.embedded.markdown meta.function-call.identifier.shell variable.function.shell
 |^^^^ markup.raw.code-fence.shell.markdown-gfm source.shell.zsh.embedded.markdown meta.function-call.arguments.shell
 
 ```
-| <- meta.code-fence.definition.end.shell.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.shell.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 
    ```zsh
    #!/usr/bin/env zsh
@@ -2294,7 +2294,7 @@ $ cmd  # no interactive shell marker
 |  ^ markup.raw.code-fence.shell.markdown-gfm source.shell.zsh.embedded.markdown meta.function-call.identifier.shell variable.function.shell
 |   ^^^^ markup.raw.code-fence.shell.markdown-gfm source.shell.zsh.embedded.markdown meta.function-call.arguments.shell
    ```
-|  ^^^ meta.code-fence.definition.end.shell.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 
    ```zsh
    $ ls
@@ -2302,8 +2302,8 @@ $ cmd  # no interactive shell marker
 |  ^ comment.other.shell
 |    ^^ meta.function-call.identifier.shell variable.function.shell
    ```
-|  ^^^ meta.code-fence.definition.end.shell.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|     ^ meta.code-fence.definition.end.shell.markdown-gfm meta.fold.code-fence.end - punctuation
+|  ^^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|     ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 
 # TEST: HTML BLOCKS ###########################################################
@@ -2991,7 +2991,7 @@ This is not a link reference definition, because it occurs inside a code block:
 
 ```
 [foo]: /url
-| <- markup.raw.code-fence.markdown-gfm - meta.link
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.markdown-gfm - meta.link
 |^^^^^^^^^^^ markup.raw.code-fence.markdown-gfm - meta.link
 ```
 
@@ -3450,12 +3450,12 @@ https://foo.bar/baz
 
 | table | followed by
 ```fenced
-| <- meta.code-fence.definition.begin.text.markdown-gfm
-|^^^^^^^^^ meta.code-fence.definition.begin.text.markdown-gfm
+| <- meta.code-fence.definition.begin.markdown-gfm
+|^^^^^^^^^ meta.code-fence.definition.begin.markdown-gfm
 code block
 ```
-| <- meta.code-fence.definition.end.text.markdown-gfm
-|^^ meta.code-fence.definition.end.text.markdown-gfm
+| <- meta.code-fence.definition.end.markdown-gfm
+|^^ meta.code-fence.definition.end.markdown-gfm
 
 A line without bolded |
 |                     ^ - punctuation.separator.table-cell
@@ -3845,21 +3845,21 @@ paragraph
 > ```
 | <- markup.quote.markdown punctuation.definition.blockquote.markdown
 |^ markup.quote.markdown - meta.code-fence
-| ^^^^ markup.quote.markdown meta.code-fence.definition.begin.text.markdown-gfm
+| ^^^^ markup.quote.markdown meta.code-fence.definition.begin.markdown-gfm
 | ^^^ punctuation.definition.raw.code-fence.begin.markdown
 
 > Quoted fenced code block language identifier
 > ```C++
 | <- markup.quote.markdown punctuation.definition.blockquote.markdown
 |^ markup.quote.markdown - meta.code-fence
-| ^^^^^^^ markup.quote.markdown meta.code-fence.definition.begin.text.markdown-gfm
+| ^^^^^^^ markup.quote.markdown meta.code-fence.definition.begin.markdown-gfm
 |    ^^^ constant.other.language-name.markdown
 
 > Quoted fenced code block language identifier
 > ```C++ info string
 | <- markup.quote.markdown punctuation.definition.blockquote.markdown
 |^ markup.quote.markdown - meta.code-fence
-| ^^^^^^^^^^^^^^^^^^^ markup.quote.markdown meta.code-fence.definition.begin.text.markdown-gfm
+| ^^^^^^^^^^^^^^^^^^^ markup.quote.markdown meta.code-fence.definition.begin.markdown-gfm
 |    ^^^ constant.other.language-name.markdown
 |       ^^^^^^^^^^^^^ - constant
 
@@ -3875,7 +3875,7 @@ paragraph
 > ```
 | <- markup.quote.markdown punctuation.definition.blockquote.markdown
 |^ markup.quote.markdown - meta.code-fence
-| ^^^^ markup.quote.markdown meta.code-fence.definition.end.text.markdown-gfm
+| ^^^^ markup.quote.markdown meta.code-fence.definition.end.markdown-gfm
 | ^^^ punctuation.definition.raw.code-fence.end.markdown
 
 > > 2nd level quoted fenced code block
@@ -3889,13 +3889,13 @@ paragraph
 > > ```
 | <- markup.quote.markdown punctuation.definition.blockquote.markdown
 |^^^ markup.quote.markdown - meta.code-fence
-|   ^^^ markup.quote.markdown meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|   ^^^ markup.quote.markdown meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 
 > Block quote followed by fenced code block
 ```
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown - meta.quote
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown - meta.quote
 ```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown - meta.quote
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown - meta.quote
 
 > Quoted fenced code block is terminated by missing > at bol
 > ```
@@ -3913,9 +3913,9 @@ no code block
 > Unterminated quoted fenced code block followed by unquoted fenced code block
 > ```
 ```
-| <- meta.code-fence.definition.begin.text.markdown-gfm - markup.quote
+| <- meta.code-fence.definition.begin.markdown-gfm - markup.quote
 ```
-| <- meta.code-fence.definition.end.text.markdown-gfm - markup.quote
+| <- meta.code-fence.definition.end.markdown-gfm - markup.quote
 
 > > ```
 > This is a paragraph highlight as code,
@@ -4285,7 +4285,7 @@ second line
 >        ```C++
 | <- markup.quote.markdown markup.list.numbered.markdown punctuation.definition.blockquote.markdown
 |^ markup.quote.markdown markup.list.numbered.markdown - meta.code-fence
-| ^^^^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown meta.code-fence.definition.begin.text.markdown-gfm
+| ^^^^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown meta.code-fence.definition.begin.markdown-gfm
 |        ^^^ punctuation.definition.raw.code-fence.begin.markdown
 |           ^^^ constant.other.language-name.markdown
 
@@ -4306,7 +4306,7 @@ second line
 >        ```
 | <- markup.quote.markdown punctuation.definition.blockquote.markdown
 |^ markup.quote.markdown markup.list.numbered.markdown - meta.code-fence
-| ^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown meta.code-fence.definition.end.text.markdown-gfm
+| ^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown meta.code-fence.definition.end.markdown-gfm
 |        ^^^ punctuation.definition.raw.code-fence.end.markdown
 
 ## https://custom-tests/block-quotes/list-blocks/unordered-items-with-reference-definitions
@@ -4665,11 +4665,11 @@ A list item may contain blocks that are separated by more than one blank line.
 1.  foo
 
     ```
-    | <- markup.list.numbered.markdown meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+    | <- markup.list.numbered.markdown meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
     bar
     | <- markup.list.numbered.markdown markup.raw.code-fence.markdown-gfm - punctuation
     ```
-    | <- markup.list.numbered.markdown meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+    | <- markup.list.numbered.markdown meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 
     baz
     | <- markup.list.numbered.markdown
@@ -5141,15 +5141,15 @@ So is this, with a empty second item:
 
 - a
 - ```
-  | <- markup.list.unnumbered.markdown meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-  |^^ markup.list.unnumbered.markdown meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+  | <- markup.list.unnumbered.markdown meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+  |^^ markup.list.unnumbered.markdown meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
   b
   | <- markup.list.unnumbered.markdown markup.raw.code-fence.markdown-gfm
 
 
   ```
-  | <- markup.list.unnumbered.markdown meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-  |^^ markup.list.unnumbered.markdown meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+  | <- markup.list.unnumbered.markdown meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+  |^^ markup.list.unnumbered.markdown meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 
 - a
 - ```
@@ -5189,12 +5189,12 @@ So is this, with a empty second item:
 - a
   > b
   ```
-  | <- markup.list.unnumbered.markdown meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-  |^^ markup.list.unnumbered.markdown meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+  | <- markup.list.unnumbered.markdown meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+  |^^ markup.list.unnumbered.markdown meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
   c
   ```
-  | <- markup.list.unnumbered.markdown meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-  |^^ markup.list.unnumbered.markdown meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+  | <- markup.list.unnumbered.markdown meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+  |^^ markup.list.unnumbered.markdown meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 
 - a
   > b
@@ -5207,13 +5207,13 @@ So is this, with a empty second item:
 ## https://spec.commonmark.org/0.30/#example-324
 
 1. ```
-   | <- markup.list.numbered.markdown meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-   |^^ markup.list.numbered.markdown meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+   | <- markup.list.numbered.markdown meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+   |^^ markup.list.numbered.markdown meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
    foo
    | <- markup.list.numbered.markdown markup.raw.code-fence.markdown-gfm
    ```
-   | <- markup.list.numbered.markdown meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-   |^^ markup.list.numbered.markdown meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+   | <- markup.list.numbered.markdown meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+   |^^ markup.list.numbered.markdown meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 
    bar
    | <- markup.list.numbered.markdown
@@ -5527,12 +5527,12 @@ global heading
 
   * foo
 	```xml
-|^^^ markup.list.unnumbered.markdown meta.code-fence.definition.begin.xml.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|    ^^ markup.list.unnumbered.markdown meta.code-fence.definition.begin.xml.markdown-gfm constant.other.language-name.markdown
+|^^^ markup.list.unnumbered.markdown meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|    ^^ markup.list.unnumbered.markdown meta.code-fence.definition.begin.markdown-gfm constant.other.language-name.markdown
 	<tag>
 |^^^^^ markup.list.unnumbered.markdown markup.raw.code-fence.xml.markdown-gfm text.xml meta.tag.xml
 	```
-|^^^ markup.list.unnumbered.markdown meta.code-fence.definition.end.xml.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^^ markup.list.unnumbered.markdown meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 
 ## https://custom-tests/list-blocks/items-with-html-blocks
 
@@ -9200,7 +9200,7 @@ paragraph
 
 ::: code-block
 ```css
-|^^^^^ meta.code-fence.definition.begin.css.markdown-gfm
+|^^^^^ meta.code-fence.definition.begin.markdown-gfm
 |^^ punctuation.definition.raw.code-fence.begin.markdown
 |  ^^^ constant.other.language-name.markdown
 ```

--- a/Rails/tests/syntax_test_rails.haml
+++ b/Rails/tests/syntax_test_rails.haml
@@ -503,8 +503,8 @@
   ```c
   void foo() {}
   ```
-  / <- meta.filter.haml meta.embedded.haml text.html.markdown.embedded.haml meta.code-fence.definition.end.c.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-  /^^ meta.filter.haml meta.embedded.haml text.html.markdown.embedded.haml meta.code-fence.definition.end.c.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+  / <- meta.filter.haml meta.embedded.haml text.html.markdown.embedded.haml meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+  /^^ meta.filter.haml meta.embedded.haml text.html.markdown.embedded.haml meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 
   - list #{@item}
   / <- meta.filter.haml meta.embedded.haml text.html.markdown.embedded.haml markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown


### PR DESCRIPTION
This commit...

1. removes syntax name from `meta.code-fence.definition.[begin|end].[syntax]`.

   As a result each code block uses common scope: `meta.code-fence.definition.[begin|end].markdown-gfm`

   Amount of unique scopes which need to be handled by ST is reduced.

2. adds `meta.code-fence.body` to content part, so code fences can be addressed or searched by `meta.code-fence` scope.

   Example:

       view.sel().add_all(view.find_by_selector("meta.code-fence"))

   selects all fenced code blocks in a document.