### PR TITLE
[Markdown] Optimize paragraph patterns and reorganize variables

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -116,31 +116,6 @@ variables:
     | __        {{balance_square_brackets_and_emphasis}}__
     )
 
-  table_cell: |-
-    (?x:
-      # Pipes inside other inline spans (such as emphasis, code, etc.) will not break a cell,
-      # emphasis in table cells can't span multiple lines
-      (?:
-        {{balance_square_brackets_pipes_and_emphasis}}
-      | {{balanced_emphasis}}
-      )+  # at least one character
-    )
-  table_first_row: |-
-    (?x:
-      # at least 2 non-escaped pipe chars on the line
-      (?:{{table_cell}}?\|){2}
-
-      # something other than whitespace followed by a pipe char or hyphen,
-      # followed by something other than whitespace and the end of the line
-    | (?! \s*\-\s+ | \s+\|){{table_cell}}\|(?!\s+$)
-    )
-
-  table_codespan_content: |-
-    (?x:
-      [^`|]             # first or only char must not be a backtick or pipe.
-      (?:[^|]*?[^`|])?  # none must be a pipe, the last additionally must not be a backtick
-    )
-
   fenced_code_block: |-
     (?x:
       (`){3,}      #   3 or more backticks
@@ -351,6 +326,35 @@ variables:
         |   {{html_block}}              # a html block begins the line
         )
       )
+    )
+
+  # Tables
+  # ======
+
+  table_first_row: |-
+    (?x:
+      # at least 2 non-escaped pipe chars on the line
+      (?:{{table_cell}}?\|){2}
+
+      # something other than whitespace followed by a pipe char or hyphen,
+      # followed by something other than whitespace and the end of the line
+    | (?! \s*\-\s+ | \s+\|){{table_cell}}\|(?!\s+$)
+    )
+
+  table_cell: |-
+    (?x:
+      # Pipes inside other inline spans (such as emphasis, code, etc.) will not break a cell,
+      # emphasis in table cells can't span multiple lines
+      (?:
+        {{balance_square_brackets_pipes_and_emphasis}}
+      | {{balanced_emphasis}}
+      )+  # at least one character
+    )
+
+  table_codespan_content: |-
+    (?x:
+      [^`|]             # first or only char must not be a backtick or pipe.
+      (?:[^|]*?[^`|])?  # none must be a pipe, the last additionally must not be a backtick
     )
 
   table_end: |-

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -179,24 +179,6 @@ variables:
   tag_unquoted_attribute_start: (?=[^{{ascii_space}}=/>}])
   tag_unquoted_attribute_break: (?=[{{ascii_space}}}]|/?>)
 
-  reference_definition: (?:\[{{reference_name}}\]\:)
-  footnote_name: (?:\^(?:\\\]|[^]])+)
-  reference_name: (?:(?:\\\]|[^]])+)
-
-  blockquote_footnote_end: |-
-    (?x: # pop out of this context if one of the following conditions are met:
-      ^(?= (?:[ \t]*>)* [ \t]*
-        (?: $                           # the line is blank (or only contains whitespace)
-        |   {{reference_definition}}    # a reference definition begins the line
-        |   {{atx_heading}}             # an ATX heading begins the line
-        |   {{fenced_code_block}}       # a fenced codeblock begins the line
-        |   {{fenced_div_block}}        # a fenced div block begins the line
-        |   {{thematic_break}}          # line is a thematic beak
-        |   {{list_item}}               # a list item begins the line
-        |   {{html_block}}              # a html block begins the line
-        )
-      )
-    )
 
   blockquote_paragraph_end: |-
     (?x: # pop out of this context if one of the following conditions are met:
@@ -216,22 +198,6 @@ variables:
     (?x: # pop out of this context if one of the following conditions are met:
       ^(?= (?:[ \t]*>)* [ \t]*
         (?: $                           # the line is blank (or only contains whitespace)
-        |   {{atx_heading}}             # an ATX heading begins the line
-        |   {{fenced_code_block}}       # a fenced codeblock begins the line
-        |   {{fenced_div_block}}        # a fenced div block begins the line
-        |   {{thematic_break}}          # line is a thematic beak
-        |   {{list_item}}               # a list item begins the line
-        |   {{html_block}}              # a html block begins the line
-        )
-      )
-    )
-
-  footnote_end: |-
-    (?x: # pop out of this context if one of the following conditions are met:
-      ^(?= [ \t]*
-        (?: $                           # the line is blank (or only contains whitespace)
-        |   {{reference_definition}}    # a reference definition begins the line
-        |   {{block_quote}}             # a blockquote begins the line
         |   {{atx_heading}}             # an ATX heading begins the line
         |   {{fenced_code_block}}       # a fenced codeblock begins the line
         |   {{fenced_div_block}}        # a fenced div block begins the line
@@ -271,6 +237,45 @@ variables:
         )
       )
     )
+
+  # References and Footnotes
+  # ========================
+
+  blockquote_footnote_end: |-
+    (?x: # pop out of this context if one of the following conditions are met:
+      ^(?= (?:[ \t]*>)* [ \t]*
+        (?: $                           # the line is blank (or only contains whitespace)
+        |   {{reference_definition}}    # a reference definition begins the line
+        |   {{atx_heading}}             # an ATX heading begins the line
+        |   {{fenced_code_block}}       # a fenced codeblock begins the line
+        |   {{fenced_div_block}}        # a fenced div block begins the line
+        |   {{thematic_break}}          # line is a thematic beak
+        |   {{list_item}}               # a list item begins the line
+        |   {{html_block}}              # a html block begins the line
+        )
+      )
+    )
+
+  footnote_end: |-
+    (?x: # pop out of this context if one of the following conditions are met:
+      ^(?= [ \t]*
+        (?: $                           # the line is blank (or only contains whitespace)
+        |   {{reference_definition}}    # a reference definition begins the line
+        |   {{block_quote}}             # a blockquote begins the line
+        |   {{atx_heading}}             # an ATX heading begins the line
+        |   {{fenced_code_block}}       # a fenced codeblock begins the line
+        |   {{fenced_div_block}}        # a fenced div block begins the line
+        |   {{thematic_break}}          # line is a thematic beak
+        |   {{list_item}}               # a list item begins the line
+        |   {{html_block}}              # a html block begins the line
+        )
+      )
+    )
+
+  footnote_name: (?:\^(?:\\\]|[^]])+)
+
+  reference_definition: (?:\[{{reference_name}}\]\:)
+  reference_name: (?:(?:\\\]|[^]])+)
 
   # Tables
   # ======

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -60,6 +60,9 @@ variables:
       [ \t]*$                    # followed by any number of tabs or spaces, followed by the end of the line
     )
 
+  # Fenced code blocks
+  # ==================
+
   fenced_code_block: |-
     (?x:
       (`){3,}      #   3 or more backticks
@@ -67,11 +70,13 @@ variables:
     |              # or
       (~){3,}      #   3 or more tildas
     )
+
   fenced_code_block_start: |-
     (?x:
       ([ \t]*)
       ({{fenced_code_block}})
     )
+
   fenced_code_block_language: |-
     (?x:             # first word of an infostring is used as language specifier
       \s*            # allow for whitespace between code block start and info string
@@ -80,6 +85,7 @@ variables:
         [^\s:;`]*    # optionally followed by any nonwhitespace character (except backticks)
       )
     )
+
   fenced_code_block_trailing_infostring_characters: |-
     (?x:
       (?:
@@ -88,6 +94,7 @@ variables:
       )?
       (\s*$\n?)              # ... until EOL (fold begin marker)
     )
+
   fenced_code_block_end: |-
     (?x:
       [ \t]*
@@ -180,6 +187,8 @@ variables:
   tag_unquoted_attribute_start: (?=[^{{ascii_space}}=/>}])
   tag_unquoted_attribute_break: (?=[{{ascii_space}}}]|/?>)
 
+  # Pragraphs
+  # =========
 
   blockquote_paragraph_end: |-
     (?x: # pop out of this context if one of the following conditions are met:

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -97,14 +97,14 @@ variables:
       )
       (\s*$\n?)      # any amount of whitespace until EOL (fold end marker)
     )
+
   fenced_code_block_escape: ^{{fenced_code_block_end}}
 
   # https://pandoc.org/MANUAL.html#divs-and-spans
   fenced_div_block: ':{3,}'
 
-  # https://spec.commonmark.org/0.30/#email-autolink
-  email_domain_commonmark: '[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?'
-  email_user_commonmark: '[a-zA-Z0-9.!#$%&''*+/=?^_`{|}~-]+'
+  # HTML blocks
+  # ===========
 
   # https://spec.commonmark.org/0.30/#html-blocks
   html_block: |-
@@ -168,6 +168,7 @@ variables:
     | section | source | summary | table | tbody | td | tfoot | th
     | thead | title | tr | track | ul
     ){{html_tag_maybe_selfclosing_break_char}}
+
   html_tag_break_char: (?:[ \t>]|$)
   html_tag_maybe_selfclosing_break_char: (?:[ \t]|/?>|$)
 
@@ -398,6 +399,13 @@ variables:
          \* {{no_space_nor_punct}}
     | \B \* {{no_space_but_punct}}
     )
+
+  # Links
+  # =====
+
+  # https://spec.commonmark.org/0.30/#email-autolink
+  email_domain_commonmark: '[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?'
+  email_user_commonmark: '[a-zA-Z0-9.!#$%&''*+/=?^_`{|}~-]+'
 
   # Prototypes
   # ==========

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -21,31 +21,37 @@ file_extensions:
   - markdn
 
 variables:
-  atx_heading: (?:[ ]{,3}[#]{1,6}(?:[ \t]|$))         # between 0 and 3 spaces, followed 1 to 6 hashes, followed by at least one space or tab or by end of the line
-  atx_heading_space: (?:(?=[ \t]+#+[ \t]*$)|[ \t]+|$) # consume spaces only if heading is not empty to ensure `atx_heading_end` can fully match closing hashes
-  atx_heading_end: (?:[ \t]+(#+))?[ \t]*($\n?)        # \n is optional so ## is matched as end punctuation in new document (at eof)
 
-  setext_heading_or_paragraph: ^(?:[ ]{,3}=+|(?=[ ]{,3}\S))   # between 0 and 3 spaces, followed by non-whitespace (consume equal signs as paragraphs may start with them)
-  setext_heading_escape: ^(?=[ ]{,3}(?:=+|-+)[ \t]*$)         # between 0 and 3 spaces, followed by at least one hyphen or equal sign (setext underline can be of any length)
-  setext_heading1_escape: ^(?=[ ]{,3}=+[ \t]*$)               # between 0 and 3 spaces, followed by at least one equal sign (setext underline can be of any length)
-  setext_heading1_end: ^[ ]{,3}(=+)[ \t]*$(\n?)               # between 0 and 3 spaces, followed by at least one equal sign (setext underline can be of any length)
-  setext_heading2_end: ^[ ]{,3}(-+)[ \t]*$(\n?)               # between 0 and 3 spaces, followed by at least one hyphen (setext underline can be of any length)
+  # Headings
+  # ========
 
-  list_setext_heading_or_paragraph: (?:[ \t]*=+|(?=[ \t]*\S))  # any number of spaces, followed by non-whitespace (consume equal signs as paragraphs may start with them)
-  list_setext_heading_escape: ^(?=[ \t]{2,}(?:==+|--+)[ \t]*$) # two or more spaces, followed by at least one hyphen or equal sign (setext underline can be of any length, but ST needs at least 2 to avoid ambiguity with empty list items)
-  list_setext_heading1_escape: ^(?=[ \t]{2,}==+[ \t]*$)        # two or more spaces, followed by at least one equal sign (setext underline can be of any length, but ST needs at least 2 to avoid ambiguity with empty list items)
-  list_setext_heading1_end: ^[ \t]{2,}(==+)[ \t]*$(\n?)        # two or more spaces, followed by at least one equal sign (setext underline can be of any length, but ST needs at least 2 to avoid ambiguity with empty list items)
-  list_setext_heading2_end: ^[ \t]{2,}(--+)[ \t]*$(\n?)        # two or more spaces, followed by at least one hyphen (setext underline can be of any length, but ST needs at least 2 to avoid ambiguity with empty list items)
+  atx_heading: (?:\#{1,6}[ \t\n])                              # 1 to 6 hashes, followed by at least one space or tab or by end of the line
+  atx_heading_space: (?:(?=[ \t]+#+[ \t]*$)|[ \t]+|$)          # consume spaces only if heading is not empty to ensure `atx_heading_end` can fully match closing hashes
+  atx_heading_end: (?:[ \t]+(#+))?[ \t]*($\n?)                 # \n is optional so ## is matched as end punctuation in new document (at eof)
 
-  block_quote: (?:[ ]{,3}(>)[ ]?)                     # between 0 and 3 spaces, followed by a greater than sign, (followed by any character or the end of the line = "only care about optional space!")
-  indented_code_block: (?:[ ]{4}|[ ]{0,3}\t)          # a visual tab of width 4 consisting of 4 spaces or 0 to 3 spaces followed by 1 tab
+  setext_heading_or_paragraph: ^(?:[ ]{,3}=+[ \t]*$|(?=[ ]{,3}\S))    # between 0 and 3 spaces, followed by non-whitespace (consume equal signs as paragraphs may start with them)
+  setext_heading_escape: ^(?=[ ]{,3}(?:=+|-+)[ \t]*$)                 # between 0 and 3 spaces, followed by at least one hyphen or equal sign (setext underline can be of any length)
+  setext_heading1_escape: ^(?=[ ]{,3}=+[ \t]*$)                       # between 0 and 3 spaces, followed by at least one equal sign (setext underline can be of any length)
+  setext_heading1_end: ^[ ]{,3}(=+)[ \t]*($\n?)                       # between 0 and 3 spaces, followed by at least one equal sign (setext underline can be of any length)
+  setext_heading2_end: ^[ ]{,3}(-+)[ \t]*($\n?)                       # between 0 and 3 spaces, followed by at least one hyphen (setext underline can be of any length)
 
-  first_list_item: (?:[ ]{,3}(?:1[.)]|[*+-])\s)       # between 0 and 3 spaces, followed by either: at least one integer and a full stop or a parenthesis, or (a star, plus or dash), followed by whitespace
-  list_item: (?:[ ]{,3}(?:\d{1,9}[.)]|[*+-])\s)       # between 0 and 3 spaces, followed by either: at least one integer and a full stop or a parenthesis, or (a star, plus or dash), followed by whitespace
+  list_setext_heading_or_paragraph: (?:[ \t]*=+[ \t]*$|(?=[ \t]*\S))  # any number of spaces, followed by non-whitespace (consume equal signs as paragraphs may start with them)
+  list_setext_heading_escape: ^(?=[ \t]{2,}(?:==+|--+)[ \t]*$)        # two or more spaces, followed by at least one hyphen or equal sign (setext underline can be of any length, but ST needs at least 2 to avoid ambiguity with empty list items)
+  list_setext_heading1_escape: ^(?=[ \t]{2,}==+[ \t]*$)               # two or more spaces, followed by at least one equal sign (setext underline can be of any length, but ST needs at least 2 to avoid ambiguity with empty list items)
+  list_setext_heading1_end: ^[ \t]{2,}(==+)[ \t]*($\n?)               # two or more spaces, followed by at least one equal sign (setext underline can be of any length, but ST needs at least 2 to avoid ambiguity with empty list items)
+  list_setext_heading2_end: ^[ \t]{2,}(--+)[ \t]*($\n?)               # two or more spaces, followed by at least one hyphen (setext underline can be of any length, but ST needs at least 2 to avoid ambiguity with empty list items)
+
+  # Common Block Indicators
+  # =======================
+
+  block_quote: '>'                             # a greater than sign, (followed by any character or the end of the line)
+  indented_code_block: (?:[ ]{4}|[ ]{0,3}\t)   # a visual tab of width 4 consisting of 4 spaces or 0 to 3 spaces followed by 1 tab
+
+  first_list_item: (?:(?:1[.)]|[*+-])[ \t\n])  # at least one integer and a full stop or a parenthesis, or (a star, plus or dash), followed by whitespace
+  list_item: (?:(?:\d{1,9}[.)]|[*+-])[ \t\n])  # at least one integer and a full stop or a parenthesis, or (a star, plus or dash), followed by whitespace
 
   thematic_break: |-
     (?x:
-      [ ]{,3}                    # between 0 to 3 spaces
       (?:                        # followed by one of the following:
         [-](?:[ \t]*[-]){2,}     # - a dash,        followed by the following at least twice: any number of spaces or tabs followed by a dash
       | [*](?:[ \t]*[*]){2,}     # - a star,        followed by the following at least twice: any number of spaces or tabs followed by a star
@@ -132,18 +138,20 @@ variables:
   table_codespan_content: |-
     (?x:
       [^`|]             # first or only char must not be a backtick or pipe.
-      (?:[^|]*?[^`|])?   # none must be a pipe, the last additionally must not be a backtick
+      (?:[^|]*?[^`|])?  # none must be a pipe, the last additionally must not be a backtick
     )
 
+  fenced_code_block: |-
+    (?x:
+      (`){3,}      #   3 or more backticks
+      (?![^`]*`)   #   not followed by any more backticks on the same line
+    |              # or
+      (~){3,}      #   3 or more tildas
+    )
   fenced_code_block_start: |-
     (?x:
       ([ \t]*)
-      (
-        (`){3,}      #   3 or more backticks
-        (?![^`]*`)   #   not followed by any more backticks on the same line
-      |              # or
-        (~){3,}      #   3 or more tildes
-      )
+      ({{fenced_code_block}})
     )
   fenced_code_block_language: |-
     (?x:             # first word of an infostring is used as language specifier
@@ -173,7 +181,7 @@ variables:
   fenced_code_block_escape: ^{{fenced_code_block_end}}
 
   # https://pandoc.org/MANUAL.html#divs-and-spans
-  fenced_div_block: '[ \t]*(:{3,})'
+  fenced_div_block: ':{3,}'
 
   # https://spec.commonmark.org/0.30/#email-autolink
   email_domain_commonmark: '[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?'
@@ -182,17 +190,14 @@ variables:
   # https://spec.commonmark.org/0.30/#html-blocks
   html_block: |-
     (?x:
-      [ ]{,3}
-      (?:
-        {{html_tag_block_end_at_close_tag}}  # html block type 1
-      | {{html_tag_block_end_at_blank_line}} # html block type 6
-      | {{html_block_open_tag}}              # html block type 7
-      | {{html_block_close_tag}}             # html block type 7
-      | {{html_block_comment}}               # html block type 2
-      | {{html_block_decl}}                  # html block type 4
-      | {{html_block_cdata}}                 # html block type 5
-      | {{html_block_preprocessor}}          # html block type 3
-      )
+      {{html_tag_block_end_at_close_tag}}  # html block type 1
+    | {{html_tag_block_end_at_blank_line}} # html block type 6
+    | {{html_block_open_tag}}              # html block type 7
+    | {{html_block_close_tag}}             # html block type 7
+    | {{html_block_comment}}               # html block type 2
+    | {{html_block_decl}}                  # html block type 4
+    | {{html_block_cdata}}                 # html block type 5
+    | {{html_block_preprocessor}}          # html block type 3
     )
   html_block_comment: <!--
   html_block_cdata: <!\[CDATA\[
@@ -259,17 +264,78 @@ variables:
   footnote_name: (?:\^(?:\\\]|[^]])+)
   reference_name: (?:(?:\\\]|[^]])+)
 
+  blockquote_footnote_end: |-
+    (?x: # pop out of this context if one of the following conditions are met:
+      ^(?= (?:[ \t]*>)* [ \t]*
+        (?: $                           # the line is blank (or only contains whitespace)
+        |   {{reference_definition}}    # a reference definition begins the line
+        |   {{atx_heading}}             # an ATX heading begins the line
+        |   {{fenced_code_block}}       # a fenced codeblock begins the line
+        |   {{fenced_div_block}}        # a fenced div block begins the line
+        |   {{thematic_break}}          # line is a thematic beak
+        |   {{list_item}}               # a list item begins the line
+        |   {{html_block}}              # a html block begins the line
+        )
+      )
+    )
+
+  blockquote_paragraph_end: |-
+    (?x: # pop out of this context if one of the following conditions are met:
+      ^(?= (?:[ \t]*>)* [ ]{,3}
+        (?: $                           # the line is blank (or only contains whitespace)
+        |   {{atx_heading}}             # an ATX heading begins the line
+        |   {{fenced_code_block}}       # a fenced codeblock begins the line
+        |   {{fenced_div_block}}        # a fenced div block begins the line
+        |   {{thematic_break}}          # line is a thematic beak
+        |   {{list_item}}               # a list item begins the line
+        |   {{html_block}}              # a html block begins the line
+        )
+      )
+    )
+
+  blockquote_nested_paragraph_end: |-
+    (?x: # pop out of this context if one of the following conditions are met:
+      ^(?= (?:[ \t]*>)* [ \t]*
+        (?: $                           # the line is blank (or only contains whitespace)
+        |   {{atx_heading}}             # an ATX heading begins the line
+        |   {{fenced_code_block}}       # a fenced codeblock begins the line
+        |   {{fenced_div_block}}        # a fenced div block begins the line
+        |   {{thematic_break}}          # line is a thematic beak
+        |   {{list_item}}               # a list item begins the line
+        |   {{html_block}}              # a html block begins the line
+        )
+      )
+    )
+
+  footnote_end: |-
+    (?x: # pop out of this context if one of the following conditions are met:
+      ^(?= [ \t]*
+        (?: $                           # the line is blank (or only contains whitespace)
+        |   {{reference_definition}}    # a reference definition begins the line
+        |   {{block_quote}}             # a blockquote begins the line
+        |   {{atx_heading}}             # an ATX heading begins the line
+        |   {{fenced_code_block}}       # a fenced codeblock begins the line
+        |   {{fenced_div_block}}        # a fenced div block begins the line
+        |   {{thematic_break}}          # line is a thematic beak
+        |   {{list_item}}               # a list item begins the line
+        |   {{html_block}}              # a html block begins the line
+        )
+      )
+    )
+
   paragraph_end: |-
     (?x: # pop out of this context if one of the following conditions are met:
-      ^(?=\s*$                        # the line is blank (or only contains whitespace)
-       |  {{block_quote}}             # a blockquote begins the line
-       |  {{atx_heading}}             # an ATX heading begins the line
-       |  {{fenced_code_block_start}} # a fenced codeblock begins the line
-       |  {{fenced_div_block}}        # a fenced div block begins the line
-       |  {{thematic_break}}          # line is a thematic beak
-       |  {{first_list_item}}         # a list item begins the line
-       |  {{html_block}}              # a html block begins the line
-       )
+      ^(?= [ \t]{,3}
+        (?: $                           # the line is blank (or only contains whitespace)
+        |   {{block_quote}}             # a blockquote begins the line
+        |   {{atx_heading}}             # an ATX heading begins the line
+        |   {{fenced_code_block}}       # a fenced codeblock begins the line
+        |   {{fenced_div_block}}        # a fenced div block begins the line
+        |   {{thematic_break}}          # line is a thematic beak
+        |   {{first_list_item}}         # a list item begins the line
+        |   {{html_block}}              # a html block begins the line
+        )
+      )
     )
 
   list_paragraph_end: |-
@@ -278,11 +344,24 @@ variables:
         (?: $                           # the line is blank (or only contains whitespace)
         |   {{block_quote}}             # a blockquote begins the line
         |   {{atx_heading}}             # an ATX heading begins the line
-        |   {{fenced_code_block_start}} # a fenced codeblock begins the line
+        |   {{fenced_code_block}}       # a fenced codeblock begins the line
         |   {{fenced_div_block}}        # a fenced div block begins the line
         |   {{thematic_break}}          # line is a thematic beak
         |   {{list_item}}               # a list item begins the line
         |   {{html_block}}              # a html block begins the line
+        )
+      )
+    )
+
+  table_end: |-
+    (?x: # pop out of this context if one of the following conditions are met:
+      ^(?= [ ]{,3}
+        (?: $                           # the line is blank (or only contains whitespace)
+        |   {{block_quote}}             # a blockquote begins the line
+        |   {{atx_heading}}             # an ATX heading begins the line
+        |   {{fenced_code_block}}       # a fenced codeblock begins the line
+        |   {{fenced_div_block}}        # a fenced div block begins the line
+        |   {{thematic_break}}          # line is a thematic beak
         )
       )
     )
@@ -587,20 +666,7 @@ contexts:
     - include: footnote-paragraph-common
 
   block-quote-footnote-paragraph-end:
-    - match: |-
-        (?x)
-        # pop out of this context if one of the following conditions are met:
-        ^(?= (?:[ \t]*>)* [ \t]*
-           (?: $                           # the line is blank (or only contains whitespace)
-           |   {{reference_definition}}    # a reference definition begins the line
-           |   {{atx_heading}}             # an ATX heading begins the line
-           |   {{fenced_code_block_start}} # a fenced codeblock begins the line
-           |   {{fenced_div_block}}        # a fenced div block begins the line
-           |   {{thematic_break}}          # line is a thematic beak
-           |   {{list_item}}               # a list item begins the line
-           |   {{html_block}}              # a html block begins the line
-           )
-        )
+    - match: '{{blockquote_footnote_end}}'
       pop: 1
 
   block-quote-link-definitions:
@@ -700,19 +766,7 @@ contexts:
     - include: inlines
 
   block-quote-nested-paragraph-end:
-    - match: |-
-        (?x)
-        # pop out of this context if one of the following conditions are met:
-        ^(?= (?:[ \t]*>)* [ \t]*
-           (?: $                           # the line is blank (or only contains whitespace)
-           |   {{atx_heading}}             # an ATX heading begins the line
-           |   {{fenced_code_block_start}} # a fenced codeblock begins the line
-           |   {{fenced_div_block}}        # a fenced div block begins the line
-           |   {{thematic_break}}          # line is a thematic beak
-           |   {{list_item}}               # a list item begins the line
-           |   {{html_block}}              # a html block begins the line
-           )
-        )
+    - match: '{{blockquote_nested_paragraph_end}}'
       pop: 1
 
 ###[ CONTAINER BLOCKS: BLOCK QUOTES > PARAGRAPHS ]############################
@@ -728,19 +782,7 @@ contexts:
     - include: inlines
 
   block-quote-paragraph-end:
-    - match: |-
-        (?x)
-        # pop out of this context if one of the following conditions are met:
-        ^(?= (?:[ \t]{,3}>)*
-           (?: \s* $                       # the line is blank (or only contains whitespace)
-           |   {{atx_heading}}             # an ATX heading begins the line
-           |   {{fenced_code_block_start}} # a fenced codeblock begins the line
-           |   {{fenced_div_block}}        # a fenced div block begins the line
-           |   {{thematic_break}}          # line is a thematic beak
-           |   {{list_item}}               # a list item begins the line
-           |   {{html_block}}              # a html block begins the line
-           )
-        )
+    - match: '{{blockquote_paragraph_end}}'
       pop: 1
 
 ###[ CONTAINER BLOCKS: LISTS ]################################################
@@ -2284,20 +2326,7 @@ contexts:
     - include: links
 
   footnote-paragraph-end:
-    - match: |-
-        (?x)
-        # pop out of this context if one of the following conditions are met:
-        ^(?= [ \t]*
-           (?: $                           # the line is blank (or only contains whitespace)
-           |   {{reference_definition}}    # a reference definition begins the line
-           |   {{atx_heading}}             # an ATX heading begins the line
-           |   {{fenced_code_block_start}} # a fenced codeblock begins the line
-           |   {{fenced_div_block}}        # a fenced div block begins the line
-           |   {{thematic_break}}          # line is a thematic beak
-           |   {{list_item}}               # a list item begins the line
-           |   {{html_block}}              # a html block begins the line
-           )
-        )
+    - match: '{{footnote_end}}'
       pop: 1
 
   link-definitions:
@@ -2402,16 +2431,7 @@ contexts:
 
   table-end:
     # The table is broken at the first empty line, or beginning of another block-level structure
-    - match: |-
-          (?x)^
-          (?= \s*$
-          |   {{atx_heading}}
-          |   {{block_quote}}
-          |   {{fenced_code_block_start}}
-          |   {{fenced_div_block}}
-          |   {{indented_code_block}}
-          |   {{thematic_break}}
-          )
+    - match: '{{table_end}}'
       pop: 1
 
   table-cell-content:
@@ -2473,7 +2493,7 @@ contexts:
 
   thematic-breaks:
     # https://spec.commonmark.org/0.30/#thematic-breaks
-    - match: (?={{thematic_break}})
+    - match: (?=[ \t]*{{thematic_break}})
       push: thematic-break-body
 
   thematic-break-body:
@@ -3554,11 +3574,11 @@ contexts:
 
   fenced-div-blocks:
     # https://pandoc.org/MANUAL.html#divs-and-spans
-    - match: '{{fenced_div_block}}[ \t]*$\n?'
+    - match: '[ \t]*({{fenced_div_block}})[ \t]*$\n?'
       scope: meta.div.markdown
       captures:
         1: punctuation.section.div.end.markdown
-    - match: '{{fenced_div_block}}'
+    - match: '[ \t]*({{fenced_div_block}})'
       captures:
         1: punctuation.section.div.begin.markdown
       push:

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -60,62 +60,6 @@ variables:
       [ \t]*$                    # followed by any number of tabs or spaces, followed by the end of the line
     )
 
-  backticks: |-
-    (?x:
-      (`{4})[^`](?:[^`]|(?!`{4})`+[^`])*(`{4})(?!`)  # 4 backticks, followed by at least one non backtick character, followed by (less than 4 backticks, or at least one non backtick character) at least once, followed by exactly 4 backticks
-    | (`{3})[^`](?:[^`]|(?!`{3})`+[^`])*(`{3})(?!`)  # 3 backticks, followed by at least one non backtick character, followed by (less than 3 backticks, or at least one non backtick character) at least once, followed by exactly 3 backticks
-    | (`{2})[^`](?:[^`]|(?!`{2})`+[^`])*(`{2})(?!`)  # 2 backticks, followed by at least one non backtick character, followed by (less than 2 backticks, or at least one non backtick character) at least once, followed by exactly 2 backticks
-    | (`{1})[^`](?:[^`]|(?!`{1})`+[^`])*(`{1})(?!`)  # 1 backtick,  followed by at least one non backtick character, followed by (                          at least one non backtick character) at least once, followed by exactly 1 backtick
-    )
-  escapes: \\[-+*/!"#$%&'(),.:;<=>?@\[\\\]^_`{|}~]
-
-  balance_square_brackets: |-
-    (?x:
-      (?:
-        \\.                               # maybe escaped character (be lazy)
-      | [^\[\]`]                          # anything that isn't a square bracket or backtick
-      | {{backticks}}                     # inline code
-      | \[ (?:                            # nested square brackets (one level deep)
-          \\.                             #  maybe escaped character (be lazy)
-        | [^\[\]`]                        #  anything that isn't a square bracket or backtick
-        | {{backticks}}                   #  inline code
-        )* \]                             #  closing square bracket
-      )+
-    )
-  balance_square_brackets_and_emphasis: |-
-    (?x:
-      (?:
-        \\.                               # maybe escaped character (be lazy)
-      | [^\[\]`_*]                        # anything that isn't a square bracket, backtick or emphasis
-      | {{backticks}}                     # inline code
-      | \[ (?:                            # nested square brackets (one level deep)
-          \\.                             #  maybe escaped character (be lazy)
-        | [^\[\]`_*]                      #  anything that isn't a square bracket, backtick or emphasis
-        | {{backticks}}                   #  inline code
-        )* \]                             #  closing square bracket
-      )+                                  # at least one character
-    )
-  balance_square_brackets_pipes_and_emphasis: |-
-    (?x:
-      (?:
-        \\.                               # maybe escaped character (be lazy)
-      | [^\[\]`_*|]                       # anything that isn't a square bracket, backtick or emphasis or table cell separator
-      | {{backticks}}                     # inline code
-      | \[ (?:                            # nested square brackets (one level deep)
-          \\.                             #  maybe escaped character (be lazy)
-        | [^\[\]`_*|]                     #  anything that isn't a square bracket, backtick or emphasis or table cell separator
-        | {{backticks}}                   #  inline code
-        )* \]                             #  closing square bracket
-      )+                                  # at least one character
-    )
-  balanced_emphasis: |-
-    (?x:
-      \*  (?!\*){{balance_square_brackets_and_emphasis}}\*  (?!\*)
-    | \*\*      {{balance_square_brackets_and_emphasis}}\*\*
-    | _   (?!_) {{balance_square_brackets_and_emphasis}}_   (?!_)
-    | __        {{balance_square_brackets_and_emphasis}}__
-    )
-
   fenced_code_block: |-
     (?x:
       (`){3,}      #   3 or more backticks
@@ -370,6 +314,67 @@ variables:
       )
     )
 
+  # Inline
+  # ======
+
+  balanced_emphasis: |-
+    (?x:
+      \*  (?!\*){{balance_square_brackets_and_emphasis}}\*  (?!\*)
+    | \*\*      {{balance_square_brackets_and_emphasis}}\*\*
+    | _   (?!_) {{balance_square_brackets_and_emphasis}}_   (?!_)
+    | __        {{balance_square_brackets_and_emphasis}}__
+    )
+
+  balance_square_brackets: |-
+    (?x:
+      (?:
+        \\.                # maybe escaped character (be lazy)
+      | [^\[\]`]           # anything that isn't a square bracket or backtick
+      | {{backticks}}      # inline code
+      | \[ (?:             # nested square brackets (one level deep)
+          \\.              #  maybe escaped character (be lazy)
+        | [^\[\]`]         #  anything that isn't a square bracket or backtick
+        | {{backticks}}    #  inline code
+        )* \]              #  closing square bracket
+      )+
+    )
+
+  balance_square_brackets_and_emphasis: |-
+    (?x:
+      (?:
+        \\.                # maybe escaped character (be lazy)
+      | [^\[\]`_*]         # anything that isn't a square bracket, backtick or emphasis
+      | {{backticks}}      # inline code
+      | \[ (?:             # nested square brackets (one level deep)
+          \\.              #  maybe escaped character (be lazy)
+        | [^\[\]`_*]       #  anything that isn't a square bracket, backtick or emphasis
+        | {{backticks}}    #  inline code
+        )* \]              #  closing square bracket
+      )+                   # at least one character
+    )
+
+  balance_square_brackets_pipes_and_emphasis: |-
+    (?x:
+      (?:
+        \\.                # maybe escaped character (be lazy)
+      | [^\[\]`_*|]        # anything that isn't a square bracket, backtick or emphasis or table cell separator
+      | {{backticks}}      # inline code
+      | \[ (?:             # nested square brackets (one level deep)
+          \\.              #  maybe escaped character (be lazy)
+        | [^\[\]`_*|]      #  anything that isn't a square bracket, backtick or emphasis or table cell separator
+        | {{backticks}}    #  inline code
+        )* \]              #  closing square bracket
+      )+                   # at least one character
+    )
+
+  backticks: |-
+    (?x:
+      (`{4})[^`](?:[^`]|(?!`{4})`+[^`])*(`{4})(?!`)  # 4 backticks, followed by at least one non backtick character, followed by (less than 4 backticks, or at least one non backtick character) at least once, followed by exactly 4 backticks
+    | (`{3})[^`](?:[^`]|(?!`{3})`+[^`])*(`{3})(?!`)  # 3 backticks, followed by at least one non backtick character, followed by (less than 3 backticks, or at least one non backtick character) at least once, followed by exactly 3 backticks
+    | (`{2})[^`](?:[^`]|(?!`{2})`+[^`])*(`{2})(?!`)  # 2 backticks, followed by at least one non backtick character, followed by (less than 2 backticks, or at least one non backtick character) at least once, followed by exactly 2 backticks
+    | (`{1})[^`](?:[^`]|(?!`{1})`+[^`])*(`{1})(?!`)  # 1 backtick,  followed by at least one non backtick character, followed by (                          at least one non backtick character) at least once, followed by exactly 1 backtick
+    )
+
   # https://spec.commonmark.org/0.30/#left-flanking-delimiter-run
   bold_italic_asterisk_begin: |-
     (?x:
@@ -388,6 +393,11 @@ variables:
          \* {{no_space_nor_punct}}
     | \B \* {{no_space_but_punct}}
     )
+
+  # Prototypes
+  # ==========
+
+  escapes: \\[-+*/!"#$%&'(),.:;<=>?@\[\\\]^_`{|}~]
 
   no_escape_behind: (?<![^\\]\\)(?<![\\]{3})
   # not followed by Unicode whitespace and not followed by a Unicode punctuation character


### PR DESCRIPTION
This PR...

1. optimizes paragraph termination patterns (1st commit) to avoid catastrophic backtracking caused by chaining whitespace patterns like `\s*(?:\s*...|\s*...)` (simplified).

   This commit improves parsing performance of syntax_test_markdown.markdown by about 6-7%

2. reorganizes variables by category and adds some separating comments.

Note: Beyond improving performance, this PR does not change behavior.