### PR TITLE
[PHP] Remove interpolation scope from JS/CSS attribute value strings

### DIFF
--- a/PHP/PHP.sublime-syntax
+++ b/PHP/PHP.sublime-syntax
@@ -170,7 +170,7 @@ contexts:
   tag-event-attribute-value-double-quoted-body:
     - meta_include_prototype: false
     - meta_scope: meta.string.html
-    - meta_content_scope: meta.interpolation.html source.js.embedded.html
+    - meta_content_scope: source.js.embedded.html
     - match: \"
       scope: string.quoted.double.html punctuation.definition.string.end.html
       pop: 1
@@ -182,7 +182,7 @@ contexts:
   tag-event-attribute-value-single-quoted-body:
     - meta_include_prototype: false
     - meta_scope: meta.string.html
-    - meta_content_scope: meta.interpolation.html source.js.embedded.html
+    - meta_content_scope: source.js.embedded.html
     - match: \'
       scope: string.quoted.single.html punctuation.definition.string.end.html
       pop: 1
@@ -204,7 +204,7 @@ contexts:
   tag-style-attribute-value-double-quoted-body:
     - meta_include_prototype: false
     - meta_scope: meta.string.html
-    - meta_content_scope: meta.interpolation.html source.css.embedded.html
+    - meta_content_scope: source.css.embedded.html
     - match: \"
       scope: string.quoted.double.html punctuation.definition.string.end.html
       pop: 1
@@ -216,7 +216,7 @@ contexts:
   tag-style-attribute-value-single-quoted-body:
     - meta_include_prototype: false
     - meta_scope: meta.string.html
-    - meta_content_scope: meta.interpolation.html source.css.embedded.html
+    - meta_content_scope: source.css.embedded.html
     - match: \'
       scope: string.quoted.single.html punctuation.definition.string.end.html
       pop: 1

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -5923,7 +5923,7 @@ function embedHtml() {
 <script>
 //^^^^^^ text.html.php meta.tag
     var foo = 4;
-// ^^^^^^^^^^^^^^ source.js.embedded
+// ^^^^^^^^^^^^^^ source.js.embedded - meta.embedded - meta.interpolation
 //  ^ keyword.declaration
 //      ^^^ variable.other.readwrite
 //          ^ keyword.operator
@@ -6109,26 +6109,30 @@ h1 {
 
 <p style="color: <?php echo "red" ?>">text</p>
 //       ^ meta.attribute-with-value.style.html meta.string.html string.quoted.double.html punctuation.definition.string.begin.html - source
-//        ^^^^^^^ meta.attribute-with-value.style.html meta.string.html source.css.embedded.html - meta.embedded.php
-//               ^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.style.html meta.string.html source.css.embedded.html meta.embedded.php
+//        ^^^^^^^ meta.attribute-with-value.style.html meta.string.html source.css.embedded.html - meta.embedded.php - meta.interpolation
+//               ^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.style.html meta.string.html source.css.embedded.html meta.embedded.php - meta.interpolation
 //                                  ^ meta.attribute-with-value.style.html meta.string.html string.quoted.double.html punctuation.definition.string.end.html - source
 //                                   ^ text.html.php meta.tag.block.any.html punctuation.definition.tag.end.html
 
 <p style='color: <?php echo 'red' ?>'>text</p>
 //       ^ meta.attribute-with-value.style.html meta.string.html string.quoted.single.html punctuation.definition.string.begin.html - source
-//        ^^^^^^^ meta.attribute-with-value.style.html meta.string.html source.css.embedded.html - meta.embedded.php
-//               ^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.style.html meta.string.html source.css.embedded.html meta.embedded.php
+//        ^^^^^^^ meta.attribute-with-value.style.html meta.string.html source.css.embedded.html - meta.embedded.php - meta.interpolation
+//               ^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.style.html meta.string.html source.css.embedded.html meta.embedded.php - meta.interpolation
 //                                  ^ meta.attribute-with-value.style.html meta.string.html string.quoted.single.html punctuation.definition.string.end.html - source
 //                                   ^ text.html.php meta.tag.block.any.html punctuation.definition.tag.end.html
 
 <p onclick="foo(<?php echo "red" ?>)">text</p>
 //         ^ meta.attribute-with-value.event.html meta.string.html string.quoted.double.html punctuation.definition.string.begin.html - source
-//          ^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.event.html meta.string.html source.js.embedded.html meta.function-call
+//          ^^^^ meta.attribute-with-value.event.html meta.string.html source.js.embedded.html meta.function-call - meta.embedded - meta.interpolation
+//              ^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.event.html meta.string.html source.js.embedded.html meta.function-call meta.embedded.php - meta.interpolation
+//                                 ^ meta.attribute-with-value.event.html meta.string.html source.js.embedded.html meta.function-call - meta.embedded - meta.interpolation
 //                                  ^ meta.attribute-with-value.event.html meta.string.html string.quoted.double.html punctuation.definition.string.end.html - source
 
 <p onclick='foo(<?php echo 'red' ?>)'>text</p>
 //         ^ meta.attribute-with-value.event.html meta.string.html string.quoted.single.html punctuation.definition.string.begin.html - source
-//          ^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.event.html meta.string.html source.js.embedded.html meta.function-call
+//          ^^^^ meta.attribute-with-value.event.html meta.string.html source.js.embedded.html meta.function-call - meta.embedded - meta.interpolation
+//              ^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.event.html meta.string.html source.js.embedded.html meta.function-call meta.embedded.php - meta.interpolation
+//                                 ^ meta.attribute-with-value.event.html meta.string.html source.js.embedded.html meta.function-call - meta.embedded - meta.interpolation
 //                                  ^ meta.attribute-with-value.event.html meta.string.html string.quoted.single.html punctuation.definition.string.end.html - source
 
 <![CDATA[Text with <? $php ?> interpolation.]]>


### PR DESCRIPTION
This PR removes `meta.interpolation` from HTML tag attribute values, with CSS or JS syntax to align with changes of PR #4054.

Note: It should have already been part of #4054.