### PR TITLE
[Regular Expressions] Add location widget settings

### DIFF
--- a/Regular Expressions/Location Widget.sublime-settings
+++ b/Regular Expressions/Location Widget.sublime-settings
@@ -1,0 +1,3 @@
+{
+	"syntax": "Packages/Regular Expressions/File Pattern.sublime-syntax"
+}


### PR DESCRIPTION
This commit adds Location Widget.sublime-settings, because it is part of deployed Regular Expressions.sublime-packages of all stable ST4 releases.

Default.sublime-package contains an empty Location Widget.sublime-settings, in case Regular Expressions package is disabled.

Goal is to avoid surprises of "Where:" input field no longer being highlighted when crafting a Regular Expressions package directly from this repository and to avoid differences between content of this repo and deployed packages.