### PR TITLE
[Python] Add support for PEP750 t-strings

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -57,7 +57,7 @@ variables:
 
   colon: ':(?!=)'
 
-  string_prefix: '[bBrRfFuU]{,2}'
+  string_prefix: '[bBfFrRtTuU]{,2}'
 
   # Prefer ranged quantifiers over python interpolation in raw f-strings
   fstring_regexp_interpolation_begin: '\{(?!\d+(?:,\d*)?\})'
@@ -2744,8 +2744,8 @@ contexts:
     - include: string-prototype
 
   triple-double-quoted-plain-raw-f-string:
-    # Triple-quoted raw f-string
-    - match: ([fF]R|R[fF])(""")
+    # Triple-quoted raw f-string or t-string
+    - match: ([fFtT]R|R[fFtT])(""")
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
@@ -2763,8 +2763,8 @@ contexts:
     - include: triple-double-quoted-f-string-replacements
 
   triple-double-quoted-raw-f-string:
-    # Triple-quoted raw f-string, treated as regex
-    - match: ([fF]r|r[fF])(""")
+    # Triple-quoted raw f-string or t-string, treated as regex
+    - match: ([fFtT]r|r[fFtT])(""")
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
@@ -2876,8 +2876,8 @@ contexts:
     - include: triple-double-quoted-string-replacements
 
   triple-double-quoted-f-string:
-    # Triple-quoted f-string
-    - match: ([fF])(""")
+    # Triple-quoted f-string or t-string
+    - match: ([fFtT])(""")
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.double.block.python punctuation.definition.string.begin.python
@@ -3093,8 +3093,8 @@ contexts:
     - include: string-prototype
 
   double-quoted-plain-raw-f-string:
-    # Single-line raw f-string
-    - match: (R[fF]|[fF]R)(")
+    # Single-line raw f-string or t-string
+    - match: ([fFtT]R|R[fFtT])(")
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
@@ -3112,8 +3112,8 @@ contexts:
     - include: double-quoted-f-string-replacements
 
   double-quoted-raw-f-string:
-    # Single-line raw f-string, treated as regex
-    - match: (r[fF]|[fF]r)(")
+    # Single-line raw f-string or t-string, treated as regex
+    - match: ([fFtT]r|r[fFtT])(")
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
@@ -3222,8 +3222,8 @@ contexts:
     - include: double-quoted-string-replacements
 
   double-quoted-f-string:
-    # Single-line f-string
-    - match: ([fF])(")
+    # Single-line f-string or t-string
+    - match: ([fFtT])(")
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.double.python punctuation.definition.string.begin.python
@@ -3428,8 +3428,8 @@ contexts:
     - include: string-prototype
 
   triple-single-quoted-plain-raw-f-string:
-    # Triple-quoted raw f-string
-    - match: ([fF]R|R[fF])(''')
+    # Triple-quoted raw f-string or t-string
+    - match: ([fFtT]R|R[fFtT])(''')
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.single.block.python punctuation.definition.string.begin.python
@@ -3447,8 +3447,8 @@ contexts:
     - include: triple-single-quoted-f-string-replacements
 
   triple-single-quoted-raw-f-string:
-    # Triple-quoted raw f-string, treated as regex
-    - match: ([fF]r|r[fF])(''')
+    # Triple-quoted raw f-string or t-string, treated as regex
+    - match: ([fFtT]r|r[fFtT])(''')
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.single.block.python punctuation.definition.string.begin.python
@@ -3559,8 +3559,8 @@ contexts:
     - include: triple-single-quoted-string-replacements
 
   triple-single-quoted-f-string:
-    # Triple-quoted f-string
-    - match: ([fF])(''')
+    # Triple-quoted f-string or t-string
+    - match: ([fFtT])(''')
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.single.block.python punctuation.definition.string.begin.python
@@ -3845,7 +3845,7 @@ contexts:
 
   single-quoted-plain-raw-f-string:
     # Single-line raw f-string
-    - match: ([fF]R|R[fF])(')
+    - match: ([fFtT]R|R[fFtT])(')
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
@@ -3864,7 +3864,7 @@ contexts:
 
   single-quoted-raw-f-string:
     # Single-line raw f-string, treated as regex
-    - match: ([fF]r|r[fF])(')
+    - match: ([fFtT]r|r[fFtT])(')
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python
@@ -3905,8 +3905,8 @@ contexts:
     - include: single-quoted-string-replacements
 
   single-quoted-f-string:
-    # Single-line f-string
-    - match: ([fF])(')
+    # Single-line f-string or t-string
+    - match: ([fFtT])(')
       captures:
         1: storage.type.string.python
         2: meta.string.python string.quoted.single.python punctuation.definition.string.begin.python

--- a/Python/tests/syntax_test_scope_tstrings.py
+++ b/Python/tests/syntax_test_scope_tstrings.py
@@ -1,0 +1,700 @@
+# SYNTAX TEST "Packages/Python/Python.sublime-syntax"
+
+  t"""^A {t"""{foo + """bar"""}"""!r} \t-string[0-9]$ \""""
+# ^ - meta.string
+#  ^^^^^^ meta.string.python - meta.interpolation
+#        ^^ meta.string.python meta.interpolation.python - meta.string meta.string
+#          ^^^ meta.string.python meta.interpolation.python meta.string.python - meta.interpolation meta.interpolation
+#             ^^^^^^^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python
+#                    ^^^^^^^^^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python meta.string.python
+#                             ^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python
+#                              ^^^ meta.string.python meta.interpolation.python meta.string.python - meta.interpolation meta.interpolation
+#                                 ^^^ meta.string.python meta.interpolation.python - meta.string meta.string
+#                                    ^^^^^^^^^^^^^^^^^^^^^^ meta.string.python - meta.interpolation - meta.string meta.string
+#                                                          ^ - meta.string
+# ^ - string
+#  ^^^^^^ string.quoted.double.block.python
+#        ^^ - string
+#          ^^^ string.quoted.double.block.python
+#             ^^^^^^^ - string
+#                    ^^^^^^^^^ string.quoted.double.block.python
+#                             ^ - string
+#                              ^^^ string.quoted.double.block.python
+#                                 ^^^ - string
+#                                    ^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.block.python
+# ^ storage.type.string.python
+#  ^^^ punctuation.definition.string.begin.python
+#     ^^^ - constant - keyword - punctuation
+#        ^ punctuation.section.interpolation.begin.python
+#         ^ storage.type.string.python
+#          ^^^ punctuation.definition.string.begin.python
+#             ^ punctuation.section.interpolation.begin.python
+#              ^^^ meta.generic-name.python
+#                  ^ keyword.operator.arithmetic.python
+#                    ^^^ punctuation.definition.string.begin.python
+#                          ^^^ punctuation.definition.string.end.python
+#                             ^ punctuation.section.interpolation.end.python
+#                              ^^^ punctuation.definition.string.end.python
+#                                 ^^ storage.modifier.conversion.python
+#                                   ^ punctuation.section.interpolation.end.python
+#                                     ^^ constant.character.escape.python
+#                                       ^^^^^^^^^^^^^^ - constant - keyword - punctuation
+#                                                     ^^ constant.character.escape.python
+#                                                       ^^^ punctuation.definition.string.end.python
+
+  T"""^A {t"""{foo + """bar"""}"""!r} \t-string[0-9]$ \""""
+# ^ - meta.string
+#  ^^^^^^ meta.string.python - meta.interpolation
+#        ^^ meta.string.python meta.interpolation.python - meta.string meta.string
+#          ^^^ meta.string.python meta.interpolation.python meta.string.python - meta.interpolation meta.interpolation
+#             ^^^^^^^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python
+#                    ^^^^^^^^^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python meta.string.python
+#                             ^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python
+#                              ^^^ meta.string.python meta.interpolation.python meta.string.python - meta.interpolation meta.interpolation
+#                                 ^^^ meta.string.python meta.interpolation.python - meta.string meta.string
+#                                    ^^^^^^^^^^^^^^^^^^^^^^ meta.string.python - meta.interpolation - meta.string meta.string
+# ^ - string
+#  ^^^^^^ string.quoted.double.block.python
+#        ^^ - string
+#          ^^^ string.quoted.double.block.python
+#             ^^^^^^^ - string
+#                    ^^^^^^^^^ string.quoted.double.block.python
+#                             ^ - string
+#                              ^^^ string.quoted.double.block.python
+#                                 ^^^ - string
+#                                    ^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.block.python
+# ^ storage.type.string.python
+#  ^^^ punctuation.definition.string.begin.python
+#     ^^^ - constant - keyword - punctuation
+#        ^ punctuation.section.interpolation.begin.python
+#         ^ storage.type.string.python
+#          ^^^ punctuation.definition.string.begin.python
+#             ^ punctuation.section.interpolation.begin.python
+#              ^^^ meta.generic-name.python
+#                  ^ keyword.operator.arithmetic.python
+#                    ^^^ punctuation.definition.string.begin.python
+#                          ^^^ punctuation.definition.string.end.python
+#                             ^ punctuation.section.interpolation.end.python
+#                              ^^^ punctuation.definition.string.end.python
+#                                 ^^ storage.modifier.conversion.python
+#                                   ^ punctuation.section.interpolation.end.python
+#                                     ^^ constant.character.escape.python
+#                                       ^^^^^^^^^^^^^^ - constant - keyword - punctuation
+#                                                     ^^ constant.character.escape.python
+#                                                       ^^^ punctuation.definition.string.end.python
+#                                                          ^ - meta.string
+
+  rt"""^A {t"""{foo + """bar"""}"""!r} \t-string[0-9]$ \""""
+# ^^ - meta.string
+#   ^^^^^^ meta.string.python - meta.interpolation
+#         ^^ meta.string.python meta.interpolation.python - meta.string meta.string
+#           ^^^ meta.string.python meta.interpolation.python meta.string.python - meta.interpolation meta.interpolation
+#              ^^^^^^^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python
+#                     ^^^^^^^^^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python meta.string.python
+#                              ^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python
+#                               ^^^ meta.string.python meta.interpolation.python meta.string.python - meta.interpolation meta.interpolation
+#                                  ^^^ meta.string.python meta.interpolation.python - meta.string meta.string
+#                                     ^^^^^^^^^^^^^^^^^^^^^^ meta.string.python - meta.interpolation - meta.string meta.string
+# ^^ - string
+#   ^^^^^^ string.quoted.double.block.python
+#         ^^ - string
+#           ^^^ string.quoted.double.block.python
+#              ^^^^^^^ - string
+#                     ^^^^^^^^^ string.quoted.double.block.python
+#                              ^ - string
+#                               ^^^ string.quoted.double.block.python
+#                                  ^^^ - string
+#                                     ^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.block.python
+# ^^ storage.type.string.python
+#   ^^^ punctuation.definition.string.begin.python
+#      ^ keyword.control.anchor.regexp
+#       ^^ - constant - keyword - punctuation
+#         ^ punctuation.section.interpolation.begin.python
+#          ^ storage.type.string.python
+#           ^^^ punctuation.definition.string.begin.python
+#              ^ punctuation.section.interpolation.begin.python
+#               ^^^ meta.generic-name.python
+#                   ^ keyword.operator.arithmetic.python
+#                     ^^^ punctuation.definition.string.begin.python
+#                           ^^^ punctuation.definition.string.end.python
+#                              ^ punctuation.section.interpolation.end.python
+#                               ^^^ punctuation.definition.string.end.python
+#                                  ^^ storage.modifier.conversion.python
+#                                    ^ punctuation.section.interpolation.end.python
+#                                      ^^ constant.character.escape.regexp
+#                                        ^^^^^^^ - constant - keyword - punctuation
+#                                               ^^^^^ meta.set.regexp
+#                                                    ^ keyword.control.anchor.regexp
+#                                                     ^ - constant - keyword - punctuation
+#                                                      ^^ constant.character.escape.regexp
+#                                                        ^^^ punctuation.definition.string.end.python
+#                                                           ^ - meta.string
+
+  RT"""^A {t"""{foo + """bar"""}"""!r} \t-string[0-9]$ \""""
+# ^^ - meta.string
+#   ^^^^^^ meta.string.python - meta.interpolation
+#         ^^ meta.string.python meta.interpolation.python - meta.string meta.string
+#           ^^^ meta.string.python meta.interpolation.python meta.string.python - meta.interpolation meta.interpolation
+#              ^^^^^^^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python
+#                     ^^^^^^^^^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python meta.string.python
+#                              ^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python
+#                               ^^^ meta.string.python meta.interpolation.python meta.string.python - meta.interpolation meta.interpolation
+#                                  ^^^ meta.string.python meta.interpolation.python - meta.string meta.string
+#                                     ^^^^^^^^^^^^^^^^^^^^^^ meta.string.python - meta.interpolation - meta.string meta.string
+# ^^ - string
+#   ^^^^^^ string.quoted.double.block.python
+#         ^^ - string
+#           ^^^ string.quoted.double.block.python
+#              ^^^^^^^ - string
+#                     ^^^^^^^^^ string.quoted.double.block.python
+#                              ^ - string
+#                               ^^^ string.quoted.double.block.python
+#                                  ^^^ - string
+#                                     ^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.block.python
+# ^^ storage.type.string.python
+#   ^^^ punctuation.definition.string.begin.python
+#      ^^^ - constant - keyword - punctuation
+#         ^ punctuation.section.interpolation.begin.python
+#          ^ storage.type.string.python
+#           ^^^ punctuation.definition.string.begin.python
+#              ^ punctuation.section.interpolation.begin.python
+#               ^^^ meta.generic-name.python
+#                   ^ keyword.operator.arithmetic.python
+#                     ^^^ punctuation.definition.string.begin.python
+#                           ^^^ punctuation.definition.string.end.python
+#                              ^ punctuation.section.interpolation.end.python
+#                               ^^^ punctuation.definition.string.end.python
+#                                  ^^ storage.modifier.conversion.python
+#                                    ^ punctuation.section.interpolation.end.python
+#                                      ^^^^^^^^^^^^^^^^^^ - constant - keyword - punctuation
+#                                                        ^^^ punctuation.definition.string.end.python
+#                                                           ^ - meta.string
+
+
+  t'''^A {t'''{foo + '''bar'''}'''!r} \t-string[0-9]$ \''''
+# ^ - meta.string
+#  ^^^^^^ meta.string.python - meta.interpolation
+#        ^^ meta.string.python meta.interpolation.python - meta.string meta.string
+#          ^^^ meta.string.python meta.interpolation.python meta.string.python - meta.interpolation meta.interpolation
+#             ^^^^^^^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python
+#                    ^^^^^^^^^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python meta.string.python
+#                             ^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python
+#                              ^^^ meta.string.python meta.interpolation.python meta.string.python - meta.interpolation meta.interpolation
+#                                 ^^^ meta.string.python meta.interpolation.python - meta.string meta.string
+#                                    ^^^^^^^^^^^^^^^^^^^^^^ meta.string.python - meta.interpolation - meta.string meta.string
+#                                                          ^ - meta.string
+# ^ - string
+#  ^^^^^^ string.quoted.single.block.python
+#        ^^ - string
+#          ^^^ string.quoted.single.block.python
+#             ^^^^^^^ - string
+#                    ^^^^^^^^^ string.quoted.single.block.python
+#                             ^ - string
+#                              ^^^ string.quoted.single.block.python
+#                                 ^^^ - string
+#                                    ^^^^^^^^^^^^^^^^^^^^^^ string.quoted.single.block.python
+# ^ storage.type.string.python
+#  ^^^ punctuation.definition.string.begin.python
+#     ^^^ - constant - keyword - punctuation
+#        ^ punctuation.section.interpolation.begin.python
+#         ^ storage.type.string.python
+#          ^^^ punctuation.definition.string.begin.python
+#             ^ punctuation.section.interpolation.begin.python
+#              ^^^ meta.generic-name.python
+#                  ^ keyword.operator.arithmetic.python
+#                    ^^^ punctuation.definition.string.begin.python
+#                          ^^^ punctuation.definition.string.end.python
+#                             ^ punctuation.section.interpolation.end.python
+#                              ^^^ punctuation.definition.string.end.python
+#                                 ^^ storage.modifier.conversion.python
+#                                   ^ punctuation.section.interpolation.end.python
+#                                     ^^ constant.character.escape.python
+#                                       ^^^^^^^^^^^^^^ - constant - keyword - punctuation
+#                                                     ^^ constant.character.escape.python
+#                                                       ^^^ punctuation.definition.string.end.python
+
+  T'''^A {t'''{foo + '''bar'''}'''!r} \t-string[0-9]$ \''''
+# ^ - meta.string
+#  ^^^^^^ meta.string.python - meta.interpolation
+#        ^^ meta.string.python meta.interpolation.python - meta.string meta.string
+#          ^^^ meta.string.python meta.interpolation.python meta.string.python - meta.interpolation meta.interpolation
+#             ^^^^^^^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python
+#                    ^^^^^^^^^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python meta.string.python
+#                             ^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python
+#                              ^^^ meta.string.python meta.interpolation.python meta.string.python - meta.interpolation meta.interpolation
+#                                 ^^^ meta.string.python meta.interpolation.python - meta.string meta.string
+#                                    ^^^^^^^^^^^^^^^^^^^^^^ meta.string.python - meta.interpolation - meta.string meta.string
+#                                                          ^ - meta.string
+# ^ - string
+#  ^^^^^^ string.quoted.single.block.python
+#        ^^ - string
+#          ^^^ string.quoted.single.block.python
+#             ^^^^^^^ - string
+#                    ^^^^^^^^^ string.quoted.single.block.python
+#                             ^ - string
+#                              ^^^ string.quoted.single.block.python
+#                                 ^^^ - string
+#                                    ^^^^^^^^^^^^^^^^^^^^^^ string.quoted.single.block.python
+# ^ storage.type.string.python
+#  ^^^ punctuation.definition.string.begin.python
+#     ^^^ - constant - keyword - punctuation
+#        ^ punctuation.section.interpolation.begin.python
+#         ^ storage.type.string.python
+#          ^^^ punctuation.definition.string.begin.python
+#             ^ punctuation.section.interpolation.begin.python
+#              ^^^ meta.generic-name.python
+#                  ^ keyword.operator.arithmetic.python
+#                    ^^^ punctuation.definition.string.begin.python
+#                          ^^^ punctuation.definition.string.end.python
+#                             ^ punctuation.section.interpolation.end.python
+#                              ^^^ punctuation.definition.string.end.python
+#                                 ^^ storage.modifier.conversion.python
+#                                   ^ punctuation.section.interpolation.end.python
+#                                     ^^ constant.character.escape.python
+#                                       ^^^^^^^^^^^^^^ - constant - keyword - punctuation
+#                                                     ^^ constant.character.escape.python
+#                                                       ^^^ punctuation.definition.string.end.python
+
+  rt'''^A {t'''{foo + '''bar'''}'''!r} \t-string[0-9]$ \''''
+# ^^ - meta.string
+#   ^^^^^^ meta.string.python - meta.interpolation
+#         ^^ meta.string.python meta.interpolation.python - meta.string meta.string
+#           ^^^ meta.string.python meta.interpolation.python meta.string.python - meta.interpolation meta.interpolation
+#              ^^^^^^^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python
+#                     ^^^^^^^^^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python meta.string.python
+#                              ^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python
+#                               ^^^ meta.string.python meta.interpolation.python meta.string.python - meta.interpolation meta.interpolation
+#                                  ^^^ meta.string.python meta.interpolation.python - meta.string meta.string
+#                                     ^^^^^^^^^^^^^^^^^^^^^^ meta.string.python - meta.interpolation - meta.string meta.string
+# ^^ - string
+#   ^^^^^^ string.quoted.single.block.python
+#         ^^ - string
+#           ^^^ string.quoted.single.block.python
+#              ^^^^^^^ - string
+#                     ^^^^^^^^^ string.quoted.single.block.python
+#                              ^ - string
+#                               ^^^ string.quoted.single.block.python
+#                                  ^^^ - string
+#                                     ^^^^^^^^^^^^^^^^^^^^^^ string.quoted.single.block.python
+# ^^ storage.type.string.python
+#   ^^^ punctuation.definition.string.begin.python
+#      ^ keyword.control.anchor.regexp
+#       ^^ - constant - keyword - punctuation
+#         ^ punctuation.section.interpolation.begin.python
+#          ^ storage.type.string.python
+#           ^^^ punctuation.definition.string.begin.python
+#              ^ punctuation.section.interpolation.begin.python
+#               ^^^ meta.generic-name.python
+#                   ^ keyword.operator.arithmetic.python
+#                     ^^^ punctuation.definition.string.begin.python
+#                           ^^^ punctuation.definition.string.end.python
+#                              ^ punctuation.section.interpolation.end.python
+#                               ^^^ punctuation.definition.string.end.python
+#                                  ^^ storage.modifier.conversion.python
+#                                    ^ punctuation.section.interpolation.end.python
+#                                      ^^ constant.character.escape.regexp
+#                                        ^^^^^^^ - constant - keyword - punctuation
+#                                               ^^^^^ meta.set.regexp
+#                                                    ^ keyword.control.anchor.regexp
+#                                                     ^ - constant - keyword - punctuation
+#                                                      ^^ constant.character.escape.regexp
+#                                                        ^^^ punctuation.definition.string.end.python
+#                                                           ^ - meta.string
+
+  RT'''^A {t'''{foo + '''bar'''}'''!r} \t-string[0-9]$ \''''
+# ^^ - meta.string
+#   ^^^^^^ meta.string.python - meta.interpolation
+#         ^^ meta.string.python meta.interpolation.python - meta.string meta.string
+#           ^^^ meta.string.python meta.interpolation.python meta.string.python - meta.interpolation meta.interpolation
+#              ^^^^^^^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python
+#                     ^^^^^^^^^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python meta.string.python
+#                              ^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python
+#                               ^^^ meta.string.python meta.interpolation.python meta.string.python - meta.interpolation meta.interpolation
+#                                  ^^^ meta.string.python meta.interpolation.python - meta.string meta.string
+#                                     ^^^^^^^^^^^^^^^^^^^^^^ meta.string.python - meta.interpolation - meta.string meta.string
+# ^^ - string
+#   ^^^^^^ string.quoted.single.block.python
+#         ^^ - string
+#           ^^^ string.quoted.single.block.python
+#              ^^^^^^^ - string
+#                     ^^^^^^^^^ string.quoted.single.block.python
+#                              ^ - string
+#                               ^^^ string.quoted.single.block.python
+#                                  ^^^ - string
+#                                     ^^^^^^^^^^^^^^^^^^^^^^ string.quoted.single.block.python
+# ^^ storage.type.string.python
+#   ^^^ punctuation.definition.string.begin.python
+#      ^^^ - constant - keyword - punctuation
+#         ^ punctuation.section.interpolation.begin.python
+#          ^ storage.type.string.python
+#           ^^^ punctuation.definition.string.begin.python
+#              ^ punctuation.section.interpolation.begin.python
+#               ^^^ meta.generic-name.python
+#                   ^ keyword.operator.arithmetic.python
+#                     ^^^ punctuation.definition.string.begin.python
+#                           ^^^ punctuation.definition.string.end.python
+#                              ^ punctuation.section.interpolation.end.python
+#                               ^^^ punctuation.definition.string.end.python
+#                                  ^^ storage.modifier.conversion.python
+#                                    ^ punctuation.section.interpolation.end.python
+#                                      ^^^^^^^^^^^^^^^^^^ - constant - keyword - punctuation
+#                                                        ^^^ punctuation.definition.string.end.python
+#                                                           ^ - meta.string
+
+  t"^A {t"{foo + "bar"}"!r} \t-string[0-9]$ \""
+# ^ - meta.string
+#  ^^^^ meta.string.python - meta.interpolation
+#      ^^ meta.string.python meta.interpolation.python - meta.string meta.string
+#        ^ meta.string.python meta.interpolation.python meta.string.python - meta.interpolation meta.interpolation
+#         ^^^^^^^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python
+#                ^^^^^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python meta.string.python
+#                     ^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python
+#                      ^ meta.string.python meta.interpolation.python meta.string.python - meta.interpolation meta.interpolation
+#                       ^^^ meta.string.python meta.interpolation.python - meta.string meta.string
+#                          ^^^^^^^^^^^^^^^^^^^^ meta.string.python - meta.interpolation - meta.string meta.string
+#                                              ^ - meta.string
+# ^ - string
+#  ^^^^ string.quoted.double.python
+#      ^^ - string
+#        ^ string.quoted.double.python
+#         ^^^^^^^ - string
+#                ^^^^^ string.quoted.double.python
+#                     ^ - string
+#                      ^ string.quoted.double.python
+#                       ^^^ - string
+#                          ^^^^^^^^^^^^^^^^^^^^ string.quoted.double.python
+# ^ storage.type.string.python
+#  ^ punctuation.definition.string.begin.python
+#   ^^^ - constant - keyword - punctuation
+#      ^ punctuation.section.interpolation.begin.python
+#       ^ storage.type.string.python
+#        ^ punctuation.definition.string.begin.python
+#         ^ punctuation.section.interpolation.begin.python
+#          ^^^ meta.generic-name.python
+#              ^ keyword.operator.arithmetic.python
+#                ^ punctuation.definition.string.begin.python
+#                    ^ punctuation.definition.string.end.python
+#                     ^ punctuation.section.interpolation.end.python
+#                      ^ punctuation.definition.string.end.python
+#                       ^^ storage.modifier.conversion.python
+#                         ^ punctuation.section.interpolation.end.python
+#                           ^^ constant.character.escape.python
+#                             ^^^^^^^^^^^^^^ - constant - keyword - punctuation
+#                                           ^^ constant.character.escape.python
+#                                             ^ punctuation.definition.string.end.python
+
+  T"^A {t"{foo + "bar"}"!r} \t-string[0-9]$ \""
+# ^ - meta.string
+#  ^^^^ meta.string.python - meta.interpolation
+#      ^^ meta.string.python meta.interpolation.python - meta.string meta.string
+#        ^ meta.string.python meta.interpolation.python meta.string.python - meta.interpolation meta.interpolation
+#         ^^^^^^^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python
+#                ^^^^^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python meta.string.python
+#                     ^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python
+#                      ^ meta.string.python meta.interpolation.python meta.string.python - meta.interpolation meta.interpolation
+#                       ^^^ meta.string.python meta.interpolation.python - meta.string meta.string
+#                          ^^^^^^^^^^^^^^^^^^^^ meta.string.python - meta.interpolation - meta.string meta.string
+#                                              ^ - meta.string
+# ^ - string
+#  ^^^^ string.quoted.double.python
+#      ^^ - string
+#        ^ string.quoted.double.python
+#         ^^^^^^^ - string
+#                ^^^^^ string.quoted.double.python
+#                     ^ - string
+#                      ^ string.quoted.double.python
+#                       ^^^ - string
+#                          ^^^^^^^^^^^^^^^^^^^^ string.quoted.double.python
+# ^ storage.type.string.python
+#  ^ punctuation.definition.string.begin.python
+#   ^^^ - constant - keyword - punctuation
+#      ^ punctuation.section.interpolation.begin.python
+#       ^ storage.type.string.python
+#        ^ punctuation.definition.string.begin.python
+#         ^ punctuation.section.interpolation.begin.python
+#          ^^^ meta.generic-name.python
+#              ^ keyword.operator.arithmetic.python
+#                ^ punctuation.definition.string.begin.python
+#                    ^ punctuation.definition.string.end.python
+#                     ^ punctuation.section.interpolation.end.python
+#                      ^ punctuation.definition.string.end.python
+#                       ^^ storage.modifier.conversion.python
+#                         ^ punctuation.section.interpolation.end.python
+#                           ^^ constant.character.escape.python
+#                             ^^^^^^^^^^^^^^ - constant - keyword - punctuation
+#                                           ^^ constant.character.escape.python
+#                                             ^ punctuation.definition.string.end.python
+
+  rt"^A {t"{foo + "bar"}"!r} \t-string[0-9]$ \""
+# ^^ - meta.string
+#   ^^^^ meta.string.python - meta.interpolation
+#       ^^ meta.string.python meta.interpolation.python - meta.string meta.string
+#         ^ meta.string.python meta.interpolation.python meta.string.python - meta.interpolation meta.interpolation
+#          ^^^^^^^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python
+#                 ^^^^^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python meta.string.python
+#                      ^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python
+#                       ^ meta.string.python meta.interpolation.python meta.string.python - meta.interpolation meta.interpolation
+#                        ^^^ meta.string.python meta.interpolation.python - meta.string meta.string
+#                           ^^^^^^^^^^^^^^^^^^^^ meta.string.python - meta.interpolation - meta.string meta.string
+#                                               ^ - meta.string
+# ^^ - string
+#   ^^^^ string.quoted.double.python
+#       ^^ - string
+#         ^ string.quoted.double.python
+#          ^^^^^^^ - string
+#                 ^^^^^ string.quoted.double.python
+#                      ^ - string
+#                       ^ string.quoted.double.python
+#                        ^^^ - string
+#                           ^^^^^^^^^^^^^^^^^^^^ string.quoted.double.python
+# ^^ storage.type.string.python
+#   ^ punctuation.definition.string.begin.python
+#    ^ keyword.control.anchor.regexp
+#     ^^ - constant - keyword - punctuation
+#       ^ punctuation.section.interpolation.begin.python
+#        ^ storage.type.string.python
+#         ^ punctuation.definition.string.begin.python
+#          ^ punctuation.section.interpolation.begin.python
+#           ^^^ meta.generic-name.python
+#               ^ keyword.operator.arithmetic.python
+#                 ^ punctuation.definition.string.begin.python
+#                     ^ punctuation.definition.string.end.python
+#                      ^ punctuation.section.interpolation.end.python
+#                       ^ punctuation.definition.string.end.python
+#                        ^^ storage.modifier.conversion.python
+#                          ^ punctuation.section.interpolation.end.python
+#                            ^^ constant.character.escape.regexp
+#                              ^^^^^^^ - constant - keyword - punctuation
+#                                     ^^^^^ meta.set.regexp
+#                                          ^ keyword.control.anchor.regexp
+#                                           ^ - constant - keyword - punctuation
+#                                            ^^ constant.character.escape.regexp
+#                                              ^ punctuation.definition.string.end.python
+
+  RT"^A {t"{foo + "bar"}"!r} \t-string[0-9]$ \""
+# ^^ - meta.string
+#   ^^^^ meta.string.python - meta.interpolation
+#       ^^ meta.string.python meta.interpolation.python - meta.string meta.string
+#         ^ meta.string.python meta.interpolation.python meta.string.python - meta.interpolation meta.interpolation
+#          ^^^^^^^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python
+#                 ^^^^^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python meta.string.python
+#                      ^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python
+#                       ^ meta.string.python meta.interpolation.python meta.string.python - meta.interpolation meta.interpolation
+#                        ^^^ meta.string.python meta.interpolation.python - meta.string meta.string
+#                           ^^^^^^^^^^^^^^^^^^^^ meta.string.python - meta.interpolation - meta.string meta.string
+#                                               ^ - meta.string
+# ^^ - string
+#   ^^^^ string.quoted.double.python
+#       ^^ - string
+#         ^ string.quoted.double.python
+#          ^^^^^^^ - string
+#                 ^^^^^ string.quoted.double.python
+#                      ^ - string
+#                       ^ string.quoted.double.python
+#                        ^^^ - string
+#                           ^^^^^^^^^^^^^^^^^^^^ string.quoted.double.python
+# ^^ storage.type.string.python
+#   ^ punctuation.definition.string.begin.python
+#    ^^^ - constant - keyword - punctuation
+#       ^ punctuation.section.interpolation.begin.python
+#        ^ storage.type.string.python
+#         ^ punctuation.definition.string.begin.python
+#          ^ punctuation.section.interpolation.begin.python
+#           ^^^ meta.generic-name.python
+#               ^ keyword.operator.arithmetic.python
+#                 ^ punctuation.definition.string.begin.python
+#                     ^ punctuation.definition.string.end.python
+#                      ^ punctuation.section.interpolation.end.python
+#                       ^ punctuation.definition.string.end.python
+#                        ^^ storage.modifier.conversion.python
+#                          ^ punctuation.section.interpolation.end.python
+#                            ^^^^^^^^^^^^^^^^^^ - constant - keyword - punctuation
+#                                              ^ punctuation.definition.string.end.python
+
+  t'^A {t'{foo + 'bar'}'!r} \t-string[0-9]$ \''
+# ^ - meta.string
+#  ^^^^ meta.string.python - meta.interpolation
+#      ^^ meta.string.python meta.interpolation.python - meta.string meta.string
+#        ^ meta.string.python meta.interpolation.python meta.string.python - meta.interpolation meta.interpolation
+#         ^^^^^^^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python
+#                ^^^^^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python meta.string.python
+#                     ^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python
+#                      ^ meta.string.python meta.interpolation.python meta.string.python - meta.interpolation meta.interpolation
+#                       ^^^ meta.string.python meta.interpolation.python - meta.string meta.string
+#                          ^^^^^^^^^^^^^^^^^^^^ meta.string.python - meta.interpolation - meta.string meta.string
+#                                              ^ - meta.string
+# ^ - string
+#  ^^^^ string.quoted.single.python
+#      ^^ - string
+#        ^ string.quoted.single.python
+#         ^^^^^^^ - string
+#                ^^^^^ string.quoted.single.python
+#                     ^ - string
+#                      ^ string.quoted.single.python
+#                       ^^^ - string
+#                          ^^^^^^^^^^^^^^^^^^^^ string.quoted.single.python
+# ^ storage.type.string.python
+#  ^ punctuation.definition.string.begin.python
+#   ^^^ - constant - keyword - punctuation
+#      ^ punctuation.section.interpolation.begin.python
+#       ^ storage.type.string.python
+#        ^ punctuation.definition.string.begin.python
+#         ^ punctuation.section.interpolation.begin.python
+#          ^^^ meta.generic-name.python
+#              ^ keyword.operator.arithmetic.python
+#                ^ punctuation.definition.string.begin.python
+#                    ^ punctuation.definition.string.end.python
+#                     ^ punctuation.section.interpolation.end.python
+#                      ^ punctuation.definition.string.end.python
+#                       ^^ storage.modifier.conversion.python
+#                         ^ punctuation.section.interpolation.end.python
+#                           ^^ constant.character.escape.python
+#                             ^^^^^^^^^^^^^^ - constant - keyword - punctuation
+#                                           ^^ constant.character.escape.python
+#                                             ^ punctuation.definition.string.end.python
+
+  T'^A {t'{foo + 'bar'}'!r} \t-string[0-9]$ \''
+# ^ - meta.string
+#  ^^^^ meta.string.python - meta.interpolation
+#      ^^ meta.string.python meta.interpolation.python - meta.string meta.string
+#        ^ meta.string.python meta.interpolation.python meta.string.python - meta.interpolation meta.interpolation
+#         ^^^^^^^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python
+#                ^^^^^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python meta.string.python
+#                     ^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python
+#                      ^ meta.string.python meta.interpolation.python meta.string.python - meta.interpolation meta.interpolation
+#                       ^^^ meta.string.python meta.interpolation.python - meta.string meta.string
+#                          ^^^^^^^^^^^^^^^^^^^^ meta.string.python - meta.interpolation - meta.string meta.string
+#                                              ^ - meta.string
+# ^ - string
+#  ^^^^ string.quoted.single.python
+#      ^^ - string
+#        ^ string.quoted.single.python
+#         ^^^^^^^ - string
+#                ^^^^^ string.quoted.single.python
+#                     ^ - string
+#                      ^ string.quoted.single.python
+#                       ^^^ - string
+#                          ^^^^^^^^^^^^^^^^^^^^ string.quoted.single.python
+# ^ storage.type.string.python
+#  ^ punctuation.definition.string.begin.python
+#   ^^^ - constant - keyword - punctuation
+#      ^ punctuation.section.interpolation.begin.python
+#       ^ storage.type.string.python
+#        ^ punctuation.definition.string.begin.python
+#         ^ punctuation.section.interpolation.begin.python
+#          ^^^ meta.generic-name.python
+#              ^ keyword.operator.arithmetic.python
+#                ^ punctuation.definition.string.begin.python
+#                    ^ punctuation.definition.string.end.python
+#                     ^ punctuation.section.interpolation.end.python
+#                      ^ punctuation.definition.string.end.python
+#                       ^^ storage.modifier.conversion.python
+#                         ^ punctuation.section.interpolation.end.python
+#                           ^^ constant.character.escape.python
+#                             ^^^^^^^^^^^^^^ - constant - keyword - punctuation
+#                                           ^^ constant.character.escape.python
+#                                             ^ punctuation.definition.string.end.python
+
+  rt'^A {t'{foo + 'bar'}'!r} \t-string[0-9]$ \''
+# ^^ - meta.string
+#   ^^^^ meta.string.python - meta.interpolation
+#       ^^ meta.string.python meta.interpolation.python - meta.string meta.string
+#         ^ meta.string.python meta.interpolation.python meta.string.python - meta.interpolation meta.interpolation
+#          ^^^^^^^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python
+#                 ^^^^^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python meta.string.python
+#                      ^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python
+#                       ^ meta.string.python meta.interpolation.python meta.string.python - meta.interpolation meta.interpolation
+#                        ^^^ meta.string.python meta.interpolation.python - meta.string meta.string
+#                           ^^^^^^^^^^^^^^^^^^^^ meta.string.python - meta.interpolation - meta.string meta.string
+#                                               ^ - meta.string
+# ^^ - string
+#   ^^^^ string.quoted.single.python
+#       ^^ - string
+#         ^ string.quoted.single.python
+#          ^^^^^^^ - string
+#                 ^^^^^ string.quoted.single.python
+#                      ^ - string
+#                       ^ string.quoted.single.python
+#                        ^^^ - string
+#                           ^^^^^^^^^^^^^^^^^^^^ string.quoted.single.python
+# ^^ storage.type.string.python
+#   ^ punctuation.definition.string.begin.python
+#    ^ keyword.control.anchor.regexp
+#     ^^ - constant - keyword - punctuation
+#       ^ punctuation.section.interpolation.begin.python
+#        ^ storage.type.string.python
+#         ^ punctuation.definition.string.begin.python
+#          ^ punctuation.section.interpolation.begin.python
+#           ^^^ meta.generic-name.python
+#               ^ keyword.operator.arithmetic.python
+#                 ^ punctuation.definition.string.begin.python
+#                     ^ punctuation.definition.string.end.python
+#                      ^ punctuation.section.interpolation.end.python
+#                       ^ punctuation.definition.string.end.python
+#                        ^^ storage.modifier.conversion.python
+#                          ^ punctuation.section.interpolation.end.python
+#                            ^^ constant.character.escape.regexp
+#                              ^^^^^^^ - constant - keyword - punctuation
+#                                     ^^^^^ meta.set.regexp
+#                                          ^ keyword.control.anchor.regexp
+#                                           ^ - constant - keyword - punctuation
+#                                            ^^ constant.character.escape.regexp
+#                                              ^ punctuation.definition.string.end.python
+
+  RT'^A {t'{foo + 'bar'}'!r} \t-string[0-9]$ \''
+# ^^ - meta.string
+#   ^^^^ meta.string.python - meta.interpolation
+#       ^^ meta.string.python meta.interpolation.python - meta.string meta.string
+#         ^ meta.string.python meta.interpolation.python meta.string.python - meta.interpolation meta.interpolation
+#          ^^^^^^^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python
+#                 ^^^^^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python meta.string.python
+#                      ^ meta.string.python meta.interpolation.python meta.string.python meta.interpolation.python
+#                       ^ meta.string.python meta.interpolation.python meta.string.python - meta.interpolation meta.interpolation
+#                        ^^^ meta.string.python meta.interpolation.python - meta.string meta.string
+#                           ^^^^^^^^^^^^^^^^^^^^ meta.string.python - meta.interpolation - meta.string meta.string
+#                                               ^ - meta.string
+# ^^ - string
+#   ^^^^ string.quoted.single.python
+#       ^^ - string
+#         ^ string.quoted.single.python
+#          ^^^^^^^ - string
+#                 ^^^^^ string.quoted.single.python
+#                      ^ - string
+#                       ^ string.quoted.single.python
+#                        ^^^ - string
+#                           ^^^^^^^^^^^^^^^^^^^^ string.quoted.single.python
+# ^^ storage.type.string.python
+#   ^ punctuation.definition.string.begin.python
+#    ^^^ - constant - keyword - punctuation
+#       ^ punctuation.section.interpolation.begin.python
+#        ^ storage.type.string.python
+#         ^ punctuation.definition.string.begin.python
+#          ^ punctuation.section.interpolation.begin.python
+#           ^^^ meta.generic-name.python
+#               ^ keyword.operator.arithmetic.python
+#                 ^ punctuation.definition.string.begin.python
+#                     ^ punctuation.definition.string.end.python
+#                      ^ punctuation.section.interpolation.end.python
+#                       ^ punctuation.definition.string.end.python
+#                        ^^ storage.modifier.conversion.python
+#                          ^ punctuation.section.interpolation.end.python
+#                            ^^^^^^^^^^^^^^^^^^ - constant - keyword - punctuation
+#                                              ^ punctuation.definition.string.end.python
+
+### [ UNSUPPORTED COMBINATIONS ]###############################################
+
+  tu"not supported"
+# ^ - storage
+#  ^ storage.type.string.python
+
+  ut"not supported"
+# ^ - storage
+#  ^ storage.type.string.python
+
+  tb"not supported"
+# ^ - storage
+#  ^ storage.type.string.python
+
+  bt"not supported"
+# ^ - storage
+#  ^ storage.type.string.python


### PR DESCRIPTION
This PR implements [PEP750](https://peps.python.org/pep-0750/) t-strings, which are a generalization of [PEP701](https://peps.python.org/pep-0701/) f-strings and share same syntax.