### PR TITLE
[CI] Enable syntax tests against stable ST build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,9 @@ jobs:
 
           # latest stable build
           # https://www.sublimetext.com/download
-          # - sublime-channel: stable
-          #   sublime-build: 4169
-          #   optional: true
+          - sublime-channel: stable
+            sublime-build: 4192
+            optional: true
 
           # latest dev build
           # https://www.sublimetext.com/dev


### PR DESCRIPTION
Resolves #4236

CAUTION: It causes syntax tests for #4195 to fail due to symbol tests relying on fixes of ST4196 or 4197+.