### PR TITLE
[ZSH] Fix parameter identifier pattern

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -3120,7 +3120,7 @@ variables:
 
   # Variable names
   variable_begin: (?={{variable_first_char}})
-  variable_first_char: '[[:alpha:]_''"$%]'
+  variable_first_char: '[{{identifier_first_char}}''"$%]'
 
   # POSIX identifiers (alpha-numeric)
   identifier: '{{identifier_first_char}}{{identifier_char}}*'

--- a/ShellScript/Zsh.sublime-syntax
+++ b/ShellScript/Zsh.sublime-syntax
@@ -1108,6 +1108,9 @@ variables:
   # Language identifier in shebang
   shebang_language: \bzsh\b
 
+  # identifiers (alpha-numeric)
+  identifier_first_char: '[[:alnum:]_]'
+
   # Numbers
   dec_break: (?![^\s|&;()}<>])  # word_break without `{`
   dec_digit: '[\d_]'

--- a/ShellScript/Zsh/tests/syntax_test_scope.zsh
+++ b/ShellScript/Zsh/tests/syntax_test_scope.zsh
@@ -1497,12 +1497,166 @@ function {
 ip=10.10.20.14
 #  ^^^^^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
+
 ###############################################################################
-#  Special Parameters                                                         #
+# 14.3 Parameter Expansion                                                    #
+# https://zsh.sourceforge.io/Doc/Release/Expansion.html#Parameter-Expansion   #
 ###############################################################################
 
+#  Special Parameters
+
+: $* ${*} ${!*} ${#*} _$*_
+# ^^ meta.interpolation.parameter.shell variable.language.special.shell
+# ^ punctuation.definition.variable.shell
+#    ^^^^ meta.interpolation.parameter.shell
+#    ^ punctuation.definition.variable.shell
+#     ^ punctuation.section.interpolation.begin.shell
+#      ^ variable.language.special.shell
+#       ^ punctuation.section.interpolation.end.shell
+#         ^^^^^ meta.interpolation.parameter.shell
+#         ^ punctuation.definition.variable.shell
+#          ^ punctuation.section.interpolation.begin.shell
+#           ^ keyword.operator.expansion.indirection.shell
+#            ^ variable.language.special.shell
+#             ^ punctuation.section.interpolation.end.shell
+#               ^^^^^ meta.interpolation.parameter.shell
+#               ^ punctuation.definition.variable.shell
+#                ^ punctuation.section.interpolation.begin.shell
+#                 ^ keyword.operator.expansion.length.shell
+#                  ^ variable.language.special.shell
+#                   ^ punctuation.section.interpolation.end.shell
+#                     ^^^^ meta.string.glob.shell
+#                     ^ string.unquoted.shell
+#                      ^^ meta.interpolation.parameter.shell variable.language.special.shell
+#                        ^ string.unquoted.shell
+
+: $@ ${@} ${!@} ${#@} _$@_
+# ^^ meta.interpolation.parameter.shell variable.language.special.shell
+# ^ punctuation.definition.variable.shell
+#    ^^^^ meta.interpolation.parameter.shell
+#    ^ punctuation.definition.variable.shell
+#     ^ punctuation.section.interpolation.begin.shell
+#      ^ variable.language.special.shell
+#       ^ punctuation.section.interpolation.end.shell
+#         ^^^^^ meta.interpolation.parameter.shell
+#         ^ punctuation.definition.variable.shell
+#          ^ punctuation.section.interpolation.begin.shell
+#           ^ keyword.operator.expansion.indirection.shell
+#            ^ variable.language.special.shell
+#             ^ punctuation.section.interpolation.end.shell
+#               ^^^^^ meta.interpolation.parameter.shell
+#               ^ punctuation.definition.variable.shell
+#                ^ punctuation.section.interpolation.begin.shell
+#                 ^ keyword.operator.expansion.length.shell
+#                  ^ variable.language.special.shell
+#                   ^ punctuation.section.interpolation.end.shell
+#                     ^^^^ meta.string.glob.shell
+#                     ^ string.unquoted.shell
+#                      ^^ meta.interpolation.parameter.shell variable.language.special.shell
+#                        ^ string.unquoted.shell
+
+: $? ${?} ${!?} ${#?} _$?_
+# ^^ meta.interpolation.parameter.shell variable.language.special.shell
+# ^ punctuation.definition.variable.shell
+#    ^^^^ meta.interpolation.parameter.shell
+#    ^ punctuation.definition.variable.shell
+#     ^ punctuation.section.interpolation.begin.shell
+#      ^ variable.language.special.shell
+#       ^ punctuation.section.interpolation.end.shell
+#         ^^^^^ meta.interpolation.parameter.shell
+#         ^ punctuation.definition.variable.shell
+#          ^ punctuation.section.interpolation.begin.shell
+#           ^ keyword.operator.expansion.indirection.shell
+#            ^ variable.language.special.shell
+#             ^ punctuation.section.interpolation.end.shell
+#               ^^^^^ meta.interpolation.parameter.shell
+#               ^ punctuation.definition.variable.shell
+#                ^ punctuation.section.interpolation.begin.shell
+#                 ^ keyword.operator.expansion.length.shell
+#                  ^ variable.language.special.shell
+#                   ^ punctuation.section.interpolation.end.shell
+#                     ^^^^ meta.string.glob.shell
+#                     ^ string.unquoted.shell
+#                      ^^ meta.interpolation.parameter.shell variable.language.special.shell
+#                        ^ string.unquoted.shell
+
+: $- ${-} ${!-} ${#-} _$-_
+# ^^ meta.interpolation.parameter.shell variable.language.special.shell
+# ^ punctuation.definition.variable.shell
+#    ^^^^ meta.interpolation.parameter.shell
+#    ^ punctuation.definition.variable.shell
+#     ^ punctuation.section.interpolation.begin.shell
+#      ^ variable.language.special.shell
+#       ^ punctuation.section.interpolation.end.shell
+#         ^^^^^ meta.interpolation.parameter.shell
+#         ^ punctuation.definition.variable.shell
+#          ^ punctuation.section.interpolation.begin.shell
+#           ^ keyword.operator.expansion.indirection.shell
+#            ^ variable.language.special.shell
+#             ^ punctuation.section.interpolation.end.shell
+#               ^^^^^ meta.interpolation.parameter.shell
+#               ^ punctuation.definition.variable.shell
+#                ^ punctuation.section.interpolation.begin.shell
+#                 ^ keyword.operator.expansion.length.shell
+#                  ^ variable.language.special.shell
+#                   ^ punctuation.section.interpolation.end.shell
+#                     ^^^^ meta.string.glob.shell
+#                     ^ string.unquoted.shell
+#                      ^^ meta.interpolation.parameter.shell variable.language.special.shell
+#                        ^ string.unquoted.shell
+
+: $$ ${$} ${!$} ${#$} _$$_
+# ^^ meta.interpolation.parameter.shell variable.language.special.shell
+# ^ punctuation.definition.variable.shell
+#    ^^^^ meta.interpolation.parameter.shell
+#    ^ punctuation.definition.variable.shell
+#     ^ punctuation.section.interpolation.begin.shell
+#      ^ variable.language.special.shell
+#       ^ punctuation.section.interpolation.end.shell
+#         ^^^^^ meta.interpolation.parameter.shell
+#         ^ punctuation.definition.variable.shell
+#          ^ punctuation.section.interpolation.begin.shell
+#           ^ keyword.operator.expansion.indirection.shell
+#            ^ variable.language.special.shell
+#             ^ punctuation.section.interpolation.end.shell
+#               ^^^^^ meta.interpolation.parameter.shell
+#               ^ punctuation.definition.variable.shell
+#                ^ punctuation.section.interpolation.begin.shell
+#                 ^ keyword.operator.expansion.length.shell
+#                  ^ variable.language.special.shell
+#                   ^ punctuation.section.interpolation.end.shell
+#                     ^^^^ meta.string.glob.shell
+#                     ^ string.unquoted.shell
+#                      ^^ meta.interpolation.parameter.shell variable.language.special.shell
+#                        ^ string.unquoted.shell
+
+: $! ${!} ${!!} ${#!} _$!_
+# ^^ meta.interpolation.parameter.shell variable.language.special.shell
+# ^ punctuation.definition.variable.shell
+#    ^^^^ meta.interpolation.parameter.shell
+#    ^ punctuation.definition.variable.shell
+#     ^ punctuation.section.interpolation.begin.shell
+#      ^ variable.language.special.shell
+#       ^ punctuation.section.interpolation.end.shell
+#         ^^^^^ meta.interpolation.parameter.shell
+#         ^ punctuation.definition.variable.shell
+#          ^ punctuation.section.interpolation.begin.shell
+#           ^ keyword.operator.expansion.indirection.shell
+#            ^ variable.language.special.shell
+#             ^ punctuation.section.interpolation.end.shell
+#               ^^^^^ meta.interpolation.parameter.shell
+#               ^ punctuation.definition.variable.shell
+#                ^ punctuation.section.interpolation.begin.shell
+#                 ^ keyword.operator.expansion.length.shell
+#                  ^ variable.language.special.shell
+#                   ^ punctuation.section.interpolation.end.shell
+#                     ^^^^ meta.string.glob.shell
+#                     ^ string.unquoted.shell
+#                      ^^ meta.interpolation.parameter.shell variable.language.special.shell
+#                        ^ string.unquoted.shell
+
 # Expands to the number of positional parameters in decimal.
-: $# ${#} ${!#} ${##} _$#_
+: $# ${#} ${!#} ${##} _$#_ _$#1_ _$#a_
 # ^^ meta.interpolation.parameter.shell variable.language.special.shell
 # ^ punctuation.definition.variable.shell
 #    ^^^^ meta.interpolation.parameter.shell
@@ -1524,8 +1678,13 @@ ip=10.10.20.14
 #                   ^ punctuation.section.interpolation.end.shell
 #                     ^ meta.string.glob.shell string.unquoted.shell
 #                      ^^^ meta.string.glob.shell meta.interpolation.parameter.shell variable.other.readwrite.shell
+#                          ^ meta.string.glob.shell string.unquoted.shell
+#                           ^^^ meta.string.glob.shell meta.interpolation.parameter.shell variable.other.readwrite.shell
+#                                ^ meta.string.glob.shell string.unquoted.shell
+#                                 ^^^ meta.string.glob.shell meta.interpolation.parameter.shell variable.other.readwrite.shell
 
-: $#__ints {1..$#__hits}
+# `#` is not a special variable, if followed by identifiers
+: $#__ints {1..$#1_hits}
 # ^^^^^^^^ meta.interpolation.parameter.shell meta.interpolation.parameter.shell variable.other.readwrite.shell
 # ^ punctuation.definition.variable.shell
 #  ^ keyword.operator.expansion.length.shell
@@ -1538,10 +1697,12 @@ ip=10.10.20.14
 #               ^ keyword.operator.expansion.length.shell
 #                      ^ punctuation.section.interpolation.end.shell
 
-###############################################################################
-# 14.3 Parameter Expansion                                                    #
-# https://zsh.sourceforge.io/Doc/Release/Expansion.html#Parameter-Expansion   #
-###############################################################################
+# User Parameter/Variable Expansions
+
+: $var      # Substitute contents of var, no splitting
+# ^^^^ meta.interpolation.parameter.shell variable.other.readwrite.shell
+# ^ punctuation.definition.variable.shell
+#  ^^^ variable.other.readwrite.shell
 
 : ${var}    # Substitute contents of var, no splitting
 # ^^^^^^ meta.interpolation.parameter.shell
@@ -6539,6 +6700,35 @@ for a in ./**/*\ *(Dod); do mv $a ${a:h}/${a:t:gs/ /_}; done   # Remove spaces f
 #                                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.shell
 #                                                              ^ punctuation.definition.comment.shell
 
+
+##############################################################################
+# 15 Parameters
+# https://zsh.sourceforge.io/Doc/Release/Parameters.html#Description-1
+##############################################################################
+
+ab=value
+# <- meta.assignment.l-value.shell variable.other.readwrite.shell
+#^ meta.assignment.l-value.shell variable.other.readwrite.shell
+# ^ meta.assignment.shell keyword.operator.assignment.shell
+#  ^^^^^ meta.assignment.r-value.shell meta.string.glob.shell string.unquoted.shell
+
+_b=value
+# <- meta.assignment.l-value.shell variable.other.readwrite.shell
+#^ meta.assignment.l-value.shell variable.other.readwrite.shell
+# ^ meta.assignment.shell keyword.operator.assignment.shell
+#  ^^^^^ meta.assignment.r-value.shell meta.string.glob.shell string.unquoted.shell
+
+10=value
+# <- meta.assignment.l-value.shell variable.other.readwrite.shell
+#^ meta.assignment.l-value.shell variable.other.readwrite.shell
+# ^ meta.assignment.shell keyword.operator.assignment.shell
+#  ^^^^^ meta.assignment.r-value.shell meta.string.glob.shell string.unquoted.shell
+
+1a=value
+# <- meta.assignment.l-value.shell variable.other.readwrite.shell
+#^ meta.assignment.l-value.shell variable.other.readwrite.shell
+# ^ meta.assignment.shell keyword.operator.assignment.shell
+#  ^^^^^ meta.assignment.r-value.shell meta.string.glob.shell string.unquoted.shell
 
 ### [ ARRAY VARIABLES ] #######################################################
 


### PR DESCRIPTION
Addresses #4244 issue 1

This commit fixes parameter/variable identifier patterns to comply with section 15.1 of ZSH language specification.

    A parameter has a name, a value, and a number of attributes. A name may be
    any sequence of alphanumeric characters and underscores, or the single
    characters ‘*’, ‘@’, ‘#’, ‘?’, ‘-’, ‘$’, or ‘!’. A parameter whose name
    begins with an alphanumeric or underscore is also referred to as a
    variable.

Variables consist of alphanumeric characters and thus can even start with
numeric characters.

Bash's `identifier` and `variable` patterns are tweaked in order to be able to implement different ZSH behavior by overriding a single variable, only.

Various tests are added to verify this pattern not only in variable assignment statements but also parameter expansions.