### PR TITLE
[ZSH] Fix expansion in parameter expansion flags

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -2784,6 +2784,9 @@ contexts:
         - parameter-expansion-modifier
         - parameter-expansion-name
         - parameter-expansion-operator
+    - include: simple-parameter-expansions
+
+  simple-parameter-expansions:
     # https://www.gnu.org/software/bash/manual/bash.html#Positional-Parameters
     - match: (\$)\d
       scope: meta.interpolation.parameter.shell variable.language.positional.shell

--- a/ShellScript/Zsh.sublime-syntax
+++ b/ShellScript/Zsh.sublime-syntax
@@ -528,7 +528,7 @@ contexts:
         - zsh-modifier-literal-string
         - zsh-modifier-expression
     # simple single char flags
-    - match: '[-~#%*@0ABCDEFLMNOPQRSTUVWXabcefikmnopqtuvwz]'
+    - match: 'q[-+]?|[-~#%*@0ABCDEFLMNOPQRSTUVWXabcefikmnoptuvwz]'
       scope: storage.modifier.expansion.flag.shell.zsh
 
   zsh-parameter-glob-ranges:

--- a/ShellScript/Zsh.sublime-syntax
+++ b/ShellScript/Zsh.sublime-syntax
@@ -508,9 +508,18 @@ contexts:
       scope: storage.modifier.expansion.flag.shell.zsh
       push: zsh-modifier-expression
     # flag:string:
+    - match: 'p[_gjsZ]'
+      scope: storage.modifier.expansion.flag.shell.zsh
+      push: zsh-modifier-interpolated-string
     - match: '[_gjsZ]'
       scope: storage.modifier.expansion.flag.shell.zsh
       push: zsh-modifier-literal-string
+    - match: 'p[lr]'
+      scope: storage.modifier.expansion.flag.shell.zsh
+      push:
+        - zsh-modifier-interpolated-string
+        - zsh-modifier-interpolated-string
+        - zsh-modifier-expression
     # flag:expr::string::string:
     - match: '[lr]'
       scope: storage.modifier.expansion.flag.shell.zsh
@@ -1036,6 +1045,102 @@ contexts:
       scope: punctuation.definition.quoted.end.shell.zsh
       pop: 1
     - include: expression-content
+
+###[ ZSH MODIFIER INTERPOLATED STRINGS ]#######################################
+
+  zsh-modifier-interpolated-string:
+    # interpolated string with restricted parmeter expansions
+    - match: \<
+      scope: punctuation.definition.quoted.begin.shell.zsh
+      set: zsh-modifier-interpolated-string-angle-body
+    - match: \{
+      scope: punctuation.definition.quoted.begin.shell.zsh
+      set: zsh-modifier-interpolated-string-brace-body
+    - match: \[
+      scope: punctuation.definition.quoted.begin.shell.zsh
+      set: zsh-modifier-interpolated-string-bracket-body
+    - match: \(
+      scope: punctuation.definition.quoted.begin.shell.zsh
+      set: zsh-modifier-interpolated-string-paren-body
+    - match: '{{glob_string_quote}}'
+      scope: punctuation.definition.quoted.begin.shell.zsh
+      set: zsh-modifier-interpolated-string-other-body
+    - include: immediately-pop
+
+  zsh-modifier-interpolated-string-angle-body:
+    - meta_include_prototype: false
+    - meta_scope: meta.quoted.glob.shell.zsh
+    - meta_content_scope: string.quoted.other.shell.zsh
+    - match: \>
+      scope: punctuation.definition.quoted.end.shell.zsh
+      pop: 1
+    - include: zsh-modifier-interpolated-string-content
+
+  zsh-modifier-interpolated-string-brace-body:
+    - meta_include_prototype: false
+    - meta_scope: meta.quoted.glob.shell.zsh
+    - meta_content_scope: string.quoted.other.shell.zsh
+    - match: \}
+      scope: punctuation.definition.quoted.end.shell.zsh
+      pop: 1
+    - include: zsh-modifier-interpolated-string-content
+
+  zsh-modifier-interpolated-string-bracket-body:
+    - meta_include_prototype: false
+    - meta_scope: meta.quoted.glob.shell.zsh
+    - meta_content_scope: string.quoted.other.shell.zsh
+    - match: \]
+      scope: punctuation.definition.quoted.end.shell.zsh
+      pop: 1
+    - include: zsh-modifier-interpolated-string-content
+
+  zsh-modifier-interpolated-string-paren-body:
+    - meta_include_prototype: false
+    - meta_scope: meta.quoted.glob.shell.zsh
+    - meta_content_scope: string.quoted.other.shell.zsh
+    - match: \)
+      scope: punctuation.definition.quoted.end.shell.zsh
+      pop: 1
+    - include: zsh-modifier-interpolated-string-content
+
+  zsh-modifier-interpolated-string-other-body:
+    - meta_include_prototype: false
+    - meta_scope: meta.quoted.glob.shell.zsh
+    - meta_content_scope: string.quoted.other.shell.zsh
+    - match: \1
+      scope: punctuation.definition.quoted.end.shell.zsh
+      pop: 1
+    - include: zsh-modifier-interpolated-string-content
+
+  zsh-modifier-interpolated-string-content:
+    - match: \"
+      scope: punctuation.definition.quoted.begin.shell.zsh
+      push: zsh-modifier-interpolated-string-double-quoted-body
+    - match: \'
+      scope: punctuation.definition.quoted.begin.shell.zsh
+      push: zsh-modifier-literal-string-single-quoted-body
+    - include: string-prototype
+    - include: any-escapes
+    - include: zsh-modifier-interpolations
+
+  zsh-modifier-interpolated-string-double-quoted-body:
+    - match: \"
+      scope: punctuation.definition.quoted.end.shell.zsh
+      pop: 1
+    - include: line-continuations
+    - include: string-prototype
+    - include: string-escapes
+    - include: zsh-modifier-interpolations
+
+  zsh-modifier-interpolations:
+    - match: (?=\$[{{identifier_char}}{{special_variables}}])
+      push: zsh-modifier-interpolation-body
+
+  zsh-modifier-interpolation-body:
+    - clear_scopes: 1
+    - meta_include_prototype: false
+    - include: simple-parameter-expansions
+    - include: immediately-pop
 
 ###[ ZSH MODIFIER LITERAL STRINGS ]############################################
 

--- a/ShellScript/Zsh.sublime-syntax
+++ b/ShellScript/Zsh.sublime-syntax
@@ -510,13 +510,13 @@ contexts:
     # flag:string:
     - match: '[_gjsZ]'
       scope: storage.modifier.expansion.flag.shell.zsh
-      push: zsh-modifier-string
+      push: zsh-modifier-literal-string
     # flag:expr::string::string:
     - match: '[lr]'
       scope: storage.modifier.expansion.flag.shell.zsh
       push:
-        - zsh-modifier-string
-        - zsh-modifier-string
+        - zsh-modifier-literal-string
+        - zsh-modifier-literal-string
         - zsh-modifier-expression
     # simple single char flags
     - match: '[-~#%*@0ABCDEFLMNOPQRSTUVWXabcefikmnopqtuvwz]'
@@ -785,7 +785,7 @@ contexts:
     # device, group, user, prefix
     - match: '[dGPU]'
       scope: storage.modifier.glob.shell.zsh
-      push: zsh-modifier-string
+      push: zsh-modifier-literal-string
     - match: |-
         (?x)
         # device files
@@ -824,7 +824,7 @@ contexts:
       scope: keyword.operator.logical.shell.zsh
       set: zsh-qualifier-fspec-number-body
     # anything else is a glob string
-    - include: zsh-modifier-string
+    - include: zsh-modifier-literal-string
 
   zsh-qualifier-fspec-number-body:
     - meta_include_prototype: false
@@ -872,7 +872,7 @@ contexts:
       push: zsh-modifier-expression
     - match: 'W'
       scope: storage.modifier.glob.shell.zsh
-      push: zsh-modifier-string
+      push: zsh-modifier-literal-string
     - match: '[&aAcefhlpPqQrtuwx]'
       scope: storage.modifier.glob.shell.zsh
     - match: ':'
@@ -1039,68 +1039,93 @@ contexts:
 
 ###[ ZSH MODIFIER LITERAL STRINGS ]############################################
 
-  zsh-modifier-string:
+  zsh-modifier-literal-string:
+    # literal string without parmeter expansions
     - match: \<
       scope: punctuation.definition.quoted.begin.shell.zsh
-      set: zsh-modifier-string-angle-body
+      set: zsh-modifier-literal-string-angle-body
     - match: \{
       scope: punctuation.definition.quoted.begin.shell.zsh
-      set: zsh-modifier-string-brace-body
+      set: zsh-modifier-literal-string-brace-body
     - match: \[
       scope: punctuation.definition.quoted.begin.shell.zsh
-      set: zsh-modifier-string-bracket-body
+      set: zsh-modifier-literal-string-bracket-body
     - match: \(
       scope: punctuation.definition.quoted.begin.shell.zsh
-      set: zsh-modifier-string-paren-body
+      set: zsh-modifier-literal-string-paren-body
     - match: '{{glob_string_quote}}'
       scope: punctuation.definition.quoted.begin.shell.zsh
-      set: zsh-modifier-string-other-body
+      set: zsh-modifier-literal-string-other-body
     - include: immediately-pop
 
-  zsh-modifier-string-angle-body:
+  zsh-modifier-literal-string-angle-body:
     - meta_include_prototype: false
     - meta_scope: meta.quoted.glob.shell.zsh
     - meta_content_scope: string.quoted.other.shell.zsh
     - match: \>
       scope: punctuation.definition.quoted.end.shell.zsh
       pop: 1
-    - include: string-unquoted-content
+    - include: zsh-modifier-literal-string-content
 
-  zsh-modifier-string-brace-body:
+  zsh-modifier-literal-string-brace-body:
     - meta_include_prototype: false
     - meta_scope: meta.quoted.glob.shell.zsh
     - meta_content_scope: string.quoted.other.shell.zsh
     - match: \}
       scope: punctuation.definition.quoted.end.shell.zsh
       pop: 1
-    - include: string-unquoted-content
+    - include: zsh-modifier-literal-string-content
 
-  zsh-modifier-string-bracket-body:
+  zsh-modifier-literal-string-bracket-body:
     - meta_include_prototype: false
     - meta_scope: meta.quoted.glob.shell.zsh
     - meta_content_scope: string.quoted.other.shell.zsh
     - match: \]
       scope: punctuation.definition.quoted.end.shell.zsh
       pop: 1
-    - include: string-unquoted-content
+    - include: zsh-modifier-literal-string-content
 
-  zsh-modifier-string-paren-body:
+  zsh-modifier-literal-string-paren-body:
     - meta_include_prototype: false
     - meta_scope: meta.quoted.glob.shell.zsh
     - meta_content_scope: string.quoted.other.shell.zsh
     - match: \)
       scope: punctuation.definition.quoted.end.shell.zsh
       pop: 1
-    - include: string-unquoted-content
+    - include: zsh-modifier-literal-string-content
 
-  zsh-modifier-string-other-body:
+  zsh-modifier-literal-string-other-body:
     - meta_include_prototype: false
     - meta_scope: meta.quoted.glob.shell.zsh
     - meta_content_scope: string.quoted.other.shell.zsh
     - match: \1
       scope: punctuation.definition.quoted.end.shell.zsh
       pop: 1
-    - include: string-unquoted-content
+    - include: zsh-modifier-literal-string-content
+
+  zsh-modifier-literal-string-content:
+    - match: \"
+      scope: punctuation.definition.quoted.begin.shell.zsh
+      push: zsh-modifier-literal-string-double-quoted-body
+    - match: \'
+      scope: punctuation.definition.quoted.begin.shell.zsh
+      push: zsh-modifier-literal-string-single-quoted-body
+    - include: string-prototype
+    - include: any-escapes
+
+  zsh-modifier-literal-string-double-quoted-body:
+    - match: \"
+      scope: punctuation.definition.quoted.end.shell.zsh
+      pop: 1
+    - include: line-continuations
+    - include: string-prototype
+    - include: string-escapes
+
+  zsh-modifier-literal-string-single-quoted-body:
+    - match: \'
+      scope: punctuation.definition.quoted.end.shell.zsh
+      pop: 1
+    - include: string-prototype
 
 ###[ VARIABLES ]###############################################################
 

--- a/ShellScript/Zsh/tests/syntax_test_scope.zsh
+++ b/ShellScript/Zsh/tests/syntax_test_scope.zsh
@@ -1856,10 +1856,16 @@ ip=10.10.20.14
 #      ^^^ variable.other.readwrite.shell
 #         ^ punctuation.section.interpolation.end.shell
 
-: ${(q)var}  # Quote characters that are special to the shell in the resulting words with backslashes
+: ${(q)var} ${(q-)foo} ${(q+)foo} # Quote characters that are special to the shell in the resulting words with backslashes
 # ^^ meta.interpolation.parameter.shell - meta.modifier
 #   ^^^ meta.interpolation.parameter.shell meta.modifier.expansion.shell.zsh
 #      ^^^^ meta.interpolation.parameter.shell - meta.modifier
+#           ^^ meta.interpolation.parameter.shell - meta.modifier
+#             ^^^^ meta.interpolation.parameter.shell meta.modifier.expansion.shell.zsh
+#                 ^^^^ meta.interpolation.parameter.shell - meta.modifier
+#                      ^^ meta.interpolation.parameter.shell - meta.modifier
+#                        ^^^^ meta.interpolation.parameter.shell meta.modifier.expansion.shell.zsh
+#                            ^^^^ meta.interpolation.parameter.shell - meta.modifier
 # ^ punctuation.definition.variable.shell
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^ punctuation.definition.modifier.begin.shell.zsh
@@ -1867,6 +1873,20 @@ ip=10.10.20.14
 #     ^ punctuation.definition.modifier.end.shell.zsh
 #      ^^^ variable.other.readwrite.shell
 #         ^ punctuation.section.interpolation.end.shell
+#           ^ punctuation.definition.variable.shell
+#            ^ punctuation.section.interpolation.begin.shell
+#             ^ punctuation.definition.modifier.begin.shell.zsh
+#              ^^ storage.modifier.expansion.flag.shell.zsh
+#                ^ punctuation.definition.modifier.end.shell.zsh
+#                 ^^^ variable.other.readwrite.shell
+#                    ^ punctuation.section.interpolation.end.shell
+#                      ^ punctuation.definition.variable.shell
+#                       ^ punctuation.section.interpolation.begin.shell
+#                        ^ punctuation.definition.modifier.begin.shell.zsh
+#                         ^^ storage.modifier.expansion.flag.shell.zsh
+#                           ^ punctuation.definition.modifier.end.shell.zsh
+#                            ^^^ variable.other.readwrite.shell
+#                               ^ punctuation.section.interpolation.end.shell
 
 : ${(Q)var}  # Remove one level of quotes from the resulting words.
 # ^^ meta.interpolation.parameter.shell - meta.modifier

--- a/ShellScript/Zsh/tests/syntax_test_scope.zsh
+++ b/ShellScript/Zsh/tests/syntax_test_scope.zsh
@@ -1614,7 +1614,7 @@ ip=10.10.20.14
 #     ^^^ variable.other.readwrite.shell
 #        ^ punctuation.section.interpolation.end.shell
 
-## Flags
+## Literal Flags
 
 : ${(#)var}  # Evaluate the resulting words as numeric expressions and interpret these as character codes.
 # ^^ meta.interpolation.parameter.shell - meta.modifier
@@ -1844,7 +1844,7 @@ ip=10.10.20.14
 #      ^^^ variable.other.readwrite.shell
 #         ^ punctuation.section.interpolation.end.shell
 
-: ${(p)var}  # This forces the value of the parameter name to be interpreted as a further parameter name
+: ${(P)var}  # This forces the value of the parameter name to be interpreted as a further parameter name
 # ^^ meta.interpolation.parameter.shell - meta.modifier
 #   ^^^ meta.interpolation.parameter.shell meta.modifier.expansion.shell.zsh
 #      ^^^^ meta.interpolation.parameter.shell - meta.modifier
@@ -2518,6 +2518,104 @@ ip=10.10.20.14
 #      ^ keyword.operator.expansion.length.shell
 #       ^^^ variable.other.readwrite.shell
 #          ^ punctuation.section.interpolation.end.shell
+
+## Interpolated Flags
+
+: ${(pj<$sep>)arr} ${(pj<str_$sep>)arr} ${(pj<st"r_$sep">)arr} ${(pj<st'r_$sep'>)arr}
+# ^^^^^^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#   ^^^^^^^^^^ meta.modifier.expansion.shell.zsh
+#   ^ punctuation.definition.modifier.begin.shell.zsh
+#    ^^ storage.modifier.expansion.flag.shell.zsh
+#      ^^^^^^ meta.quoted.glob.shell.zsh
+#      ^ punctuation.definition.quoted.begin.shell.zsh
+#       ^^^^ meta.interpolation.parameter.shell variable.other.readwrite.shell - string
+#       ^ punctuation.definition.variable.shell
+#           ^ punctuation.definition.quoted.end.shell.zsh
+#            ^ punctuation.definition.modifier.end.shell.zsh
+#             ^^^ variable.other.readwrite.shell
+#                ^ punctuation.section.interpolation.end.shell
+#                  ^^^^^^^^^^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell
+#                  ^ punctuation.definition.variable.shell
+#                   ^ punctuation.section.interpolation.begin.shell
+#                    ^^^^^^^^^^^^^^ meta.modifier.expansion.shell.zsh
+#                    ^ punctuation.definition.modifier.begin.shell.zsh
+#                     ^^ storage.modifier.expansion.flag.shell.zsh
+#                       ^^^^^^^^^^ meta.quoted.glob.shell.zsh
+#                       ^ punctuation.definition.quoted.begin.shell.zsh
+#                        ^^^^ string.quoted.other.shell.zsh
+#                            ^^^^ meta.interpolation.parameter.shell variable.other.readwrite.shell - string
+#                            ^ punctuation.definition.variable.shell
+#                                ^ punctuation.definition.quoted.end.shell.zsh
+#                                 ^ punctuation.definition.modifier.end.shell.zsh
+#                                  ^^^ variable.other.readwrite.shell
+#                                     ^ punctuation.section.interpolation.end.shell
+#                                       ^^^^^^^^^^^^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell
+#                                       ^ punctuation.definition.variable.shell
+#                                        ^ punctuation.section.interpolation.begin.shell
+#                                         ^^^^^^^^^^^^^^^^ meta.modifier.expansion.shell.zsh
+#                                         ^ punctuation.definition.modifier.begin.shell.zsh
+#                                          ^^ storage.modifier.expansion.flag.shell.zsh
+#                                            ^^^^^^^^^^^^ meta.quoted.glob.shell.zsh
+#                                            ^ punctuation.definition.quoted.begin.shell.zsh
+#                                             ^^^^^ string.quoted.other.shell.zsh
+#                                               ^ punctuation.definition.quoted.begin.shell.zsh
+#                                                  ^^^^ meta.interpolation.parameter.shell variable.other.readwrite.shell - string
+#                                                  ^ punctuation.definition.variable.shell
+#                                                      ^ string.quoted.other.shell.zsh punctuation.definition.quoted.end.shell.zsh
+#                                                       ^ punctuation.definition.quoted.end.shell.zsh
+#                                                        ^ punctuation.definition.modifier.end.shell.zsh
+#                                                         ^^^ variable.other.readwrite.shell
+#                                                            ^ punctuation.section.interpolation.end.shell
+#                                                              ^^^^^^^^^^^^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell
+#                                                              ^ punctuation.definition.variable.shell
+#                                                               ^ punctuation.section.interpolation.begin.shell
+#                                                                ^^^^^^^^^^^^^^^^ meta.modifier.expansion.shell.zsh
+#                                                                ^ punctuation.definition.modifier.begin.shell.zsh
+#                                                                 ^^ storage.modifier.expansion.flag.shell.zsh
+#                                                                   ^^^^^^^^^^^^ meta.quoted.glob.shell.zsh
+#                                                                   ^ punctuation.definition.quoted.begin.shell.zsh
+#                                                                    ^^^^^^^^^^ string.quoted.other.shell.zsh - variable
+#                                                                      ^ punctuation.definition.quoted.begin.shell.zsh
+#                                                                             ^ punctuation.definition.quoted.end.shell.zsh
+#                                                                              ^ punctuation.definition.quoted.end.shell.zsh
+#                                                                               ^ punctuation.definition.modifier.end.shell.zsh
+#                                                                                ^^^ variable.other.readwrite.shell
+#                                                                                   ^ punctuation.section.interpolation.end.shell
+
+: ${(ps:del$im:)var}  # Force field splitting at the separator string.
+# ^^^^^^^^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#   ^^^^^^^^^^^^ meta.modifier.expansion.shell.zsh
+#   ^ punctuation.definition.modifier.begin.shell.zsh
+#    ^^ storage.modifier.expansion.flag.shell.zsh
+#      ^^^^^^^^ meta.quoted.glob.shell.zsh
+#      ^ punctuation.definition.quoted.begin.shell.zsh
+#       ^^^ string.quoted.other.shell.zsh - variable
+#          ^^^ meta.interpolation.parameter.shell variable.other.readwrite.shell - string
+#          ^ punctuation.definition.variable.shell
+#             ^ punctuation.definition.quoted.end.shell.zsh
+#              ^ punctuation.definition.modifier.end.shell.zsh
+#               ^^^ variable.other.readwrite.shell
+#                  ^ punctuation.section.interpolation.end.shell
+
+: ${(pZ+$opt+)var}  # As z but takes a combination of option letters between a following pair of delimiter characters.
+# ^^^^^^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#   ^^^^^^^^^^ meta.modifier.expansion.shell.zsh
+#   ^ punctuation.definition.modifier.begin.shell.zsh
+#    ^^ storage.modifier.expansion.flag.shell.zsh
+#      ^^^^^^ meta.quoted.glob.shell.zsh
+#      ^ punctuation.definition.quoted.begin.shell.zsh
+#       ^^^^ meta.interpolation.parameter.shell variable.other.readwrite.shell
+#       ^ punctuation.definition.variable.shell
+#           ^ punctuation.definition.quoted.end.shell.zsh
+#            ^ punctuation.definition.modifier.end.shell.zsh
+#             ^^^ variable.other.readwrite.shell
+#                ^ punctuation.section.interpolation.end.shell
 
 ## Operators
 

--- a/ShellScript/Zsh/tests/syntax_test_scope.zsh
+++ b/ShellScript/Zsh/tests/syntax_test_scope.zsh
@@ -2084,6 +2084,107 @@ ip=10.10.20.14
 #                                                                ^ punctuation.section.interpolation.end.shell
 #                                                                 ^ - meta.interpolation
 
+# Note: flags are literals (variable expansion is NOT performed)
+# see: https://github.com/sublimehq/Packages/issues/4244
+: ${(j<$j>)arr} ${(j<$(ls)>)arr} ${(j<${>)arr}
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell
+# ^^^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#   ^^^^^^^ meta.modifier.expansion.shell.zsh
+#   ^ punctuation.definition.modifier.begin.shell.zsh
+#    ^ storage.modifier.expansion.flag.shell.zsh
+#     ^^^^ meta.quoted.glob.shell.zsh
+#     ^ punctuation.definition.quoted.begin.shell.zsh
+#      ^^ string.quoted.other.shell.zsh
+#        ^ punctuation.definition.quoted.end.shell.zsh
+#         ^ punctuation.definition.modifier.end.shell.zsh
+#          ^^^ variable.other.readwrite.shell
+#             ^ punctuation.section.interpolation.end.shell
+#               ^^^^^^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell
+#               ^ punctuation.definition.variable.shell
+#                ^ punctuation.section.interpolation.begin.shell
+#                 ^^^^^^^^^^ meta.modifier.expansion.shell.zsh
+#                 ^ punctuation.definition.modifier.begin.shell.zsh
+#                  ^ storage.modifier.expansion.flag.shell.zsh
+#                   ^^^^^^^ meta.quoted.glob.shell.zsh
+#                   ^ punctuation.definition.quoted.begin.shell.zsh
+#                    ^^^^^ string.quoted.other.shell.zsh
+#                         ^ punctuation.definition.quoted.end.shell.zsh
+#                          ^ punctuation.definition.modifier.end.shell.zsh
+#                           ^^^ variable.other.readwrite.shell
+#                              ^ punctuation.section.interpolation.end.shell
+#                                ^^^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell
+#                                ^ punctuation.definition.variable.shell
+#                                 ^ punctuation.section.interpolation.begin.shell
+#                                  ^^^^^^^ meta.modifier.expansion.shell.zsh
+#                                  ^ punctuation.definition.modifier.begin.shell.zsh
+#                                   ^ storage.modifier.expansion.flag.shell.zsh
+#                                    ^^^^ meta.quoted.glob.shell.zsh
+#                                    ^ punctuation.definition.quoted.begin.shell.zsh
+#                                     ^^ string.quoted.other.shell.zsh
+#                                       ^ punctuation.definition.quoted.end.shell.zsh
+#                                        ^ punctuation.definition.modifier.end.shell.zsh
+#                                         ^^^ variable.other.readwrite.shell
+#                                            ^ punctuation.section.interpolation.end.shell
+
+# Note: Quotation marks must be balanced though
+: ${(j<"\$j\"">)arr} ${(j<'\$j'>)arr}
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell
+# ^^^^^^^^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#   ^^^^^^^^^^^^ meta.modifier.expansion.shell.zsh
+#   ^ punctuation.definition.modifier.begin.shell.zsh
+#    ^ storage.modifier.expansion.flag.shell.zsh
+#     ^^^^^^^^^ meta.quoted.glob.shell.zsh
+#     ^ punctuation.definition.quoted.begin.shell.zsh
+#      ^^^^^^^ string.quoted.other.shell.zsh
+#      ^ punctuation.definition.quoted.begin.shell.zsh
+#       ^^ constant.character.escape.shell
+#          ^^ constant.character.escape.shell
+#            ^ punctuation.definition.quoted.end.shell.zsh
+#             ^ punctuation.definition.quoted.end.shell.zsh
+#              ^ punctuation.definition.modifier.end.shell.zsh
+#               ^^^ variable.other.readwrite.shell
+#                  ^ punctuation.section.interpolation.end.shell
+#                    ^^^^^^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell
+#                    ^ punctuation.definition.variable.shell
+#                     ^ punctuation.section.interpolation.begin.shell
+#                      ^^^^^^^^^^ meta.modifier.expansion.shell.zsh
+#                      ^ punctuation.definition.modifier.begin.shell.zsh
+#                       ^ storage.modifier.expansion.flag.shell.zsh
+#                        ^^^^^^^ meta.quoted.glob.shell.zsh
+#                        ^ punctuation.definition.quoted.begin.shell.zsh
+#                         ^^^^^ string.quoted.other.shell.zsh
+#                         ^ punctuation.definition.quoted.begin.shell.zsh
+#                             ^ punctuation.definition.quoted.end.shell.zsh
+#                              ^ punctuation.definition.quoted.end.shell.zsh
+#                               ^ punctuation.definition.modifier.end.shell.zsh
+#                                ^^^ variable.other.readwrite.shell
+#                                   ^ punctuation.section.interpolation.end.shell
+
+: ${(j<"\$j\">)arr} ${(j<'\$j">)arr}
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.modifier.expansion.shell.zsh
+#   ^ punctuation.definition.modifier.begin.shell.zsh
+#    ^ storage.modifier.expansion.flag.shell.zsh
+#     ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.quoted.glob.shell.zsh
+#     ^ punctuation.definition.quoted.begin.shell.zsh
+#      ^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.other.shell.zsh
+#      ^ punctuation.definition.quoted.begin.shell.zsh
+#       ^^ constant.character.escape.shell
+#          ^^ constant.character.escape.shell
+#                         ^^ constant.character.escape.shell
+#                            ^ punctuation.definition.quoted.end.shell.zsh
+#                             ^ punctuation.definition.quoted.end.shell.zsh
+#                              ^ punctuation.definition.modifier.end.shell.zsh
+#                               ^^^ variable.other.readwrite.shell
+#                                  ^ punctuation.section.interpolation.end.shell
+
 : ${(l:expr::string1::string2:)var}
 # ^^ meta.interpolation.parameter.shell - meta.modifier
 #   ^^ meta.interpolation.parameter.shell meta.modifier.expansion.shell.zsh - meta.modifier.expansion.shell.zsh meta.string
@@ -2196,9 +2297,7 @@ ip=10.10.20.14
 #             ^ - meta.interpolation
 #              ^^ meta.interpolation.parameter.shell - meta.modifier.expansion
 #                ^^ meta.interpolation.parameter.shell meta.modifier.expansion.shell.zsh - meta.quoted.glob
-#                  ^^^^ meta.interpolation.parameter.shell meta.modifier.expansion.shell.zsh meta.quoted.glob.shell.zsh
-#                      ^^^ meta.interpolation.parameter.shell meta.modifier.expansion.shell.zsh meta.quoted.glob.shell.zsh meta.interpolation.parameter.shell variable.other.readwrite.shell
-#                         ^ meta.interpolation.parameter.shell meta.modifier.expansion.shell.zsh meta.quoted.glob.shell.zsh
+#                  ^^^^^^^^ meta.interpolation.parameter.shell meta.modifier.expansion.shell.zsh meta.quoted.glob.shell.zsh
 #                          ^ meta.interpolation.parameter.shell meta.modifier.expansion.shell.zsh - meta.quoted.glob
 #                           ^^^^ meta.function-call.arguments.shell meta.string.glob.shell meta.interpolation.parameter.shell - meta.modifier.expansion
 #                               ^ - meta.interpolation
@@ -2217,8 +2316,7 @@ ip=10.10.20.14
 #                ^ punctuation.definition.modifier.begin.shell.zsh
 #                 ^ storage.modifier.expansion.flag.shell.zsh
 #                  ^ punctuation.definition.quoted.begin.shell.zsh
-#                   ^^^ string.quoted.other.shell.zsh - variable
-#                      ^^^ variable.other.readwrite.shell - string
+#                   ^^^^^^ string.quoted.other.shell.zsh - variable
 #                         ^ punctuation.definition.quoted.end.shell.zsh
 #                          ^ punctuation.definition.modifier.end.shell.zsh
 #                           ^^^ variable.other.readwrite.shell
@@ -2278,16 +2376,14 @@ ip=10.10.20.14
 #                                                 ^^^ variable.other.readwrite.shell
 #                                                    ^ punctuation.section.interpolation.end.shell
 #                                                      ^^ meta.interpolation.parameter.shell - meta.modifier
-#                                                        ^^^ meta.interpolation.parameter.shell meta.modifier.expansion.shell.zsh - meta.interpolation meta.interpolation
-#                                                           ^^^^ meta.interpolation.parameter.shell meta.modifier.expansion.shell.zsh meta.interpolation.parameter.shell
-#                                                               ^^ meta.interpolation.parameter.shell meta.modifier.expansion.shell.zsh - meta.interpolation meta.interpolation
+#                                                        ^^^^^^^^^ meta.interpolation.parameter.shell meta.modifier.expansion.shell.zsh - meta.interpolation meta.interpolation
 #                                                                 ^^^^ meta.interpolation.parameter.shell - meta.modifier
 #                                                      ^ punctuation.definition.variable.shell
 #                                                       ^ punctuation.section.interpolation.begin.shell
 #                                                        ^ punctuation.definition.modifier.begin.shell.zsh
 #                                                         ^ storage.modifier.expansion.flag.shell.zsh
 #                                                          ^ punctuation.definition.quoted.begin.shell.zsh
-#                                                           ^^^^ meta.interpolation.parameter.shell variable.other.readwrite.shell
+#                                                           ^^^^ string.quoted.other.shell.zsh
 #                                                               ^ punctuation.definition.quoted.end.shell.zsh
 #                                                                ^ punctuation.definition.modifier.end.shell.zsh
 #                                                                 ^^^ variable.other.readwrite.shell


### PR DESCRIPTION
Addresses #4244 issue 2 and 5

This PR...

1. removes normal interpolation/expansions within parameter expansion flags' arguments
2. adds limited variable expansion within flag arguments if `p`-flag is set
3. fixes `q+` and `q-` flags