### PR TITLE
[ZSH] Fix globs in autoload arguments

### DIFF
--- a/ShellScript/Zsh.sublime-syntax
+++ b/ShellScript/Zsh.sublime-syntax
@@ -91,16 +91,6 @@ contexts:
 
 ###[ BUILTINS ]################################################################
 
-  cmd-builtin:
-    - meta_prepend: true
-    - match: autoload{{cmd_break}}
-      scope:
-        meta.function-call.identifier.shell
-        support.function.shell.zsh
-      set:
-        - cmd-args-meta
-        - cmd-args-end-of-options-then-function-references
-
   cmd-mapfile: []
   cmd-read: []
 
@@ -1138,9 +1128,9 @@ variables:
   # 17 Shell Builtin Commands
   # https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#Shell-Builtin-Commands
   builtin_cmds: |-
-    (?x: \. | \: | bg | bindkey | bye | cap | cd | chdir | clone | comparguments
-    | compcall | compctl | compdescribe | compfiles | compgroups | compquote
-    | comptags | comptry | compvalues | dirs | disable | disown | echotc
+    (?x: \. | \: | autoload | bg | bindkey | bye | cap | cd | chdir | clone
+    | comparguments | compcall | compctl | compdescribe | compfiles | compgroups
+    | compquote | comptags | comptry | compvalues | dirs | disable | disown | echotc
     | echoti | emulate | enable | eval | fc | fg | float | functions | getcap
     | getln | getopts | hash | history | integer | job | jobs | kill | limit
     | logout | popd | print | printf | pushd | pushln | pwd | r | read | rehash

--- a/ShellScript/Zsh/tests/syntax_test_scope.zsh
+++ b/ShellScript/Zsh/tests/syntax_test_scope.zsh
@@ -1135,19 +1135,42 @@ typeset -fu func;
 #           ^^^^ entity.name.function.shell
 
 autoload +X
-# <- meta.function-call.identifier.shell support.function.shell.zsh
-#^^^^^^^ meta.function-call.identifier.shell support.function.shell.zsh
+# <- meta.function-call.identifier.shell support.function.shell
+#^^^^^^^ meta.function-call.identifier.shell support.function.shell
 #       ^^^ meta.function-call.arguments.shell
 #        ^^ variable.parameter.option.shell
 
 fpath=(~/myfuncs $fpath)
 autoload myfunc1 myfunc2
-# <- meta.function-call.identifier.shell support.function.shell.zsh
-#^^^^^^^ meta.function-call.identifier.shell support.function.shell.zsh
+# <- meta.function-call.identifier.shell support.function.shell
+#^^^^^^^ meta.function-call.identifier.shell support.function.shell
 #       ^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell
-#        ^^^^^^^ variable.function.shell
-#                ^^^^^^^ variable.function.shell
+#        ^^^^^^^ meta.string.glob.shell string.unquoted.shell
+#                ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
+autoload /path/to/func
+#^^^^^^^ meta.function-call.identifier.shell support.function.shell
+#       ^^^^^^^^^^^^^^ meta.function-call.arguments.shell
+#        ^^^^^^^^^^^^^ meta.string.glob.shell string.unquoted.shell
+
+autoload $dir/*/*~*.zwc(#q.N:t)
+#^^^^^^^ meta.function-call.identifier.shell support.function.shell
+#       ^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell
+#        ^^^^^^^^^^^^^^^^^^^^^^ meta.string.glob.shell
+#        ^^^^ meta.interpolation.parameter.shell meta.interpolation.parameter.shell variable.other.readwrite.shell
+#        ^ punctuation.definition.variable.shell
+#            ^^^^^^^^^^ string.unquoted.shell
+#             ^ constant.other.wildcard.asterisk.shell
+#               ^ constant.other.wildcard.asterisk.shell
+#                ^ keyword.operator.logical.regexp.shell.zsh
+#                 ^ constant.other.wildcard.asterisk.shell
+#                      ^^^^^^^^ meta.modifier.glob.shell.zsh
+#                      ^^ punctuation.definition.modifier.begin.shell.zsh
+#                        ^ storage.modifier.mode.glob.shell.zsh
+#                         ^^ storage.modifier.glob.shell.zsh
+#                           ^ punctuation.separator.sequence.shell.zsh
+#                            ^ storage.modifier.glob.shell.zsh
+#                             ^ punctuation.definition.modifier.end.shell.zsh
 
 ###############################################################################
 # 9.2 Anonymous Functions                                                     #


### PR DESCRIPTION
Addresses #4244 issue 4

This PR removes special treatment of `autoload´ command as arguments can be any kind of glob string. Any effort to support globs while maintaining proper function name highlighting is probably beyond what's useful.