### PR TITLE
[ZSH] Fix positional parameter assignments

### DIFF
--- a/ShellScript/Zsh.sublime-syntax
+++ b/ShellScript/Zsh.sublime-syntax
@@ -105,6 +105,15 @@ contexts:
     - meta_prepend: true
     - include: redirections
 
+###[ VARIABLE DEFINITIONS ]####################################################
+
+  def-variable:
+    - meta_prepend: true
+    # positional parameter assignments
+    - match: \d{1,2}(?=(?:\[[^\]]*\])*{{varassign}})
+      scope: meta.assignment.l-value.shell variable.language.positional.shell
+      set: literal-array-value-assignment
+
 ###[ BUILTINS ]################################################################
 
   cmd-mapfile: []
@@ -1113,9 +1122,6 @@ contexts:
 variables:
   # Language identifier in shebang
   shebang_language: \bzsh\b
-
-  # identifiers (alpha-numeric)
-  identifier_first_char: '[[:alnum:]_]'
 
   # Numbers
   dec_break: (?![^\s|&;()}<>])  # word_break without `{`

--- a/ShellScript/Zsh/tests/syntax_test_scope.zsh
+++ b/ShellScript/Zsh/tests/syntax_test_scope.zsh
@@ -1739,12 +1739,13 @@ ip=10.10.20.14
 #                     ^ meta.string.glob.shell string.unquoted.shell
 #                      ^^^ meta.string.glob.shell meta.interpolation.parameter.shell variable.other.readwrite.shell
 #                          ^ meta.string.glob.shell string.unquoted.shell
-#                           ^^^ meta.string.glob.shell meta.interpolation.parameter.shell variable.other.readwrite.shell
+#                           ^^ meta.string.glob.shell meta.interpolation.parameter.shell variable.language.special.shell
+#                             ^^ meta.string.glob.shell string.unquoted.shell
 #                                ^ meta.string.glob.shell string.unquoted.shell
 #                                 ^^^ meta.string.glob.shell meta.interpolation.parameter.shell variable.other.readwrite.shell
 
 # `#` is not a special variable, if followed by identifiers
-: $#__ints {1..$#1_hits}
+: $#__ints {1..$#__hits}
 # ^^^^^^^^ meta.interpolation.parameter.shell meta.interpolation.parameter.shell variable.other.readwrite.shell
 # ^ punctuation.definition.variable.shell
 #  ^ keyword.operator.expansion.length.shell
@@ -6779,18 +6780,23 @@ _b=value
 #  ^^^^^ meta.assignment.r-value.shell meta.string.glob.shell string.unquoted.shell
 
 10=value
-# <- meta.assignment.l-value.shell variable.other.readwrite.shell
-#^ meta.assignment.l-value.shell variable.other.readwrite.shell
+# <- meta.assignment.l-value.shell variable.language.positional.shell
+#^ meta.assignment.l-value.shell variable.language.positional.shell
 # ^ meta.assignment.shell keyword.operator.assignment.shell
 #  ^^^^^ meta.assignment.r-value.shell meta.string.glob.shell string.unquoted.shell
 
 1a=value
-# <- meta.assignment.l-value.shell variable.other.readwrite.shell
-#^ meta.assignment.l-value.shell variable.other.readwrite.shell
-# ^ meta.assignment.shell keyword.operator.assignment.shell
-#  ^^^^^ meta.assignment.r-value.shell meta.string.glob.shell string.unquoted.shell
+# <- - meta.assignment
+#^^^^^^^ - meta.assignment
 
 ### [ ARRAY VARIABLES ] #######################################################
+
+10[1]=value
+# <- meta.assignment.l-value.shell variable.language.positional.shell
+#^ meta.assignment.l-value.shell variable.language.positional.shell
+# ^^^ meta.assignment.l-value.shell meta.item-access.shell
+#    ^ meta.assignment.shell keyword.operator.assignment.shell
+#     ^^^^^ meta.assignment.r-value.shell meta.string.glob.shell string.unquoted.shell
 
 var[1]=Hello
 # <- variable.other.readwrite.shell


### PR DESCRIPTION
This PR is a follow-up of PR #4245 to avoid possible false positives, especially in arithmetic expressions caused by wrong assumptions about how identifiers work in ZSH. It "just" supports assigning new values to positional parameters, which Bash doesn't.

This commit therefore reverts changes to `identifier_first_char` variable in favor of prepending dedicated pattern for positional parameter assignments.