### PR TITLE
[ZSH] Fix redundant meta.interpolation scope

### DIFF
--- a/ShellScript/Zsh.sublime-syntax
+++ b/ShellScript/Zsh.sublime-syntax
@@ -475,7 +475,7 @@ contexts:
       push: zsh-parameter-subscription
     # length operator has precedence over special parameters
     - match: (\$)(\#?){{identifier}}
-      scope: meta.interpolation.parameter.shell variable.other.readwrite.shell
+      scope: variable.other.readwrite.shell
       captures:
         1: punctuation.definition.variable.shell
         2: keyword.operator.expansion.length.shell

--- a/ShellScript/Zsh/tests/syntax_test_scope.zsh
+++ b/ShellScript/Zsh/tests/syntax_test_scope.zsh
@@ -1229,7 +1229,7 @@ autoload $dir/*/*~*.zwc(#q.N:t)
 #^^^^^^^ meta.function-call.identifier.shell support.function.shell
 #       ^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell
 #        ^^^^^^^^^^^^^^^^^^^^^^ meta.string.glob.shell
-#        ^^^^ meta.interpolation.parameter.shell meta.interpolation.parameter.shell variable.other.readwrite.shell
+#        ^^^^ meta.interpolation.parameter.shell variable.other.readwrite.shell
 #        ^ punctuation.definition.variable.shell
 #            ^^^^^^^^^^ string.unquoted.shell
 #             ^ constant.other.wildcard.asterisk.shell
@@ -1805,14 +1805,14 @@ ip=10.10.20.14
 
 # `#` is not a special variable, if followed by identifiers
 : $#__ints {1..$#__hits}
-# ^^^^^^^^ meta.interpolation.parameter.shell meta.interpolation.parameter.shell variable.other.readwrite.shell
+# ^^^^^^^^ meta.interpolation.parameter.shell variable.other.readwrite.shell
 # ^ punctuation.definition.variable.shell
 #  ^ keyword.operator.expansion.length.shell
 #          ^^^^^^^^^^^^^ meta.interpolation.brace.shell
 #          ^ punctuation.section.interpolation.begin.shell
 #           ^ meta.number.integer.decimal.shell constant.numeric.value.shell
 #            ^^ keyword.operator.range.shell
-#              ^^^^^^^^ meta.interpolation.parameter.shell meta.interpolation.parameter.shell variable.other.readwrite.shell
+#              ^^^^^^^^ meta.interpolation.parameter.shell variable.other.readwrite.shell
 #              ^ punctuation.definition.variable.shell
 #               ^ keyword.operator.expansion.length.shell
 #                      ^ punctuation.section.interpolation.end.shell


### PR DESCRIPTION
This commit removes a redundant `meta.interpolation` scope in ZSH.

The pushed `zsh-parameter-subscription` context includes a `meta_scope: meta.interpolation` already.