### PR TITLE
[ZSH] Add operator for numeric representation of characters

### DIFF
--- a/ShellScript/Zsh.sublime-syntax
+++ b/ShellScript/Zsh.sublime-syntax
@@ -361,6 +361,17 @@ contexts:
 
 ###[ LITERALS ]################################################################
 
+  expression-numbers:
+    - meta_prepend: true
+    # numeric representation of constant character
+    - match: (\#\#)(.)
+      captures:
+        1: keyword.operator.arithmetic.shell.zsh
+        2: constant.other.character.shell.zsh
+    # numeric representation of variable's content's first character
+    - match: \#
+      scope: keyword.operator.arithmetic.shell.zsh
+
   base-numbers:
     - meta_prepend: true
     - match: (\d{{dec_digit}}*(\.){{dec_digit}}*(?:[eE][-+]?{{dec_digit}}*)?){{word_break}}

--- a/ShellScript/Zsh/tests/syntax_test_scope.zsh
+++ b/ShellScript/Zsh/tests/syntax_test_scope.zsh
@@ -1546,6 +1546,17 @@ function {
 #    ^^^^ meta.number.integer.other.shell constant.numeric.base.shell
 #        ^^^^^^^^^^ meta.number.integer.other.shell constant.numeric.value.shell
 
+  (( #var + ##chr ##c+hr ))
+#    ^ keyword.operator.arithmetic.shell.zsh - variable
+#     ^^^ variable.other.readwrite.shell - keyword
+#           ^^ keyword.operator.arithmetic.shell.zsh - variable
+#             ^ constant.other.character.shell.zsh - variable
+#              ^^ variable.other.readwrite.shell - constant
+#                 ^^ keyword.operator.arithmetic.shell.zsh - variable
+#                   ^ constant.other.character.shell.zsh - variable
+#                    ^ keyword.operator.arithmetic.shell
+#                     ^^ variable.other.readwrite.shell - constant
+
   (( abs(1 - 5) + 3 ))  # arithmetic function calls
 # ^^^^^^^^^^^^^^^^^^^^ meta.compound.arithmetic.shell
 #    ^^^ meta.function-call.identifier.shell.zsh
@@ -3674,7 +3685,7 @@ stash) || true)
 # ^^^^^^^^^^^^ meta.interpolation.arithmetic.shell
 # ^ punctuation.definition.variable.shell
 #  ^^ punctuation.section.interpolation.begin.shell
-#     ^ invalid.illegal.unexpected-token.shell
+#     ^ keyword.operator.arithmetic.shell.zsh
 #       ^^^ variable.other.readwrite.shell
 #           ^^ punctuation.section.interpolation.end.shell
 
@@ -3682,7 +3693,7 @@ stash) || true)
 # ^^^^^^^^^^^ meta.interpolation.arithmetic.shell
 # ^ punctuation.definition.variable.shell
 #  ^^ punctuation.section.interpolation.begin.shell
-#     ^ invalid.illegal.unexpected-token.shell
+#     ^ keyword.operator.arithmetic.shell.zsh
 #      ^^^ variable.other.readwrite.shell
 #          ^^ punctuation.section.interpolation.end.shell
 
@@ -3709,7 +3720,7 @@ stash) || true)
 # ^^^^^^^^^^ meta.interpolation.arithmetic.shell
 # ^ punctuation.definition.variable.shell
 #  ^ punctuation.section.interpolation.begin.shell
-#    ^ invalid.illegal.unexpected-token.shell
+#    ^ keyword.operator.arithmetic.shell.zsh
 #      ^^^ variable.other.readwrite.shell
 #          ^ punctuation.section.interpolation.end.shell
 
@@ -3717,7 +3728,7 @@ stash) || true)
 # ^^^^^^^^^ meta.interpolation.arithmetic.shell
 # ^ punctuation.definition.variable.shell
 #  ^ punctuation.section.interpolation.begin.shell
-#    ^ invalid.illegal.unexpected-token.shell
+#    ^ keyword.operator.arithmetic.shell.zsh
 #     ^^^ variable.other.readwrite.shell
 #         ^ punctuation.section.interpolation.end.shell
 


### PR DESCRIPTION
This PR addresses #4244 issue 11

The `##` returns following literal character to its numeric representation.

The `#` returns numeric representation of (immediately) following variable's first character.

Valid only within arithmetic expressions.