### PR TITLE
[ShellScript] Improve number base prefixes

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -1901,12 +1901,12 @@ contexts:
       scope: meta.number.integer.decimal.shell constant.numeric.value.shell
 
   base-numbers:
-    # A leading ‘0x’ or ‘0X’ denotes hexadecimal.
-    - match: 0[xX]
+    # A leading ‘0x’, ‘0X’ or ‘16#’ denote hexadecimal.
+    - match: 0[xX]|16#
       scope: constant.numeric.base.shell
       push: hex-number-body
     # Constants with a leading 0 are interpreted as octal numbers.
-    - match: 0(?=[0-7$])
+    - match: 0(?=[0-7$])|8#
       scope: constant.numeric.base.shell
       push: oct-number-body
     # Otherwise, numbers take the form [base#]n, where the optional base is a
@@ -1922,13 +1922,13 @@ contexts:
     # Note: Leading sign is scoped as operator for consistent highlighting as
     #       we can't distinguish operators from sign for sure everywhere.
     # A leading ‘0x’ or ‘0X’ denotes hexadecimal.
-    - match: ([-+]?)(0[xX])
+    - match: ([-+]?)(0[xX]|16#)
       captures:
         1: keyword.operator.arithmetic.shell
         2: constant.numeric.base.shell
       set: hex-number-body
     # Constants with a leading 0 are interpreted as octal numbers.
-    - match: ([-+]?)(0)(?=[0-7$])
+    - match: ([-+]?)(0(?=[0-7$])|8#)
       scope: meta.number.integer.octal.shell
       captures:
         1: keyword.operator.arithmetic.shell

--- a/ShellScript/Bash/tests/syntax_test_scope.bash
+++ b/ShellScript/Bash/tests/syntax_test_scope.bash
@@ -13150,15 +13150,19 @@ true false
 #                       ^ meta.number.integer.hexadecimal.shell constant.numeric.value.shell
 #                        ^ - meta.number - constant
 
+(( 16#${_:0:2}DEF ))
+#  ^^^ meta.number.integer.hexadecimal.shell constant.numeric.base.shell
+#     ^^^^^^^^ meta.number.integer.hexadecimal.shell meta.interpolation.parameter.shell
+#             ^^^ meta.number.integer.hexadecimal.shell constant.numeric.value.shell
+#                ^ - meta.number - constant
+
+(( 8#127 ))
+#  ^^ meta.number.integer.octal.shell constant.numeric.base.shell
+#    ^^^ meta.number.integer.octal.shell constant.numeric.value.shell
+
 (( 64#123@_ ))
 #  ^^^ meta.number.integer.other.shell constant.numeric.base.shell
 #     ^^^^^ meta.number.integer.other.shell constant.numeric.value.shell
-
-(( 16#${_:0:2}DEF ))
-#  ^^^ meta.number.integer.other.shell constant.numeric.base.shell
-#     ^^^^^^^^ meta.number.integer.other.shell meta.interpolation.parameter.shell
-#             ^^^ meta.number.integer.other.shell constant.numeric.value.shell
-#                ^ - meta.number - constant
 
 : -target 20.10.2.4:8080 -port 80
 #         ^^^^^^^^^^^^^^ meta.string.glob.shell string.unquoted.shell

--- a/ShellScript/Zsh.sublime-syntax
+++ b/ShellScript/Zsh.sublime-syntax
@@ -363,6 +363,9 @@ contexts:
 
   base-numbers:
     - meta_prepend: true
+    - match: 0[bB]
+      scope: constant.numeric.base.shell.zsh
+      push: bin-number-body
     - match: (\d{{dec_digit}}*(\.){{dec_digit}}*(?:[eE][-+]?{{dec_digit}}*)?){{word_break}}
       scope: meta.number.float.decimal.shell.zsh
       captures:
@@ -371,6 +374,11 @@ contexts:
 
   number:
     - meta_prepend: true
+    - match: ([-+]?)(0[bB])
+      captures:
+        1: keyword.operator.arithmetic.shell.zsh
+        2: constant.numeric.base.shell.zsh
+      set: bin-number-body
     - match: ([-+]?)(\d{{dec_digit}}*(\.){{dec_digit}}*(?:[eE][-+]?{{dec_digit}}*)?){{word_break}}
       scope: meta.number.float.decimal.shell.zsh
       captures:
@@ -378,6 +386,14 @@ contexts:
         2: constant.numeric.value.shell.zsh
         3: punctuation.separator.decimal.shell.zsh
       pop: 1
+
+  bin-number-body:
+    - meta_include_prototype: false
+    - meta_scope: meta.number.integer.binary.shell.zsh
+    - match: '[01]+'
+      scope: constant.numeric.value.shell.zsh
+    - include: variable-expansions
+    - include: immediately-pop
 
 ###[ STRING PATH PATTERN MATCHING ]############################################
 

--- a/ShellScript/Zsh.sublime-syntax
+++ b/ShellScript/Zsh.sublime-syntax
@@ -363,7 +363,7 @@ contexts:
 
   base-numbers:
     - meta_prepend: true
-    - match: 0[bB]
+    - match: 0[bB]|2#
       scope: constant.numeric.base.shell.zsh
       push: bin-number-body
     - match: (\d{{dec_digit}}*(\.){{dec_digit}}*(?:[eE][-+]?{{dec_digit}}*)?){{word_break}}
@@ -374,7 +374,7 @@ contexts:
 
   number:
     - meta_prepend: true
-    - match: ([-+]?)(0[bB])
+    - match: ([-+]?)(0[bB]|2#)
       captures:
         1: keyword.operator.arithmetic.shell.zsh
         2: constant.numeric.base.shell.zsh

--- a/ShellScript/Zsh/tests/syntax_test_scope.zsh
+++ b/ShellScript/Zsh/tests/syntax_test_scope.zsh
@@ -1542,17 +1542,27 @@ function {
   (( 3_162.277_660_168_379_5 ))  # numbers can contain underscores
 #    ^^^^^^^^^^^^^^^^^^^^^^^ meta.number.float.decimal.shell.zsh constant.numeric.value.shell.zsh
 
-  (( 0b10 0B11 ))
+  (( 0b10 0B11 2#10 ))
 #    ^^ meta.number.integer.binary.shell constant.numeric.base.shell
 #      ^^ meta.number.integer.binary.shell constant.numeric.value.shell
 #         ^^ meta.number.integer.binary.shell constant.numeric.base.shell
 #           ^^ meta.number.integer.binary.shell constant.numeric.value.shell
+#              ^^ meta.number.integer.binary.shell.zsh constant.numeric.base.shell.zsh
+#                ^^ meta.number.integer.binary.shell.zsh constant.numeric.value.shell.zsh
 
-  (( 0x20 0X20 ))
+  (( 04723 8#4723 ))
+#    ^ meta.number.integer.octal.shell constant.numeric.base.shell
+#     ^^^^ meta.number.integer.octal.shell constant.numeric.value.shell
+#          ^^ meta.number.integer.octal.shell constant.numeric.base.shell
+#            ^^^^ meta.number.integer.octal.shell constant.numeric.value.shell
+
+  (( 0x20 0X20 16#AF ))
 #    ^^ meta.number.integer.hexadecimal.shell constant.numeric.base.shell
 #      ^^ meta.number.integer.hexadecimal.shell constant.numeric.value.shell
 #         ^^ meta.number.integer.hexadecimal.shell constant.numeric.base.shell
 #           ^^ meta.number.integer.hexadecimal.shell constant.numeric.value.shell
+#              ^^^ meta.number.integer.hexadecimal.shell constant.numeric.base.shell
+#                 ^^ meta.number.integer.hexadecimal.shell constant.numeric.value.shell
 
   (( 2_4#234_2abd27 ))
 #    ^^^^ meta.number.integer.other.shell constant.numeric.base.shell

--- a/ShellScript/Zsh/tests/syntax_test_scope.zsh
+++ b/ShellScript/Zsh/tests/syntax_test_scope.zsh
@@ -1542,6 +1542,18 @@ function {
   (( 3_162.277_660_168_379_5 ))  # numbers can contain underscores
 #    ^^^^^^^^^^^^^^^^^^^^^^^ meta.number.float.decimal.shell.zsh constant.numeric.value.shell.zsh
 
+  (( 0b10 0B11 ))
+#    ^^ meta.number.integer.binary.shell constant.numeric.base.shell
+#      ^^ meta.number.integer.binary.shell constant.numeric.value.shell
+#         ^^ meta.number.integer.binary.shell constant.numeric.base.shell
+#           ^^ meta.number.integer.binary.shell constant.numeric.value.shell
+
+  (( 0x20 0X20 ))
+#    ^^ meta.number.integer.hexadecimal.shell constant.numeric.base.shell
+#      ^^ meta.number.integer.hexadecimal.shell constant.numeric.value.shell
+#         ^^ meta.number.integer.hexadecimal.shell constant.numeric.base.shell
+#           ^^ meta.number.integer.hexadecimal.shell constant.numeric.value.shell
+
   (( 2_4#234_2abd27 ))
 #    ^^^^ meta.number.integer.other.shell constant.numeric.base.shell
 #        ^^^^^^^^^^ meta.number.integer.other.shell constant.numeric.value.shell


### PR DESCRIPTION
This PR...

1. adds support for binary numbers (`0b` prefix) in ZSH
2. properly scopes `base#` in Bash and ZSH.