### PR TITLE
[SQL] Fix: Postgre comments don't need a space after the double dash

### DIFF
--- a/SQL/PostgreSQL.sublime-syntax
+++ b/SQL/PostgreSQL.sublime-syntax
@@ -66,6 +66,14 @@ contexts:
         2: punctuation.section.brackets.end.psql
       set: maybe-group
 
+###[ COMMENTS ]################################################################
+
+  double-dash-comments:
+    - meta_append: true
+    - match: '--'
+      scope: punctuation.definition.comment.sql
+      push: inside-double-dash-comment
+
 ###[ DECLARE STATEMENTS ]######################################################
 
   declare-statements:

--- a/SQL/PostgreSQL.sublime-syntax
+++ b/SQL/PostgreSQL.sublime-syntax
@@ -69,7 +69,6 @@ contexts:
 ###[ COMMENTS ]################################################################
 
   double-dash-comments:
-    - meta_append: true
     - match: '--'
       scope: punctuation.definition.comment.sql
       push: inside-double-dash-comment

--- a/SQL/tests/syntax/syntax_test_postgres.psql
+++ b/SQL/tests/syntax/syntax_test_postgres.psql
@@ -551,3 +551,15 @@ value := E'\u1234 \U9876A001'
 --         ^^^^^^ constant.character.escape
 --               ^ - constant
 --                ^^^^^^^^^^ constant.character.escape
+
+-- this is a comment
+-- ^^^^^^^^^^^^^^^^^^ comment.line.double-dash.sql
+
+select no_comment_here;
+--^^^^^^^^^^^^^^^^^^^^^^ - comment
+--^^^^ keyword.other.dml.sql
+--     ^^^^^^^^^^^^^^^ meta.column-name.sql
+--                    ^ punctuation.terminator.statement.sql
+
+--this is also a comment
+--^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-dash.sql


### PR DESCRIPTION
[reported on the forum](https://forum.sublimetext.com/t/sql-syntax-highlighting-doesnt-recognize-double-dash-with-no-space-after-it-as-comments/76241?u=kingkeith)