### PR TITLE
[ZSH] Fix declare/typeset/unset variable assignments

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -448,7 +448,7 @@ contexts:
 
   cmd-declare-args:
     # option contains -f or -F
-    - match: ([-+])[aAgiIlnrtux]*[Ff][aAgiIlnrtux]*{{opt_break}}
+    - match: ([-+])[A-Za-z]*[Ff][A-Za-z]*{{opt_break}}
       scope:
         meta.parameter.option.shell
         variable.parameter.option.shell
@@ -456,7 +456,7 @@ contexts:
         1: punctuation.definition.parameter.shell
       set: cmd-args-end-of-options-then-function-declarations
     # option contains any mix of iA or Ai
-    - match: ([-+])(?:[agIlnrtux]*?i[iagIlnrtux]*?A|[agIlnrtux]*?A[aAgIlnrtux]*?i)[aAgiIlnrtux]*?{{opt_break}}
+    - match: ([-+])(?:[A-Za-z]*?i[A-Za-z]*?A|[A-Za-z]*?A[A-Za-z]*?i)[A-Za-z]*?{{opt_break}}
       scope:
         meta.parameter.option.shell
         variable.parameter.option.shell
@@ -464,7 +464,7 @@ contexts:
         1: punctuation.definition.parameter.shell
       set: cmd-args-end-of-options-then-variables-arithmetic-mappings
     # option contains any mix of ia or ai or i
-    - match: ([-+])[aAgiIlnrtux]*?i[aAgiIlnrtux]*?{{opt_break}}
+    - match: ([-+])[A-Za-z]*?i[A-Za-z]*?{{opt_break}}
       scope:
         meta.parameter.option.shell
         variable.parameter.option.shell
@@ -472,7 +472,7 @@ contexts:
         1: punctuation.definition.parameter.shell
       set: cmd-declare-variables-with-arithmetic-values
     # option contains A
-    - match: ([-+])[aAgIlnrtux]*?A[aAgIlnrtux]*?{{opt_break}}
+    - match: ([-+])[A-Za-z]*?A[A-Za-z]*?{{opt_break}}
       scope:
         meta.parameter.option.shell
         variable.parameter.option.shell
@@ -483,7 +483,7 @@ contexts:
     - include: cmd-args-end-of-options-then-variables-literal-values
 
   cmd-declare-variables-with-arithmetic-values:
-    - match: ([-+])[aAgiIlnrtux]*?A[aAgiIlnrtux]*?{{opt_break}}
+    - match: ([-+])[A-Za-z]*?A[A-Za-z]*?{{opt_break}}
       scope:
         meta.parameter.option.shell
         variable.parameter.option.shell
@@ -493,7 +493,7 @@ contexts:
     - include: cmd-args-end-of-options-then-variables-arithmetic-values
 
   cmd-declare-variables-with-literal-mappings:
-    - match: ([-+])[aAgiIlnrtux]*?i[aAgiIlnrtux]*?{{opt_break}}
+    - match: ([-+])[A-Za-z]*?i[A-Za-z]*?{{opt_break}}
       scope:
         meta.parameter.option.shell
         variable.parameter.option.shell
@@ -3123,7 +3123,7 @@ variables:
 
   # Variable names
   variable_begin: (?={{variable_first_char}})
-  variable_first_char: '[{{identifier_first_char}}''"$%]'
+  variable_first_char: '[{{identifier_first_char}}''"%${\\]'
 
   # POSIX identifiers (alpha-numeric)
   identifier: '{{identifier_first_char}}{{identifier_char}}*'

--- a/ShellScript/Bash/tests/syntax_test_scope.bash
+++ b/ShellScript/Bash/tests/syntax_test_scope.bash
@@ -10296,6 +10296,44 @@ declare foo         # 'foo' is a variable name
 #          ^ - variable.other.readwrite
 #                  ^ - meta.declaration.variable
 
+declare \_foo      # '\_' escaped first char in variable name
+#^^^^^^^^^^^^ meta.declaration.variable.shell
+#            ^ - meta.declaration
+# <- keyword.declaration.variable.shell
+#       ^^^^^ variable.other.readwrite.shell
+#       ^^ constant.character.escape.shell
+#            ^ - variable.other.readwrite
+#                  ^ - meta.declaration.variable
+
+declare '_foo'     # single quoted variable name
+#^^^^^^^^^^^^^ meta.declaration.variable.shell
+#             ^ - meta.declaration
+# <- keyword.declaration.variable.shell
+#       ^^^^^^ variable.other.readwrite.shell
+#       ^ punctuation.definition.quoted.begin.shell
+#            ^ punctuation.definition.quoted.end.shell
+#             ^ - variable.other.readwrite
+#                  ^ - meta.declaration.variable
+
+declare "_foo"     # double quoted variable name
+#^^^^^^^^^^^^^ meta.declaration.variable.shell
+#             ^ - meta.declaration
+# <- keyword.declaration.variable.shell
+#       ^^^^^^ variable.other.readwrite.shell
+#       ^ punctuation.definition.quoted.begin.shell
+#            ^ punctuation.definition.quoted.end.shell
+#             ^ - variable.other.readwrite
+#                  ^ - meta.declaration.variable
+
+declare $foo       # interpolated variable name
+#^^^^^^^^^^^ meta.declaration.variable.shell
+#           ^ - meta.declaration
+# <- keyword.declaration.variable.shell
+#       ^^^^ meta.interpolation.parameter.shell variable.other.readwrite.shell
+#       ^ punctuation.definition.variable.shell
+#           ^ - variable.other.readwrite
+#                  ^ - meta.declaration.variable
+
 declare foo|       # '|' terminates statement
 #^^^^^^^^^^ meta.declaration.variable.shell
 #          ^ - meta.declaration
@@ -10333,11 +10371,25 @@ declare foo; bar=baz # 2nd statement after ';'
 #^^^^^^ keyword.declaration.variable.shell
 #       ^^^ variable.other.readwrite.shell
 #          ^ punctuation.terminator.statement.shell
-#            ^^^ variable.other.readwrite.shell
-#               ^ keyword.operator.assignment.shell
-#                ^^^ meta.string.glob.shell string.unquoted.shell
+#            ^^^ meta.assignment.l-value.shell variable.other.readwrite.shell
+#               ^ meta.assignment.shell keyword.operator.assignment.shell
+#                ^^^ meta.assignment.r-value.shell meta.string.glob.shell string.unquoted.shell
 #                   ^ - meta.string - string - comment
 #                    ^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.shell
+
+declare {var1,var2,var3}=value  # multiple assignments via brace expansion
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.declaration.variable.shell
+#^^^^^^ keyword.declaration.variable.shell
+#       ^^^^^^^^^^^^^^^^ meta.assignment.l-value.shell meta.interpolation.brace.shell
+#       ^ punctuation.section.interpolation.begin.shell
+#        ^^^^ meta.string.shell string.unquoted.shell
+#            ^ punctuation.separator.sequence.shell
+#             ^^^^ meta.string.shell string.unquoted.shell
+#                 ^ punctuation.separator.sequence.shell
+#                  ^^^^ meta.string.shell string.unquoted.shell
+#                      ^ punctuation.section.interpolation.end.shell
+#                       ^ meta.assignment.shell keyword.operator.assignment.shell
+#                        ^^^^^ meta.assignment.r-value.shell meta.string.glob.shell string.unquoted.shell
 
 declare foo==bar baz =buz  # assignment must immediately follow a variable
 #^^^^^^^^^^^^^^^^^^^^^^^^ meta.declaration.variable.shell

--- a/ShellScript/Zsh/tests/syntax_test_scope.zsh
+++ b/ShellScript/Zsh/tests/syntax_test_scope.zsh
@@ -7566,3 +7566,306 @@ illegals=( | & ; < > )
 mapfile # mapfile is not a known/built-in command in ZSH
 # <- meta.function-call.identifier.shell variable.function.shell - support.function
 #^^^^^^ meta.function-call.identifier.shell variable.function.shell - support.function
+
+
+##############################################################################
+# 17 "typeset" Shell Builtin Command
+##############################################################################
+
+typeset             # comment
+#<- meta.declaration.variable.shell keyword.declaration.variable.shell
+#^^^^^^ meta.declaration.variable.shell keyword.declaration.variable.shell
+#      ^ - meta.declaration.variable
+#                   ^^^^^^^^^^ comment.line.number-sign.shell
+
+typeset foo         # 'foo' is a variable name
+#^^^^^^^^^^ meta.declaration.variable.shell
+#          ^ - meta.declaration
+# <- keyword.declaration.variable.shell
+#          ^ - variable.other.readwrite
+#                  ^ - meta.declaration.variable
+
+typeset \_foo      # '\_' escaped first char in variable name
+#^^^^^^^^^^^^ meta.declaration.variable.shell
+#            ^ - meta.declaration
+# <- keyword.declaration.variable.shell
+#       ^^^^^ variable.other.readwrite.shell
+#       ^^ constant.character.escape.shell
+#            ^ - variable.other.readwrite
+#                  ^ - meta.declaration.variable
+
+typeset '_foo'     # single quoted variable name
+#^^^^^^^^^^^^^ meta.declaration.variable.shell
+#             ^ - meta.declaration
+# <- keyword.declaration.variable.shell
+#       ^^^^^^ variable.other.readwrite.shell
+#       ^ punctuation.definition.quoted.begin.shell
+#            ^ punctuation.definition.quoted.end.shell
+#             ^ - variable.other.readwrite
+#                  ^ - meta.declaration.variable
+
+typeset "_foo"     # double quoted variable name
+#^^^^^^^^^^^^^ meta.declaration.variable.shell
+#             ^ - meta.declaration
+# <- keyword.declaration.variable.shell
+#       ^^^^^^ variable.other.readwrite.shell
+#       ^ punctuation.definition.quoted.begin.shell
+#            ^ punctuation.definition.quoted.end.shell
+#             ^ - variable.other.readwrite
+#                  ^ - meta.declaration.variable
+
+foo='svar=val'
+typeset $foo       # interpolated variable name
+#^^^^^^^^^^^ meta.declaration.variable.shell
+#           ^ - meta.declaration
+# <- keyword.declaration.variable.shell
+#       ^^^^ meta.interpolation.parameter.shell variable.other.readwrite.shell
+#       ^ punctuation.definition.variable.shell
+#           ^ - variable.other.readwrite
+#                  ^ - meta.declaration.variable
+
+typeset foo|       # '|' terminates statement
+#^^^^^^^^^^ meta.declaration.variable.shell
+#          ^ - meta.declaration
+# <- keyword.declaration.variable.shell
+#          ^ keyword.operator
+
+typeset foo |      # '|' terminates statement
+#^^^^^^^^^^ meta.declaration.variable.shell
+#          ^ - meta.declaration
+# <- keyword.declaration.variable.shell
+#           ^ keyword.operator
+
+typeset foo&       # '&' terminates statement
+#^^^^^^^^^^ meta.declaration.variable.shell
+#          ^ - meta.declaration
+# <- keyword.declaration.variable.shell
+#          ^ keyword.operator
+
+typeset foo &      # '&' terminates statement
+#^^^^^^^^^^ meta.declaration.variable.shell
+#          ^ - meta.declaration
+# <- keyword.declaration.variable.shell
+#           ^ keyword.operator
+
+typeset foo ;     # ';' terminates statement
+#^^^^^^^^^^ meta.declaration.variable.shell
+#          ^ - meta.declaration
+# <- keyword.declaration.variable.shell
+#           ^ punctuation.terminator.statement.shell
+
+declare foo; bar=baz # 2nd statement after ';'
+#^^^^^^^^^^ meta.declaration.variable.shell
+#          ^^ - meta.declaration
+# <- keyword.declaration.variable.shell
+#^^^^^^ keyword.declaration.variable.shell
+#       ^^^ variable.other.readwrite.shell
+#          ^ punctuation.terminator.statement.shell
+#            ^^^ variable.other.readwrite.shell
+#               ^ keyword.operator.assignment.shell
+#                ^^^ meta.string.glob.shell string.unquoted.shell
+#                   ^ - meta.string - string - comment
+#                    ^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.shell
+
+typeset {var1,var2,var3}=value  # multiple assignments via brace expansion
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.declaration.variable.shell
+#^^^^^^ keyword.declaration.variable.shell
+#       ^^^^^^^^^^^^^^^^ meta.assignment.l-value.shell meta.interpolation.brace.shell
+#       ^ punctuation.section.interpolation.begin.shell
+#        ^^^^ meta.string.shell string.unquoted.shell
+#            ^ punctuation.separator.sequence.shell
+#             ^^^^ meta.string.shell string.unquoted.shell
+#                 ^ punctuation.separator.sequence.shell
+#                  ^^^^ meta.string.shell string.unquoted.shell
+#                      ^ punctuation.section.interpolation.end.shell
+#                       ^ meta.assignment.shell keyword.operator.assignment.shell
+#                        ^^^^^ meta.assignment.r-value.shell meta.string.glob.shell string.unquoted.shell
+
+typeset foo==bar baz =buz  # assignment must immediately follow a variable
+#^^^^^^^^^^^^^^^^^^^^^^^^ meta.declaration.variable.shell
+#                        ^ - meta.declaration
+# <- keyword.declaration.variable.shell
+#      ^ - variable
+#       ^^^ variable.other.readwrite.shell
+#          ^ keyword.operator.assignment.shell
+#           ^^^^ meta.string.glob.shell string.unquoted.shell
+#           ^ punctuation.definition.expansion.shell.zsh
+#               ^ - variable
+#                ^^^ variable.other.readwrite.shell
+#                   ^ - variable
+#                    ^^^^ invalid.illegal.unexpected-token.shell
+#                        ^ - variable
+
+typeset foo=<input.txt
+#^^^^^^^ meta.declaration.variable.shell - meta.assignment - meta.redirection
+#       ^^^ meta.declaration.variable.shell meta.assignment.l-value.shell - meta.redirection
+#          ^ meta.declaration.variable.shell meta.assignment.shell - meta.redirection
+#           ^^^^^^^^^^ meta.declaration.variable.shell meta.assignment.r-value.shell meta.redirection.shell
+#                     ^ - meta.declaration
+# <- keyword.declaration.variable.shell
+#       ^^^ variable.other.readwrite.shell
+#          ^ keyword.operator.assignment.shell
+#           ^ keyword.operator.assignment.redirection.shell
+#            ^^^^^^^^^ meta.string.glob.shell string.unquoted.shell
+
+# string value with pattern expansion
+typeset bar=\
+foo?bar+2*baz/$buz # comment
+# <- meta.declaration.variable.shell meta.assignment.r-value.shell meta.string.glob.shell string.unquoted.shell
+#^^^^^^^^^^^^^ meta.declaration.variable.shell meta.assignment.r-value.shell meta.string.glob.shell string.unquoted.shell
+#             ^^^^ meta.string.glob.shell meta.interpolation.parameter.shell variable.other.readwrite.shell - string
+#                 ^ - meta.declaration
+#                  ^^^^^^^^^^ comment.line.number-sign.shell
+
+# simple arithmetic expression value
+typeset -i bar=\
+foo?bar+2*baz/$buz # comment
+# <- meta.declaration.variable.shell variable.other.readwrite.shell
+#^^^^^^^^^^^^^^^^^ meta.declaration.variable.shell meta.assignment.r-value.shell meta.arithmetic.shell
+#                 ^ - meta.declaration - meta.assignment - meta.arithmetic
+#^^ variable.other.readwrite.shell
+#  ^ - variable
+#   ^^^ variable.other.readwrite.shell
+#      ^ keyword.operator.arithmetic.shell
+#       ^ meta.number.integer.decimal.shell constant.numeric.value.shell
+#        ^ keyword.operator.arithmetic.shell
+#         ^^^ variable.other.readwrite.shell
+#            ^ keyword.operator.arithmetic.shell
+#             ^^^^ meta.interpolation.parameter.shell variable.other.readwrite.shell
+#                  ^^^^^^^^^^ comment.line.number-sign.shell
+
+# Normal builtin interface
+builtin typeset svar=$(echo two words)
+#       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.declaration.variable.shell
+#       ^^^^^^^ keyword.declaration.variable.shell
+#               ^^^^ meta.assignment.l-value.shell variable.other.readwrite.shell
+#                   ^ meta.assignment.shell keyword.operator.assignment.shell
+#                    ^^^^^^^^^^^^^^^^^ meta.assignment.r-value.shell meta.string.glob.shell meta.interpolation.command.shell
+#                    ^ punctuation.definition.variable.shell
+#                     ^ punctuation.section.interpolation.begin.shell
+#                      ^^^^ meta.function-call.identifier.shell support.function.shell
+#                          ^^^^^^^^^^ meta.function-call.arguments.shell
+#                           ^^^ meta.string.glob.shell string.unquoted.shell
+#                               ^^^^^ meta.string.glob.shell string.unquoted.shell
+#                                    ^ punctuation.section.interpolation.end.shell
+
+# Reserved word parsing
+typeset svar=$(echo one word) avar=(several words)
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.declaration.variable.shell
+#^^^^^^ keyword.declaration.variable.shell
+#       ^^^^ meta.assignment.l-value.shell variable.other.readwrite.shell
+#           ^ meta.assignment.shell keyword.operator.assignment.shell
+#            ^^^^^^^^^^^^^^^^ meta.assignment.r-value.shell meta.string.glob.shell meta.interpolation.command.shell
+#            ^ punctuation.definition.variable.shell
+#             ^ punctuation.section.interpolation.begin.shell
+#              ^^^^ meta.function-call.identifier.shell support.function.shell
+#                  ^^^^^^^^^ meta.function-call.arguments.shell
+#                   ^^^ meta.string.glob.shell string.unquoted.shell
+#                       ^^^^ meta.string.glob.shell string.unquoted.shell
+#                           ^ punctuation.section.interpolation.end.shell
+#                             ^^^^ meta.assignment.l-value.shell variable.other.readwrite.shell
+#                                 ^ meta.assignment.shell keyword.operator.assignment.shell
+#                                  ^^^^^^^^^^^^^^^ meta.assignment.r-value.shell meta.sequence.list.shell
+#                                  ^ punctuation.section.sequence.begin.shell
+#                                   ^^^^^^^ meta.string.glob.shell string.unquoted.shell
+#                                           ^^^^^ meta.string.glob.shell string.unquoted.shell
+#                                                ^ punctuation.section.sequence.end.shell
+
+# scalar parameter names as patterns
+typeset -m \*fo=value
+#^^^^^^^^^^^^^^^^^^^^ meta.declaration.variable.shell
+#^^^^^^ keyword.declaration.variable.shell
+#       ^^ meta.parameter.option.shell variable.parameter.option.shell
+#       ^ punctuation.definition.parameter.shell
+#          ^^^^ meta.assignment.l-value.shell variable.other.readwrite.shell
+#          ^^ constant.character.escape.shell
+#              ^ meta.assignment.shell keyword.operator.assignment.shell
+#               ^^^^^ meta.assignment.r-value.shell meta.string.glob.shell string.unquoted.shell
+
+# array parameter names as patterns
+typeset -am \*fo=("value" "value")
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.declaration.variable.shell
+#^^^^^^ keyword.declaration.variable.shell
+#       ^^^ meta.parameter.option.shell variable.parameter.option.shell
+#       ^ punctuation.definition.parameter.shell
+#           ^^^^ meta.assignment.l-value.shell variable.other.readwrite.shell
+#           ^^ constant.character.escape.shell
+#               ^ meta.assignment.shell keyword.operator.assignment.shell
+#                ^^^^^^^^^^^^^^^^^ meta.assignment.r-value.shell meta.sequence.list.shell
+#                ^ punctuation.section.sequence.begin.shell
+#                 ^^^^^^^ meta.string.glob.shell string.quoted.double.shell
+#                 ^ punctuation.definition.string.begin.shell
+#                       ^ punctuation.definition.string.end.shell
+#                         ^^^^^^^ meta.string.glob.shell string.quoted.double.shell
+#                         ^ punctuation.definition.string.begin.shell
+#                               ^ punctuation.definition.string.end.shell
+#                                ^ punctuation.section.sequence.end.shell
+
+# mapping parameter names as patterns
+typeset -Am \*fo=("key" "value")
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.declaration.variable.shell
+#^^^^^^ keyword.declaration.variable.shell
+#       ^^^ meta.parameter.option.shell variable.parameter.option.shell
+#       ^ punctuation.definition.parameter.shell
+#           ^^^^ meta.assignment.l-value.shell variable.other.readwrite.shell
+#           ^^ constant.character.escape.shell
+#               ^ meta.assignment.shell keyword.operator.assignment.shell
+#                ^^^^^^^^^^^^^^^ meta.assignment.r-value.shell meta.sequence.list.shell
+#                ^ punctuation.section.sequence.begin.shell
+#                 ^^^^^ meta.item-access.shell entity.name.key.shell
+#                 ^ punctuation.definition.quoted.begin.shell
+#                     ^ punctuation.definition.quoted.end.shell
+#                       ^^^^^^^ meta.string.glob.shell string.quoted.double.shell
+#                       ^ punctuation.definition.string.begin.shell
+#                             ^ punctuation.definition.string.end.shell
+#                              ^ punctuation.section.sequence.end.shell
+
+# function names as patterns
+typeset -fm \*fo=func
+#^^^^^^^^^^^^^^^^^^^^ meta.declaration.variable.shell
+#^^^^^^ keyword.declaration.variable.shell
+#       ^^^ meta.parameter.option.shell variable.parameter.option.shell
+#       ^ punctuation.definition.parameter.shell
+#           ^^^^^^^^^ meta.command.shell entity.name.function.shell
+#           ^^ constant.character.escape.shell
+
+typeset -mp "(${1:-${(@j:|:)hooktypes}})_functions"
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.declaration.variable.shell
+#^^^^^^ keyword.declaration.variable.shell
+#       ^^^ meta.parameter.option.shell variable.parameter.option.shell
+#       ^ punctuation.definition.parameter.shell
+#           ^^ variable.other.readwrite.shell
+#           ^ punctuation.definition.quoted.begin.shell
+#             ^^^^^ meta.interpolation.parameter.shell - meta.interpolation meta.interpolation
+#             ^ punctuation.definition.variable.shell
+#              ^ punctuation.section.interpolation.begin.shell
+#                  ^^^^^^^^^^^^^^^^^^^ meta.interpolation.parameter.shell meta.interpolation.parameter.shell
+#                  ^ punctuation.definition.variable.shell
+#                   ^ punctuation.section.interpolation.begin.shell
+#                                    ^^ punctuation.section.interpolation.end.shell
+#                                     ^ meta.interpolation.parameter.shell - meta.interpolation meta.interpolation
+#                                      ^^^^^^^^^^^^ variable.other.readwrite.shell
+#                                                 ^ punctuation.definition.quoted.end.shell
+
+
+##############################################################################
+# 17 "unset" Shell Builtin Command
+##############################################################################
+
+unset -m \*a
+#^^^^ meta.function-call.identifier.shell support.function.shell
+#    ^^^^^^^ meta.function-call.arguments.shell
+#     ^^ meta.parameter.option.shell variable.parameter.option.shell
+#     ^ punctuation.definition.parameter.shell
+#        ^^^ meta.assignment.l-value.shell variable.other.readwrite.shell
+#        ^^ constant.character.escape.shell
+
+unset -m a\* # ok
+#^^^^ meta.function-call.identifier.shell support.function.shell
+#    ^^^^^^^ meta.function-call.arguments.shell
+#     ^^ meta.parameter.option.shell variable.parameter.option.shell
+#     ^ punctuation.definition.parameter.shell
+#        ^^^ meta.assignment.l-value.shell variable.other.readwrite.shell
+#         ^^ constant.character.escape.shell
+#            ^^^^ comment.line.number-sign.shell
+#            ^ punctuation.definition.comment.shell


### PR DESCRIPTION
Addresses #4244 issue 15

This commit...

1. reduces strictness of `declare` and `typeset` option patterns, in order to ensure `-m` option (or any new one) doesn't break distinction between literal/arithmetic/array/mapping value highlighting.

   Only important flags `i`, `a`, `A` and `f` are taken into account.

2. adds `\\` and `{` as valid variable name begin characters to fix identifiers starting with escaped characters or brace expansions.

Note: Fixes Bash and Zsh.