### PR TITLE
[ShellScript] Fix nested arithmetic groups

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -1582,19 +1582,20 @@ contexts:
     - match: \'
       scope: punctuation.definition.quoted.begin.shell
       push: expression-single-quoted-body
-    - match: \(
-      scope: punctuation.section.group.begin.shell
-      push: expression-group-body
+    - include: expression-groups
     - include: expression-common
 
   expression-double-quoted-body:
     - match: \"
       scope: punctuation.definition.quoted.end.shell
       pop: 1
+    - include: expression-double-quoted-groups
+    - include: expression-common
+
+  expression-double-quoted-groups:
     - match: \(
       scope: punctuation.section.group.begin.shell
       push: expression-double-quoted-group-body
-    - include: expression-common
 
   expression-double-quoted-group-body:
     - meta_scope: meta.group.shell
@@ -1603,16 +1604,20 @@ contexts:
       pop: 1
     - match: (?=")
       pop: 1
+    - include: expression-double-quoted-groups
     - include: expression-common
 
   expression-single-quoted-body:
     - match: \'
       scope: punctuation.definition.quoted.end.shell
       pop: 1
+    - include: expression-single-quoted-groups
+    - include: expression-common
+
+  expression-single-quoted-groups:
     - match: \(
       scope: punctuation.section.group.begin.shell
       push: expression-single-quoted-group-body
-    - include: expression-common
 
   expression-single-quoted-group-body:
     - meta_scope: meta.group.shell
@@ -1621,13 +1626,20 @@ contexts:
       pop: 1
     - match: (?=')
       pop: 1
+    - include: expression-single-quoted-groups
     - include: expression-common
+
+  expression-groups:
+    - match: \(
+      scope: punctuation.section.group.begin.shell
+      push: expression-group-body
 
   expression-group-body:
     - meta_scope: meta.group.shell
     - match: \)
       scope: punctuation.section.group.end.shell
       pop: 1
+    - include: expression-groups
     - include: expression-common
 
   expression-common:

--- a/ShellScript/Bash/tests/syntax_test_scope.bash
+++ b/ShellScript/Bash/tests/syntax_test_scope.bash
@@ -13349,6 +13349,110 @@ ip=10.10.20.14
 ((a+=b))
 #    ^ - string.unquoted
 
+(( val = ( a - ( b * c + ( d - e ) ) ) / "d" ))
+#^ meta.compound.arithmetic.shell - meta.arithmetic
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.arithmetic.shell meta.arithmetic.shell
+#                                            ^^ meta.compound.arithmetic.shell - meta.arithmetic
+# ^^^^^^^ - meta.group
+#        ^^^^^^ meta.group.shell - meta.group meta.group
+#              ^^^^^^^^^^ meta.group.shell meta.group.shell - meta.group meta.group meta.group
+#                        ^^^^^^^^^ meta.group.shell meta.group.shell meta.group.shell
+#                                 ^^ meta.group.shell meta.group.shell - meta.group meta.group meta.group
+#                                   ^^ meta.group.shell - meta.group meta.group
+#                                     ^^^^^^^ - meta.group
+#^ punctuation.section.compound.begin.shell
+#  ^^^ variable.other.readwrite.shell
+#      ^ keyword.operator.assignment.shell
+#        ^ punctuation.section.group.begin.shell
+#          ^ variable.other.readwrite.shell
+#            ^ keyword.operator.arithmetic.shell
+#              ^ punctuation.section.group.begin.shell
+#                ^ variable.other.readwrite.shell
+#                  ^ keyword.operator.arithmetic.shell
+#                    ^ variable.other.readwrite.shell
+#                      ^ keyword.operator.arithmetic.shell
+#                        ^ punctuation.section.group.begin.shell
+#                          ^ variable.other.readwrite.shell
+#                            ^ keyword.operator.arithmetic.shell
+#                              ^ variable.other.readwrite.shell
+#                                ^ punctuation.section.group.end.shell
+#                                  ^ punctuation.section.group.end.shell
+#                                    ^ punctuation.section.group.end.shell
+#                                      ^ keyword.operator.arithmetic.shell
+#                                        ^ punctuation.definition.quoted.begin.shell
+#                                         ^ variable.other.readwrite.shell
+#                                          ^ punctuation.definition.quoted.end.shell
+#                                            ^^ punctuation.section.compound.end.shell
+
+(( val = '( a - ( b * c + ( d - e ) ) ) / d' ))
+#^ meta.compound.arithmetic.shell - meta.arithmetic
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.arithmetic.shell meta.arithmetic.shell
+#                                            ^^ meta.compound.arithmetic.shell - meta.arithmetic
+# ^^^^^^^^ - meta.group
+#         ^^^^^^ meta.group.shell - meta.group meta.group
+#               ^^^^^^^^^^ meta.group.shell meta.group.shell - meta.group meta.group meta.group
+#                         ^^^^^^^^^ meta.group.shell meta.group.shell meta.group.shell
+#                                  ^^ meta.group.shell meta.group.shell - meta.group meta.group meta.group
+#                                    ^^ meta.group.shell - meta.group meta.group
+#                                      ^^^^^^ - meta.group
+#^ punctuation.section.compound.begin.shell
+#  ^^^ variable.other.readwrite.shell
+#      ^ keyword.operator.assignment.shell
+#        ^ punctuation.definition.quoted.begin.shell
+#         ^ punctuation.section.group.begin.shell
+#           ^ variable.other.readwrite.shell
+#             ^ keyword.operator.arithmetic.shell
+#               ^ punctuation.section.group.begin.shell
+#                 ^ variable.other.readwrite.shell
+#                   ^ keyword.operator.arithmetic.shell
+#                     ^ variable.other.readwrite.shell
+#                       ^ keyword.operator.arithmetic.shell
+#                         ^ punctuation.section.group.begin.shell
+#                           ^ variable.other.readwrite.shell
+#                             ^ keyword.operator.arithmetic.shell
+#                               ^ variable.other.readwrite.shell
+#                                 ^ punctuation.section.group.end.shell
+#                                   ^ punctuation.section.group.end.shell
+#                                     ^ punctuation.section.group.end.shell
+#                                       ^ keyword.operator.arithmetic.shell
+#                                         ^ variable.other.readwrite.shell
+#                                          ^ punctuation.definition.quoted.end.shell
+#                                            ^^ punctuation.section.compound.end.shell
+
+(( val = "( a - ( b * c + ( d - e ) ) ) / d" ))
+#^ meta.compound.arithmetic.shell - meta.arithmetic
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.arithmetic.shell meta.arithmetic.shell
+#                                            ^^ meta.compound.arithmetic.shell - meta.arithmetic
+# ^^^^^^^^ - meta.group
+#         ^^^^^^ meta.group.shell - meta.group meta.group
+#               ^^^^^^^^^^ meta.group.shell meta.group.shell - meta.group meta.group meta.group
+#                         ^^^^^^^^^ meta.group.shell meta.group.shell meta.group.shell
+#                                  ^^ meta.group.shell meta.group.shell - meta.group meta.group meta.group
+#                                    ^^ meta.group.shell - meta.group meta.group
+#                                      ^^^^^^ - meta.group
+#^ punctuation.section.compound.begin.shell
+#  ^^^ variable.other.readwrite.shell
+#      ^ keyword.operator.assignment.shell
+#        ^ punctuation.definition.quoted.begin.shell
+#         ^ punctuation.section.group.begin.shell
+#           ^ variable.other.readwrite.shell
+#             ^ keyword.operator.arithmetic.shell
+#               ^ punctuation.section.group.begin.shell
+#                 ^ variable.other.readwrite.shell
+#                   ^ keyword.operator.arithmetic.shell
+#                     ^ variable.other.readwrite.shell
+#                       ^ keyword.operator.arithmetic.shell
+#                         ^ punctuation.section.group.begin.shell
+#                           ^ variable.other.readwrite.shell
+#                             ^ keyword.operator.arithmetic.shell
+#                               ^ variable.other.readwrite.shell
+#                                 ^ punctuation.section.group.end.shell
+#                                   ^ punctuation.section.group.end.shell
+#                                     ^ punctuation.section.group.end.shell
+#                                       ^ keyword.operator.arithmetic.shell
+#                                         ^ variable.other.readwrite.shell
+#                                          ^ punctuation.definition.quoted.end.shell
+#                                            ^^ punctuation.section.compound.end.shell
 
 ###############################################################################
 # 7.1 Job Control Basics                                                      #


### PR DESCRIPTION
Fixes #4268

This PR fixes nested groups in arithmetic expressions not being scoped, which causes patterns to fallback to compound command expansion.