### PR TITLE
[Common] Scope `in` as `keyword.control` again

### DIFF
--- a/ASP/ASP.sublime-syntax
+++ b/ASP/ASP.sublime-syntax
@@ -682,7 +682,7 @@ contexts:
   control_flow_foreach_in:
     - meta_scope: meta.for.block.asp
     - match: '\b(?i:In){{whitespace_or_end_of_statement}}'
-      scope: keyword.operator.iteration.in.asp
+      scope: keyword.control.loop.in.asp
       set: [inside_control_flow_for, expression_until_end_of_statement]
 
   control_flow_forto:

--- a/ASP/syntax_test_asp.asp
+++ b/ASP/syntax_test_asp.asp
@@ -878,7 +878,7 @@
    '<- - meta.between-if-and-then.asp
    '^^^^^^^^ keyword.control.flow.asp
    '         ^^^^^^ variable.other.asp
-   '                ^^ keyword.operator.iteration.in.asp
+   '                ^^ keyword.control.loop.in.asp
    '                                  ^ meta.for.block.asp
         Response.Write(vbCrLf & cookie)
        '^^^^^^^^ support.class.asp
@@ -1231,7 +1231,7 @@ test = "hello%>
 <%
         for each item in list
        '^^^^^^^^ text.html.asp source.asp.embedded.html meta.method.asp meta.method.body.asp meta.for.block.asp keyword.control.flow.asp
-       '              ^^ text.html.asp source.asp.embedded.html meta.method.asp meta.method.body.asp meta.for.block.asp keyword.operator.iteration.in.asp
+       '              ^^ text.html.asp source.asp.embedded.html meta.method.asp meta.method.body.asp meta.for.block.asp keyword.control.loop.in.asp
             %><li><%= item %></li><%
                     '^^^^^^ text.html.asp source.asp.embedded.html meta.method.asp meta.method.body.asp meta.for.block.asp
            '  ^ punctuation.definition.tag.begin.html

--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -495,7 +495,7 @@ contexts:
 
   ctl-for-in:
     - match: (?i:in){{keyword_break}}
-      scope: keyword.operator.iteration.in.dosbatch
+      scope: keyword.control.loop.in.dosbatch
       pop: 1
     - include: else-pop
 

--- a/Batch File/tests/syntax_test_batch_file.bat
+++ b/Batch File/tests/syntax_test_batch_file.bat
@@ -1990,7 +1990,7 @@ is a #@$虎" strange label
 :: ^^^ keyword.control.loop.for.dosbatch
 ::     ^^ punctuation.definition.variable.dosbatch
 ::     ^^^ variable.other.readwrite.dosbatch
-::         ^^ keyword.operator.iteration.in.dosbatch
+::         ^^ keyword.control.loop.in.dosbatch
 ::            ^ punctuation.section.set.begin.dosbatch
 ::             ^ meta.number.integer.decimal.dosbatch constant.numeric.value.dosbatch
 ::              ^ punctuation.separator.comma.dosbatch
@@ -2006,7 +2006,7 @@ is a #@$虎" strange label
 ::        ^^ variable.parameter.option.recursive.dosbatch
 ::           ^^ punctuation.definition.variable.dosbatch
 ::           ^^^ variable.other.readwrite.dosbatch
-::               ^^ keyword.operator.iteration.in.dosbatch
+::               ^^ keyword.control.loop.in.dosbatch
 ::                  ^ punctuation.section.set.begin.dosbatch
 ::                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.set.dosbatch
 ::                          ^ punctuation.separator.comma.dosbatch
@@ -2026,7 +2026,7 @@ is a #@$虎" strange label
 ::    ^^ variable.parameter.option.recursive.dosbatch
 ::       ^^ punctuation.definition.variable.dosbatch
 ::       ^^^ variable.other.readwrite.dosbatch
-::           ^^ keyword.operator.iteration.in.dosbatch
+::           ^^ keyword.control.loop.in.dosbatch
 ::              ^ punctuation.section.set.begin.dosbatch
 ::              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.set.dosbatch
 ::                      ^ punctuation.separator.comma.dosbatch
@@ -2040,7 +2040,7 @@ is a #@$虎" strange label
    %%f IN (folder1, ..\folder2, C:\folder) DO command
 :: ^^ punctuation.definition.variable.dosbatch
 :: ^^^ variable.other.readwrite.dosbatch
-::     ^^ keyword.operator.iteration.in.dosbatch
+::     ^^ keyword.control.loop.in.dosbatch
 ::        ^ punctuation.section.set.begin.dosbatch
 ::        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.set.dosbatch
 ::                ^ punctuation.separator.comma.dosbatch
@@ -2053,7 +2053,7 @@ is a #@$虎" strange label
    /D /r ^
    %%f ^
    IN (folder1, ..\folder2, C:\folder) DO command
-:: ^^ keyword.operator.iteration.in.dosbatch
+:: ^^ keyword.control.loop.in.dosbatch
 ::    ^ punctuation.section.set.begin.dosbatch
 ::    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.set.dosbatch
 ::            ^ punctuation.separator.comma.dosbatch
@@ -2106,7 +2106,7 @@ is a #@$虎" strange label
 ::                 ^ punctuation.definition.string.end.dosbatch
 ::                   ^^ punctuation.definition.variable.dosbatch
 ::                   ^^^ variable.other.readwrite.dosbatch
-::                       ^^ keyword.operator.iteration.in.dosbatch
+::                       ^^ keyword.control.loop.in.dosbatch
 ::                          ^ punctuation.section.set.begin.dosbatch
 ::                          ^ meta.set.dosbatch punctuation.section.set.begin.dosbatch - meta.embedded
 ::                           ^ punctuation.section.embedded.begin.dosbatch
@@ -2133,7 +2133,7 @@ is a #@$虎" strange label
 ::     ^ punctuation.definition.variable.dosbatch
 ::     ^^ variable.parameter.option.range.dosbatch
 ::        ^^ invalid.illegal.variable.dosbatch
-::           ^^ keyword.operator.iteration.in.dosbatch
+::           ^^ keyword.control.loop.in.dosbatch
 ::              ^ punctuation.section.set.begin.dosbatch
 ::              ^^^^^^^^^ meta.set.dosbatch
 ::               ^ meta.number.integer.decimal.dosbatch constant.numeric.value.dosbatch
@@ -2151,7 +2151,7 @@ is a #@$虎" strange label
 ::     ^^ variable.parameter.option.recursive.dosbatch
 ::        ^^^^^^^^^^^^^^^^^^^^ string.unquoted.dosbatch
 ::                             ^^^^^ invalid.illegal.variable.dosbatch
-::                                   ^^ keyword.operator.iteration.in.dosbatch
+::                                   ^^ keyword.control.loop.in.dosbatch
 
    FOR /R C:\dir name\file name.ext %%f IN (.) DO command
 :: ^^^ keyword.control.loop.for.dosbatch
@@ -2162,7 +2162,7 @@ is a #@$虎" strange label
 ::                         ^^^^^^^^ invalid.illegal.variable.dosbatch
 ::                                  ^^ punctuation.definition.variable.dosbatch
 ::                                  ^^^ variable.other.readwrite.dosbatch
-::                                      ^^ keyword.operator.iteration.in.dosbatch
+::                                      ^^ keyword.control.loop.in.dosbatch
 
    FOR /R 'C:\dir name\file name.ext' %%f IN (*.ext) DO command
 :: ^^^ keyword.control.loop.for.dosbatch
@@ -2173,7 +2173,7 @@ is a #@$虎" strange label
 ::                          ^^^^^^^^^ invalid.illegal.variable.dosbatch
 ::                                    ^^ punctuation.definition.variable.dosbatch
 ::                                    ^^^ variable.other.readwrite.dosbatch
-::                                        ^^ keyword.operator.iteration.in.dosbatch
+::                                        ^^ keyword.control.loop.in.dosbatch
 
    FOR /R "C:\dir name\file-name.ext" %%f IN (set) DO command
 :: ^^^ keyword.control.loop.for.dosbatch
@@ -2184,12 +2184,12 @@ is a #@$虎" strange label
 ::                                  ^ punctuation.definition.string.end.dosbatch
 ::                                    ^^ punctuation.definition.variable.dosbatch
 ::                                    ^^^ variable.other.readwrite.dosbatch
-::                                        ^^ keyword.operator.iteration.in.dosbatch
+::                                        ^^ keyword.control.loop.in.dosbatch
 
    FOR /Z %%f IN (foo & bar | < baz > && no || false) DO command
 ::     ^^ invalid.illegal.parameter.dosbatch
 ::        ^^^ variable.other.readwrite.dosbatch
-::            ^^ keyword.operator.iteration.in.dosbatch
+::            ^^ keyword.control.loop.in.dosbatch
 ::                    ^ invalid.illegal.operator.dosbatch
 ::                          ^ invalid.illegal.operator.dosbatch
 ::                            ^ invalid.illegal.operator.dosbatch
@@ -2200,7 +2200,7 @@ is a #@$虎" strange label
    for %%i in (1, 2,  3) do (
       for %%j in (%%i) do (
 ::        ^^^ variable.other.readwrite.dosbatch
-::            ^^ keyword.operator.iteration.in.dosbatch
+::            ^^ keyword.control.loop.in.dosbatch
 ::               ^ punctuation.section.set.begin.dosbatch
 ::                ^^^  string.unquoted.dosbatch
 ::                ^^ constant.character.escape.dosbatch

--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -2316,7 +2316,7 @@ contexts:
 
   foreach_var_assignment:
     - match: \bin\b
-      scope: keyword.operator.iteration.in.cs
+      scope: keyword.control.loop.in.cs
       set: line_of_code_in
     - match: (?=\)|\})
       pop: true

--- a/C#/tests/syntax_test_C#7.cs
+++ b/C#/tests/syntax_test_C#7.cs
@@ -494,7 +494,7 @@ class Foo {
 ///                       ^ punctuation.separator.sequence
 ///                         ^^^ variable.other
 ///                            ^ punctuation.section.sequence.end
-///                              ^^ keyword.operator.iteration.in.cs
+///                              ^^ keyword.control.loop.in.cs
         {
             Console.WriteLine($"{name} is {age} years old.");
         }
@@ -509,7 +509,7 @@ class Foo {
 ///                   ^ punctuation.separator.sequence
 ///                     ^ variable.other
 ///                      ^ punctuation.section.sequence.end
-///                        ^^ keyword.operator.iteration.in.cs
+///                        ^^ keyword.control.loop.in.cs
 ///                           ^^^^^^^^^ variable.other
 ///                                    ^ punctuation.section.group.end
         {
@@ -527,7 +527,7 @@ class Foo {
 ///                      ^^^ support.type
 ///                          ^ variable.other
 ///                           ^ punctuation.section.sequence.end
-///                             ^^ keyword.operator.iteration.in.cs
+///                             ^^ keyword.control.loop.in.cs
 ///                                ^^^^^^^^^ variable.other
 ///                                         ^ punctuation.section.group.end
         ; // empty statement

--- a/C#/tests/syntax_test_GeneralStructure.cs
+++ b/C#/tests/syntax_test_GeneralStructure.cs
@@ -291,7 +291,7 @@ namespace TestNamespace . Test
 ///                 ^ punctuation.section.group.begin
 ///                  ^^^ storage.type
 ///                      ^^^^ variable.other
-///                           ^^ keyword.operator.iteration.in.cs
+///                           ^^ keyword.control.loop.in.cs
 ///                              ^^^^^^^^^^ variable.other
 ///                                        ^ punctuation.section.group.end
             {}

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1561,7 +1561,7 @@ contexts:
       scope: invalid.illegal.missing-in.python
       pop: 1
     - match: in\b
-      scope: keyword.operator.iteration.in.python
+      scope: keyword.control.loop.in.python
       set: for-statement-in
     - include: line-continuation-or-pop
     - include: expression-in-a-statement
@@ -1793,7 +1793,7 @@ contexts:
   for-expression-target-list:
     - meta_scope: meta.expression.generator.python
     - match: in\b
-      scope: keyword.operator.iteration.in.python
+      scope: keyword.control.loop.in.python
       pop: 1
     - match: (?=[)\]}])
       pop: 1

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -911,7 +911,7 @@ def _():
     for
 #   ^^^ keyword.control.loop.for
     b = c in d
-#         ^^ keyword.operator.logical - keyword.operator.iteration.in
+#         ^^ keyword.operator.logical - keyword.control.loop.in
 
     for \
         a \
@@ -924,7 +924,7 @@ def _():
 #   ^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.loop.for
 #   ^^^^^ storage.modifier.async
 #         ^^^ keyword.control.loop.for
-#               ^^ keyword.operator.iteration.in
+#               ^^ keyword.control.loop.in
 #                          ^ punctuation.section.block.loop.for
         pass
 
@@ -2536,7 +2536,7 @@ class Class():
 #     ^ meta.generic-name.python
 #       ^^^ keyword.control.loop.for.generator.python
 #           ^ meta.generic-name.python
-#             ^^ keyword.operator.iteration.in.python
+#             ^^ keyword.control.loop.in.python
 #                ^^^^^^^ meta.function-call.identifier.python variable.function.python
 #                       ^^ meta.function-call.arguments.python
 #                         ^ punctuation.section.sequence.end.python
@@ -2552,7 +2552,7 @@ class Class():
 #     ^ meta.generic-name.python
 #       ^^^ keyword.control.loop.for.generator.python
 #           ^ meta.generic-name.python
-#             ^^ keyword.operator.iteration.in.python
+#             ^^ keyword.control.loop.in.python
 #                ^^^^^^^ meta.function-call.identifier.python variable.function.python
 #                       ^^ meta.function-call.arguments.python
 #                         ^ punctuation.section.sequence.end.python
@@ -2730,24 +2730,24 @@ generator = (i for i in range(100))
 #           ^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence.generator.python
 #              ^^^^^^^^ meta.expression.generator
 #              ^^^ keyword.control.loop.for.generator
-#                    ^^ keyword.operator.iteration.in
+#                    ^^ keyword.control.loop.in
 list_ = [i for i in range(100)]
 #       ^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence
 #          ^^^^^^^^ meta.expression.generator
 #          ^^^ keyword.control.loop.for.generator
-#                ^^ keyword.operator.iteration.in
+#                ^^ keyword.control.loop.in
 set_ = {i for i in range(100)}
 #      ^^^^^^^^^^^^^^^^^^^^^^^ meta.set
 #         ^^^^^^^^ meta.expression.generator
 #         ^^^ keyword.control.loop.for.generator
-#               ^^ keyword.operator.iteration.in
+#               ^^ keyword.control.loop.in
 set_ = {x * x for x in y}
 #      ^^^^^^^^^^^^^^^^^^ meta.set
 #             ^^^^^^^^ meta.expression.generator
 #      ^ punctuation.section.set.begin
 #         ^ keyword.operator.arithmetic
 #             ^^^ keyword.control.loop.for.generator
-#                   ^^ keyword.operator.iteration.in
+#                   ^^ keyword.control.loop.in
 #                       ^ punctuation.section.set.end
 set_ = {x ** 2 for x in y}
 #      ^^^^^^^^^^^^^^^^^^ meta.set
@@ -2755,7 +2755,7 @@ set_ = {x ** 2 for x in y}
 #      ^ punctuation.section.set.begin
 #         ^^ keyword.operator.arithmetic
 #              ^^^ keyword.control.loop.for.generator
-#                    ^^ keyword.operator.iteration.in
+#                    ^^ keyword.control.loop.in
 #                        ^ punctuation.section.set.end
 dict_ = {i: i for i in range(100)}
 #       ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping - meta.mapping meta.mapping
@@ -2766,7 +2766,7 @@ dict_ = {i: i for i in range(100)}
 #            ^^^^^^^^^^^^^^^^^^^^^ meta.mapping.python
 #             ^^^^^^^^ meta.expression.generator
 #             ^^^ keyword.control.loop.for.generator
-#                   ^^ keyword.operator.iteration.in
+#                   ^^ keyword.control.loop.in
 dict_ = {x * x: 1 for x in y}
 #       ^ meta.mapping.python
 #        ^^^^^ meta.mapping.key.python
@@ -2777,7 +2777,7 @@ dict_ = {x * x: 1 for x in y}
 #          ^ keyword.operator.arithmetic
 #             ^ punctuation.separator.key-value
 #                 ^^^ keyword.control.loop.for.generator
-#                       ^^ keyword.operator.iteration.in
+#                       ^^ keyword.control.loop.in
 #                           ^ punctuation.section.mapping.end
 dict_ = {x ** 2: 1 for x in y}
 #       ^ meta.mapping.python
@@ -2789,7 +2789,7 @@ dict_ = {x ** 2: 1 for x in y}
 #          ^^ keyword.operator.arithmetic
 #              ^ punctuation.separator.key-value
 #                  ^^^ keyword.control.loop.for.generator
-#                        ^^ keyword.operator.iteration.in
+#                        ^^ keyword.control.loop.in
 #                            ^ punctuation.section.mapping.end
 list_ = [i for i in range(100) if i > 0 else -1]
 #       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence
@@ -2799,7 +2799,7 @@ list_ = [i for i in range(100) if i > 0 else -1]
 
 list2_ = [i in range(10) for i in range(100) if i in range(5, 15)]
 #           ^^ keyword.operator.logical
-#                              ^^ keyword.operator.iteration.in
+#                              ^^ keyword.control.loop.in
 #                                                 ^^ keyword.operator.logical
 
 generator = ((k1, k2, v) for ((k1, k2), v) in xs)
@@ -2863,7 +2863,7 @@ unpack_ = [*(_ for [[][:], *_] in [((1, 2), "woops")])]
 #                          ^ keyword.operator.unpacking.sequence.python
 #                           ^ meta.path.python variable.language.anonymous.python
 #                            ^ punctuation.section.sequence.end.python
-#                              ^^ keyword.operator.iteration.in.python
+#                              ^^ keyword.control.loop.in.python
 #                                 ^ punctuation.section.sequence.begin.python
 #                                  ^ punctuation.section.sequence.begin.python
 #                                   ^ punctuation.section.sequence.begin.python
@@ -2891,7 +2891,7 @@ list_ = [lambda: 1 for i in range(10)]
 #                ^ constant.numeric.value.python
 #                  ^^^ keyword.control.loop.for.generator.python
 #                      ^ meta.generic-name.python
-#                        ^^ keyword.operator.iteration.in.python
+#                        ^^ keyword.control.loop.in.python
 #                           ^^^^^ support.function.builtin.python
 #                                ^ punctuation.section.arguments.begin.python
 #                                 ^^ constant.numeric.value.python
@@ -2911,7 +2911,7 @@ generator_ = (lambda: 1 for i in range(10))
 #                     ^ constant.numeric.value.python
 #                       ^^^ keyword.control.loop.for.generator.python
 #                           ^ meta.generic-name.python
-#                             ^^ keyword.operator.iteration.in.python
+#                             ^^ keyword.control.loop.in.python
 #                                ^^^^^ support.function.builtin.python
 #                                     ^ punctuation.section.arguments.begin.python
 #                                      ^^ constant.numeric.value.python
@@ -2931,7 +2931,7 @@ set_ = {lambda: 1 for i in range(10)}
 #               ^ constant.numeric.value.python
 #                 ^^^ keyword.control.loop.for.generator.python
 #                     ^ meta.generic-name.python
-#                       ^^ keyword.operator.iteration.in.python
+#                       ^^ keyword.control.loop.in.python
 #                          ^^^^^ support.function.builtin.python
 #                               ^ punctuation.section.arguments.begin.python
 #                                ^^ constant.numeric.value.python
@@ -2951,10 +2951,10 @@ list((i for i in generator), 123)
 _ = [m
      for cls in self.__class__.mro()
 #    ^^^ keyword.control.loop.for.generator
-#            ^^ keyword.operator.iteration.in
+#            ^^ keyword.control.loop.in
      for m in cls.__dict__]
 #    ^^^ keyword.control.loop.for.generator
-#          ^^ keyword.operator.iteration.in
+#          ^^ keyword.control.loop.in
 
 result = [i async for i in aiter() if i % 2]
 #           ^^^^^ storage.modifier.async
@@ -3031,7 +3031,7 @@ generator = (
 #   ^^^ keyword.control.loop.for.generator
     i
     in
-#   ^^ keyword.operator.iteration.in
+#   ^^ keyword.control.loop.in
     range(100)
 )
 

--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -595,7 +595,7 @@ contexts:
   for-variable:
     # note: variables are not scoped, currently
     - match: \bin\b
-      scope: keyword.operator.iteration.in.ruby
+      scope: keyword.control.loop.in.ruby
       set: after-keyword
     - match: (?=(?:end|do)\b(?![?!]))|$
       pop: true

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -1646,7 +1646,7 @@ end
 
 for item in items do
 #^^ keyword.control.loop.for.ruby
-#        ^^ keyword.operator.iteration.in.ruby
+#        ^^ keyword.control.loop.in.ruby
 #                 ^^ keyword.control.block.do.ruby
 end
 #^^ keyword.control.block.end.ruby

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -1296,7 +1296,7 @@ contexts:
 
   loop-iterator-wordlist:
     - match: in{{cmd_break}}
-      scope: keyword.operator.iteration.in.shell
+      scope: keyword.control.loop.in.shell
       set: loop-iterator-wordlist-body
     - include: cmd-args-end
     - include: else-pop

--- a/ShellScript/Bash/tests/syntax_test_scope.bash
+++ b/ShellScript/Bash/tests/syntax_test_scope.bash
@@ -1149,7 +1149,7 @@ for in in in in
 #^^^^^^^^^^^^^^ meta.statement.loop.for.shell
 #^^ keyword.control.loop.for.shell
 #   ^^ variable.other.readwrite.shell - keyword
-#      ^^ keyword.operator.iteration.in.shell
+#      ^^ keyword.control.loop.in.shell
 #         ^^ meta.string.glob.shell string.unquoted.shell
 #            ^^ meta.string.glob.shell string.unquoted.shell
 
@@ -1186,7 +1186,7 @@ for x; do echo "${!x}"; done
 for i in for in do echo done; do echo $i; done;
 # <- meta.statement.loop.for.shell keyword.control.loop.for.shell
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.loop.for.shell
-#     ^^ keyword.operator.iteration.in.shell
+#     ^^ keyword.control.loop.in.shell
 #       ^ - meta.string
 #        ^^^ meta.string.glob.shell string.unquoted.shell
 #           ^ - meta.string
@@ -1209,7 +1209,7 @@ for i in { [ \( ; do echo $i; done;
 # <- meta.statement.loop.for.shell keyword.control.loop.for.shell
 #^^^^^^^^^^^^^^ meta.statement.loop.for.shell
 #   ^ variable.other.readwrite.shell
-#     ^^ keyword.operator.iteration.in.shell
+#     ^^ keyword.control.loop.in.shell
 #       ^ - meta.string
 #        ^ meta.string.glob.shell string.unquoted.shell
 #         ^ - meta.string
@@ -1229,7 +1229,7 @@ for i in str1 $str2 "str3" 'str4' st$r5; do echo $i; done;
 # <- meta.statement.loop.for.shell keyword.control.loop.for.shell
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.loop.for.shell
 #   ^ variable.other.readwrite.shell
-#     ^^ keyword.operator.iteration.in.shell
+#     ^^ keyword.control.loop.in.shell
 #        ^^^^ meta.string.glob.shell string.unquoted.shell
 #             ^^^^^ meta.interpolation.parameter.shell variable.other.readwrite.shell
 #                   ^^^^^^ meta.string.glob.shell string.quoted.double.shell
@@ -1248,7 +1248,7 @@ for i in <files.txt; do echo $i; done;
 # <- meta.statement.loop.for.shell keyword.control.loop.for.shell
 #^^^^^^^^^^^^^^^^^^ meta.statement.loop.for.shell
 #   ^ variable.other.readwrite.shell
-#     ^^ keyword.operator.iteration.in.shell
+#     ^^ keyword.control.loop.in.shell
 #        ^ keyword.operator.assignment.redirection.shell
 #                  ^ punctuation.terminator.statement.shell
 #                    ^^ keyword.control.loop.do.shell
@@ -1264,7 +1264,7 @@ for i in {foo,bar,baz}; do echo $i; done;
 # <- meta.statement.loop.for.shell keyword.control.loop.for.shell
 #^^^^^^^^^^^^^^^^^^^^^ meta.statement.loop.for.shell
 #   ^ variable.other.readwrite.shell
-#     ^^ keyword.operator.iteration.in.shell
+#     ^^ keyword.control.loop.in.shell
 #        ^ meta.string.glob.shell meta.interpolation.brace.shell punctuation.section.interpolation.begin.shell - string
 #         ^^^ meta.string.glob.shell meta.interpolation.brace.shell meta.string.shell string.unquoted.shell
 #            ^ meta.string.glob.shell meta.interpolation.brace.shell punctuation.separator.sequence.shell - string
@@ -1278,7 +1278,7 @@ for i in for pre{foo,bar,baz}suf; do echo $i; done;
 # <- meta.statement.loop.for.shell keyword.control.loop.for.shell
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.loop.for.shell
 #   ^ variable.other.readwrite.shell
-#     ^^ keyword.operator.iteration.in.shell
+#     ^^ keyword.control.loop.in.shell
 #        ^^^ meta.string.glob.shell string.unquoted.shell
 #           ^ - meta.string
 #            ^^^ meta.string.glob.shell string.unquoted.shell - meta.interpolation
@@ -1296,7 +1296,7 @@ for i in {1..10}; do echo $i; done;
 # <- meta.statement.loop.for.shell keyword.control.loop.for.shell
 #^^^^^^^^^^^^^^^ meta.statement.loop.for.shell
 #   ^ variable.other.readwrite.shell
-#     ^^ keyword.operator.iteration.in.shell
+#     ^^ keyword.control.loop.in.shell
 #        ^^^^^^^ meta.interpolation.brace.shell
 #        ^ punctuation.section.interpolation.begin.shell
 #         ^ meta.number.integer.decimal.shell constant.numeric.value.shell
@@ -1316,7 +1316,7 @@ for i in {-10..+20}; do echo $i; done;
 # <- meta.statement.loop.for.shell keyword.control.loop.for.shell
 #^^^^^^^^^^^^^^^^^^ meta.statement.loop.for.shell
 #   ^ variable.other.readwrite.shell
-#     ^^ keyword.operator.iteration.in.shell
+#     ^^ keyword.control.loop.in.shell
 #        ^^^^^^^^^^ meta.interpolation.brace.shell
 #        ^ punctuation.section.interpolation.begin.shell
 #         ^ meta.number.integer.decimal.shell keyword.operator.arithmetic.shell
@@ -1338,7 +1338,7 @@ for i in {-10..+20..-4}; do echo $i; done;
 # <- meta.statement.loop.for.shell keyword.control.loop.for.shell
 #^^^^^^^^^^^^^^^^^^^^^^ meta.statement.loop.for.shell
 #   ^ variable.other.readwrite.shell
-#     ^^ keyword.operator.iteration.in.shell
+#     ^^ keyword.control.loop.in.shell
 #        ^^^^^^^^^^^^^^ meta.interpolation.brace.shell
 #        ^ punctuation.section.interpolation.begin.shell
 #         ^ meta.number.integer.decimal.shell keyword.operator.arithmetic.shell
@@ -1363,7 +1363,7 @@ for i in (foo bar baz); do echo $i; done;
 # <- meta.statement.loop.for.shell keyword.control.loop.for.shell
 #^^^^^^^^^^^^^^^^^^^^ meta.statement.loop.for.shell
 #   ^ variable.other.readwrite.shell
-#     ^^ keyword.operator.iteration.in.shell
+#     ^^ keyword.control.loop.in.shell
 #        ^ meta.statement.loop.for.shell invalid.illegal.unexpected-token.shell
 #         ^^^ meta.statement.loop.for.shell meta.string.glob.shell string.unquoted.shell
 #            ^ - meta.string
@@ -1382,7 +1382,7 @@ for domain in $domains; do echo $domain; done
 #^^^^^^^^^^^^^^^^^^^^^ meta.statement.loop.for.shell
 #^^ keyword.control.loop.for.shell
 #   ^^^^^^ variable.other.readwrite.shell - keyword
-#          ^^ keyword.operator.iteration.in.shell
+#          ^^ keyword.control.loop.in.shell
 #             ^^^^^^^^ variable.other.readwrite.shell
 #                     ^ punctuation.terminator.statement.shell
 #                       ^^ keyword.control.loop.do.shell
@@ -1397,7 +1397,7 @@ for i in $(seq 100); do
 #^^^^^^^^^^^^^^^^^^ meta.statement.loop.for.shell
 #^^ keyword.control.loop.for.shell
 #        ^^^^^^^^^^ meta.interpolation.command.shell
-#     ^^ keyword.operator.iteration.in.shell
+#     ^^ keyword.control.loop.in.shell
 #        ^ punctuation.definition.variable.shell
 #         ^ punctuation.section.interpolation.begin.shell
 #          ^^^ meta.function-call variable.function.shell
@@ -1420,7 +1420,7 @@ for \
 #<- meta.statement.loop.for.shell
 #^^^^^^^^^^^^^^^^^^^ meta.statement.loop.for.shell
 # ^^^ variable.other.readwrite.shell
-#     ^^ keyword.operator.iteration.in.shell
+#     ^^ keyword.control.loop.in.shell
 #        ^^^ meta.string.glob.shell string.unquoted.shell
 #            ^^^ meta.string.glob.shell string.unquoted.shell
 #                ^^^ meta.string.glob.shell string.unquoted.shell
@@ -1429,9 +1429,9 @@ for \
 for \
   var \
 in foo bar baz;
-#<- meta.statement.loop.for.shell keyword.operator.iteration.in.shell
+#<- meta.statement.loop.for.shell keyword.control.loop.in.shell
 #^^^^^^^^^^^^^ meta.statement.loop.for.shell
-#^ meta.statement.loop.for.shell keyword.operator.iteration.in.shell
+#^ meta.statement.loop.for.shell keyword.control.loop.in.shell
 #  ^^^ meta.string.glob.shell string.unquoted.shell
 #      ^^^ meta.string.glob.shell string.unquoted.shell
 #          ^^^ meta.string.glob.shell string.unquoted.shell
@@ -1445,7 +1445,7 @@ in foo bar baz;
 #                             ^^ meta.interpolation.command.shell meta.interpolation.parameter.shell variable.other.readwrite.shell - meta.statement.loop
 #                               ^^^^^^ meta.interpolation.command.shell - meta.statement.loop - meta.interpolation meta.interpolation
 #^^^ keyword.control.loop.for.shell
-#      ^^ keyword.operator.iteration.in.shell
+#      ^^ keyword.control.loop.in.shell
 #         ^ punctuation.definition.variable.shell
 #          ^ punctuation.section.interpolation.begin.shell
 #           ^^^ meta.function-call.identifier.shell variable.function.shell
@@ -1520,7 +1520,7 @@ select in in in select do done; do echo $in; done;
 #                             ^^ - meta.statement.loop - meta.sequence
 #^^^^^ keyword.control.loop.select.shell
 #      ^^ variable.other.readwrite.shell
-#         ^^ keyword.operator.iteration.in.shell
+#         ^^ keyword.control.loop.in.shell
 #           ^ - meta.string - string
 #            ^^ meta.string.glob.shell string.unquoted.shell
 #              ^ - meta.string - string
@@ -1545,7 +1545,7 @@ select \
 #          ^^^^^^^^^^^^^ meta.statement.loop.select.shell meta.sequence.list.shell meta.string.glob.shell
 #                       ^^ - meta.statement.loop - meta.sequence
 # ^^^^^ variable.other.readwrite.shell
-#       ^^ keyword.operator.iteration.in.shell
+#       ^^ keyword.control.loop.in.shell
 #          ^ meta.interpolation.tilde.shell variable.language.tilde.shell - string
 #           ^^^^^^^^^^^^ string.unquoted.shell
 #            ^^ constant.other.wildcard.asterisk.shell
@@ -1560,7 +1560,7 @@ select \
 #   ^ meta.statement.loop.select.shell meta.sequence.list.shell - meta.string
 #    ^^^^^^^^^^^^^ meta.statement.loop.select.shell meta.sequence.list.shell meta.string.glob.shell
 #                 ^^ - meta.statement.loop - meta.sequence
-# ^^ keyword.operator.iteration.in.shell
+# ^^ keyword.control.loop.in.shell
 #    ^ meta.interpolation.tilde.shell variable.language.tilde.shell - string
 #     ^^^^^^^^^^^^ string.unquoted.shell
 #      ^^ constant.other.wildcard.asterisk.shell
@@ -1584,7 +1584,7 @@ select \
 select fname in *;
 # <- keyword.control.loop.select.shell
 #^^^^^ keyword.control.loop.select.shell
-#            ^^ keyword.operator.iteration.in.shell
+#            ^^ keyword.control.loop.in.shell
 #               ^ meta.string.glob.shell string.unquoted.shell
 #                ^ punctuation.terminator.statement.shell
 do

--- a/ShellScript/Zsh/tests/syntax_test_scope.zsh
+++ b/ShellScript/Zsh/tests/syntax_test_scope.zsh
@@ -90,7 +90,7 @@ for in in in word2; do echo $in; done
 # <- keyword.control.loop.for.shell
 #^^ keyword.control.loop.for.shell
 #   ^^ variable.other.readwrite.shell
-#      ^^ keyword.operator.iteration.in.shell
+#      ^^ keyword.control.loop.in.shell
 #         ^^ meta.string.glob.shell string.unquoted.shell
 #            ^^^^^ meta.string.glob.shell string.unquoted.shell
 #                 ^ punctuation.terminator.statement.shell
@@ -107,7 +107,7 @@ for a b c in word1 word2 word3; do echo $c $b $a; done
 #   ^ variable.other.readwrite.shell
 #     ^ variable.other.readwrite.shell
 #       ^ variable.other.readwrite.shell
-#         ^^ keyword.operator.iteration.in.shell
+#         ^^ keyword.control.loop.in.shell
 #            ^^^^^^^^^^^^^^^^^ meta.sequence.list.shell
 #            ^^^^^ meta.string.glob.shell string.unquoted.shell
 #                  ^^^^^ meta.string.glob.shell string.unquoted.shell
@@ -188,7 +188,7 @@ select name in word1 word2; do echo $name; done
 # <- keyword.control.loop.select.shell
 #^^^^^ keyword.control.loop.select.shell
 #      ^^^^ variable.other.readwrite.shell
-#           ^^ keyword.operator.iteration.in.shell
+#           ^^ keyword.control.loop.in.shell
 #              ^^^^^ meta.string.glob.shell string.unquoted.shell
 #                    ^^^^^ meta.string.glob.shell string.unquoted.shell
 #                         ^ punctuation.terminator.statement.shell
@@ -412,7 +412,7 @@ for name in word1 word2; echo me;
 # <- keyword.control.loop.for.shell
 #^^ keyword.control.loop.for.shell
 #   ^^^^ variable.other.readwrite.shell
-#        ^^ keyword.operator.iteration.in.shell
+#        ^^ keyword.control.loop.in.shell
 #           ^^^^^ meta.string.glob.shell string.unquoted.shell
 #                 ^^^^^ meta.string.glob.shell string.unquoted.shell
 #                      ^ punctuation.terminator.statement.shell
@@ -565,7 +565,7 @@ select name in word1 word2; do echo $name; done;
 # <- keyword.control.loop.select.shell
 #^^^^^ keyword.control.loop.select.shell
 #      ^^^^ variable.other.readwrite.shell
-#           ^^ keyword.operator.iteration.in.shell
+#           ^^ keyword.control.loop.in.shell
 #              ^^^^^ meta.string.glob.shell string.unquoted.shell
 #                    ^^^^^ meta.string.glob.shell string.unquoted.shell
 #                         ^ punctuation.terminator.statement.shell
@@ -7182,7 +7182,7 @@ for a in ./**/*\ *(Dod); do mv $a ${a:h}/${a:t:gs/ /_}; done   # Remove spaces f
 #^^^^^^^^^^^^^^^^^^^^^^ meta.statement.loop.for.shell
 #^^ keyword.control.loop.for.shell
 #   ^ variable.other.readwrite.shell
-#     ^^ keyword.operator.iteration.in.shell
+#     ^^ keyword.control.loop.in.shell
 #       ^^^^^^^^^^^^^^^ meta.sequence.list.shell
 #        ^^^^^^^^^^^^^^ meta.string.glob.shell
 #        ^^^^^^^^^ string.unquoted.shell


### PR DESCRIPTION
This is a follow-up to #4227 (1e76a91), which introduced this new
unified `keyword.operator.iteration.in` scope. However, this `in` is a
keyword that is used in loop statements and not an operator and should
thus be scoped similar to `keyword.control.loop.for`. I opted to simply
replace `for` with `in` in the above as it allows for sufficient context
of the (loop-related control flow) keyword while not binding it to the
`for` like it was used in some instances before.

This "new" scope is already used by the Terraform third-party package:
https://github.com/SublimeText/Terraform/pull/86