### PR TITLE
[ShellScript] Add Zsh subscript flags

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -1560,7 +1560,7 @@ contexts:
     # attempt to scope subscript content arithmetic expression
     # if anything unrecognized was found, fallback to plain string
     - match: ''
-      branch_point: subscript
+      branch_point: subscript-content
       branch:
         - subscript-expression-content
         - subscript-plain-content
@@ -1568,7 +1568,7 @@ contexts:
   subscript-else-fail:
     - include: line-continuations
     - match: (?=\S)
-      fail: subscript
+      fail: subscript-content
 
   subscript-expression-content:
     - meta_content_scope: meta.arithmetic.shell

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -302,6 +302,7 @@ contexts:
     - match: (?={{identifier}}(?:\[[^\]]*\])*{{varassign}})
       set:
         - literal-array-value-assignment
+        - subscript
         - variable-name-begin
 
   variable-name-begin:
@@ -318,32 +319,6 @@ contexts:
     - include: literal-unquoted-content
     - match: '{{identifier_break}}'
       pop: 1
-
-  variable-subscription:
-    - include: variable-subscriptions
-    - include: line-continuations
-    - include: immediately-pop
-
-  variable-subscriptions:
-    - match: (\[)([*@])(\])
-      scope: meta.item-access.shell
-      captures:
-        1: punctuation.section.item-access.begin.shell
-        2: variable.language.array.shell
-        3: punctuation.section.item-access.end.shell
-    - match: \[
-      scope: punctuation.section.item-access.begin.shell
-      push: variable-subscription-body
-
-  variable-subscription-body:
-    - meta_include_prototype: false
-    - meta_scope: meta.item-access.shell
-    - meta_content_scope: meta.arithmetic.shell
-    - match: \]
-      scope: punctuation.section.item-access.end.shell
-      pop: 1
-    - include: eoc-pop
-    - include: expression-content
 
   assignment-value-meta:
     - meta_include_prototype: false
@@ -1027,6 +1002,7 @@ contexts:
     - match: '{{variable_begin}}'
       push:
         - arithmetic-mapping-value-assignment
+        - subscript
         - variable-name-begin
     - include: illegal-words
 
@@ -1042,6 +1018,7 @@ contexts:
     - match: '{{variable_begin}}'
       push:
         - arithmetic-array-value-assignment
+        - subscript
         - variable-name-begin
     - include: illegal-words
 
@@ -1057,6 +1034,7 @@ contexts:
     - match: '{{variable_begin}}'
       push:
         - literal-mapping-value-assignment
+        - subscript
         - variable-name-begin
     - include: illegal-words
 
@@ -1072,6 +1050,7 @@ contexts:
     - match: '{{variable_begin}}'
       push:
         - literal-array-value-assignment
+        - subscript
         - variable-name-begin
     - include: illegal-words
 
@@ -1324,7 +1303,8 @@ contexts:
       set:
         - assignment-value-meta
         - arithmetic-array-value
-    - include: variable-subscription
+    - include: line-continuations
+    - include: immediately-pop
 
   arithmetic-array-value:
     # maybe indexed array of or single arithmetic expression value
@@ -1344,7 +1324,8 @@ contexts:
       set:
         - assignment-value-meta
         - arithmetic-mapping-value
-    - include: variable-subscription
+    - include: line-continuations
+    - include: immediately-pop
 
   arithmetic-mapping-value:
     # maybe associative of or single arithmetic expression value
@@ -1400,7 +1381,8 @@ contexts:
       set:
         - assignment-value-meta
         - literal-array-value
-    - include: variable-subscription
+    - include: line-continuations
+    - include: immediately-pop
 
   literal-array-value:
     # maybe indexed array of or single literal/string value
@@ -1422,7 +1404,8 @@ contexts:
       set:
         - assignment-value-meta
         - literal-mapping-value
-    - include: variable-subscription
+    - include: line-continuations
+    - include: immediately-pop
 
   literal-mapping-value:
     # maybe associative array of or single literal/string value
@@ -1545,6 +1528,138 @@ contexts:
     - include: line-continuations
     - include: comments
 
+###[ SUBSCRIPTS ]##############################################################
+
+  subscript:
+    # 6.7 Arrays
+    # https://www.gnu.org/software/bash/manual/bash.html#Arrays
+    - match: (\[)([*@])(\])
+      scope: meta.item-access.shell
+      captures:
+        1: punctuation.section.item-access.begin.shell
+        2: variable.language.array.shell
+        3: punctuation.section.item-access.end.shell
+      pop: 1
+    - match: \[
+      scope: punctuation.section.item-access.begin.shell
+      set: subscript-body
+    - include: line-continuations
+    - include: immediately-pop
+
+  subscript-body:
+    - meta_include_prototype: false
+    - meta_scope: meta.item-access.shell
+    - match: \]
+      scope: punctuation.section.item-access.end.shell
+      pop: 1
+    - include: eoc-pop
+    - include: comma-separators
+    - include: subscript-content
+
+  subscript-content:
+    # attempt to scope subscript content arithmetic expression
+    # if anything unrecognized was found, fallback to plain string
+    - match: ''
+      branch_point: subscript
+      branch:
+        - subscript-expression-content
+        - subscript-plain-content
+
+  subscript-else-fail:
+    - include: line-continuations
+    - match: (?=\S)
+      fail: subscript
+
+  subscript-expression-content:
+    - meta_content_scope: meta.arithmetic.shell
+    - match: (?=[],])
+      pop: 1
+    # arithmetic expression content without word boundary checks
+    - match: \"
+      scope: punctuation.definition.quoted.begin.shell
+      push: subscript-expression-double-quoted-body
+    - match: \'
+      scope: punctuation.definition.quoted.begin.shell
+      push: subscript-expression-single-quoted-body
+    - include: subscript-expression-groups
+    - include: expression-common
+    - include: subscript-else-fail
+
+  subscript-expression-double-quoted-body:
+    - match: \"
+      scope: punctuation.definition.quoted.end.shell
+      pop: 1
+    - include: subscript-expression-double-quoted-groups
+    - include: expression-common
+    - include: subscript-else-fail
+
+  subscript-expression-double-quoted-groups:
+    - match: \(
+      scope: punctuation.section.group.begin.shell
+      push: subscript-expression-double-quoted-group-body
+
+  subscript-expression-double-quoted-group-body:
+    - meta_scope: meta.group.shell
+    - match: \)
+      scope: punctuation.section.group.end.shell
+      pop: 1
+    - match: (?=")
+      pop: 1
+    - include: subscript-expression-double-quoted-groups
+    - include: expression-common
+    - include: subscript-else-fail
+
+  subscript-expression-single-quoted-body:
+    - match: \'
+      scope: punctuation.definition.quoted.end.shell
+      pop: 1
+    - include: subscript-expression-single-quoted-groups
+    - include: expression-common
+    - include: subscript-else-fail
+
+  subscript-expression-single-quoted-groups:
+    - match: \(
+      scope: punctuation.section.group.begin.shell
+      push: subscript-expression-single-quoted-group-body
+
+  subscript-expression-single-quoted-group-body:
+    - meta_scope: meta.group.shell
+    - match: \)
+      scope: punctuation.section.group.end.shell
+      pop: 1
+    - match: (?=')
+      pop: 1
+    - include: subscript-expression-single-quoted-groups
+    - include: expression-common
+    - include: subscript-else-fail
+
+  subscript-expression-groups:
+    - match: \(
+      scope: punctuation.section.group.begin.shell
+      push: subscript-expression-group-body
+
+  subscript-expression-group-body:
+    - meta_scope: meta.group.shell
+    - match: \)
+      scope: punctuation.section.group.end.shell
+      pop: 1
+    - include: subscript-expression-groups
+    - include: expression-common
+    - include: subscript-else-fail
+
+  subscript-plain-content:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.shell string.unquoted.shell
+    - match: (?=[],])
+      pop: 1
+    - include: subscript-plain-common
+
+  subscript-plain-common:
+    - include: string-quotes
+    - include: string-prototype
+    - include: any-escapes
+    - include: string-interpolations
+
 ###[ ARITHMETIC EXPRESSIONS ]##################################################
 
   arithmetic-word:
@@ -1572,6 +1687,7 @@ contexts:
       scope: punctuation.section.group.begin.shell
       push: expression-group-body
     - include: expression-common
+    - include: expression-illegals
     - include: word-end
 
   expression-content:
@@ -1584,6 +1700,7 @@ contexts:
       push: expression-single-quoted-body
     - include: expression-groups
     - include: expression-common
+    - include: expression-illegals
 
   expression-double-quoted-body:
     - match: \"
@@ -1591,6 +1708,7 @@ contexts:
       pop: 1
     - include: expression-double-quoted-groups
     - include: expression-common
+    - include: expression-illegals
 
   expression-double-quoted-groups:
     - match: \(
@@ -1606,6 +1724,7 @@ contexts:
       pop: 1
     - include: expression-double-quoted-groups
     - include: expression-common
+    - include: expression-illegals
 
   expression-single-quoted-body:
     - match: \'
@@ -1613,6 +1732,7 @@ contexts:
       pop: 1
     - include: expression-single-quoted-groups
     - include: expression-common
+    - include: expression-illegals
 
   expression-single-quoted-groups:
     - match: \(
@@ -1628,6 +1748,7 @@ contexts:
       pop: 1
     - include: expression-single-quoted-groups
     - include: expression-common
+    - include: expression-illegals
 
   expression-groups:
     - match: \(
@@ -1641,6 +1762,7 @@ contexts:
       pop: 1
     - include: expression-groups
     - include: expression-common
+    - include: expression-illegals
 
   expression-common:
     # multi char operators
@@ -1670,7 +1792,6 @@ contexts:
     - include: booleans
     - include: expression-numbers
     - include: expression-variables
-    - include: expression-illegals
 
   expression-illegals:
     - match: '{{word_char}}'
@@ -1687,7 +1808,7 @@ contexts:
     # variables within arithmetic expressions must not contain quotes
     - match: (?=[{{identifier_first_char}}$%])
       push:
-        - variable-subscription
+        - subscript
         - expression-variable-chars
 
   expression-variable-chars:
@@ -2039,6 +2160,13 @@ contexts:
 ###[ STRINGS ]#################################################################
 
   string-unquoted-content:
+    - include: string-quotes
+    - include: string-prototype
+    - include: any-escapes
+    - include: brace-interpolations
+    - include: string-interpolations
+
+  string-quotes:
     # [Bash] 3.1.2.5
     - match: \$?\"
       scope: punctuation.definition.string.begin.shell
@@ -2050,10 +2178,6 @@ contexts:
     - match: \'
       scope: punctuation.definition.string.begin.shell
       push: string-single-quoted-body
-    - include: string-prototype
-    - include: any-escapes
-    - include: brace-interpolations
-    - include: string-interpolations
 
   string-ansi-c-body:
     - clear_scopes: 1  # clear `string.unquoted`
@@ -2794,30 +2918,39 @@ contexts:
       push:
         - parameter-expansion-meta
         - parameter-expansion-modifier
+        - subscript
         - parameter-expansion-name
         - parameter-expansion-operator
-    - include: simple-parameter-expansions
+    - match: (?=\${{word_char}})
+      push: simple-parmeter-expansion
 
-  simple-parameter-expansions:
+  simple-parmeter-expansion:
+    - meta_include_prototype: false
+    - meta_scope: meta.interpolation.parameter.shell
     # https://www.gnu.org/software/bash/manual/bash.html#Positional-Parameters
     - match: (\$)\d
-      scope: meta.interpolation.parameter.shell variable.language.positional.shell
+      scope: variable.language.positional.shell
       captures:
         1: punctuation.definition.variable.shell
+      pop: 1
     # https://www.gnu.org/software/bash/manual/bash.html#Shell-Variables
     - match: (\$){{builtin_variables}}
-      scope: meta.interpolation.parameter.shell variable.language.builtin.shell
+      scope: variable.language.builtin.shell
       captures:
         1: punctuation.definition.variable.shell
+      pop: 1
     # https://www.gnu.org/software/bash/manual/bash.html#Special-Parameters
     - match: (\$){{special_variables}}
-      scope: meta.interpolation.parameter.shell variable.language.special.shell
+      scope: variable.language.special.shell
       captures:
         1: punctuation.definition.variable.shell
+      pop: 1
     - match: (\$){{identifier}}
-      scope: meta.interpolation.parameter.shell variable.other.readwrite.shell
+      scope: variable.other.readwrite.shell
       captures:
         1: punctuation.definition.variable.shell
+      pop: 1
+    - include: immediately-pop
 
   parameter-expansion-meta:
     - meta_include_prototype: false
@@ -2901,7 +3034,6 @@ contexts:
       set:
         - parameter-expansion-pattern
         - maybe-tilde-interpolation
-    - include: variable-subscriptions
 
   parameter-expansion-substr-start:
     - meta_content_scope: meta.arithmetic.shell

--- a/ShellScript/Bash/tests/syntax_test_scope.bash
+++ b/ShellScript/Bash/tests/syntax_test_scope.bash
@@ -4969,6 +4969,183 @@ foo}
 #                                        ^ punctuation.section.item-access.end.shell
 #                                         ^ punctuation.section.interpolation.end.shell
 
+: ${var[1][2]}
+# ^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access - string
+#      ^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - string
+#         ^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access - string
+#             ^ - meta.string
+#   ^^^ variable.other.readwrite.shell
+#      ^ punctuation.section.item-access.begin.shell
+#       ^ meta.arithmetic.shell meta.number.integer.decimal.shell constant.numeric.value.shell
+#        ^ punctuation.section.item-access.end.shell
+#            ^ punctuation.section.interpolation.end.shell
+
+: "${var[1][2]}"
+# ^ meta.string.glob.shell - meta.interpolation
+#  ^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access - string
+#       ^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - string
+#          ^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access - string
+#              ^ meta.string.glob.shell - meta.interpolation
+# ^ string.quoted.double.shell punctuation.definition.string.begin.shell
+#    ^^^ variable.other.readwrite.shell
+#       ^ punctuation.section.item-access.begin.shell
+#        ^ meta.arithmetic.shell meta.number.integer.decimal.shell constant.numeric.value.shell
+#         ^ punctuation.section.item-access.end.shell
+#             ^ punctuation.section.interpolation.end.shell
+#              ^ punctuation.definition.string.end.shell
+
+: ${var[CURRENT - 1]}
+# ^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#      ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.arithmetic
+#       ^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell meta.arithmetic.shell
+#                  ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.arithmetic
+#                   ^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#                    ^ - meta.string
+#   ^^^ variable.other.readwrite.shell
+#      ^ punctuation.section.item-access.begin.shell
+#       ^^^^^^^ variable.other.readwrite.shell
+#               ^ keyword.operator.arithmetic.shell
+#                 ^ meta.number.integer.decimal.shell constant.numeric.value.shell
+#                  ^ punctuation.section.item-access.end.shell
+#                   ^ punctuation.section.interpolation.end.shell
+
+: ${var[(CURRENT - 1)]}
+# ^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#      ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.arithmetic
+#       ^^^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell meta.arithmetic.shell meta.group.shell
+#                    ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.arithmetic
+#                     ^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#                      ^ - meta.string
+#   ^^^ variable.other.readwrite.shell
+#      ^ punctuation.section.item-access.begin.shell
+#       ^ punctuation.section.group.begin.shell
+#        ^^^^^^^ variable.other.readwrite.shell
+#                ^ keyword.operator.arithmetic.shell
+#                  ^ meta.number.integer.decimal.shell constant.numeric.value.shell
+#                   ^ punctuation.section.group.end.shell
+#                    ^ punctuation.section.item-access.end.shell
+#                     ^ punctuation.section.interpolation.end.shell
+
+: ${var["CURRENT - 1"]}
+# ^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#      ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.arithmetic
+#       ^^^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell meta.arithmetic.shell
+#                    ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.arithmetic
+#                     ^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#                      ^ - meta.string
+#   ^^^ variable.other.readwrite.shell
+#      ^ punctuation.section.item-access.begin.shell
+#       ^ punctuation.definition.quoted.begin.shell
+#        ^^^^^^^ variable.other.readwrite.shell
+#                ^ keyword.operator.arithmetic.shell
+#                  ^ meta.number.integer.decimal.shell constant.numeric.value.shell
+#                   ^ punctuation.definition.quoted.end.shell
+#                    ^ punctuation.section.item-access.end.shell
+#                     ^ punctuation.section.interpolation.end.shell
+
+: ${var['CURRENT - 1']}
+# ^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#      ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.arithmetic
+#       ^^^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell meta.arithmetic.shell
+#                    ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.arithmetic
+#                     ^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#                      ^ - meta.string
+#   ^^^ variable.other.readwrite.shell
+#      ^ punctuation.section.item-access.begin.shell
+#       ^ punctuation.definition.quoted.begin.shell
+#        ^^^^^^^ variable.other.readwrite.shell
+#                ^ keyword.operator.arithmetic.shell
+#                  ^ meta.number.integer.decimal.shell constant.numeric.value.shell
+#                   ^ punctuation.definition.quoted.end.shell
+#                    ^ punctuation.section.item-access.end.shell
+#                     ^ punctuation.section.interpolation.end.shell
+
+# Everything not looking like an arithmetic
+# expression is scoped plain string
+# -----------------------------------------
+
+: ${var[my.key]}
+# ^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#      ^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell
+#              ^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#   ^^^ variable.other.readwrite.shell
+#      ^ punctuation.section.item-access.begin.shell
+#       ^^^^^^ meta.string.shell string.unquoted.shell - meta.arithmetic
+#             ^ punctuation.section.item-access.end.shell
+#              ^ punctuation.section.interpolation.end.shell
+
+: ${var['my.key']}  # quotes must be balanced
+# ^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#      ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.item-access meta.string
+#       ^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell meta.string.shell
+#               ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.item-access meta.string
+#                ^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#      ^ punctuation.section.item-access.begin.shell
+#       ^^^^^^^^ string.quoted.single.shell
+#       ^ punctuation.definition.string.begin.shell
+#              ^ punctuation.definition.string.end.shell
+#               ^ punctuation.section.item-access.end.shell
+#                ^ punctuation.section.interpolation.end.shell
+
+: ${var["my.key"]}  # quotes must be balanced
+# ^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#      ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.item-access meta.string
+#       ^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell meta.string.shell
+#               ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.item-access meta.string
+#                ^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#      ^ punctuation.section.item-access.begin.shell
+#       ^^^^^^^^ string.quoted.double.shell
+#       ^ punctuation.definition.string.begin.shell
+#              ^ punctuation.definition.string.end.shell
+#               ^ punctuation.section.item-access.end.shell
+#                ^ punctuation.section.interpolation.end.shell
+
+: ${var[my".key"]}  # quotes must be balanced
+# ^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#      ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.item-access meta.string
+#       ^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell meta.string.shell
+#               ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.item-access meta.string
+#                ^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#      ^ punctuation.section.item-access.begin.shell
+#       ^^ meta.string.shell string.unquoted.shell
+#         ^^^^^^ string.quoted.double.shell
+#         ^ punctuation.definition.string.begin.shell
+#              ^ punctuation.definition.string.end.shell
+#               ^ punctuation.section.item-access.end.shell
+#                ^ punctuation.section.interpolation.end.shell
+
+: ${var[(my.{key[0]})]}  # brackets don't need to be balanced (in Bash)
+# ^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#      ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.item-access meta.string
+#       ^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell meta.string.shell
+#                 ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.item-access meta.string
+#                  ^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#                   ^^^ - meta.string.glob
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#   ^^^ variable.other.readwrite.shell
+#      ^ punctuation.section.item-access.begin.shell
+#       ^^^^^^^^^^ string.unquoted.shell
+#                 ^ punctuation.section.item-access.end.shell
+#                  ^ punctuation.section.interpolation.end.shell
+#                   ^ invalid.illegal.stray.shell
+
+: ${var[{my.{key}]}}]}  # nested stray brackets
+# ^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#      ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.item-access meta.string
+#       ^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell meta.string.shell
+#                ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.item-access meta.string
+#                 ^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#                  ^^^ meta.string.glob.shell - meta.interpolation
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#   ^^^ variable.other.readwrite.shell
+#      ^ punctuation.section.item-access.begin.shell
+#       ^^^^^^^^^ string.unquoted.shell
+#                ^ punctuation.section.item-access.end.shell
+#                 ^ punctuation.section.interpolation.end.shell
+#                  ^^^ string.unquoted.shell
+
 ################################
 
 : ${#foo}

--- a/ShellScript/Zsh.sublime-syntax
+++ b/ShellScript/Zsh.sublime-syntax
@@ -112,7 +112,9 @@ contexts:
     # positional parameter assignments
     - match: \d{1,2}(?=(?:\[[^\]]*\])*{{varassign}})
       scope: meta.assignment.l-value.shell variable.language.positional.shell
-      set: literal-array-value-assignment
+      set:
+        - literal-array-value-assignment
+        - subscript
 
 ###[ BUILTINS ]################################################################
 
@@ -258,6 +260,106 @@ contexts:
       pop: 1
     - include: comments
     - include: group-path-patterns
+
+###[ SUBSCRIPTS ]##############################################################
+
+  subscript-content:
+    # https://zsh.sourceforge.io/Doc/Release/Parameters.html#Array-Subscripts
+    - match: ''
+      branch_point: subscript
+      branch:
+        - zsh-subscript-flags
+        - subscript-expression-content
+        - subscript-plain-content
+
+  zsh-subscript-flags:
+    # https://zsh.sourceforge.io/Doc/Release/Parameters.html#Subscript-Flags
+    - match: \(
+      scope: meta.modifier.subscript.shell.zsh punctuation.definition.modifier.begin.shell.zsh
+      set: zsh-subscript-flag-pattern-body
+    - include: line-continuations
+    - match: ''
+      fail: subscript
+
+  zsh-subscript-flag-pattern-body:
+    - meta_content_scope: meta.modifier.subscript.shell.zsh
+    - match: \)
+      scope: meta.modifier.subscript.shell.zsh punctuation.definition.modifier.end.shell.zsh
+      set: zsh-subscript-pattern-content
+    - include: zsh-subscript-flag-common
+
+  zsh-subscript-flag-plain-body:
+    - meta_content_scope: meta.modifier.subscript.shell.zsh
+    - match: \)
+      scope: meta.modifier.subscript.shell.zsh punctuation.definition.modifier.end.shell.zsh
+      set: subscript-plain-content
+    - include: zsh-subscript-flag-common
+
+  zsh-subscript-flag-common:
+    # key is pattern
+    - match: '[iIkKrR]'
+      scope: meta.modifier.subscript.shell.zsh storage.modifier.subscript.shell.zsh
+      set: zsh-subscript-flag-pattern-body
+    # key is plain text
+    - match: e
+      scope: meta.modifier.subscript.shell.zsh storage.modifier.subscript.shell.zsh
+      set: zsh-subscript-flag-plain-body
+    # additional flags
+    - match: '[bn]'
+      scope: storage.modifier.subscript.shell.zsh
+      push: zsh-modifier-expression
+    - match: s
+      scope: storage.modifier.subscript.shell.zsh
+      push: zsh-modifier-literal-string
+    - match: '[fpw]'
+      scope: storage.modifier.subscript.shell.zsh
+    - include: line-continuations
+    - match: ''
+      fail: subscript
+
+  zsh-subscript-pattern-content:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.glob.shell.zsh string.unquoted.shell
+    - match: (?=[],])
+      pop: 1
+    - include: pattern-main-content
+
+  subscript-plain-common:
+    - meta_append: true
+    # note: brackets must be balanced whithin subscripts
+    - match: \<
+      push: zsh-subscript-plain-angled-body
+    - match: \{
+      push: zsh-subscript-plain-braces-body
+    - match: \[
+      push: zsh-subscript-plain-brackets-body
+    - match: \(
+      push: zsh-subscript-plain-parens-body
+    - include: illegal-stray
+
+  zsh-subscript-plain-angled-body:
+    - meta_include_prototype: false
+    - match: \>
+      pop: 1
+    - include: subscript-plain-common
+
+  zsh-subscript-plain-braces-body:
+    - meta_include_prototype: false
+    - match: \}
+      pop: 1
+    - include: subscript-plain-common
+
+  zsh-subscript-plain-brackets-body:
+    - meta_include_prototype: false
+    - match: \]
+      pop: 1
+    - include: subscript-plain-common
+
+  zsh-subscript-plain-parens-body:
+    - meta_include_prototype: false
+    - match: \)
+      pop: 1
+    - include: subscript-plain-common
 
 ###[ ARITHMETIC EXPRESSIONS ]##################################################
 
@@ -485,34 +587,44 @@ contexts:
       push:
         - parameter-expansion-meta
         - parameter-expansion-modifier
+        - subscript
         - parameter-expansion-name
         - parameter-expansion-operator
         - zsh-parameter-flags
-    # https://www.gnu.org/software/bash/manual/bash.html#Positional-Parameters
+    - match: (?=\${{word_char}})
+      push:
+        - parameter-expansion-meta
+        - subscript
+        - simple-parmeter-expansion
+
+  simple-parmeter-expansion:
+    - meta_include_prototype: false
+    # https://zsh.sourceforge.io/Doc/Release/Parameters.html#Positional-Parameters
     - match: (\$)\d
       scope: variable.language.positional.shell
       captures:
         1: punctuation.definition.variable.shell
-      push: zsh-parameter-subscription
-    # https://www.gnu.org/software/bash/manual/bash.html#Shell-Variables
+      pop: 1
+    # https://zsh.sourceforge.io/Doc/Release/Parameters.html#Parameters-Set-By-The-Shell
     - match: (\$){{builtin_variables}}
       scope: variable.language.builtin.shell
       captures:
         1: punctuation.definition.variable.shell
-      push: zsh-parameter-subscription
-    # length operator has precedence over special parameters
+      pop: 1
+    # length operator has precedence over special parameters in ZSH
     - match: (\$)(\#?){{identifier}}
       scope: variable.other.readwrite.shell
       captures:
         1: punctuation.definition.variable.shell
         2: keyword.operator.expansion.length.shell
-      push: zsh-parameter-subscription
-    # https://www.gnu.org/software/bash/manual/bash.html#Special-Parameters
+      pop: 1
+    # https://zsh.sourceforge.io/Doc/Release/Parameters.html#Description-1
     - match: (\$){{special_variables}}
       scope: variable.language.special.shell
       captures:
         1: punctuation.definition.variable.shell
-      push: zsh-parameter-subscription
+      pop: 1
+    - include: immediately-pop
 
   parameter-expansion-operator:
     # 14.3 Parameter Expansion
@@ -641,11 +753,6 @@ contexts:
     # range operator is crucial
     - include: zsh-glob-range-operator
     - include: zsh-parameter-glob-range-fail
-
-  zsh-parameter-subscription:
-    - meta_include_prototype: false
-    - meta_scope: meta.interpolation.parameter.shell
-    - include: variable-subscription
 
 ###[ TILDE EXPANSIONS ]########################################################
 
@@ -1215,12 +1322,14 @@ contexts:
 
   zsh-modifier-interpolations:
     - match: (?=\$[{{identifier_char}}{{special_variables}}])
-      push: zsh-modifier-interpolation-body
+      push:
+        - zsh-modifier-interpolation-meta
+        - simple-parmeter-expansion
 
-  zsh-modifier-interpolation-body:
+  zsh-modifier-interpolation-meta:
     - clear_scopes: 1
     - meta_include_prototype: false
-    - include: simple-parameter-expansions
+    - meta_scope: meta.interpolation.parameter.shell
     - include: immediately-pop
 
 ###[ ZSH MODIFIER LITERAL STRINGS ]############################################

--- a/ShellScript/Zsh.sublime-syntax
+++ b/ShellScript/Zsh.sublime-syntax
@@ -266,7 +266,7 @@ contexts:
   subscript-content:
     # https://zsh.sourceforge.io/Doc/Release/Parameters.html#Array-Subscripts
     - match: ''
-      branch_point: subscript
+      branch_point: subscript-content
       branch:
         - zsh-subscript-flags
         - subscript-expression-content
@@ -279,7 +279,7 @@ contexts:
       set: zsh-subscript-flag-pattern-body
     - include: line-continuations
     - match: ''
-      fail: subscript
+      fail: subscript-content
 
   zsh-subscript-flag-pattern-body:
     - meta_content_scope: meta.modifier.subscript.shell.zsh
@@ -317,7 +317,7 @@ contexts:
       scope: storage.modifier.subscript.shell.zsh
     - include: line-continuations
     - match: ''
-      fail: subscript
+      fail: subscript-content
 
   zsh-subscript-pattern-content:
     - meta_include_prototype: false

--- a/ShellScript/Zsh.sublime-syntax
+++ b/ShellScript/Zsh.sublime-syntax
@@ -307,7 +307,9 @@ contexts:
     # additional flags
     - match: '[bn]'
       scope: storage.modifier.subscript.shell.zsh
-      push: zsh-modifier-expression
+      push:
+        - immediately-pop  # workaround https://github.com/sublimehq/sublime_text/issues/4069
+        - zsh-modifier-expression
     - match: s
       scope: storage.modifier.subscript.shell.zsh
       push: zsh-modifier-literal-string

--- a/ShellScript/Zsh/tests/syntax_test_scope.zsh
+++ b/ShellScript/Zsh/tests/syntax_test_scope.zsh
@@ -7255,7 +7255,424 @@ _b=value
 # <- - meta.assignment
 #^^^^^^^ - meta.assignment
 
-### [ ARRAY VARIABLES ] #######################################################
+
+##############################################################################
+# 15.2 Array Parameters
+# https://zsh.sourceforge.io/Doc/Release/Parameters.html#Array-Parameters
+##############################################################################
+
+illegals=( | & ; < > )
+#          ^ invalid.illegal.unexpected-token.shell
+#            ^ invalid.illegal.unexpected-token.shell
+#              ^ invalid.illegal.unexpected-token.shell
+#                ^ invalid.illegal.unexpected-token.shell
+#                  ^ invalid.illegal.unexpected-token.shell
+
+
+##############################################################################
+# 15.2.1 Array Subscripts
+# https://zsh.sourceforge.io/Doc/Release/Parameters.html#Array-Subscripts
+##############################################################################
+
+echo $var[1] World
+#<- meta.function-call.identifier.shell support.function.shell
+#^^^ meta.function-call.identifier.shell support.function.shell
+#   ^^^^^^^^^^^^^^ meta.function-call.arguments.shell
+#    ^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell
+#        ^^^ meta.item-access.shell - variable
+#        ^ punctuation.section.item-access.begin.shell
+#         ^ meta.arithmetic.shell meta.number.integer.decimal.shell constant.numeric.value.shell
+#          ^ punctuation.section.item-access.end.shell
+#            ^^^^^ meta.string.glob.shell string.unquoted.shell - meta.interpolation
+
+: $var[1][2]
+# ^^^^^^^^^^ meta.string.glob.shell
+# ^^^^^^^ meta.interpolation.parameter.shell
+# ^^^^ variable.other.readwrite.shell
+# ^ punctuation.definition.variable.shell
+#     ^^^ meta.item-access.shell
+#     ^ punctuation.section.item-access.begin.shell
+#      ^ meta.arithmetic.shell meta.number.integer.decimal.shell constant.numeric.value.shell
+#       ^ punctuation.section.item-access.end.shell
+#        ^^^ string.unquoted.shell meta.set.regexp.shell
+#        ^ punctuation.definition.set.begin.regexp.shell
+#          ^ punctuation.definition.set.end.regexp.shell
+
+: "$var[1][2]"
+# ^ meta.string.glob.shell - meta.interpolation
+#  ^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - string
+#         ^^^^ meta.string.glob.shell - meta.interpolation
+# ^ string.quoted.double.shell punctuation.definition.string.begin.shell
+#  ^^^^ variable.other.readwrite.shell
+#  ^ punctuation.definition.variable.shell
+#      ^^^ meta.item-access.shell
+#      ^ punctuation.section.item-access.begin.shell
+#       ^ meta.arithmetic.shell meta.number.integer.decimal.shell constant.numeric.value.shell
+#        ^ punctuation.section.item-access.end.shell
+#         ^^^^ string.quoted.double.shell
+#            ^ punctuation.definition.string.end.shell
+
+: $var[CURRENT - 1]
+# ^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#     ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.arithmetic
+#      ^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell meta.arithmetic.shell
+#                 ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.arithmetic
+#                  ^ - meta.string
+# ^^^^ variable.other.readwrite.shell
+# ^ punctuation.definition.variable.shell
+#     ^ punctuation.section.item-access.begin.shell
+#      ^^^^^^^ variable.other.readwrite.shell
+#              ^ keyword.operator.arithmetic.shell
+#                ^ meta.number.integer.decimal.shell constant.numeric.value.shell
+#                 ^ punctuation.section.item-access.end.shell
+
+: $var[(CURRENT - 1)]
+# ^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#     ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.arithmetic
+#      ^^^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell meta.arithmetic.shell meta.group.shell
+#                   ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.arithmetic
+#                    ^ - meta.string
+# ^^^^ variable.other.readwrite.shell
+# ^ punctuation.definition.variable.shell
+#     ^ punctuation.section.item-access.begin.shell
+#      ^ punctuation.section.group.begin.shell
+#       ^^^^^^^ variable.other.readwrite.shell
+#               ^ keyword.operator.arithmetic.shell
+#                 ^ meta.number.integer.decimal.shell constant.numeric.value.shell
+#                  ^ punctuation.section.group.end.shell
+#                   ^ punctuation.section.item-access.end.shell
+
+: $var["CURRENT - 1"]
+# ^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#     ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.arithmetic
+#      ^^^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell meta.arithmetic.shell
+#                   ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.arithmetic
+#                    ^ - meta.string
+# ^^^^ variable.other.readwrite.shell
+# ^ punctuation.definition.variable.shell
+#     ^ punctuation.section.item-access.begin.shell
+#      ^ punctuation.definition.quoted.begin.shell
+#       ^^^^^^^ variable.other.readwrite.shell
+#               ^ keyword.operator.arithmetic.shell
+#                 ^ meta.number.integer.decimal.shell constant.numeric.value.shell
+#                  ^ punctuation.definition.quoted.end.shell
+#                   ^ punctuation.section.item-access.end.shell
+
+: $var['CURRENT - 1']
+# ^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#     ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.arithmetic
+#      ^^^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell meta.arithmetic.shell
+#                   ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.arithmetic
+#                    ^ - meta.string
+# ^^^^ variable.other.readwrite.shell
+# ^ punctuation.definition.variable.shell
+#     ^ punctuation.section.item-access.begin.shell
+#      ^ punctuation.definition.quoted.begin.shell
+#       ^^^^^^^ variable.other.readwrite.shell
+#               ^ keyword.operator.arithmetic.shell
+#                 ^ meta.number.integer.decimal.shell constant.numeric.value.shell
+#                  ^ punctuation.definition.quoted.end.shell
+#                   ^ punctuation.section.item-access.end.shell
+
+# Everything not looking like an arithmetic
+# expression is scoped plain string
+# -----------------------------------------
+
+: $var[my.key]
+# ^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#     ^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell
+# ^^^^ variable.other.readwrite.shell
+# ^ punctuation.definition.variable.shell
+#     ^ punctuation.section.item-access.begin.shell
+#      ^^^^^^ meta.string.shell string.unquoted.shell - meta.arithmetic
+#            ^ punctuation.section.item-access.end.shell
+
+: $var['my.key']  # quotes must be balanced
+# ^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#     ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.item-access meta.string
+#      ^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell meta.string.shell
+#              ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.item-access meta.string
+#               ^ - meta.string.glob.shell
+#     ^ punctuation.section.item-access.begin.shell
+#      ^^^^^^^^ string.quoted.single.shell
+#      ^ punctuation.definition.string.begin.shell
+#             ^ punctuation.definition.string.end.shell
+#              ^ punctuation.section.item-access.end.shell
+
+: $var["my.key"]  # quotes must be balanced
+# ^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#     ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.item-access meta.string
+#      ^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell meta.string.shell
+#              ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.item-access meta.string
+#               ^ - meta.string.glob.shell
+#     ^ punctuation.section.item-access.begin.shell
+#      ^^^^^^^^ string.quoted.double.shell
+#      ^ punctuation.definition.string.begin.shell
+#             ^ punctuation.definition.string.end.shell
+#              ^ punctuation.section.item-access.end.shell
+
+: $var[my".key"]  # quotes must be balanced
+# ^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#     ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.item-access meta.string
+#      ^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell meta.string.shell
+#              ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.item-access meta.string
+#               ^ - meta.string.glob.shell
+#     ^ punctuation.section.item-access.begin.shell
+#      ^^ meta.string.shell string.unquoted.shell
+#        ^^^^^^ string.quoted.double.shell
+#        ^ punctuation.definition.string.begin.shell
+#             ^ punctuation.definition.string.end.shell
+#              ^ punctuation.section.item-access.end.shell
+
+: $var[\"my\".key\"]  # odd number of quotes must be escaped
+# ^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#     ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.item-access meta.string
+#      ^^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell meta.string.shell
+#                  ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.item-access meta.string
+#                   ^ - meta.string.glob.shell
+#     ^ punctuation.section.item-access.begin.shell
+#      ^^^^^^^^^^^^ string.unquoted.shell
+#      ^^ constant.character.escape.shell
+#          ^^ constant.character.escape.shell
+#                ^^ constant.character.escape.shell
+#                  ^ punctuation.section.item-access.end.shell
+
+: $var[(my.{key[0]})]  # all sorts of brackets must be balanced
+# ^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#     ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.item-access meta.string
+#      ^^^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell meta.string.shell
+#                   ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.item-access meta.string
+#                    ^ - meta.string.glob.shell
+#     ^ punctuation.section.item-access.begin.shell
+#      ^^^^^^^^^^^^^ string.unquoted.shell
+#                   ^ punctuation.section.item-access.end.shell
+
+: $var[{my.{key}]}}]  # nested stray brackets
+# ^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#     ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.item-access meta.string
+#      ^^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell meta.string.shell
+#                  ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.item-access meta.string
+#                   ^ - meta.string.glob.shell
+#     ^ punctuation.section.item-access.begin.shell
+#      ^^^^^^^^^^^^ string.unquoted.shell
+#                  ^ punctuation.section.item-access.end.shell
+
+: $var[{my.{key}\]\}}]  # unbalanced brackets must be escaped
+# ^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#     ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.item-access meta.string
+#      ^^^^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell meta.string.shell
+#                    ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.item-access meta.string
+#                     ^ - meta.string.glob.shell
+#     ^ punctuation.section.item-access.begin.shell
+#               ^^^^ constant.character.escape.shell
+#                    ^ punctuation.section.item-access.end.shell
+
+# extended parameter expansions in braces
+# ---------------------------------------
+
+: ${var[1][2]}
+# ^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access - string
+#      ^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - string
+#         ^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access - string
+#             ^ - meta.string
+#   ^^^ variable.other.readwrite.shell
+#      ^ punctuation.section.item-access.begin.shell
+#       ^ meta.arithmetic.shell meta.number.integer.decimal.shell constant.numeric.value.shell
+#        ^ punctuation.section.item-access.end.shell
+#            ^ punctuation.section.interpolation.end.shell
+
+: "${var[1][2]}"
+# ^ meta.string.glob.shell - meta.interpolation
+#  ^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access - string
+#       ^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - string
+#          ^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access - string
+#              ^ meta.string.glob.shell - meta.interpolation
+# ^ string.quoted.double.shell punctuation.definition.string.begin.shell
+#    ^^^ variable.other.readwrite.shell
+#       ^ punctuation.section.item-access.begin.shell
+#        ^ meta.arithmetic.shell meta.number.integer.decimal.shell constant.numeric.value.shell
+#         ^ punctuation.section.item-access.end.shell
+#             ^ punctuation.section.interpolation.end.shell
+#              ^ punctuation.definition.string.end.shell
+
+: ${var[CURRENT - 1]}
+# ^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#      ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.arithmetic
+#       ^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell meta.arithmetic.shell
+#                  ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.arithmetic
+#                   ^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#                    ^ - meta.string
+#   ^^^ variable.other.readwrite.shell
+#      ^ punctuation.section.item-access.begin.shell
+#       ^^^^^^^ variable.other.readwrite.shell
+#               ^ keyword.operator.arithmetic.shell
+#                 ^ meta.number.integer.decimal.shell constant.numeric.value.shell
+#                  ^ punctuation.section.item-access.end.shell
+#                   ^ punctuation.section.interpolation.end.shell
+
+: ${var[(CURRENT - 1)]}
+# ^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#      ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.arithmetic
+#       ^^^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell meta.arithmetic.shell meta.group.shell
+#                    ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.arithmetic
+#                     ^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#                      ^ - meta.string
+#   ^^^ variable.other.readwrite.shell
+#      ^ punctuation.section.item-access.begin.shell
+#       ^ punctuation.section.group.begin.shell
+#        ^^^^^^^ variable.other.readwrite.shell
+#                ^ keyword.operator.arithmetic.shell
+#                  ^ meta.number.integer.decimal.shell constant.numeric.value.shell
+#                   ^ punctuation.section.group.end.shell
+#                    ^ punctuation.section.item-access.end.shell
+#                     ^ punctuation.section.interpolation.end.shell
+
+: ${var["CURRENT - 1"]}
+# ^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#      ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.arithmetic
+#       ^^^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell meta.arithmetic.shell
+#                    ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.arithmetic
+#                     ^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#                      ^ - meta.string
+#   ^^^ variable.other.readwrite.shell
+#      ^ punctuation.section.item-access.begin.shell
+#       ^ punctuation.definition.quoted.begin.shell
+#        ^^^^^^^ variable.other.readwrite.shell
+#                ^ keyword.operator.arithmetic.shell
+#                  ^ meta.number.integer.decimal.shell constant.numeric.value.shell
+#                   ^ punctuation.definition.quoted.end.shell
+#                    ^ punctuation.section.item-access.end.shell
+#                     ^ punctuation.section.interpolation.end.shell
+
+: ${var['CURRENT - 1']}
+# ^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#      ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.arithmetic
+#       ^^^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell meta.arithmetic.shell
+#                    ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.arithmetic
+#                     ^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#                      ^ - meta.string
+#   ^^^ variable.other.readwrite.shell
+#      ^ punctuation.section.item-access.begin.shell
+#       ^ punctuation.definition.quoted.begin.shell
+#        ^^^^^^^ variable.other.readwrite.shell
+#                ^ keyword.operator.arithmetic.shell
+#                  ^ meta.number.integer.decimal.shell constant.numeric.value.shell
+#                   ^ punctuation.definition.quoted.end.shell
+#                    ^ punctuation.section.item-access.end.shell
+#                     ^ punctuation.section.interpolation.end.shell
+
+# Everything not looking like an arithmetic
+# expression is scoped plain string
+# -----------------------------------------
+
+: ${var[my.key]}
+# ^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#      ^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell
+#              ^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#   ^^^ variable.other.readwrite.shell
+#      ^ punctuation.section.item-access.begin.shell
+#       ^^^^^^ meta.string.shell string.unquoted.shell - meta.arithmetic
+#             ^ punctuation.section.item-access.end.shell
+#              ^ punctuation.section.interpolation.end.shell
+
+: ${var['my.key']}  # quotes must be balanced
+# ^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#      ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.item-access meta.string
+#       ^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell meta.string.shell
+#               ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.item-access meta.string
+#                ^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#      ^ punctuation.section.item-access.begin.shell
+#       ^^^^^^^^ string.quoted.single.shell
+#       ^ punctuation.definition.string.begin.shell
+#              ^ punctuation.definition.string.end.shell
+#               ^ punctuation.section.item-access.end.shell
+#                ^ punctuation.section.interpolation.end.shell
+
+: ${var["my.key"]}  # quotes must be balanced
+# ^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#      ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.item-access meta.string
+#       ^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell meta.string.shell
+#               ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.item-access meta.string
+#                ^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#      ^ punctuation.section.item-access.begin.shell
+#       ^^^^^^^^ string.quoted.double.shell
+#       ^ punctuation.definition.string.begin.shell
+#              ^ punctuation.definition.string.end.shell
+#               ^ punctuation.section.item-access.end.shell
+#                ^ punctuation.section.interpolation.end.shell
+
+: ${var[my".key"]}  # quotes must be balanced
+# ^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#      ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.item-access meta.string
+#       ^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell meta.string.shell
+#               ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.item-access meta.string
+#                ^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#      ^ punctuation.section.item-access.begin.shell
+#       ^^ meta.string.shell string.unquoted.shell
+#         ^^^^^^ string.quoted.double.shell
+#         ^ punctuation.definition.string.begin.shell
+#              ^ punctuation.definition.string.end.shell
+#               ^ punctuation.section.item-access.end.shell
+#                ^ punctuation.section.interpolation.end.shell
+
+: ${var[\"my\".key\"]}  # odd number of quotes must be escaped
+# ^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#      ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.item-access meta.string
+#       ^^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell meta.string.shell
+#                   ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.item-access meta.string
+#                    ^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#      ^ punctuation.section.item-access.begin.shell
+#       ^^^^^^^^^^^^ string.unquoted.shell
+#       ^^ constant.character.escape.shell
+#           ^^ constant.character.escape.shell
+#                 ^^ constant.character.escape.shell
+#                   ^ punctuation.section.item-access.end.shell
+#                    ^ punctuation.section.interpolation.end.shell
+
+: ${var[(my.{key[0]})]}  # all sorts of brackets must be balanced
+# ^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#      ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.item-access meta.string
+#       ^^^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell meta.string.shell
+#                    ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.item-access meta.string
+#                     ^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#   ^^^ variable.other.readwrite.shell
+#      ^ punctuation.section.item-access.begin.shell
+#       ^^^^^^^^^^^^^ string.unquoted.shell
+#                    ^ punctuation.section.item-access.end.shell
+#                     ^ punctuation.section.interpolation.end.shell
+
+: ${var[{my.{key}]}}]}  # nested stray brackets
+# ^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#      ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.item-access meta.string
+#       ^^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell meta.string.shell
+#                   ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.item-access meta.string
+#                    ^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#   ^^^ variable.other.readwrite.shell
+#      ^ punctuation.section.item-access.begin.shell
+#       ^^^^^^^^^^^^ string.unquoted.shell
+#                   ^ punctuation.section.item-access.end.shell
+#                    ^ punctuation.section.interpolation.end.shell
+
+: ${var[{my.{key}\]\}}]}  # unbalanced brackets must be escaped
+# ^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#      ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.item-access meta.string
+#       ^^^^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell meta.string.shell
+#                     ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.item-access meta.string
+#                      ^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
+#      ^ punctuation.section.item-access.begin.shell
+#                ^^^^ constant.character.escape.shell
+#                     ^ punctuation.section.item-access.end.shell
+#                      ^ punctuation.section.interpolation.end.shell
+
+
+##############################################################################
+# 15.2.2 Array Element Assignments
+# https://zsh.sourceforge.io/Doc/Release/Parameters.html#Array-Element-Assignment
+##############################################################################
 
 10[1]=value
 # <- meta.assignment.l-value.shell variable.language.positional.shell
@@ -7274,29 +7691,200 @@ var[1]=Hello
 #     ^ keyword.operator.assignment.shell
 #      ^^^^^ meta.string.glob.shell string.unquoted.shell
 
-echo $var[1] World
-#<- meta.function-call.identifier.shell support.function.shell
-#^^^ meta.function-call.identifier.shell support.function.shell
-#   ^^^^^^^^^^^^^^ meta.function-call.arguments.shell
-#    ^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell
-#        ^^^ meta.item-access.shell - variable
-#        ^ punctuation.section.item-access.begin.shell
-#         ^ meta.arithmetic.shell meta.number.integer.decimal.shell constant.numeric.value.shell
-#          ^ punctuation.section.item-access.end.shell
-#            ^^^^^ meta.string.glob.shell string.unquoted.shell - meta.interpolation
-
 
 ##############################################################################
-# 15.2 Array Parameters
-# https://zsh.sourceforge.io/Doc/Release/Parameters.html#Array-Parameters
+# 15.2.3 Subscript Flags
+# https://zsh.sourceforge.io/Doc/Release/Parameters.html#Subscript-Flags
 ##############################################################################
 
-illegals=( | & ; < > )
-#          ^ invalid.illegal.unexpected-token.shell
-#            ^ invalid.illegal.unexpected-token.shell
-#              ^ invalid.illegal.unexpected-token.shell
-#                ^ invalid.illegal.unexpected-token.shell
-#                  ^ invalid.illegal.unexpected-token.shell
+: $var[(w)idx]                  # Scalar subscript work on words instead of chars
+#     ^^^^^^^^ meta.item-access.shell
+#     ^ punctuation.section.item-access.begin.shell
+#      ^^^ meta.modifier.subscript.shell.zsh
+#      ^ punctuation.definition.modifier.begin.shell.zsh
+#       ^ storage.modifier.subscript.shell.zsh
+#        ^ punctuation.definition.modifier.end.shell.zsh
+#         ^^^ meta.string.glob.shell.zsh string.unquoted.shell - meta.modifier
+#            ^ punctuation.section.item-access.end.shell
+
+: $var[(s:string:)key]          # This gives the string that separates words
+#     ^^^^^^^^^^^^^^^^ meta.item-access.shell
+#     ^ punctuation.section.item-access.begin.shell
+#      ^^^^^^^^^^^ meta.modifier.subscript.shell.zsh
+#      ^ punctuation.definition.modifier.begin.shell.zsh
+#       ^ storage.modifier.subscript.shell.zsh
+#        ^^^^^^^^ meta.quoted.glob.shell.zsh
+#        ^ punctuation.definition.quoted.begin.shell.zsh
+#         ^^^^^^ string.quoted.other.shell.zsh
+#               ^ punctuation.definition.quoted.end.shell.zsh
+#                ^ punctuation.definition.modifier.end.shell.zsh
+#                 ^^^ meta.string.glob.shell.zsh string.unquoted.shell - meta.modifier
+#                    ^ punctuation.section.item-access.end.shell
+
+: $var[(p)key]                  # Recognize the same escape sequences as the print builtin in s-flag argument
+#     ^^^^^^^^ meta.item-access.shell
+#     ^ punctuation.section.item-access.begin.shell
+#      ^^^ meta.modifier.subscript.shell.zsh
+#      ^ punctuation.definition.modifier.begin.shell.zsh
+#       ^ storage.modifier.subscript.shell.zsh
+#        ^ punctuation.definition.modifier.end.shell.zsh
+#         ^^^ meta.string.glob.shell.zsh string.unquoted.shell - meta.modifier
+#            ^ punctuation.section.item-access.end.shell
+
+: $var[(f)idx]                  # Scalar subscript work on lines instead of chars
+#     ^^^^^^^^ meta.item-access.shell
+#     ^ punctuation.section.item-access.begin.shell
+#      ^^^ meta.modifier.subscript.shell.zsh
+#      ^ punctuation.definition.modifier.begin.shell.zsh
+#       ^ storage.modifier.subscript.shell.zsh
+#        ^ punctuation.definition.modifier.end.shell.zsh
+#         ^^^ meta.string.glob.shell.zsh string.unquoted.shell - meta.modifier
+#            ^ punctuation.section.item-access.end.shell
+
+: $var[(r)([^@]##@|)pat]        # Reverse subscripting: key is taken as a pattern
+#     ^^^^^^^^^^^^^^^^^^ meta.item-access.shell
+#     ^ punctuation.section.item-access.begin.shell
+#      ^^^ meta.modifier.subscript.shell.zsh
+#      ^ punctuation.definition.modifier.begin.shell.zsh
+#       ^ storage.modifier.subscript.shell.zsh
+#        ^ punctuation.definition.modifier.end.shell.zsh
+#         ^^^^^^^^^^ meta.string.glob.shell.zsh meta.group.regexp.shell string.unquoted.shell
+#                   ^^^ meta.string.glob.shell.zsh string.unquoted.shell - meta.group - meta.modifier.subscript
+#                      ^ punctuation.section.item-access.end.shell
+
+: $var[(R)([^@]##@|)pat]        # Like ‘r’, but gives the last match.
+#     ^^^^^^^^^^^^^^^^^^ meta.item-access.shell
+#     ^ punctuation.section.item-access.begin.shell
+#      ^^^ meta.modifier.subscript.shell.zsh
+#      ^ punctuation.definition.modifier.begin.shell.zsh
+#       ^ storage.modifier.subscript.shell.zsh
+#        ^ punctuation.definition.modifier.end.shell.zsh
+#         ^^^^^^^^^^ meta.string.glob.shell.zsh meta.group.regexp.shell string.unquoted.shell
+#                   ^^^ meta.string.glob.shell.zsh string.unquoted.shell - meta.group - meta.modifier.subscript
+#                      ^ punctuation.section.item-access.end.shell
+
+: $var[(i)([^@]##@|)pat]        # Like ‘r’, but gives the index of the match instead
+#     ^^^^^^^^^^^^^^^^^^ meta.item-access.shell
+#     ^ punctuation.section.item-access.begin.shell
+#      ^^^ meta.modifier.subscript.shell.zsh
+#      ^ punctuation.definition.modifier.begin.shell.zsh
+#       ^ storage.modifier.subscript.shell.zsh
+#        ^ punctuation.definition.modifier.end.shell.zsh
+#         ^^^^^^^^^^ meta.string.glob.shell.zsh meta.group.regexp.shell string.unquoted.shell
+#                   ^^^ meta.string.glob.shell.zsh string.unquoted.shell - meta.group - meta.modifier.subscript
+#                      ^ punctuation.section.item-access.end.shell
+
+: $var[(I)([^@]##@|)pat]        # Like ‘i’, but gives the index of the last match
+#     ^^^^^^^^^^^^^^^^^^ meta.item-access.shell
+#     ^ punctuation.section.item-access.begin.shell
+#      ^^^ meta.modifier.subscript.shell.zsh
+#      ^ punctuation.definition.modifier.begin.shell.zsh
+#       ^ storage.modifier.subscript.shell.zsh
+#        ^ punctuation.definition.modifier.end.shell.zsh
+#         ^^^^^^^^^^ meta.string.glob.shell.zsh meta.group.regexp.shell string.unquoted.shell
+#                   ^^^ meta.string.glob.shell.zsh string.unquoted.shell - meta.group - meta.modifier.subscript
+#                      ^ punctuation.section.item-access.end.shell
+
+: $var[(k)([^@]##@|)pat]        # keys are interpreted as patterns
+#     ^^^^^^^^^^^^^^^^^^ meta.item-access.shell
+#     ^ punctuation.section.item-access.begin.shell
+#      ^^^ meta.modifier.subscript.shell.zsh
+#      ^ punctuation.definition.modifier.begin.shell.zsh
+#       ^ storage.modifier.subscript.shell.zsh
+#        ^ punctuation.definition.modifier.end.shell.zsh
+#         ^^^^^^^^^^ meta.string.glob.shell.zsh meta.group.regexp.shell string.unquoted.shell
+#                   ^^^ meta.string.glob.shell.zsh string.unquoted.shell - meta.group - meta.modifier.subscript
+#                      ^ punctuation.section.item-access.end.shell
+
+: $var[(K)([^@]##@|)pat]        # keys are interpreted as patterns
+#     ^^^^^^^^^^^^^^^^^^ meta.item-access.shell
+#     ^ punctuation.section.item-access.begin.shell
+#      ^^^ meta.modifier.subscript.shell.zsh
+#      ^ punctuation.definition.modifier.begin.shell.zsh
+#       ^ storage.modifier.subscript.shell.zsh
+#        ^ punctuation.definition.modifier.end.shell.zsh
+#         ^^^^^^^^^^ meta.string.glob.shell.zsh meta.group.regexp.shell string.unquoted.shell
+#                   ^^^ meta.string.glob.shell.zsh string.unquoted.shell - meta.group - meta.modifier.subscript
+#                      ^ punctuation.section.item-access.end.shell
+
+: $var[(n:expr:)key]            # expr evaluates to nth last element,word or char
+#     ^^^^^^^^^^^^^^ meta.item-access.shell
+#     ^ punctuation.section.item-access.begin.shell
+#      ^^^^^^^^^ meta.modifier.subscript.shell.zsh
+#      ^ punctuation.definition.modifier.begin.shell.zsh
+#       ^ storage.modifier.subscript.shell.zsh
+#        ^^^^^^ meta.quoted.glob.shell.zsh
+#        ^ punctuation.definition.quoted.begin.shell.zsh
+#         ^^^^ meta.arithmetic.shell variable.other.readwrite.shell
+#             ^ punctuation.definition.quoted.end.shell.zsh
+#              ^ punctuation.definition.modifier.end.shell.zsh
+#               ^^^ meta.string.glob.shell.zsh string.unquoted.shell - meta.modifier
+#                  ^ punctuation.section.item-access.end.shell
+
+: $var[(b:expr:)key]            # expr evaluates to nth last element,word or char
+#     ^^^^^^^^^^^^^^ meta.item-access.shell
+#     ^ punctuation.section.item-access.begin.shell
+#      ^^^^^^^^^ meta.modifier.subscript.shell.zsh
+#      ^ punctuation.definition.modifier.begin.shell.zsh
+#       ^ storage.modifier.subscript.shell.zsh
+#        ^^^^^^ meta.quoted.glob.shell.zsh
+#        ^ punctuation.definition.quoted.begin.shell.zsh
+#         ^^^^ meta.arithmetic.shell variable.other.readwrite.shell
+#             ^ punctuation.definition.quoted.end.shell.zsh
+#              ^ punctuation.definition.modifier.end.shell.zsh
+#               ^^^ meta.string.glob.shell.zsh string.unquoted.shell - meta.modifier
+#                  ^ punctuation.section.item-access.end.shell
+
+: $var[(e)([^@]##{@}|)plain]    # plain string matching
+#     ^^^^^^^^^^^^^^^^^^^^^^ meta.item-access.shell
+#     ^ punctuation.section.item-access.begin.shell
+#      ^^^ meta.modifier.subscript.shell.zsh
+#      ^ punctuation.definition.modifier.begin.shell.zsh
+#       ^ storage.modifier.subscript.shell.zsh
+#        ^ punctuation.definition.modifier.end.shell.zsh
+#         ^^^^^^^^^^^^^^^^^ meta.string.shell string.unquoted.shell - meta.group - meta.modifier - keyword - punctuation
+#                          ^ punctuation.section.item-access.end.shell
+
+: $var[(X)([^@]##@|)plain]      # unrecognized flags or plain text
+#     ^^^^^^^^^^^^^^^^^^^^ meta.item-access.shell
+#     ^ punctuation.section.item-access.begin.shell
+#      ^^^^^^^^^^^^^^^^^^ meta.string.shell string.unquoted.shell - meta.group - meta.modifier - keyword - punctuation
+#                        ^ punctuation.section.item-access.end.shell
+
+: $var[(X)i+i]                  # unrecognized flags fallback to arithmetic
+#     ^^^^^^^^ meta.item-access.shell
+#     ^ punctuation.section.item-access.begin.shell
+#      ^^^^^^ meta.arithmetic.shell
+#      ^^^ meta.group.shell
+#      ^ punctuation.section.group.begin.shell
+#       ^ variable.other.readwrite.shell
+#        ^ punctuation.section.group.end.shell
+#         ^ variable.other.readwrite.shell
+#          ^ keyword.operator.arithmetic.shell
+#           ^ variable.other.readwrite.shell
+#            ^ punctuation.section.item-access.end.shell
+
+: $var[(i)^pat*,(e)^str*,-10]   # multi-dimensional (associative) arrays
+#     ^^^^^^^^^^^^^^^^^^^^^^^ meta.item-access.shell
+#     ^ punctuation.section.item-access.begin.shell - string
+#      ^^^ meta.modifier.subscript.shell.zsh
+#      ^ punctuation.definition.modifier.begin.shell.zsh
+#       ^ storage.modifier.subscript.shell.zsh
+#        ^ punctuation.definition.modifier.end.shell.zsh
+#         ^^^^^ meta.string.glob.shell.zsh string.unquoted.shell
+#         ^ keyword.operator.logical.regexp.shell.zsh
+#             ^ constant.other.wildcard.asterisk.shell
+#              ^ punctuation.separator.sequence.shell - string
+#               ^^^ meta.modifier.subscript.shell.zsh
+#               ^ punctuation.definition.modifier.begin.shell.zsh
+#                ^ storage.modifier.subscript.shell.zsh
+#                 ^ punctuation.definition.modifier.end.shell.zsh
+#                  ^^^^^ meta.string.shell string.unquoted.shell
+#                       ^ punctuation.separator.sequence.shell
+#                        ^^^ meta.arithmetic.shell
+#                        ^ keyword.operator.arithmetic.shell
+#                         ^^ meta.number.integer.decimal.shell constant.numeric.value.shell
+#                           ^ punctuation.section.item-access.end.shell - string
 
 
 ##############################################################################


### PR DESCRIPTION
Addresses #4244 issue 3

This PR...

1. implements subscripts with branching to heuristically distinguish indexed array item access from key based access of associative array items.

   Branches try to ...
   1. match subscript flags followed by patterns or plain text (only ZSH)
   2. match valid arithmetic expressions
   3. fallback to plain string subscripts

   Expressions related contexts have been slightly refactored to re-use most
   parts in subscripts while accounting for unique bailout requirements aka.
   failing related branch in case of illegal syntax being found.

2. restricts patterns to consume at most one subscript bracket pair after each parameter name to comply with language behavior.

   This change involves pushing a dedicated context to consume simple variable expansions (e.g. `$var`) onto stack (see: simple-parmeter-expansion), which significantly reduces syntax cache size of both Bash and Zsh by about 25%.

3. organizes related contexts in a dedicated section and changes context names by using the term `subscript` instead of `subscription`.

Syntax tests are organized by Bash/Zsh manual chapters.