### PR TITLE
[ShellScript] Fix missing tilde expansion in test expressions

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -740,7 +740,9 @@ contexts:
     - match: (!=|==?)\s*
       captures:
         1: keyword.operator.comparison.shell
-      push: compound-test-pattern
+      push:
+        - compound-test-pattern
+        - maybe-tilde-interpolation
     - match: '[<>]=?'
       scope: keyword.operator.comparison.shell
     - include: line-continuations
@@ -778,7 +780,9 @@ contexts:
     - match: (!=|==?)\s*
       captures:
         1: keyword.operator.comparison.shell
-      push: compound-test-group-pattern
+      push:
+        - compound-test-group-pattern
+        - maybe-tilde-interpolation
     - match: '[<>]=?'
       scope: keyword.operator.comparison.shell
     - include: line-continuations

--- a/ShellScript/Bash/tests/syntax_test_scope.bash
+++ b/ShellScript/Bash/tests/syntax_test_scope.bash
@@ -4686,6 +4686,18 @@ test $me -eq ~/~foo
 #            ^ meta.string.glob.shell meta.interpolation.tilde.shell variable.language.tilde.shell
 #             ^^^^^ meta.string.glob.shell string.unquoted.shell - meta.interpolation - variable
 
+[ $me == ~/~foo ]
+#        ^ meta.string.glob.shell meta.interpolation.tilde.shell variable.language.tilde.shell
+#         ^^^^^ meta.string.glob.shell string.unquoted.shell - meta.interpolation.tilde
+
+[[ $me == ~/~foo ]]
+#         ^ meta.string.regexp.shell meta.interpolation.tilde.shell variable.language.tilde.shell
+#          ^^^^^ meta.string.regexp.shell string.unquoted.shell - meta.interpolation.tilde
+
+[[ ( $me == ~/~foo ) ]]
+#           ^ meta.string.regexp.shell meta.interpolation.tilde.shell variable.language.tilde.shell
+#            ^^^^^ meta.string.regexp.shell string.unquoted.shell - meta.interpolation.tilde
+
 ~/.bin/~app
 # <- meta.function-call.identifier.shell meta.interpolation.tilde.shell variable.language.tilde.shell - variable.function
 #^^^^^^^^^^ meta.function-call.identifier.shell variable.function.shell


### PR DESCRIPTION
This commit fixes first `~` after `==` or `!=` operator not being scoped tilde-expansion.

Verified with following code by replacing `username` with current user.

```
a=/home/username/Bin
[ $a = ~/Bin ] && echo yes
```