### PR TITLE
[ZSH] Fix glob flag argument bailout

### DIFF
--- a/ShellScript/Zsh.sublime-syntax
+++ b/ShellScript/Zsh.sublime-syntax
@@ -574,7 +574,9 @@ contexts:
     # flag:expr:
     - match: 'I'
       scope: storage.modifier.expansion.flag.shell.zsh
-      push: zsh-modifier-expression
+      push:
+        - immediately-pop  # workaround https://github.com/sublimehq/sublime_text/issues/4069
+        - zsh-modifier-expression
     # flag:string:
     - match: 'p[_gjsZ]'
       scope: storage.modifier.expansion.flag.shell.zsh
@@ -959,7 +961,9 @@ contexts:
         - zsh-modifier-subst-pattern
     - match: 'F'
       scope: storage.modifier.glob.shell.zsh
-      push: zsh-modifier-expression
+      push:
+        - immediately-pop  # workaround https://github.com/sublimehq/sublime_text/issues/4069
+        - zsh-modifier-expression
     - match: 'W'
       scope: storage.modifier.glob.shell.zsh
       push: zsh-modifier-literal-string
@@ -1078,8 +1082,13 @@ contexts:
       scope: punctuation.definition.quoted.begin.shell.zsh
       set: zsh-modifier-expression-paren-body
     - match: '{{glob_string_quote}}'
-      scope: punctuation.definition.quoted.begin.shell.zsh
-      set: zsh-modifier-expression-other-body
+      scope: meta.quoted.glob.shell.zsh punctuation.definition.quoted.begin.shell.zsh
+      embed: expression-content
+      embed_scope: meta.quoted.glob.shell.zsh meta.arithmetic.shell
+      escape: \1
+      escape_captures:
+        0: meta.quoted.glob.shell.zsh punctuation.definition.quoted.end.shell.zsh
+      pop: 1
     - include: immediately-pop
 
   zsh-modifier-expression-angle-body:
@@ -1114,15 +1123,6 @@ contexts:
     - meta_scope: meta.quoted.glob.shell.zsh
     - meta_content_scope: meta.arithmetic.shell
     - match: \)
-      scope: punctuation.definition.quoted.end.shell.zsh
-      pop: 1
-    - include: expression-content
-
-  zsh-modifier-expression-other-body:
-    - meta_include_prototype: false
-    - meta_scope: meta.quoted.glob.shell.zsh
-    - meta_content_scope: meta.arithmetic.shell
-    - match: \1
       scope: punctuation.definition.quoted.end.shell.zsh
       pop: 1
     - include: expression-content

--- a/ShellScript/Zsh/tests/syntax_test_scope.zsh
+++ b/ShellScript/Zsh/tests/syntax_test_scope.zsh
@@ -2762,16 +2762,40 @@ ip=10.10.20.14
 #          ^^^ variable.other.readwrite.shell
 #             ^ punctuation.section.interpolation.end.shell
 
-: ${(r.10.5.)var}   # no floating point numbers within period enclosed arguments allowed
+: ${(r.10.5.)var}   # any period anywhere terminates a flag argument opened via period
+# ^^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
+#     ^^^^ meta.modifier.expansion.shell.zsh meta.quoted.glob.shell.zsh
 #      ^^ meta.number.integer.decimal.shell constant.numeric.value.shell
-#        ^^ - meta.number - constant.numeric
+#        ^^^ - meta.number - constant.numeric
+#         ^^^ meta.modifier.expansion.shell.zsh - meta.quoted
+#            ^^^^ - meta.modifier
 
-: ${(r.(10.5).)var} # no floating point numbers within period enclosed arguments allowed
+: ${(r.'10.5'.)var} # any period anywhere terminates a flag argument opened via period
+# ^^^^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
+#     ^^^^^ meta.modifier.expansion.shell.zsh meta.quoted.glob.shell.zsh
 #       ^^ meta.number.integer.decimal.shell constant.numeric.value.shell
 #         ^^ - meta.number - constant.numeric
+#          ^^^^ meta.modifier.expansion.shell.zsh - meta.quoted
+#              ^^^^ - meta.modifier
+
+: ${(r.$( (( 10.5 )) ).)var} # any period anywhere terminates a flag argument opened via period
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
+#     ^^^^^^^^^^ meta.modifier.expansion.shell.zsh meta.quoted.glob.shell.zsh
+#            ^^ meta.number.integer.decimal.shell constant.numeric.value.shell
+#              ^^ - meta.number - constant.numeric
+#               ^^^ meta.modifier.expansion.shell.zsh - meta.quoted
+#                  ^^^^^^^^^ - meta.modifier
+
+: ${(r.(10.5).)var} # any period anywhere terminates a flag argument opened via period
+# ^^^^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
+#     ^^^^^ meta.modifier.expansion.shell.zsh meta.quoted.glob.shell.zsh
+#       ^^ meta.number.integer.decimal.shell constant.numeric.value.shell
+#         ^^ - meta.number - constant.numeric
+#          ^^ meta.modifier.expansion.shell.zsh - meta.quoted
+#            ^^^^^^ - meta.modifier
 
 : ${(r+(10+5)+)var} # enclosing characters take precedence over expression terms/operators
-# ^^^^^^^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell
+# ^^^^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 # ^ punctuation.definition.variable.shell
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^^^^^^^^^ meta.modifier.expansion.shell.zsh

--- a/ShellScript/Zsh/tests/syntax_test_scope.zsh
+++ b/ShellScript/Zsh/tests/syntax_test_scope.zsh
@@ -2745,6 +2745,48 @@ ip=10.10.20.14
 #                              ^^^ variable.other.readwrite.shell
 #                                 ^ punctuation.section.interpolation.end.shell
 
+: ${(r.10.)var}   # no floating point numbers within period enclosed arguments allowed
+# ^^ meta.interpolation.parameter.shell - meta.modifier
+#   ^^^^^^^ meta.interpolation.parameter.shell meta.modifier.expansion.shell.zsh
+#          ^^^^ meta.interpolation.parameter.shell - meta.modifier
+#              ^ - meta.interpolation
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#   ^ punctuation.definition.modifier.begin.shell.zsh
+#    ^ storage.modifier.expansion.flag.shell.zsh
+#     ^^^^ meta.quoted.glob.shell.zsh
+#     ^ punctuation.definition.quoted.begin.shell.zsh
+#      ^^ meta.arithmetic.shell meta.number.integer.decimal.shell constant.numeric.value.shell
+#        ^ punctuation.definition.quoted.end.shell.zsh
+#         ^ punctuation.definition.modifier.end.shell.zsh
+#          ^^^ variable.other.readwrite.shell
+#             ^ punctuation.section.interpolation.end.shell
+
+: ${(r.10.5.)var}   # no floating point numbers within period enclosed arguments allowed
+#      ^^ meta.number.integer.decimal.shell constant.numeric.value.shell
+#        ^^ - meta.number - constant.numeric
+
+: ${(r.(10.5).)var} # no floating point numbers within period enclosed arguments allowed
+#       ^^ meta.number.integer.decimal.shell constant.numeric.value.shell
+#         ^^ - meta.number - constant.numeric
+
+: ${(r+(10+5)+)var} # enclosing characters take precedence over expression terms/operators
+# ^^^^^^^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#   ^^^^^^^^^ meta.modifier.expansion.shell.zsh
+#   ^ punctuation.definition.modifier.begin.shell.zsh
+#    ^ storage.modifier.expansion.flag.shell.zsh
+#     ^^^^^ meta.quoted.glob.shell.zsh
+#     ^ punctuation.definition.quoted.begin.shell.zsh
+#      ^^^ meta.arithmetic.shell meta.group.shell
+#      ^ punctuation.section.group.begin.shell
+#       ^^ meta.number.integer.decimal.shell constant.numeric.value.shell
+#         ^ punctuation.definition.quoted.end.shell.zsh
+#           ^ punctuation.definition.modifier.end.shell.zsh
+#            ^ keyword.operator.expansion.valid.shell.zsh
+#                 ^ punctuation.section.interpolation.end.shell
+
 : ${(s.:.)var} ${(s:del$im:)var}  # Force field splitting at the separator string.
 # ^^ meta.interpolation.parameter.shell - meta.modifier
 #   ^^ meta.interpolation.parameter.shell meta.modifier.expansion.shell.zsh - meta.quoted.glob


### PR DESCRIPTION
Addresses #4244 issue 10

This PR ensures to properly terminate Zsh glob flag arguments' expressions as soon as the matching quotation character is consumed.

Luckily `embed` can be used to ensure proper bailout with least efforts.

Note: An additional `immediately-pop` context is pushed onto stack together with `zsh-modifier-expression` to workaround ST core issue https://github.com/sublimehq/sublime_text/issues/4069 and properly apply parent meta scopes to tokens consumed by `escape_captures` pattern.