### PR TITLE
[JavaScript] Fix close_tag for JSX

### DIFF
--- a/JavaScript/Default.sublime-keymap
+++ b/JavaScript/Default.sublime-keymap
@@ -89,4 +89,13 @@
             { "key": "following_text", "operator": "regex_contains", "operand": "^\\]", "match_all": true }
         ]
     },
+
+    // JSX close tag
+    { "keys": ["/"], "command": "close_tag", "args": { "insert_slash": true }, "context":
+        [
+            { "key": "selector", "operator": "equal", "operand": "meta.jsx - string - comment", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_match", "operand": ".*<$", "match_all": true },
+            { "key": "setting.auto_close_tags" }
+        ]
+    }
 ]

--- a/JavaScript/JSX.sublime-syntax
+++ b/JavaScript/JSX.sublime-syntax
@@ -130,9 +130,9 @@ contexts:
     - match: '>'
       scope: meta.tag.js punctuation.definition.tag.end.js
       set: jsx-body
-    - match: '/'
+    - match: '/\s*>'
       scope: meta.tag.js punctuation.definition.tag.end.js
-      set: jsx-expect-tag-end
+      pop: 1
     - match: '{{jsx_identifier}}'
       scope: entity.other.attribute-name.js
     - match: '='


### PR DESCRIPTION
This PR...

1. adjusts JSX tag patterns to ensure self-closing tag punctuation such as `/>` or `/ >` is consumed as single token in order to help `close_tag` detecting matching opening and closing tags properly

   Note: Technically, JSX allows `/` and `>` to appear on multiple lines. This commit however assumes it being unlikely enough in favor of fixing core `close_tag` command.

2. adds a key binding to enable automatic tag closing when typing `</` the same way like in HTML and XML.

addresses https://github.com/sublimehq/sublime_text/issues/5309

caused by: https://forum.sublimetext.com/t/html-react-auto-closing-of-tags-broken-by-self-closing-tags/76296/2