### PR TITLE
[Python] Fix comma in type hints breaking syntax

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -562,7 +562,8 @@ contexts:
     #       type-hints in annotations, which share syntax with normal expressions
     - match: \|
       scope: keyword.operator.arithmetic.python
-    - include: sequence-separators
+    - match: ','
+      scope: punctuation.separator.sequence.python
 
 ###[ DECORATORS ]#############################################################
 

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -3770,6 +3770,15 @@ class TypeCommentTest:
 #                             ^^^^ support.type.python
 #                                 ^ punctuation.section.brackets.end.python
 
+# type: I.Literal("file"),
+#^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.python
+class Test:
+#^^^^^^^^^^ meta.class.python
+#^^^^ keyword.declaration.class.python
+#     ^^^^ entity.name.class.python
+#         ^ punctuation.section.class.begin.python
+    pass
+
 
 ##################
 # Assignment Expressions


### PR DESCRIPTION
This PR implements `,` in type hint comments without pushing to `allow-unpack-operators` context as it causes first statement after such comment to appear broken.