### PR TITLE
[ShellScript] Improve built-in and compound test expressions

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -742,6 +742,7 @@ contexts:
       set:
         - compound-test-eregexp-body
         - eregexp-unexpected-quantifier
+        - maybe-tilde-interpolation
 
   compound-test-eregexp-body:
     - meta_include_prototype: false

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -694,6 +694,8 @@ contexts:
       scope: keyword.operator.comparison.shell
     - match: '<(?!<)|>(?!>)'
       scope: keyword.operator.comparison.shell
+    - match: -[ao]{{opt_break}}(?!\s*(=~|!=|==?))
+      scope: keyword.operator.logical.shell
     - include: cmd-args-end
     - include: test-expression-common
 
@@ -790,13 +792,13 @@ contexts:
     - include: line-continuations
 
   test-expression-common:
-    - match: ([-+])[aobcdefghknoprstuvwxzGLNORS]{{opt_break}}(?!\s*(=~|!=|==?))
+    - match: ([-+])[bcdefghknprstuvwxzGLNORS]{{opt_break}}(?!\s*(=~|!=|==?))
       scope:
         meta.parameter.option.shell
         variable.parameter.option.shell
       captures:
         1: punctuation.definition.parameter.shell
-    - match: ([-+])(?:ef|nt|ot|eq|ne|lt|le|gt|ge){{opt_break}}(?!\s*(=~|!=|==?))
+    - match: -(?:ef|nt|ot|eq|ne|lt|le|gt|ge){{opt_break}}(?!\s*(=~|!=|==?))
       scope: keyword.operator.comparison.shell
     - match: '&&|\|\||!'
       scope: keyword.operator.logical.shell

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -706,37 +706,8 @@ contexts:
       captures:
         1: punctuation.section.compound.end.shell
       pop: 1
-    - match: (=~)\s*
-      captures:
-        1: keyword.operator.comparison.shell
-      push:
-        - compound-test-eregexp
-        - eregexp-unexpected-quantifier
-    - match: (!=|==?)\s*
-      captures:
-        1: keyword.operator.comparison.shell
-      push:
-        - compound-test-pattern
-        - maybe-tilde-interpolation
-    - include: compound-test-common
-
-  compound-test-eregexp:
-    - meta_include_prototype: false
-    - meta_content_scope: meta.string.regexp.shell string.unquoted.shell
-    - match: (?=[\s;])
-      pop: 1
-    - include: line-continuations
-    - include: eregexp-main-content
-    - include: illegal-pipeseps
-
-  compound-test-pattern:
-    - meta_include_prototype: false
-    - meta_content_scope: meta.string.regexp.shell string.unquoted.shell
-    - match: (?=[\s;])
-      pop: 1
-    - include: line-continuations
-    - include: pattern-main-content
-    - include: illegal-pipeseps
+    - include: illegal-stray
+    - include: compound-test-content
 
   compound-test-group-body:
     - meta_scope: meta.group.shell
@@ -746,48 +717,56 @@ contexts:
     # bailout from group at end of compound test
     - match: (?={{wspace}}\]\])
       pop: 1
-    - match: (=~)\s*
-      captures:
-        1: keyword.operator.comparison.shell
-      push:
-        - compound-test-group-eregexp
-        - eregexp-unexpected-quantifier
-    - match: (!=|==?)\s*
-      captures:
-        1: keyword.operator.comparison.shell
-      push:
-        - compound-test-group-pattern
-        - maybe-tilde-interpolation
-    - include: compound-test-common
+    - include: compound-test-content
 
-  compound-test-group-eregexp:
-    - meta_include_prototype: false
-    - meta_content_scope: meta.string.regexp.shell string.unquoted.shell
-    - match: (?=[\s;)])
-      pop: 1
-    - include: line-continuations
-    - include: eregexp-main-content
-    - include: illegal-pipeseps
-
-  compound-test-group-pattern:
-    - meta_include_prototype: false
-    - meta_content_scope: meta.string.regexp.shell string.unquoted.shell
-    - match: (?=[\s;)])
-      pop: 1
-    - include: line-continuations
-    - include: pattern-main-content
-    - include: illegal-pipeseps
-
-  compound-test-common:
+  compound-test-content:
     - match: \(
       scope: punctuation.section.group.begin.shell
       push: compound-test-group-body
+    - match: =~
+      scope: keyword.operator.comparison.shell
+      push: compound-test-eregexp
+    - match: '[=!]?='
+      scope: keyword.operator.comparison.shell
+      push: compound-test-pattern
     - match: '[<>]=?'
       scope: keyword.operator.comparison.shell
-    - include: line-continuations
     - include: test-expression-operators
+    - include: line-continuations
     - include: comments
     - include: cmd-args-values
+
+  compound-test-eregexp:
+    - meta_include_prototype: false
+    - match: '{{word_begin}}'
+      set:
+        - compound-test-eregexp-body
+        - eregexp-unexpected-quantifier
+
+  compound-test-eregexp-body:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.regexp.shell string.unquoted.shell
+    - include: eregexp-main-content
+    - include: compound-test-pattern-end
+
+  compound-test-pattern:
+    - meta_include_prototype: false
+    - match: '{{word_begin}}'
+      set:
+        - compound-test-pattern-body
+        - maybe-tilde-interpolation
+
+  compound-test-pattern-body:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.regexp.shell string.unquoted.shell
+    - include: pattern-main-content
+    - include: compound-test-pattern-end
+
+  compound-test-pattern-end:
+    - match: '[<>]+'   # note: would otherwise match as comparison operators
+      scope: invalid.illegal.unexpected-token.shell
+      pop: 1
+    - include: word-end
 
   test-expression-operators:
     - match: ([-+])[bcdefghknprstuvwxzGLNORS]{{opt_break}}(?!\s*(=~|!=|==?))
@@ -800,7 +779,8 @@ contexts:
       scope: keyword.operator.comparison.shell
     - match: '&&|\|\||!'
       scope: keyword.operator.logical.shell
-    - include: illegal-pipeseps
+    - match: '[{{pipe_seps}}]'
+      scope: invalid.illegal.unexpected-token.shell
 
 ###[ TRAP BUILTINS ]###########################################################
 
@@ -2698,8 +2678,6 @@ contexts:
   eregexp-literals:
     - match: \.
       scope: keyword.other.any.regexp.shell
-    - match: \)
-      scope: invalid.illegal.stray.regexp.shell
 
 ###[ EXPANSIONS ]##############################################################
 
@@ -3191,10 +3169,6 @@ contexts:
   illegal-options:
     - match: (--|[-+]){{identifier}}
       scope: invalid.illegal.parameter.shell
-
-  illegal-pipeseps:
-    - match: '[{{pipe_seps}}]'
-      scope: invalid.illegal.unexpected-token.shell
 
   illegal-stray:
     - match: '[)}\]]'

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -679,28 +679,77 @@ contexts:
       set: cmd-test-args
 
   builtin-test-body:
+    - meta_include_prototype: false
     - meta_scope: meta.compound.conditional.shell
-    - match: '{{wspace}}(\])'
-      captures:
-        1: punctuation.section.compound.end.shell
+    - match: \]
+      scope: punctuation.section.compound.end.shell
       pop: 1
     - include: cmd-test-args
 
   cmd-test-args:
+    - meta_include_prototype: false
     - meta_content_scope: meta.function-call.arguments.shell
-    - match: =~|[<>]=
-      scope: invalid.illegal.operator.shell
-    - match: '!=|==?'
+    - include: eoc-pop
+    # logical operators
+    - match: '!'
+      scope: keyword.operator.logical.shell
+    - match: -[ao]{{opt_break}}
+      scope: keyword.operator.logical.shell
+    # test expressions like `-f file`
+    - match: '{{test_options}}'
+      scope: meta.parameter.option.shell variable.parameter.option.shell
+      captures:
+        1: punctuation.definition.parameter.shell
+      push: cmd-test-pattern
+    # comparison expressions
+    - match: '{{word_begin}}'
+      branch_point: cmd-test-comparison
+      branch:
+        - cmd-test-string-comparison   # note: try string comparison first as it is more likely
+        - arithmetic-comparison        # note: built-in tests only support basic integer expressions
+
+  cmd-test-string-comparison:
+    # comparison like `string < string` or `string =~ pattern`
+    - meta_include_prototype: false
+    - match: ''
+      set:
+        - cmd-test-string-operator
+        - cmd-test-pattern
+
+  cmd-test-string-operator:
+    - meta_include_prototype: false
+    - match: '{{file_comparison_operators}}'
       scope: keyword.operator.comparison.shell
+      set: cmd-test-pattern
+    - match: =~
+      scope: invalid.illegal.operator.shell
+      set: cmd-test-pattern
+    - match: '[=!]?='
+      scope: keyword.operator.comparison.shell
+      set: cmd-test-pattern
+    - match: '[<>]='
+      scope: invalid.illegal.operator.shell
+      set: cmd-test-pattern
     - match: '<(?!<)|>(?!>)'
       scope: keyword.operator.comparison.shell
-    - match: -[ao]{{opt_break}}(?!\s*(=~|!=|==?))
-      scope: keyword.operator.logical.shell
-    - include: cmd-args-end
-    - include: test-expression-operators
-    - include: cmd-args-values
+      set: cmd-test-pattern
+    - match: (?={{arithmetic_comparison_operators}})
+      fail: cmd-test-comparison
+    - include: eoc-pop
+    - include: else-pop
+
+  cmd-test-pattern:
+    - meta_include_prototype: false
+    - match: (?=\])
+      pop: 1
+    - include: eoc-pop
+    - include: redirection
+    - include: boolean
+    - include: string-path-pattern
+
 
   compound-test-body:
+    - meta_include_prototype: false
     - meta_scope: meta.compound.conditional.shell
     - match: '{{wspace}}(\]\])'
       captures:
@@ -710,34 +759,73 @@ contexts:
     - include: compound-test-content
 
   compound-test-group-body:
+    - meta_include_prototype: false
     - meta_scope: meta.group.shell
     - match: \)
       scope: punctuation.section.group.end.shell
       pop: 1
-    # bailout from group at end of compound test
-    - match: (?={{wspace}}\]\])
-      pop: 1
+    - include: compound-test-end-ahead
     - include: compound-test-content
 
+  compound-test-end-ahead:
+    - match: (?={{wspace}}\]\])
+      pop: 1
+
   compound-test-content:
+    - include: comments
+    # groups
     - match: \(
       scope: punctuation.section.group.begin.shell
       push: compound-test-group-body
+    # logical operators
+    - match: '&&|\|\||!'
+      scope: keyword.operator.logical.shell
+    - match: '[&|;]'
+      scope: invalid.illegal.unexpected-token.shell
+    # test expressions like `-f file`
+    - match: '{{test_options}}'
+      scope: meta.parameter.option.shell variable.parameter.option.shell
+      captures:
+        1: punctuation.definition.parameter.shell
+      push: compound-test-pattern
+    # comparison expressions
+    - match: '{{word_begin}}'
+      branch_point: compound-test-comparison
+      branch:
+        - compound-test-string-comparison  # note: try string comparison first as it is more likely
+        - arithmetic-comparison
+
+  compound-test-string-comparison:
+    # comparison like `string < string` or `string =~ pattern`
+    - meta_include_prototype: false
+    - match: ''
+      set:
+        - compound-test-string-operator
+        - compound-test-pattern
+
+  compound-test-string-operator:
+    - meta_include_prototype: false
+    - match: '{{file_comparison_operators}}'
+      scope: keyword.operator.comparison.shell
+      set: compound-test-pattern
     - match: =~
       scope: keyword.operator.comparison.shell
-      push: compound-test-eregexp
+      set: compound-test-eregexp
     - match: '[=!]?='
       scope: keyword.operator.comparison.shell
-      push: compound-test-pattern
+      set: compound-test-pattern
     - match: '[<>]=?'
       scope: keyword.operator.comparison.shell
-    - include: test-expression-operators
-    - include: line-continuations
+      set: compound-test-pattern
+    - match: (?={{arithmetic_comparison_operators}})
+      fail: compound-test-comparison
     - include: comments
-    - include: cmd-args-values
+    - include: compound-test-end-ahead
+    - include: else-pop
 
   compound-test-eregexp:
     - meta_include_prototype: false
+    - include: compound-test-end-ahead
     - match: '{{word_begin}}'
       set:
         - compound-test-eregexp-body
@@ -752,6 +840,7 @@ contexts:
 
   compound-test-pattern:
     - meta_include_prototype: false
+    - include: compound-test-end-ahead
     - include: boolean
     - include: devnull
     - match: '{{word_begin}}'
@@ -761,7 +850,7 @@ contexts:
 
   compound-test-pattern-body:
     - meta_include_prototype: false
-    - meta_content_scope: meta.string.regexp.shell string.unquoted.shell
+    - meta_content_scope: meta.string.glob.shell string.unquoted.shell
     - include: pattern-main-content
     - include: compound-test-pattern-end
 
@@ -770,20 +859,6 @@ contexts:
       scope: invalid.illegal.unexpected-token.shell
       pop: 1
     - include: word-end
-
-  test-expression-operators:
-    - match: ([-+])[bcdefghknprstuvwxzGLNORS]{{opt_break}}(?!\s*(=~|!=|==?))
-      scope:
-        meta.parameter.option.shell
-        variable.parameter.option.shell
-      captures:
-        1: punctuation.definition.parameter.shell
-    - match: -(?:ef|nt|ot|eq|ne|lt|le|gt|ge){{opt_break}}(?!\s*(=~|!=|==?))
-      scope: keyword.operator.comparison.shell
-    - match: '&&|\|\||!'
-      scope: keyword.operator.logical.shell
-    - match: '[{{pipe_seps}}]'
-      scope: invalid.illegal.unexpected-token.shell
 
 ###[ TRAP BUILTINS ]###########################################################
 
@@ -1646,6 +1721,22 @@ contexts:
     - include: string-interpolations
 
 ###[ ARITHMETIC EXPRESSIONS ]##################################################
+
+  arithmetic-comparison:
+    # arithmetic comparison like `1+2 -eq 2+1`
+    - meta_include_prototype: false
+    - match: ''
+      set:
+        - arithmetic-operator
+        - arithmetic-word
+
+  arithmetic-operator:
+    - meta_include_prototype: false
+    - match: '{{arithmetic_comparison_operators}}'
+      scope: keyword.operator.comparison.shell
+      set: arithmetic-word
+    - include: comments
+    - include: else-pop
 
   arithmetic-word:
     # A `word` which is interpreted as arithmetic expression
@@ -3299,6 +3390,11 @@ variables:
   hex_digit: \h
   oct_digit: '[0-7]'
   varassign: '[-+]?='
+
+  # 12 Test Expressions
+  arithmetic_comparison_operators: -(?:eq|ne|lt|le|gt|ge){{opt_break}}
+  file_comparison_operators: -(?:ef|nt|ot){{opt_break}}
+  test_options: ([-+])[bcdefghknprstuvwxzGLNORS]{{opt_break}}(?!\s*(=~|!=|==?))
 
   # 3.3 Shell Functions
   # Implicit function definition without `function` keyword

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -697,7 +697,8 @@ contexts:
     - match: -[ao]{{opt_break}}(?!\s*(=~|!=|==?))
       scope: keyword.operator.logical.shell
     - include: cmd-args-end
-    - include: test-expression-common
+    - include: test-expression-operators
+    - include: cmd-args-values
 
   compound-test-body:
     - meta_scope: meta.compound.conditional.shell
@@ -720,10 +721,7 @@ contexts:
       push:
         - compound-test-pattern
         - maybe-tilde-interpolation
-    - match: '[<>]=?'
-      scope: keyword.operator.comparison.shell
-    - include: line-continuations
-    - include: test-expression-common
+    - include: compound-test-common
 
   compound-test-eregexp:
     - meta_include_prototype: false
@@ -760,10 +758,7 @@ contexts:
       push:
         - compound-test-group-pattern
         - maybe-tilde-interpolation
-    - match: '[<>]=?'
-      scope: keyword.operator.comparison.shell
-    - include: line-continuations
-    - include: test-expression-common
+    - include: compound-test-common
 
   compound-test-group-eregexp:
     - meta_include_prototype: false
@@ -791,7 +786,15 @@ contexts:
       pop: 1
     - include: line-continuations
 
-  test-expression-common:
+  compound-test-common:
+    - match: '[<>]=?'
+      scope: keyword.operator.comparison.shell
+    - include: line-continuations
+    - include: test-expression-operators
+    - include: comments
+    - include: cmd-args-values
+
+  test-expression-operators:
     - match: ([-+])[bcdefghknprstuvwxzGLNORS]{{opt_break}}(?!\s*(=~|!=|==?))
       scope:
         meta.parameter.option.shell
@@ -803,8 +806,6 @@ contexts:
     - match: '&&|\|\||!'
       scope: keyword.operator.logical.shell
     - include: illegal-pipeseps
-    - include: comments
-    - include: cmd-args-values
 
 ###[ TRAP BUILTINS ]###########################################################
 

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -706,9 +706,6 @@ contexts:
       captures:
         1: punctuation.section.compound.end.shell
       pop: 1
-    - match: \(
-      scope: punctuation.section.group.begin.shell
-      push: compound-test-group-body
     - match: (=~)\s*
       captures:
         1: keyword.operator.comparison.shell
@@ -746,6 +743,9 @@ contexts:
     - match: \)
       scope: punctuation.section.group.end.shell
       pop: 1
+    # bailout from group at end of compound test
+    - match: (?={{wspace}}\]\])
+      pop: 1
     - match: (=~)\s*
       captures:
         1: keyword.operator.comparison.shell
@@ -763,30 +763,25 @@ contexts:
   compound-test-group-eregexp:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.regexp.shell string.unquoted.shell
-    - include: compound-test-group-pattern-end
+    - match: (?=[\s;)])
+      pop: 1
+    - include: line-continuations
     - include: eregexp-main-content
     - include: illegal-pipeseps
 
   compound-test-group-pattern:
     - meta_include_prototype: false
     - meta_content_scope: meta.string.regexp.shell string.unquoted.shell
-    - include: compound-test-group-pattern-end
+    - match: (?=[\s;)])
+      pop: 1
+    - include: line-continuations
     - include: pattern-main-content
     - include: illegal-pipeseps
 
-  compound-test-group-pattern-end:
-    - match: '{{wspace}}(\]\])'
-      captures:
-        1: invalid.illegal.unexpected-token.shell
-      pop: 3
-    - match: $\n?
-      scope: invalid.illegal.unexpected-token.shell
-      pop: 3
-    - match: (?=\s*(?:&&|\|\||;|\)))
-      pop: 1
-    - include: line-continuations
-
   compound-test-common:
+    - match: \(
+      scope: punctuation.section.group.begin.shell
+      push: compound-test-group-body
     - match: '[<>]=?'
       scope: keyword.operator.comparison.shell
     - include: line-continuations

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -752,6 +752,8 @@ contexts:
 
   compound-test-pattern:
     - meta_include_prototype: false
+    - include: boolean
+    - include: devnull
     - match: '{{word_begin}}'
       set:
         - compound-test-pattern-body
@@ -2010,6 +2012,14 @@ contexts:
       scope: constant.language.boolean.true.shell
       pop: 1
 
+  devnull:
+    - match: (/)dev(/)null{{word_break}}
+      scope: meta.string.glob.shell meta.path.shell constant.language.null.shell
+      captures:
+        1: punctuation.separator.path.shell
+        2: punctuation.separator.path.shell
+      pop: 1
+
   numbers:
     # strictly consume full numbers only, for use in contexts with strings
     - include: base-numbers
@@ -2233,12 +2243,7 @@ contexts:
       push: group-path-pattern
 
   group-path-pattern:
-    - match: (/)dev(/)null{{word_break}}
-      scope: meta.path.shell constant.language.null.shell
-      captures:
-        1: punctuation.separator.path.shell
-        2: punctuation.separator.path.shell
-      pop: 1
+    - include: devnull
     - match: '{{illegal_group_separators}}+'
       scope: invalid.illegal.unexpected-token.shell
       pop: 1
@@ -2260,12 +2265,7 @@ contexts:
       push: string-path-pattern
 
   string-path-pattern:
-    - match: (/)dev(/)null{{word_break}}
-      scope: meta.path.shell constant.language.null.shell
-      captures:
-        1: punctuation.separator.path.shell
-        2: punctuation.separator.path.shell
-      pop: 1
+    - include: devnull
     - match: '{{word_begin}}'
       set:
         - string-path-pattern-body

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -50,10 +50,12 @@ contexts:
       push: statement
 
   statement:
-    # reserved words
+    # reserved words and builtin commands which
+    #  can't be augmented by function definitions
     - include: redirections
     - include: eoc-pop
     - include: operators
+    - include: cmd-compound-test
     - include: cmd-control
     # definitions
     - include: def-variable
@@ -665,12 +667,128 @@ contexts:
     - include: cmd-args-options
     - include: else-pop
 
+###[ COMPOUND TEST BUILTINS ]##################################################
+
+  cmd-compound-test:
+    - match: \[\[(?=\s)
+      scope: punctuation.section.compound.begin.shell
+      set: cmd-compound-test-body
+
+  cmd-compound-test-body:
+    - meta_include_prototype: false
+    - meta_scope: meta.compound.conditional.shell
+    - match: '{{wspace}}(\]\])'
+      captures:
+        1: punctuation.section.compound.end.shell
+      pop: 1
+    - include: illegal-stray
+    - include: cmd-compound-test-content
+
+  cmd-compound-test-group-body:
+    - meta_include_prototype: false
+    - meta_scope: meta.group.shell
+    - match: \)
+      scope: punctuation.section.group.end.shell
+      pop: 1
+    - include: cmd-compound-test-end-ahead
+    - include: cmd-compound-test-content
+
+  cmd-compound-test-end-ahead:
+    - match: (?={{wspace}}\]\])
+      pop: 1
+
+  cmd-compound-test-content:
+    - include: comments
+    # groups
+    - match: \(
+      scope: punctuation.section.group.begin.shell
+      push: cmd-compound-test-group-body
+    # logical operators
+    - match: '&&|\|\||!'
+      scope: keyword.operator.logical.shell
+    - match: '[&|;]'
+      scope: invalid.illegal.unexpected-token.shell
+    # test expressions like `-f file`
+    - match: '{{test_options}}'
+      scope: meta.parameter.option.shell variable.parameter.option.shell
+      captures:
+        1: punctuation.definition.parameter.shell
+      push: cmd-compound-test-pattern
+    # comparison expressions
+    - match: '{{word_begin}}'
+      branch_point: cmd-compound-test-comparison
+      branch:
+        - cmd-compound-test-string-comparison  # note: try string comparison first as it is more likely
+        - arithmetic-comparison
+
+  cmd-compound-test-string-comparison:
+    # comparison like `string < string` or `string =~ pattern`
+    - meta_include_prototype: false
+    - match: ''
+      set:
+        - cmd-compound-test-string-operator
+        - cmd-compound-test-pattern
+
+  cmd-compound-test-string-operator:
+    - meta_include_prototype: false
+    - match: '{{file_comparison_operators}}'
+      scope: keyword.operator.comparison.shell
+      set: cmd-compound-test-pattern
+    - match: =~
+      scope: keyword.operator.comparison.shell
+      set: cmd-compound-test-eregexp
+    - match: '[=!]?='
+      scope: keyword.operator.comparison.shell
+      set: cmd-compound-test-pattern
+    - match: '[<>]=?'
+      scope: keyword.operator.comparison.shell
+      set: cmd-compound-test-pattern
+    - match: (?={{arithmetic_comparison_operators}})
+      fail: cmd-compound-test-comparison
+    - include: comments
+    - include: cmd-compound-test-end-ahead
+    - include: else-pop
+
+  cmd-compound-test-eregexp:
+    - meta_include_prototype: false
+    - include: cmd-compound-test-end-ahead
+    - match: '{{word_begin}}'
+      set:
+        - cmd-compound-test-eregexp-body
+        - eregexp-unexpected-quantifier
+        - maybe-tilde-interpolation
+
+  cmd-compound-test-eregexp-body:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.regexp.shell string.unquoted.shell
+    - include: eregexp-main-content
+    - include: cmd-compound-test-pattern-end
+
+  cmd-compound-test-pattern:
+    - meta_include_prototype: false
+    - include: cmd-compound-test-end-ahead
+    - include: boolean
+    - include: devnull
+    - match: '{{word_begin}}'
+      set:
+        - cmd-compound-test-pattern-body
+        - maybe-tilde-interpolation
+
+  cmd-compound-test-pattern-body:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.glob.shell string.unquoted.shell
+    - include: pattern-main-content
+    - include: cmd-compound-test-pattern-end
+
+  cmd-compound-test-pattern-end:
+    - match: '[<>]+'   # note: would otherwise match as comparison operators
+      scope: invalid.illegal.unexpected-token.shell
+      pop: 1
+    - include: word-end
+
 ###[ TEST BUILTINS ]###########################################################
 
   cmd-test:
-    - match: \[\[(?=\s)
-      scope: punctuation.section.compound.begin.shell
-      set: compound-test-body
     - match: \[(?=\s)
       scope: punctuation.section.compound.begin.shell
       set: builtin-test-body
@@ -746,119 +864,6 @@ contexts:
     - include: redirection
     - include: boolean
     - include: string-path-pattern
-
-
-  compound-test-body:
-    - meta_include_prototype: false
-    - meta_scope: meta.compound.conditional.shell
-    - match: '{{wspace}}(\]\])'
-      captures:
-        1: punctuation.section.compound.end.shell
-      pop: 1
-    - include: illegal-stray
-    - include: compound-test-content
-
-  compound-test-group-body:
-    - meta_include_prototype: false
-    - meta_scope: meta.group.shell
-    - match: \)
-      scope: punctuation.section.group.end.shell
-      pop: 1
-    - include: compound-test-end-ahead
-    - include: compound-test-content
-
-  compound-test-end-ahead:
-    - match: (?={{wspace}}\]\])
-      pop: 1
-
-  compound-test-content:
-    - include: comments
-    # groups
-    - match: \(
-      scope: punctuation.section.group.begin.shell
-      push: compound-test-group-body
-    # logical operators
-    - match: '&&|\|\||!'
-      scope: keyword.operator.logical.shell
-    - match: '[&|;]'
-      scope: invalid.illegal.unexpected-token.shell
-    # test expressions like `-f file`
-    - match: '{{test_options}}'
-      scope: meta.parameter.option.shell variable.parameter.option.shell
-      captures:
-        1: punctuation.definition.parameter.shell
-      push: compound-test-pattern
-    # comparison expressions
-    - match: '{{word_begin}}'
-      branch_point: compound-test-comparison
-      branch:
-        - compound-test-string-comparison  # note: try string comparison first as it is more likely
-        - arithmetic-comparison
-
-  compound-test-string-comparison:
-    # comparison like `string < string` or `string =~ pattern`
-    - meta_include_prototype: false
-    - match: ''
-      set:
-        - compound-test-string-operator
-        - compound-test-pattern
-
-  compound-test-string-operator:
-    - meta_include_prototype: false
-    - match: '{{file_comparison_operators}}'
-      scope: keyword.operator.comparison.shell
-      set: compound-test-pattern
-    - match: =~
-      scope: keyword.operator.comparison.shell
-      set: compound-test-eregexp
-    - match: '[=!]?='
-      scope: keyword.operator.comparison.shell
-      set: compound-test-pattern
-    - match: '[<>]=?'
-      scope: keyword.operator.comparison.shell
-      set: compound-test-pattern
-    - match: (?={{arithmetic_comparison_operators}})
-      fail: compound-test-comparison
-    - include: comments
-    - include: compound-test-end-ahead
-    - include: else-pop
-
-  compound-test-eregexp:
-    - meta_include_prototype: false
-    - include: compound-test-end-ahead
-    - match: '{{word_begin}}'
-      set:
-        - compound-test-eregexp-body
-        - eregexp-unexpected-quantifier
-        - maybe-tilde-interpolation
-
-  compound-test-eregexp-body:
-    - meta_include_prototype: false
-    - meta_content_scope: meta.string.regexp.shell string.unquoted.shell
-    - include: eregexp-main-content
-    - include: compound-test-pattern-end
-
-  compound-test-pattern:
-    - meta_include_prototype: false
-    - include: compound-test-end-ahead
-    - include: boolean
-    - include: devnull
-    - match: '{{word_begin}}'
-      set:
-        - compound-test-pattern-body
-        - maybe-tilde-interpolation
-
-  compound-test-pattern-body:
-    - meta_include_prototype: false
-    - meta_content_scope: meta.string.glob.shell string.unquoted.shell
-    - include: pattern-main-content
-    - include: compound-test-pattern-end
-
-  compound-test-pattern-end:
-    - match: '[<>]+'   # note: would otherwise match as comparison operators
-      scope: invalid.illegal.unexpected-token.shell
-      pop: 1
-    - include: word-end
 
 ###[ TRAP BUILTINS ]###########################################################
 

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -1764,9 +1764,7 @@ contexts:
 
   arithmetic-word-unquoted-body:
     - meta_scope: meta.arithmetic.shell
-    - match: \(
-      scope: punctuation.section.group.begin.shell
-      push: expression-group-body
+    - include: expression-groups
     - include: expression-common
     - include: expression-illegals
     - include: word-end

--- a/ShellScript/Bash/tests/syntax_test_scope.bash
+++ b/ShellScript/Bash/tests/syntax_test_scope.bash
@@ -2012,7 +2012,7 @@ if [ "$1" != "" -a "$2" != "" ]; then
 #  ^ punctuation.section.compound.begin.shell
 #     ^^ variable.language.positional.shell
 #         ^^ keyword.operator.comparison.shell
-#               ^^ meta.compound.conditional.shell variable.parameter.option.shell
+#               ^^ keyword.operator.logical.shell
 #                   ^^ variable.language.positional.shell
 #                       ^^ keyword.operator.comparison.shell
 #                             ^ punctuation.section.compound.end.shell
@@ -2688,6 +2688,15 @@ done
 #                 ^^ keyword.operator.logical.shell
 #                         ^ punctuation.section.group.end.shell
 #                           ^^ punctuation.section.compound.end.shell
+
+[[ expr -a expr -o expr ]]    # -a and -o arguments have no meaning
+#^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#  ^^^^ meta.string.glob.shell string.unquoted.shell
+#       ^^ - keyword.operator
+#          ^^^^ meta.string.glob.shell string.unquoted.shell
+#               ^^ - keyword.operator
+#                  ^^^^ meta.string.glob.shell string.unquoted.shell
+#                       ^ punctuation.section.compound.end.shell
 
 
 ## File Comparisons
@@ -12473,6 +12482,32 @@ doc
 #^^^^^^^^^^^^^ meta.compound.conditional.shell
 
 
+## Logical Operators
+## -----------------
+
+[ expr -a expr -o expr ]
+#^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+# ^^^^ meta.string.glob.shell string.unquoted.shell
+#      ^^ keyword.operator.logical.shell
+#         ^^^^ meta.string.glob.shell string.unquoted.shell
+#              ^^ keyword.operator.logical.shell
+#                 ^^^^ meta.string.glob.shell string.unquoted.shell
+#                      ^ punctuation.section.compound.end.shell
+
+[ $var = true -a $var != false ]
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+# ^^^^ meta.string.glob.shell meta.interpolation.parameter.shell variable.other.readwrite.shell
+# ^ punctuation.definition.variable.shell
+#      ^ keyword.operator.comparison.shell
+#        ^^^^ constant.language.boolean.true.shell
+#             ^^ keyword.operator.logical.shell
+#                ^^^^ meta.string.glob.shell meta.interpolation.parameter.shell variable.other.readwrite.shell
+#                ^ punctuation.definition.variable.shell
+#                     ^^ keyword.operator.comparison.shell
+#                        ^^^^^ constant.language.boolean.false.shell
+#                              ^ punctuation.section.compound.end.shell
+
+
 ## File Comparisons
 ## ----------------
 
@@ -12637,6 +12672,18 @@ test-=
 test+=
 #^^^^^ - support.function
 
+test expr -a expr -o expr -- | cmd |& cmd
+# <- meta.function-call.identifier.shell support.function.shell
+#^^^ meta.function-call.identifier.shell support.function.shell
+#   ^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell
+#                           ^^^ - meta.function-call
+#         ^^ keyword.operator.logical.shell
+#                 ^^ keyword.operator.logical.shell
+#                         ^^ - keyword
+#                            ^ keyword.operator.assignment.pipe.shell
+#                              ^^^ meta.function-call.identifier.shell variable.function.shell
+#                                  ^^ keyword.operator.assignment.pipe.shell
+
 test $var != 0
 #<- meta.function-call.identifier.shell support.function.shell
 #^^^ meta.function-call.identifier.shell support.function.shell
@@ -12714,18 +12761,6 @@ test ${var[0]} != var[^0-9]*$
 #              ^^ keyword.operator.comparison.shell
 #                 ^^^^^^^^^^^ meta.string.glob.shell string.unquoted.shell - meta.string.regexp
 
-test expr -a expr -o expr -- | cmd |& cmd
-# <- meta.function-call.identifier.shell support.function.shell
-#^^^ meta.function-call.identifier.shell support.function.shell
-#   ^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell
-#                           ^^^ - meta.function-call
-#         ^^ meta.parameter.option.shell variable.parameter.option.shell
-#                 ^^ meta.parameter.option.shell variable.parameter.option.shell
-#                         ^^ - keyword
-#                            ^ keyword.operator.assignment.pipe.shell
-#                              ^^^ meta.function-call.identifier.shell variable.function.shell
-#                                  ^^ keyword.operator.assignment.pipe.shell
-
 test ! $line == ^[0-9]+$
 # <- meta.function-call.identifier.shell support.function.shell
 #^^^ meta.function-call.identifier.shell - meta.function-call.arguments
@@ -12754,7 +12789,7 @@ if test expr -a expr ; then echo "success"; fi
 #  ^^^^ meta.function-call.identifier.shell support.function.shell
 #      ^^^^^^^^^^^^^ meta.function-call.arguments.shell
 #                   ^^^^^^^^ - meta.function-call
-#            ^^ meta.parameter.option.shell variable.parameter.option.shell
+#            ^^ keyword.operator.logical.shell
 #                    ^ punctuation.terminator.statement.shell
 #                      ^^^^ keyword.control.conditional.then.shell
 #                           ^^^^ support.function.shell

--- a/ShellScript/Bash/tests/syntax_test_scope.bash
+++ b/ShellScript/Bash/tests/syntax_test_scope.bash
@@ -9016,6 +9016,16 @@ stash) || true)
 #          ^ punctuation.section.group.end.regexp.shell
 #            ^^ punctuation.section.compound.end.shell
 
+[[ $path == /dev/null ]]
+#^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#^ punctuation.section.compound.begin.shell
+#  ^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell variable.other.readwrite.shell
+#  ^ punctuation.definition.variable.shell
+#        ^^ keyword.operator.comparison.shell
+#           ^^^^^^^^^ meta.string.glob.shell meta.path.shell constant.language.null.shell
+#           ^ punctuation.separator.path.shell
+#               ^ punctuation.separator.path.shell
+#                     ^^ punctuation.section.compound.end.shell
 
 ###############################################################################
 # POSIX extended regular expression pattern matching                          #

--- a/ShellScript/Bash/tests/syntax_test_scope.bash
+++ b/ShellScript/Bash/tests/syntax_test_scope.bash
@@ -1912,11 +1912,13 @@ if [[ $- =~ *i* ]] ; then echo shell is not interactive; fi
 
 if [[ "$ERL_TOP" != ";"; ]];then;fi
 #^ keyword.control.conditional.if.shell
-#  ^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
-#  ^^^^^^^^^^^^^^^^^ - meta.string.regexp
-#                   ^^^ meta.string.regexp.shell
+#  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#  ^^^ - meta.string
+#     ^^^^^^^^^^ meta.string.glob.shell
+#               ^^^^ - meta.string
+#                   ^^^ meta.string.glob.shell
 #                      ^ invalid.illegal.unexpected-token.shell - meta.string
-#                       ^^^ - meta.string.regexp
+#                       ^^^ - meta.string
 #                          ^ punctuation.terminator.statement.shell
 #                           ^^^^ keyword.control.conditional.then.shell
 #                               ^ punctuation.terminator.statement.shell
@@ -2780,7 +2782,7 @@ done
 #  ^ keyword.operator.logical.shell
 #    ^^^ meta.string.glob.shell string.unquoted.shell
 #        ^^ keyword.operator.comparison.shell
-#           ^^^ meta.string.regexp.shell string.unquoted.shell
+#           ^^^ meta.string.glob.shell string.unquoted.shell
 #               ^ punctuation.section.compound.end.shell
 
 [[ str != str ]]
@@ -2788,7 +2790,7 @@ done
 #^^^^^^^^^^^^^^^ meta.compound.conditional.shell
 #  ^^^ meta.string.glob.shell string.unquoted.shell
 #      ^^ keyword.operator.comparison.shell
-#         ^^^ meta.string.regexp.shell string.unquoted.shell
+#         ^^^ meta.string.glob.shell string.unquoted.shell
 #             ^ punctuation.section.compound.end.shell
 
 [[ str == str ]]
@@ -2796,7 +2798,7 @@ done
 #^^^^^^^^^^^^^^^ meta.compound.conditional.shell
 #  ^^^ meta.string.glob.shell string.unquoted.shell
 #      ^^ keyword.operator.comparison.shell
-#         ^^^ meta.string.regexp.shell string.unquoted.shell
+#         ^^^ meta.string.glob.shell string.unquoted.shell
 #             ^ punctuation.section.compound.end.shell
 
 [[ str = str ]]
@@ -2804,7 +2806,7 @@ done
 #^^^^^^^^^^^^^^ meta.compound.conditional.shell
 #  ^^^ meta.string.glob.shell string.unquoted.shell
 #      ^ keyword.operator.comparison.shell
-#        ^^^ meta.string.regexp.shell string.unquoted.shell
+#        ^^^ meta.string.glob.shell string.unquoted.shell
 #            ^ punctuation.section.compound.end.shell
 
 [[ str < str ]]
@@ -2842,18 +2844,20 @@ done
 [[ -e == -e ]]     # a syntax error in bash but allowed in zsh
 #  ^^ meta.string.glob.shell string.unquoted.shell - variable
 #     ^^ keyword.operator.comparison.shell
-#        ^^ meta.string.regexp.shell string.unquoted.shell - variable
+#        ^^ meta.string.glob.shell string.unquoted.shell - variable
 
 [[ '-e' == -e ]]   # -e undergoes pattern matching on the right
 #  ^^^^ meta.string.glob.shell string.quoted.single.shell
 #       ^^ keyword.operator.comparison.shell
-#          ^^ meta.string.regexp.shell string.unquoted.shell - variable
+#          ^^ meta.string.glob.shell string.unquoted.shell - variable
 
 [[ ! ($foo == pat) ]]
 # <- meta.compound.conditional.shell - meta.group
 #^^^^ meta.compound.conditional.shell - meta.group
-#    ^^^^^^^^^ meta.compound.conditional.shell meta.group.shell - meta.string.regexp
-#             ^^^ meta.compound.conditional.shell meta.group.shell meta.string.regexp.shell
+#    ^ meta.compound.conditional.shell meta.group.shell - meta.string
+#     ^^^^ meta.compound.conditional.shell meta.group.shell meta.string.glob.shell meta.interpolation.parameter.shell variable.other.readwrite.shell
+#         ^^^^ meta.compound.conditional.shell meta.group.shell - meta.string
+#             ^^^ meta.compound.conditional.shell meta.group.shell meta.string.glob.shell
 #                ^ meta.compound.conditional.shell meta.group.shell - meta.string
 #                 ^^^ meta.compound.conditional.shell - meta.group
 
@@ -2863,7 +2867,7 @@ done
 #    ^ meta.compound.conditional.shell meta.group.shell - meta.string
 #     ^^^^ meta.compound.conditional.shell meta.group.shell meta.string.glob.shell meta.interpolation.parameter.shell variable.other.readwrite.shell
 #         ^^^^ meta.compound.conditional.shell meta.group.shell - meta.string
-#             ^^ meta.compound.conditional.shell meta.group.shell meta.string.regexp.shell constant.character.escape.shell
+#             ^^ meta.compound.conditional.shell meta.group.shell meta.string.glob.shell constant.character.escape.shell
 #               ^ meta.compound.conditional.shell meta.group.shell - meta.string
 #                ^^^ meta.compound.conditional.shell - meta.group
 
@@ -2872,15 +2876,15 @@ done
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
 #  ^^^^ variable.other.readwrite.shell
 #       ^^ keyword.operator.comparison.shell
-#          ^^^^^ meta.string.regexp.shell
+#          ^^^^^ meta.string.glob.shell
 #                ^^ keyword.operator.logical.shell
 #                   ^^^^ variable.other.readwrite.shell
 #                        ^^ keyword.operator.comparison.shell
-#                           ^^^^^ meta.string.regexp.shell
+#                           ^^^^^ meta.string.glob.shell
 #                                 ^^ keyword.operator.logical.shell
 #                                    ^^^^ variable.other.readwrite.shell
 #                                         ^^ keyword.operator.comparison.shell
-#                                            ^^^ meta.string.regexp.shell
+#                                            ^^^ meta.string.glob.shell
 #                                                ^^ punctuation.section.compound.end.shell
 
 [[ ( $foo == 'bar' || $foo == "baz" ) && $bar == baz ]]
@@ -2891,16 +2895,16 @@ done
 #  ^ punctuation.section.group.begin.shell
 #    ^^^^ variable.other.readwrite.shell
 #         ^^ keyword.operator.comparison.shell
-#            ^^^^^ meta.string.regexp.shell
+#            ^^^^^ meta.string.glob.shell
 #                  ^^ keyword.operator.logical.shell
 #                     ^^^^ variable.other.readwrite.shell
 #                          ^^ keyword.operator.comparison.shell
-#                             ^^^^^ meta.string.regexp.shell
+#                             ^^^^^ meta.string.glob.shell
 #                                   ^ punctuation.section.group.end.shell
 #                                     ^^ keyword.operator.logical.shell
 #                                        ^^^^ variable.other.readwrite.shell
 #                                             ^^ keyword.operator.comparison.shell
-#                                                ^^^ meta.string.regexp.shell
+#                                                ^^^ meta.string.glob.shell
 #                                                    ^^ punctuation.section.compound.end.shell
 
 [[ ! ((( $foo == 'bar' ) || $foo == "baz" ) && ($bar == baz)) ]]
@@ -2918,20 +2922,95 @@ done
 #    ^^^ punctuation.section.group.begin.shell
 #        ^^^^ variable.other.readwrite.shell
 #             ^^ keyword.operator.comparison.shell
-#                ^^^^^ meta.string.regexp.shell
+#                ^^^^^ meta.string.glob.shell
 #                      ^ punctuation.section.group.end.shell
 #                        ^^ keyword.operator.logical.shell
 #                           ^^^^ variable.other.readwrite.shell
 #                                ^^ keyword.operator.comparison.shell
-#                                   ^^^^^ meta.string.regexp.shell
+#                                   ^^^^^ meta.string.glob.shell
 #                                         ^ punctuation.section.group.end.shell
 #                                           ^^ keyword.operator.logical.shell
 #                                              ^ punctuation.section.group.begin.shell
 #                                               ^^^^ variable.other.readwrite.shell
 #                                                    ^^ keyword.operator.comparison.shell
-#                                                       ^^^ meta.string.regexp.shell
+#                                                       ^^^ meta.string.glob.shell
 #                                                          ^^ punctuation.section.group.end.shell
 #                                                             ^^ punctuation.section.compound.end.shell
+
+
+## Arithmetic Comparisons
+## ----------------------
+
+[[ arg+1 -lt 2+a+(5-b) ]]   # arithmetic comparison
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^ meta.compound.conditional.shell - meta.arithmetic
+#  ^^^^^ meta.compound.conditional.shell meta.arithmetic.shell
+#       ^^^^^ meta.compound.conditional.shell - meta.arithmetic
+#            ^^^^ meta.compound.conditional.shell meta.arithmetic.shell - meta.group
+#                ^^^^^ meta.compound.conditional.shell meta.arithmetic.shell meta.group.shell
+#                     ^^ meta.compound.conditional.shell - meta.arithmetic
+#^ punctuation.section.compound.begin.shell
+#  ^^^ variable.other.readwrite.shell
+#        ^^^ keyword.operator.comparison.shell
+#            ^ meta.number.integer.decimal.shell constant.numeric.value.shell
+#             ^ keyword.operator.arithmetic.shell
+#              ^ variable.other.readwrite.shell
+#               ^ keyword.operator.arithmetic.shell
+#                ^ punctuation.section.group.begin.shell
+#                  ^ keyword.operator.arithmetic.shell
+#                   ^ variable.other.readwrite.shell
+#                    ^ punctuation.section.group.end.shell
+#                      ^^ punctuation.section.compound.end.shell
+
+[[ "c + $d" -eq "1 * ( a % ( b * 5) )" ]]
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#  ^^^^^^^^ meta.quoted.shell meta.arithmetic.shell
+#          ^^^^^ - meta.arithmetic
+#               ^^^^^ meta.quoted.shell meta.arithmetic.shell - meta.group
+#                    ^^^^^^ meta.quoted.shell meta.arithmetic.shell meta.group.shell - meta.group meta.group
+#                          ^^^^^^^^ meta.quoted.shell meta.arithmetic.shell meta.group.shell meta.group.shell
+#                                  ^^ meta.quoted.shell meta.arithmetic.shell meta.group.shell - meta.group meta.group
+#                                    ^ meta.quoted.shell meta.arithmetic.shell - meta.group
+#                                     ^^ - meta.arithmetic
+#  ^ punctuation.definition.quoted.begin.shell
+#   ^ variable.other.readwrite.shell
+#     ^ keyword.operator.arithmetic.shell
+#       ^^ meta.interpolation.parameter.shell variable.other.readwrite.shell
+#       ^ punctuation.definition.variable.shell
+#         ^ punctuation.definition.quoted.end.shell
+#           ^^^ keyword.operator.comparison.shell
+#               ^ punctuation.definition.quoted.begin.shell
+#                ^ meta.number.integer.decimal.shell constant.numeric.value.shell
+#                  ^ keyword.operator.arithmetic.shell
+#                    ^ punctuation.section.group.begin.shell
+#                      ^ variable.other.readwrite.shell
+#                        ^ keyword.operator.arithmetic.shell
+#                          ^ punctuation.section.group.begin.shell
+#                            ^ variable.other.readwrite.shell
+#                              ^ keyword.operator.arithmetic.shell
+#                                ^ meta.number.integer.decimal.shell constant.numeric.value.shell
+#                                 ^ punctuation.section.group.end.shell
+#                                   ^ punctuation.section.group.end.shell
+#                                    ^ punctuation.definition.quoted.end.shell
+#                                      ^^ punctuation.section.compound.end.shell
+
+[[ -eq -ge -eq -eq -eq -eq ]]  # operators like `-eq` appear only on certain positions
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#^ punctuation.section.compound.begin.shell
+#  ^^^ meta.arithmetic.shell
+#  ^ keyword.operator.arithmetic.shell
+#   ^^ variable.other.readwrite.shell
+#      ^^^ keyword.operator.comparison.shell
+#          ^^^ meta.arithmetic.shell
+#          ^ keyword.operator.arithmetic.shell
+#           ^^ variable.other.readwrite.shell
+#              ^^^ meta.arithmetic.shell
+#              ^ keyword.operator.arithmetic.shell
+#               ^^ variable.other.readwrite.shell
+#                  ^^^ keyword.operator.comparison.shell
+#                      ^ keyword.operator.arithmetic.shell
+#                       ^^ variable.other.readwrite.shell
+#                          ^^ punctuation.section.compound.end.shell
 
 
 ###############################################################################
@@ -4992,20 +5071,23 @@ echo "~/~foo" # literal quoted string
 #    ^^^^^^^^ meta.function-call.arguments.shell meta.string.glob.shell string.quoted.double.shell - meta.interpolation - variable
 
 test $me -eq ~/~foo
-#            ^ meta.string.glob.shell meta.interpolation.tilde.shell variable.language.tilde.shell
-#             ^^^^^ meta.string.glob.shell string.unquoted.shell - meta.interpolation - variable
+#            ^^^^^^ meta.arithmetic.shell
+#            ^ keyword.operator.bitwise.shell
+#             ^keyword.operator.arithmetic.shell
+#              ^ keyword.operator.bitwise.shell
+#               ^^^variable.other.readwrite.shell
 
 [ $me == ~/~foo ]
 #        ^ meta.string.glob.shell meta.interpolation.tilde.shell variable.language.tilde.shell
 #         ^^^^^ meta.string.glob.shell string.unquoted.shell - meta.interpolation.tilde
 
 [[ $me == ~/~foo ]]
-#         ^ meta.string.regexp.shell meta.interpolation.tilde.shell variable.language.tilde.shell
-#          ^^^^^ meta.string.regexp.shell string.unquoted.shell - meta.interpolation.tilde
+#         ^ meta.string.glob.shell meta.interpolation.tilde.shell variable.language.tilde.shell
+#          ^^^^^ meta.string.glob.shell string.unquoted.shell - meta.interpolation.tilde
 
 [[ ( $me == ~/~foo ) ]]
-#           ^ meta.string.regexp.shell meta.interpolation.tilde.shell variable.language.tilde.shell
-#            ^^^^^ meta.string.regexp.shell string.unquoted.shell - meta.interpolation.tilde
+#           ^ meta.string.glob.shell meta.interpolation.tilde.shell variable.language.tilde.shell
+#            ^^^^^ meta.string.glob.shell string.unquoted.shell - meta.interpolation.tilde
 
 [[ $me =~ ~/~foo ]]
 #         ^ meta.string.regexp.shell meta.interpolation.tilde.shell variable.language.tilde.shell
@@ -5466,7 +5548,7 @@ foo}
 #       ^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell meta.string.shell
 #                 ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.item-access.shell - meta.item-access meta.string
 #                  ^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.item-access
-#                   ^^^ - meta.string.glob
+#                   ^^^ - meta.string
 # ^ punctuation.definition.variable.shell
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^^^ variable.other.readwrite.shell
@@ -8858,10 +8940,10 @@ stash) || true)
 ###############################################################################
 
 [[ abc == ?[a-z]? ]]  # evaluates to true
-#         ^ meta.string.regexp.shell - meta.set
-#          ^^^^^ meta.string.regexp.shell meta.set.regexp.shell
-#               ^ meta.string.regexp.shell - meta.set
-#                ^ - meta.string.regexp
+#         ^ meta.string.glob.shell - meta.set
+#          ^^^^^ meta.string.glob.shell meta.set.regexp.shell
+#               ^ meta.string.glob.shell - meta.set
+#                ^ - meta.string
 #         ^ constant.other.wildcard.questionmark.shell
 #          ^ punctuation.definition.set.begin.regexp.shell
 #           ^^^ constant.other.range.regexp.shell
@@ -8869,38 +8951,38 @@ stash) || true)
 #               ^ constant.other.wildcard.questionmark.shell
 
 [[ abc == ??[a-z] ]]  # evaluates to true
-#         ^^ meta.string.regexp.shell - meta.set
-#           ^^^^^ meta.string.regexp.shell meta.set.regexp.shell
-#                ^ - meta.string.regexp
+#         ^^ meta.string.glob.shell - meta.set
+#           ^^^^^ meta.string.glob.shell meta.set.regexp.shell
+#                ^ - meta.string
 #         ^^ constant.other.wildcard.questionmark.shell
 #           ^ punctuation.definition.set.begin.regexp.shell
 #            ^^^ constant.other.range.regexp.shell
 #               ^ punctuation.definition.set.end.regexp.shell
 
 [[ abc == [a-z]?? ]]  # evaluates to true
-#         ^^^^^ meta.string.regexp.shell meta.set.regexp.shell
-#              ^^ meta.string.regexp.shell - meta.set
-#                ^ - meta.string.regexp
+#         ^^^^^ meta.string.glob.shell meta.set.regexp.shell
+#              ^^ meta.string.glob.shell - meta.set
+#                ^ - meta.string
 #         ^ punctuation.definition.set.begin.regexp.shell
 #          ^^^ constant.other.range.regexp.shell
 #             ^ punctuation.definition.set.end.regexp.shell
 #              ^^ constant.other.wildcard.questionmark.shell
 
 [[ abc == *[a-z] ]]  # evaluates to true
-#         ^ meta.string.regexp.shell - meta.set
-#          ^^^^^ meta.string.regexp.shell meta.set.regexp.shell
-#               ^ - meta.string.regexp
+#         ^ meta.string.glob.shell - meta.set
+#          ^^^^^ meta.string.glob.shell meta.set.regexp.shell
+#               ^ - meta.string
 #         ^ constant.other.wildcard.asterisk.shell
 #          ^ punctuation.definition.set.begin.regexp.shell
 #           ^^^ constant.other.range.regexp.shell
 #              ^ punctuation.definition.set.end.regexp.shell
 
 [[ abc == ?(?[a-z]?) ]]  # evaluates to true
-#         ^ meta.string.regexp.shell - meta.group
-#          ^^ meta.string.regexp.shell meta.group.regexp.shell - meta.set
-#            ^^^^^ meta.string.regexp.shell meta.group.regexp.shell meta.set.regexp.shell
-#                 ^^ meta.string.regexp.shell meta.group.regexp.shell - meta.set
-#                   ^ - meta.string.regexp
+#         ^ meta.string.glob.shell - meta.group
+#          ^^ meta.string.glob.shell meta.group.regexp.shell - meta.set
+#            ^^^^^ meta.string.glob.shell meta.group.regexp.shell meta.set.regexp.shell
+#                 ^^ meta.string.glob.shell meta.group.regexp.shell - meta.set
+#                   ^ - meta.string
 #         ^ keyword.operator.quantifier.regexp.shell
 #          ^ punctuation.section.group.begin.regexp.shell
 #           ^ constant.other.wildcard.questionmark.shell
@@ -8911,21 +8993,21 @@ stash) || true)
 
 [[ abc == ^abc|bca$ ]]
 #^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
-#         ^^^^ meta.string.regexp.shell string.unquoted.shell - keyword
+#         ^^^^ meta.string.glob.shell string.unquoted.shell - keyword
 #             ^ invalid.illegal.unexpected-token.shell - meta.string
 #              ^^^^ meta.string.glob.shell string.unquoted.shell
 #                   ^^ punctuation.section.compound.end.shell
 
 [[ abc == ^abc&bca$ ]]
 #^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
-#         ^^^^ meta.string.regexp.shell string.unquoted.shell - keyword
+#         ^^^^ meta.string.glob.shell string.unquoted.shell - keyword
 #             ^ invalid.illegal.unexpected-token.shell - meta.string
 #              ^^^^ meta.string.glob.shell string.unquoted.shell
 #                   ^^ punctuation.section.compound.end.shell
 
 [[ a\$b*c == a'$b*'? ]]
 #^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
-#            ^^^^^^^ meta.string.regexp.shell
+#            ^^^^^^^ meta.string.glob.shell
 #             ^ punctuation.definition.string.begin.shell
 #              ^^^ - constant - keyword - variable
 #                 ^ punctuation.definition.string.end.shell
@@ -8933,7 +9015,7 @@ stash) || true)
 
 [[ a"$bc*"c == *"$bc*"c ]]
 #^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
-#              ^^^^^^^^ meta.string.regexp.shell
+#              ^^^^^^^^ meta.string.glob.shell
 #              ^ constant.other.wildcard.asterisk.shell
 #               ^ punctuation.definition.string.begin.shell
 #                ^^^ variable.other.readwrite.shell
@@ -8942,8 +9024,8 @@ stash) || true)
 
 [[ $foo == !(foo|bar|???|*|'?'|'*') ]]
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
-#          ^ meta.string.regexp.shell
-#           ^^^^^^^^^^^^^^^^^^^^^^^ meta.string.regexp.shell meta.group.regexp.shell
+#          ^ meta.string.glob.shell
+#           ^^^^^^^^^^^^^^^^^^^^^^^ meta.string.glob.shell meta.group.regexp.shell
 #          ^ keyword.operator.quantifier.regexp.shell
 #           ^ punctuation.section.group.begin.regexp.shell
 #               ^ keyword.operator.alternation.regexp.shell
@@ -8962,9 +9044,11 @@ stash) || true)
 
 [[ ( $foo == *
 #^^ meta.compound.conditional.shell - meta.group
-#  ^^^^^^^^^^ meta.compound.conditional.shell meta.group.shell - meta.string.regexp
-#            ^ meta.compound.conditional.shell meta.group.shell meta.string.regexp.shell
-#             ^ meta.compound.conditional.shell meta.group.shell - meta.string.regexp invalid.illegal.unexpected-token.shell
+#  ^^ meta.compound.conditional.shell meta.group.shell - meta.string
+#    ^^^^ meta.compound.conditional.shell meta.group.shell meta.string.glob.shell
+#        ^^^^ meta.compound.conditional.shell meta.group.shell - meta.string
+#            ^ meta.compound.conditional.shell meta.group.shell meta.string.glob.shell
+#             ^ meta.compound.conditional.shell meta.group.shell - meta.string invalid.illegal.unexpected-token.shell
    )
 #^^^ meta.compound.conditional.shell meta.group.shell
 #  ^ punctuation.section.group.end.shell
@@ -8976,18 +9060,20 @@ stash) || true)
 
 [[ ( $foo == *\
 [^0-9]? ) ]]   # note: line continuation is only valid without leading whitespace, but we ignore it
-# <- meta.compound.conditional.shell meta.group.shell meta.string.regexp.shell
-#^^^^^ meta.compound.conditional.shell meta.group.shell meta.string.regexp.shell meta.set.regexp.shell
-#     ^ meta.compound.conditional.shell meta.group.shell meta.string.regexp.shell - meta.set
-#      ^^ meta.compound.conditional.shell meta.group.shell - meta.string.regexp
+# <- meta.compound.conditional.shell meta.group.shell meta.string.glob.shell
+#^^^^^ meta.compound.conditional.shell meta.group.shell meta.string.glob.shell meta.set.regexp.shell
+#     ^ meta.compound.conditional.shell meta.group.shell meta.string.glob.shell - meta.set
+#      ^^ meta.compound.conditional.shell meta.group.shell - meta.string
 #        ^^^ meta.compound.conditional.shell - meta.group
 #         ^^ punctuation.section.compound.end.shell
 
 [[ ( $foo == ? ]] # incomplete group
 #^^ meta.compound.conditional.shell - meta.group
-#  ^^^^^^^^^^ meta.compound.conditional.shell meta.group.shell - meta.string.regexp
-#            ^ meta.compound.conditional.shell meta.group.shell meta.string.regexp.shell
-#             ^^^ meta.compound.conditional.shell - meta.group - meta.string.regexp
+#  ^^ meta.compound.conditional.shell meta.group.shell - meta.string
+#    ^^^^ meta.compound.conditional.shell meta.group.shell meta.string.glob.shell meta.interpolation.parameter.shell variable.other.readwrite.shell
+#        ^^^^ meta.compound.conditional.shell meta.group.shell - meta.string
+#            ^ meta.compound.conditional.shell meta.group.shell meta.string.glob.shell
+#             ^^^ meta.compound.conditional.shell - meta.group - meta.string
 #              ^^ punctuation.section.compound.end.shell
 
 [[ ( $foo == ? ]]
@@ -8996,17 +9082,19 @@ stash) || true)
 #^^^^^^^^^^^^^^ - meta.conditional
 
 [[ $foo == +( ]]
-#^^^^^^^^^^ meta.compound.conditional.shell - meta.string.regexp - meta.group
-#          ^ meta.compound.conditional.shell meta.string.regexp.shell - meta.group
-#           ^^^^^ meta.compound.conditional.shell meta.string.regexp.shell meta.group.regexp.shell
+# ^ meta.compound.conditional.shell - meta.string
+#  ^^^^ meta.compound.conditional.shell meta.string.glob.shell meta.interpolation.parameter.shell variable.other.readwrite.shell
+#      ^^^^ meta.compound.conditional.shell - meta.string - meta.group
+#          ^ meta.compound.conditional.shell meta.string.glob.shell - meta.group
+#           ^^^^^ meta.compound.conditional.shell meta.string.glob.shell meta.group.regexp.shell
 #          ^ keyword.operator.quantifier.regexp.shell
 #           ^ punctuation.section.group.begin.regexp.shell
 #             ^^ - punctuation
    [!0-9]+ ) ]]
-# <- meta.compound.conditional.shell meta.string.regexp.shell meta.group.regexp.shell
-#^^ meta.compound.conditional.shell meta.string.regexp.shell meta.group.regexp.shell - meta.set
-#  ^^^^^^ meta.compound.conditional.shell meta.string.regexp.shell meta.group.regexp.shell meta.set.regexp.shell
-#        ^^^ meta.compound.conditional.shell meta.string.regexp.shell meta.group.regexp.shell - meta.set
+# <- meta.compound.conditional.shell meta.string.glob.shell meta.group.regexp.shell
+#^^ meta.compound.conditional.shell meta.string.glob.shell meta.group.regexp.shell - meta.set
+#  ^^^^^^ meta.compound.conditional.shell meta.string.glob.shell meta.group.regexp.shell meta.set.regexp.shell
+#        ^^^ meta.compound.conditional.shell meta.string.glob.shell meta.group.regexp.shell - meta.set
 #           ^^^ - meta.string.regexp
 #  ^ punctuation.definition.set.begin.regexp.shell
 #   ^ keyword.operator.logical.regexp.shell
@@ -12562,6 +12650,22 @@ typeset -f _init_completion > /dev/null && complete -F _upto upto
 #   ^^^^ meta.string.glob.shell string.unquoted.shell
 #        ^ punctuation.section.compound.end.shell
 
+[ >str ]    # may contain redirections
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^ meta.compound.conditional.shell
+# ^^^^ meta.redirection.shell
+# ^ keyword.operator.assignment.redirection.shell
+#  ^^^ string.unquoted.shell
+#      ^ punctuation.section.compound.end.shell
+
+[ <str ]    # may contain redirections
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^ meta.compound.conditional.shell
+# ^^^^ meta.redirection.shell
+# ^ keyword.operator.assignment.redirection.shell
+#  ^^^ string.unquoted.shell
+#      ^ punctuation.section.compound.end.shell
+
 [ >>str ]   # may contain redirections
 # <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
 #^^^^^^^^ meta.compound.conditional.shell
@@ -12698,6 +12802,17 @@ doc
 #       ^^^ meta.string.glob.shell string.unquoted.shell
 #           ^ punctuation.section.compound.end.shell
 
+[ <in1 < <in2 ]
+#^^^^^^^^^^^^^^ meta.compound.conditional.shell
+# ^^^^ meta.redirection.shell
+# ^ keyword.operator.assignment.redirection.shell
+#  ^^^ meta.string.glob.shell string.unquoted.shell
+#      ^ keyword.operator.comparison.shell
+#        ^^^^ meta.redirection.shell
+#        ^ keyword.operator.assignment.redirection.shell
+#         ^^^ meta.string.glob.shell string.unquoted.shell
+#             ^ punctuation.section.compound.end.shell
+
 
 ## Invalid Comparison Operators
 ## ----------------------------
@@ -12737,6 +12852,47 @@ doc
 #      ^^^ keyword.operator.comparison.shell
 #          ^ meta.number.integer.decimal.shell constant.numeric.value.shell
 #            ^ punctuation.section.compound.end.shell
+
+[ a -eq 5 ]     # integer comparison
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^ meta.compound.conditional.shell
+# ^ meta.arithmetic.shell variable.other.readwrite.shell
+#   ^^^ keyword.operator.comparison.shell
+#       ^ meta.arithmetic.shell meta.number.integer.decimal.shell constant.numeric.value.shell
+#         ^ punctuation.section.compound.end.shell
+
+[ 4 -lt a ]     # integer comparison
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^ meta.compound.conditional.shell
+# ^ meta.arithmetic.shell meta.number.integer.decimal.shell constant.numeric.value.shell
+#   ^^^ keyword.operator.comparison.shell
+#       ^ meta.arithmetic.shell variable.other.readwrite.shell
+#         ^ punctuation.section.compound.end.shell
+
+[ a -gt b ]     # integer comparison
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^ meta.compound.conditional.shell
+# ^ meta.arithmetic.shell variable.other.readwrite.shell
+#   ^^^ keyword.operator.comparison.shell
+#       ^ meta.arithmetic.shell variable.other.readwrite.shell
+#         ^ punctuation.section.compound.end.shell
+
+[ -eq -ge -eq -eq -eq -eq ]  # operators like `-eq` appear only on certain positions
+#^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+# ^^^ meta.arithmetic.shell
+# ^ keyword.operator.arithmetic.shell
+#  ^^ variable.other.readwrite.shell
+#     ^^^ keyword.operator.comparison.shell
+#         ^^^ meta.arithmetic.shell
+#         ^ keyword.operator.arithmetic.shell
+#          ^^ variable.other.readwrite.shell
+#             ^^^ meta.arithmetic.shell
+#             ^ keyword.operator.arithmetic.shell
+#              ^^ variable.other.readwrite.shell
+#                 ^^^ keyword.operator.comparison.shell
+#                     ^ keyword.operator.arithmetic.shell
+#                      ^^ variable.other.readwrite.shell
+#                         ^ punctuation.section.compound.end.shell
 
 
 ###############################################################################
@@ -12800,7 +12956,7 @@ test $var != 0
 #   ^^^^^^^^^^ meta.function-call.arguments.shell - meta.string.regexp
 #             ^ - meta.function-call
 #         ^^ keyword.operator.comparison.shell
-#            ^ constant.numeric.value.shell
+#            ^ meta.string.glob.shell string.unquoted.shell
 
 test $var == true
 #<- meta.function-call.identifier.shell support.function.shell

--- a/ShellScript/Bash/tests/syntax_test_scope.bash
+++ b/ShellScript/Bash/tests/syntax_test_scope.bash
@@ -12382,6 +12382,219 @@ typeset -f _init_completion > /dev/null && complete -F _upto upto
 
 
 ###############################################################################
+# 4.2 Bash Builtin Commands ( [...] )                                         #
+# https://www.gnu.org/software/bash/manual/bash.html#index-test               #
+###############################################################################
+
+![ ]
+# <- punctuation.definition.history.shell
+#^ punctuation.section.compound.begin.shell
+#  ^ punctuation.section.compound.end.shell
+
+! [ ]
+# <- keyword.operator.logical.shell
+# ^ punctuation.section.compound.begin.shell
+#   ^ punctuation.section.compound.end.shell
+
+[  ]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^ meta.compound.conditional.shell
+#  ^ punctuation.section.compound.end.shell
+
+[
+]
+# <- - meta.conditional - support.function
+
+[ \
+]
+# <- meta.compound.conditional.shell punctuation.section.compound.end.shell
+
+[ # terminated by comments ]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^ - meta.conditional - comment
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.shell - meta.conditional
+
+# <- - meta.compound
+
+[ ; cmd ]   # terminated by `;`
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^ - meta.conditional
+# ^ punctuation.terminator.statement.shell
+#   ^^^ variable.function.shell
+#       ^ string.unquoted.shell
+
+[ && cmd ]  # can't contain top-level `&&`
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^ - meta.conditional
+# ^^ keyword.operator.logical.shell
+#    ^^^ variable.function.shell
+#        ^ string.unquoted.shell
+
+[ || cmd ]  # can't contain top-level `||`
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^ - meta.conditional
+# ^^ keyword.operator.logical.shell
+#    ^^^ variable.function.shell
+#        ^ string.unquoted.shell
+
+[ ! expr ]
+#^^^^^^^^^ meta.compound.conditional.shell
+# ^ keyword.operator.logical.shell
+#   ^^^^ meta.string.glob.shell string.unquoted.shell
+#        ^ punctuation.section.compound.end.shell
+
+[ >>str ]   # may contain redirections
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^ meta.compound.conditional.shell
+# ^^^^^ meta.redirection.shell
+# ^^ keyword.operator.assignment.redirection.shell
+#   ^^^ string.unquoted.shell
+#       ^ punctuation.section.compound.end.shell
+
+# heredocs causing issues, but no way around it
+[ <<doc ]  # <- ] should close the conditional
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^ meta.compound.conditional.shell
+# ^^ keyword.operator.assignment.redirection.shell
+#   ^^^ meta.tag.heredoc.begin.shell entity.name.tag.heredoc.shell
+doc
+# <- meta.tag.heredoc.end.shell entity.name.tag.heredoc.shell
+
+
+## Test Expressions
+## ----------------
+
+[ -f file ]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^ meta.compound.conditional.shell
+
+[ -v varname ]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^ meta.compound.conditional.shell
+
+
+## File Comparisons
+## ----------------
+
+[ file1 -ef file2 ]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+# ^^^^^ meta.string.glob.shell string.unquoted.shell
+#       ^^^ keyword.operator.comparison.shell
+#           ^^^^^ meta.string.glob.shell string.unquoted.shell
+#                 ^ punctuation.section.compound.end.shell
+
+[ file1 -nt file2 ]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+# ^^^^^ meta.string.glob.shell string.unquoted.shell
+#       ^^^ keyword.operator.comparison.shell
+#           ^^^^^ meta.string.glob.shell string.unquoted.shell
+#                 ^ punctuation.section.compound.end.shell
+
+[ file1 -ot file2 ]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+# ^^^^^ meta.string.glob.shell string.unquoted.shell
+#       ^^^ keyword.operator.comparison.shell
+#           ^^^^^ meta.string.glob.shell string.unquoted.shell
+#                 ^ punctuation.section.compound.end.shell
+
+
+## String Comparison Operators
+## ---------------------------
+
+[ ! str != str ]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+# ^ keyword.operator.logical.shell
+#   ^^^ meta.string.glob.shell string.unquoted.shell
+#       ^^ keyword.operator.comparison.shell
+#          ^^^ meta.string.glob.shell string.unquoted.shell
+#              ^ punctuation.section.compound.end.shell
+
+[ str != str ]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^ meta.compound.conditional.shell
+# ^^^ meta.string.glob.shell string.unquoted.shell
+#     ^^ keyword.operator.comparison.shell
+#        ^^^ meta.string.glob.shell string.unquoted.shell
+#            ^ punctuation.section.compound.end.shell
+
+[ str == str ]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^ meta.compound.conditional.shell
+# ^^^ meta.string.glob.shell string.unquoted.shell
+#     ^^ keyword.operator.comparison.shell
+#        ^^^ meta.string.glob.shell string.unquoted.shell
+#            ^ punctuation.section.compound.end.shell
+
+[ str = str ]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^ meta.compound.conditional.shell
+# ^^^ meta.string.glob.shell string.unquoted.shell
+#     ^ keyword.operator.comparison.shell
+#       ^^^ meta.string.glob.shell string.unquoted.shell
+#           ^ punctuation.section.compound.end.shell
+
+[ str < str ]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^ meta.compound.conditional.shell
+# ^^^ meta.string.glob.shell string.unquoted.shell
+#     ^ keyword.operator.comparison.shell
+#       ^^^ meta.string.glob.shell string.unquoted.shell
+#           ^ punctuation.section.compound.end.shell
+
+[ str > str ]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^ meta.compound.conditional.shell
+# ^^^ meta.string.glob.shell string.unquoted.shell
+#     ^ keyword.operator.comparison.shell
+#       ^^^ meta.string.glob.shell string.unquoted.shell
+#           ^ punctuation.section.compound.end.shell
+
+
+## Invalid Comparison Operators
+## ----------------------------
+
+[ str >= str ]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^ meta.compound.conditional.shell
+# ^^^ meta.string.glob.shell string.unquoted.shell
+#     ^^ invalid.illegal.operator.shell
+#        ^^^ meta.string.glob.shell string.unquoted.shell
+#            ^ punctuation.section.compound.end.shell
+
+[ str <= str ]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^ meta.compound.conditional.shell
+# ^^^ meta.string.glob.shell string.unquoted.shell
+#     ^^ invalid.illegal.operator.shell
+#        ^^^ meta.string.glob.shell string.unquoted.shell
+#            ^ punctuation.section.compound.end.shell
+
+[ str =~ str ]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^ meta.compound.conditional.shell
+# ^^^ meta.string.glob.shell string.unquoted.shell
+#     ^^ invalid.illegal.operator.shell
+#        ^^^ meta.string.glob.shell string.unquoted.shell
+#            ^ punctuation.section.compound.end.shell
+
+
+## Integer Comparisons
+## -------------------
+
+[ $arg -lt 2 ]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^ meta.compound.conditional.shell
+# ^^^^ variable.other.readwrite.shell
+#      ^^^ keyword.operator.comparison.shell
+#          ^ meta.number.integer.decimal.shell constant.numeric.value.shell
+#            ^ punctuation.section.compound.end.shell
+
+
+###############################################################################
 # 4.2 Bash Builtin Commands (test)                                            #
 # https://www.gnu.org/software/bash/manual/bash.html#index-test               #
 # test expr                                                                   #
@@ -13328,192 +13541,6 @@ sudo --reset-timestamp -n -f -- rm -rf
 : $UID
 # ^^^^ variable.language.builtin.shell
 # ^ punctuation.definition.variable.shell
-
-
-###############################################################################
-# 6.4 Bash Conditional Expressions                                            #
-# https://www.gnu.org/software/bash/manual/bash.html#Bash-Conditional-Expressions
-###############################################################################
-
-![ ]
-# <- punctuation.definition.history.shell
-#^ punctuation.section.compound.begin.shell
-#  ^ punctuation.section.compound.end.shell
-
-! [ ]
-# <- keyword.operator.logical.shell
-# ^ punctuation.section.compound.begin.shell
-#   ^ punctuation.section.compound.end.shell
-
-[  ]
-# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
-#^^^ meta.compound.conditional.shell
-#  ^ punctuation.section.compound.end.shell
-
-[
-]
-# <- - meta.conditional - support.function
-
-[ \
-]
-# <- meta.compound.conditional.shell punctuation.section.compound.end.shell
-
-[ # comment ]
-# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
-#^ - meta.conditional - comment
-# ^^^^^^^^^^^^ comment.line.number-sign.shell - meta.conditional
-
-[ ; cmd ]
-# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
-#^^^^^^^^^ - meta.conditional
-# ^ punctuation.terminator.statement.shell
-#   ^^^ variable.function.shell
-#       ^ string.unquoted.shell
-
-[ && cmd ]
-# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
-#^^^^^^^^^^ - meta.conditional
-# ^^ keyword.operator.logical.shell
-#    ^^^ variable.function.shell
-#        ^ string.unquoted.shell
-
-[ || cmd ]
-# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
-#^^^^^^^^^^ - meta.conditional
-# ^^ keyword.operator.logical.shell
-#    ^^^ variable.function.shell
-#        ^ string.unquoted.shell
-
-[ >>cmd ]
-# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
-#^^^^^^^^ meta.compound.conditional.shell
-# ^^^^^ meta.redirection.shell
-# ^^ keyword.operator.assignment.redirection.shell
-#   ^^^ string.unquoted.shell
-#       ^ punctuation.section.compound.end.shell
-
-# heredocs causing issues, but no way around it
-[ <<cmd ]  # <- ] should close the conditional
-# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
-#^^^^^^^^ meta.compound.conditional.shell
-# ^^ keyword.operator.assignment.redirection.shell
-#   ^^^ meta.tag.heredoc.begin.shell entity.name.tag.heredoc.shell
-cmd
-# <- meta.tag.heredoc.end.shell entity.name.tag.heredoc.shell
-
-[ -a file ]
-# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
-#^^^^^^^^^^ meta.compound.conditional.shell
-
-[ -v varname ]
-# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
-#^^^^^^^^^^^^^ meta.compound.conditional.shell
-
-[ file1 -ef file2 ]
-# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
-#^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
-# ^^^^^ meta.string.glob.shell string.unquoted.shell
-#       ^^^ keyword.operator.comparison.shell
-#           ^^^^^ meta.string.glob.shell string.unquoted.shell
-#                 ^ punctuation.section.compound.end.shell
-
-[ file1 -nt file2 ]
-# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
-#^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
-# ^^^^^ meta.string.glob.shell string.unquoted.shell
-#       ^^^ keyword.operator.comparison.shell
-#           ^^^^^ meta.string.glob.shell string.unquoted.shell
-#                 ^ punctuation.section.compound.end.shell
-
-[ file1 -ot file2 ]
-# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
-#^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
-# ^^^^^ meta.string.glob.shell string.unquoted.shell
-#       ^^^ keyword.operator.comparison.shell
-#           ^^^^^ meta.string.glob.shell string.unquoted.shell
-#                 ^ punctuation.section.compound.end.shell
-
-[ ! str != str ]
-# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
-#^^^^^^^^^^^^^^^ meta.compound.conditional.shell
-# ^ keyword.operator.logical.shell
-#   ^^^ meta.string.glob.shell string.unquoted.shell
-#       ^^ keyword.operator.comparison.shell
-#          ^^^ meta.string.glob.shell string.unquoted.shell
-#              ^ punctuation.section.compound.end.shell
-
-[ str != str ]
-# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
-#^^^^^^^^^^^^^ meta.compound.conditional.shell
-# ^^^ meta.string.glob.shell string.unquoted.shell
-#     ^^ keyword.operator.comparison.shell
-#        ^^^ meta.string.glob.shell string.unquoted.shell
-#            ^ punctuation.section.compound.end.shell
-
-[ str == str ]
-# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
-#^^^^^^^^^^^^^ meta.compound.conditional.shell
-# ^^^ meta.string.glob.shell string.unquoted.shell
-#     ^^ keyword.operator.comparison.shell
-#        ^^^ meta.string.glob.shell string.unquoted.shell
-#            ^ punctuation.section.compound.end.shell
-
-[ str =~ str ]
-# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
-#^^^^^^^^^^^^^ meta.compound.conditional.shell
-# ^^^ meta.string.glob.shell string.unquoted.shell
-#     ^^ invalid.illegal.operator.shell
-#        ^^^ meta.string.glob.shell string.unquoted.shell
-#            ^ punctuation.section.compound.end.shell
-
-[ str >= str ]
-# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
-#^^^^^^^^^^^^^ meta.compound.conditional.shell
-# ^^^ meta.string.glob.shell string.unquoted.shell
-#     ^^ invalid.illegal.operator.shell
-#        ^^^ meta.string.glob.shell string.unquoted.shell
-#            ^ punctuation.section.compound.end.shell
-
-[ str <= str ]
-# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
-#^^^^^^^^^^^^^ meta.compound.conditional.shell
-# ^^^ meta.string.glob.shell string.unquoted.shell
-#     ^^ invalid.illegal.operator.shell
-#        ^^^ meta.string.glob.shell string.unquoted.shell
-#            ^ punctuation.section.compound.end.shell
-
-[ str = str ]
-# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
-#^^^^^^^^^^^^ meta.compound.conditional.shell
-# ^^^ meta.string.glob.shell string.unquoted.shell
-#     ^ keyword.operator.comparison.shell
-#       ^^^ meta.string.glob.shell string.unquoted.shell
-#           ^ punctuation.section.compound.end.shell
-
-
-[ str < str ]
-# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
-#^^^^^^^^^^^^ meta.compound.conditional.shell
-# ^^^ meta.string.glob.shell string.unquoted.shell
-#     ^ keyword.operator.comparison.shell
-#       ^^^ meta.string.glob.shell string.unquoted.shell
-#           ^ punctuation.section.compound.end.shell
-
-[ str > str ]
-# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
-#^^^^^^^^^^^^ meta.compound.conditional.shell
-# ^^^ meta.string.glob.shell string.unquoted.shell
-#     ^ keyword.operator.comparison.shell
-#       ^^^ meta.string.glob.shell string.unquoted.shell
-#           ^ punctuation.section.compound.end.shell
-
-[ $arg -lt 2 ]
-# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
-#^^^^^^^^^^^^^ meta.compound.conditional.shell
-# ^^^^ variable.other.readwrite.shell
-#      ^^^ keyword.operator.comparison.shell
-#          ^ meta.number.integer.decimal.shell constant.numeric.value.shell
-#            ^ punctuation.section.compound.end.shell
 
 ###############################################################################
 # Bash Numeric Constants                                                      #

--- a/ShellScript/Bash/tests/syntax_test_scope.bash
+++ b/ShellScript/Bash/tests/syntax_test_scope.bash
@@ -1461,147 +1461,6 @@ in foo bar baz;
 
 ###############################################################################
 # 3.2.5 Compound Commands                                                     #
-# 3.2.5.1 Looping Constructs (select loops)                                   #
-# https://www.gnu.org/software/bash/manual/bash.html#index-select             #
-###############################################################################
-
-select;
-#^^^^^ keyword.control.loop.select.shell
-#     ^ - keyword.control.loop
-select&
-#^^^^^ keyword.control.loop.select.shell
-#     ^ - keyword.control.loop
-select|
-#^^^^^ keyword.control.loop.select.shell
-#     ^ - keyword.control.loop
-select>/dev/null
-#^^^^^ keyword.control.loop.select.shell
-#     ^ - keyword.control.loop
-select -
-#^^^^^ keyword.control.loop.select.shell
-#     ^ - keyword.control.loop
-select()
-#^^^^^ keyword.control.loop.select.shell
-#     ^ - keyword.control.loop
-select[]
-#^^^^^^^ - keyword.control
-select{}
-#^^^^^^^ - keyword.control
-select-
-#^^^^^^ - keyword.control
--select
-#^^^^^^ - keyword.control
-select+
-#^^^^^^ - keyword.control
-select$
-#^^^^^^ - keyword.control
-select$var
-#^^^^^^^^^ - keyword.control
-select=
-#^^^^^^ - keyword.control
-select-=
-#^^^^^^^ - keyword.control
-select+=
-#^^^^^^^ - keyword.control
-
-select select select select
-# <- meta.statement.loop.select.shell keyword.control.loop.select.shell
-#^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.loop.select.shell
-#                          ^ - meta.statement.loop
-#^^^^^ keyword.control.loop.select.shell
-#      ^^^^^^ variable.other.readwrite.shell
-#             ^^^^^^ keyword.control.loop.select.shell
-#                    ^^^^^^ variable.other.readwrite.shell
-
-select in in in select do done; do echo $in; done;
-# <- meta.statement.loop.select.shell keyword.control.loop.select.shell
-#^^^^^^^^^^^ meta.statement.loop.select.shell - meta.sequence
-#           ^^^^^^^^^^^^^^^^^^ meta.statement.loop.select.shell meta.sequence.list.shell
-#                             ^^ - meta.statement.loop - meta.sequence
-#^^^^^ keyword.control.loop.select.shell
-#      ^^ variable.other.readwrite.shell
-#         ^^ keyword.control.loop.in.shell
-#           ^ - meta.string - string
-#            ^^ meta.string.glob.shell string.unquoted.shell
-#              ^ - meta.string - string
-#               ^^^^^^ meta.string.glob.shell string.unquoted.shell
-#                     ^ - meta.string - string
-#                      ^^ meta.string.glob.shell string.unquoted.shell
-#                        ^ - meta.string - string
-#                         ^^^^ meta.string.glob.shell string.unquoted.shell
-#                             ^ punctuation.terminator.statement.shell
-#                               ^^ keyword.control.loop.do.shell
-#                                  ^^^^ support.function.shell
-#                                       ^^^ meta.interpolation.parameter.shell variable.other.readwrite.shell
-#                                          ^ punctuation.terminator.statement.shell
-#                                            ^^^^ keyword.control.loop.end.shell
-#                                                ^ punctuation.terminator.statement.shell
-
-select \
-  fname in ~/**/*.~\$tmp; do rm -f $fname; done;
-# <- meta.statement.loop.select.shell
-#^^^^^^^^^ meta.statement.loop.select.shell - meta.sequence
-#         ^ meta.statement.loop.select.shell meta.sequence.list.shell - meta.string
-#          ^^^^^^^^^^^^^ meta.statement.loop.select.shell meta.sequence.list.shell meta.string.glob.shell
-#                       ^^ - meta.statement.loop - meta.sequence
-# ^^^^^ variable.other.readwrite.shell
-#       ^^ keyword.control.loop.in.shell
-#          ^ meta.interpolation.tilde.shell variable.language.tilde.shell - string
-#           ^^^^^^^^^^^^ string.unquoted.shell
-#            ^^ constant.other.wildcard.asterisk.shell
-#               ^ constant.other.wildcard.asterisk.shell
-#                  ^^ constant.character.escape.shell
-
-select \
-  fname \
-  in ~/**/*.~\$tmp; do rm -f $fname; done;
-# <- meta.statement.loop.select.shell
-#^^^ meta.statement.loop.select.shell - meta.sequence
-#   ^ meta.statement.loop.select.shell meta.sequence.list.shell - meta.string
-#    ^^^^^^^^^^^^^ meta.statement.loop.select.shell meta.sequence.list.shell meta.string.glob.shell
-#                 ^^ - meta.statement.loop - meta.sequence
-# ^^ keyword.control.loop.in.shell
-#    ^ meta.interpolation.tilde.shell variable.language.tilde.shell - string
-#     ^^^^^^^^^^^^ string.unquoted.shell
-#      ^^ constant.other.wildcard.asterisk.shell
-#         ^ constant.other.wildcard.asterisk.shell
-#            ^^ constant.character.escape.shell
-
-select \
-  fname \
-  in \
-  ~/**/*.~\$tmp; do rm -f $fname; done;
-# <- meta.statement.loop.select.shell
-#^ meta.statement.loop.select.shell meta.sequence.list.shell - meta.string
-# ^^^^^^^^^^^^^ meta.statement.loop.select.shell meta.sequence.list.shell meta.string.glob.shell
-#              ^^ - meta.statement.loop - meta.sequence
-# ^ meta.interpolation.tilde.shell variable.language.tilde.shell - string
-#  ^^^^^^^^^^^^ string.unquoted.shell
-#   ^^ constant.other.wildcard.asterisk.shell
-#      ^ constant.other.wildcard.asterisk.shell
-#         ^^ constant.character.escape.shell
-
-select fname in *;
-# <- keyword.control.loop.select.shell
-#^^^^^ keyword.control.loop.select.shell
-#            ^^ keyword.control.loop.in.shell
-#               ^ meta.string.glob.shell string.unquoted.shell
-#                ^ punctuation.terminator.statement.shell
-do
-# <- keyword.control.loop.do.shell
-  echo you picked $fname \($REPLY\)
-# ^^^^ meta.function-call.identifier.shell support.function.shell
-#     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell
-#                                  ^ - meta.function-call
-  break;
-# ^^^^^ keyword.control.flow.break.shell
-#      ^ punctuation.terminator.statement.shell
-done
-# <- keyword.control.loop.end.shell
-
-
-###############################################################################
-# 3.2.5 Compound Commands                                                     #
 # 3.2.5.1 Looping Constructs (until loops)                                    #
 # https://www.gnu.org/software/bash/manual/bash.html#index-until              #
 ###############################################################################
@@ -2623,6 +2482,147 @@ case $1 in
 *)
   _G_unquoted_arg=$1 ;;
 esac
+
+
+###############################################################################
+# 3.2.5 Compound Commands                                                     #
+# 3.2.5.2 Conditional Constructs (select)                                     #
+# https://www.gnu.org/software/bash/manual/bash.html#index-select             #
+###############################################################################
+
+select;
+#^^^^^ keyword.control.loop.select.shell
+#     ^ - keyword.control.loop
+select&
+#^^^^^ keyword.control.loop.select.shell
+#     ^ - keyword.control.loop
+select|
+#^^^^^ keyword.control.loop.select.shell
+#     ^ - keyword.control.loop
+select>/dev/null
+#^^^^^ keyword.control.loop.select.shell
+#     ^ - keyword.control.loop
+select -
+#^^^^^ keyword.control.loop.select.shell
+#     ^ - keyword.control.loop
+select()
+#^^^^^ keyword.control.loop.select.shell
+#     ^ - keyword.control.loop
+select[]
+#^^^^^^^ - keyword.control
+select{}
+#^^^^^^^ - keyword.control
+select-
+#^^^^^^ - keyword.control
+-select
+#^^^^^^ - keyword.control
+select+
+#^^^^^^ - keyword.control
+select$
+#^^^^^^ - keyword.control
+select$var
+#^^^^^^^^^ - keyword.control
+select=
+#^^^^^^ - keyword.control
+select-=
+#^^^^^^^ - keyword.control
+select+=
+#^^^^^^^ - keyword.control
+
+select select select select
+# <- meta.statement.loop.select.shell keyword.control.loop.select.shell
+#^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.loop.select.shell
+#                          ^ - meta.statement.loop
+#^^^^^ keyword.control.loop.select.shell
+#      ^^^^^^ variable.other.readwrite.shell
+#             ^^^^^^ keyword.control.loop.select.shell
+#                    ^^^^^^ variable.other.readwrite.shell
+
+select in in in select do done; do echo $in; done;
+# <- meta.statement.loop.select.shell keyword.control.loop.select.shell
+#^^^^^^^^^^^ meta.statement.loop.select.shell - meta.sequence
+#           ^^^^^^^^^^^^^^^^^^ meta.statement.loop.select.shell meta.sequence.list.shell
+#                             ^^ - meta.statement.loop - meta.sequence
+#^^^^^ keyword.control.loop.select.shell
+#      ^^ variable.other.readwrite.shell
+#         ^^ keyword.control.loop.in.shell
+#           ^ - meta.string - string
+#            ^^ meta.string.glob.shell string.unquoted.shell
+#              ^ - meta.string - string
+#               ^^^^^^ meta.string.glob.shell string.unquoted.shell
+#                     ^ - meta.string - string
+#                      ^^ meta.string.glob.shell string.unquoted.shell
+#                        ^ - meta.string - string
+#                         ^^^^ meta.string.glob.shell string.unquoted.shell
+#                             ^ punctuation.terminator.statement.shell
+#                               ^^ keyword.control.loop.do.shell
+#                                  ^^^^ support.function.shell
+#                                       ^^^ meta.interpolation.parameter.shell variable.other.readwrite.shell
+#                                          ^ punctuation.terminator.statement.shell
+#                                            ^^^^ keyword.control.loop.end.shell
+#                                                ^ punctuation.terminator.statement.shell
+
+select \
+  fname in ~/**/*.~\$tmp; do rm -f $fname; done;
+# <- meta.statement.loop.select.shell
+#^^^^^^^^^ meta.statement.loop.select.shell - meta.sequence
+#         ^ meta.statement.loop.select.shell meta.sequence.list.shell - meta.string
+#          ^^^^^^^^^^^^^ meta.statement.loop.select.shell meta.sequence.list.shell meta.string.glob.shell
+#                       ^^ - meta.statement.loop - meta.sequence
+# ^^^^^ variable.other.readwrite.shell
+#       ^^ keyword.control.loop.in.shell
+#          ^ meta.interpolation.tilde.shell variable.language.tilde.shell - string
+#           ^^^^^^^^^^^^ string.unquoted.shell
+#            ^^ constant.other.wildcard.asterisk.shell
+#               ^ constant.other.wildcard.asterisk.shell
+#                  ^^ constant.character.escape.shell
+
+select \
+  fname \
+  in ~/**/*.~\$tmp; do rm -f $fname; done;
+# <- meta.statement.loop.select.shell
+#^^^ meta.statement.loop.select.shell - meta.sequence
+#   ^ meta.statement.loop.select.shell meta.sequence.list.shell - meta.string
+#    ^^^^^^^^^^^^^ meta.statement.loop.select.shell meta.sequence.list.shell meta.string.glob.shell
+#                 ^^ - meta.statement.loop - meta.sequence
+# ^^ keyword.control.loop.in.shell
+#    ^ meta.interpolation.tilde.shell variable.language.tilde.shell - string
+#     ^^^^^^^^^^^^ string.unquoted.shell
+#      ^^ constant.other.wildcard.asterisk.shell
+#         ^ constant.other.wildcard.asterisk.shell
+#            ^^ constant.character.escape.shell
+
+select \
+  fname \
+  in \
+  ~/**/*.~\$tmp; do rm -f $fname; done;
+# <- meta.statement.loop.select.shell
+#^ meta.statement.loop.select.shell meta.sequence.list.shell - meta.string
+# ^^^^^^^^^^^^^ meta.statement.loop.select.shell meta.sequence.list.shell meta.string.glob.shell
+#              ^^ - meta.statement.loop - meta.sequence
+# ^ meta.interpolation.tilde.shell variable.language.tilde.shell - string
+#  ^^^^^^^^^^^^ string.unquoted.shell
+#   ^^ constant.other.wildcard.asterisk.shell
+#      ^ constant.other.wildcard.asterisk.shell
+#         ^^ constant.character.escape.shell
+
+select fname in *;
+# <- keyword.control.loop.select.shell
+#^^^^^ keyword.control.loop.select.shell
+#            ^^ keyword.control.loop.in.shell
+#               ^ meta.string.glob.shell string.unquoted.shell
+#                ^ punctuation.terminator.statement.shell
+do
+# <- keyword.control.loop.do.shell
+  echo you picked $fname \($REPLY\)
+# ^^^^ meta.function-call.identifier.shell support.function.shell
+#     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell
+#                                  ^ - meta.function-call
+  break;
+# ^^^^^ keyword.control.flow.break.shell
+#      ^ punctuation.terminator.statement.shell
+done
+# <- keyword.control.loop.end.shell
 
 
 ###############################################################################

--- a/ShellScript/Bash/tests/syntax_test_scope.bash
+++ b/ShellScript/Bash/tests/syntax_test_scope.bash
@@ -2652,6 +2652,39 @@ done
 # ^^ punctuation.section.compound.begin.shell
 #    ^^ punctuation.section.compound.end.shell
 
+[[ () ]]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^ meta.compound.conditional.shell
+#^ punctuation.section.compound.begin.shell
+#  ^^ meta.group.shell
+#  ^ punctuation.section.group.begin.shell
+#   ^ punctuation.section.group.end.shell
+#     ^^ punctuation.section.compound.end.shell
+
+[[ ((  ) ) ]]
+#^^ meta.compound.conditional.shell - meta.group
+#  ^ meta.compound.conditional.shell meta.group.shell - meta.group meta.group
+#   ^^^^ meta.compound.conditional.shell meta.group.shell meta.group.shell
+#       ^^ meta.compound.conditional.shell meta.group.shell - meta.group meta.group
+#         ^^^ meta.compound.conditional.shell - meta.group
+#^ punctuation.section.compound.begin.shell
+#  ^^ punctuation.section.group.begin.shell
+#      ^ punctuation.section.group.end.shell
+#        ^ punctuation.section.group.end.shell
+#          ^^ punctuation.section.compound.end.shell
+
+[[ ( (  )) ]]
+#^^ meta.compound.conditional.shell - meta.group
+#  ^^ meta.compound.conditional.shell meta.group.shell - meta.group meta.group
+#    ^^^^ meta.compound.conditional.shell meta.group.shell meta.group.shell
+#        ^ meta.compound.conditional.shell meta.group.shell - meta.group meta.group
+#         ^^^ meta.compound.conditional.shell - meta.group
+#^ punctuation.section.compound.begin.shell
+#  ^ punctuation.section.group.begin.shell
+#    ^ punctuation.section.group.begin.shell
+#       ^^ punctuation.section.group.end.shell
+#          ^^ punctuation.section.compound.end.shell
+
 
 ## Logical Operators
 ## -----------------
@@ -2679,30 +2712,6 @@ done
 #       ^^ keyword.operator.logical.shell
 #               ^^ keyword.operator.logical.shell
 #                       ^^ punctuation.section.compound.end.shell
-
-[[ ((  ) ) ]]
-#^^ meta.compound.conditional.shell - meta.group
-#  ^ meta.compound.conditional.shell meta.group.shell - meta.group meta.group
-#   ^^^^ meta.compound.conditional.shell meta.group.shell meta.group.shell
-#       ^^ meta.compound.conditional.shell meta.group.shell - meta.group meta.group
-#         ^^^ meta.compound.conditional.shell - meta.group
-#^ punctuation.section.compound.begin.shell
-#  ^^ punctuation.section.group.begin.shell
-#      ^ punctuation.section.group.end.shell
-#        ^ punctuation.section.group.end.shell
-#          ^^ punctuation.section.compound.end.shell
-
-[[ ( (  )) ]]
-#^^ meta.compound.conditional.shell - meta.group
-#  ^^ meta.compound.conditional.shell meta.group.shell - meta.group meta.group
-#    ^^^^ meta.compound.conditional.shell meta.group.shell meta.group.shell
-#        ^ meta.compound.conditional.shell meta.group.shell - meta.group meta.group
-#         ^^^ meta.compound.conditional.shell - meta.group
-#^ punctuation.section.compound.begin.shell
-#  ^ punctuation.section.group.begin.shell
-#    ^ punctuation.section.group.begin.shell
-#       ^^ punctuation.section.group.end.shell
-#          ^^ punctuation.section.compound.end.shell
 
 [[ expr && ( expr || expr ) ]]
 # <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
@@ -3478,7 +3487,7 @@ time () {  }   # reserved words cannot be overwritten by local function definiti
 #      ^ meta.function-call.shell meta.function.anonymous.shell
 #       ^^^^ meta.function-call.shell meta.function.anonymous.body.shell meta.block.shell
 
-alias () {  }  # built-in functions/commands can be overwritten
+alias () {  }  # various built-in functions/commands can be overwritten
 #^^^^^ meta.function.identifier.shell
 #     ^^ meta.function.parameters.shell
 #       ^ meta.function.shell
@@ -3488,6 +3497,25 @@ alias () {  }  # built-in functions/commands can be overwritten
 #      ^ punctuation.section.parameters.end.shell
 #        ^ punctuation.section.block.begin.shell
 #           ^ punctuation.section.block.end.shell
+
+[ () ]
+# <- meta.function.identifier.shell entity.name.function.shell
+#^ meta.function.identifier.shell
+# ^^ meta.function.parameters.shell
+#   ^ meta.function.shell
+#    ^ variable.function.shell
+
+test () {  }  # various built-in functions/commands can be overwritten
+# <- meta.function.identifier.shell entity.name.function.shell
+#^^^^ meta.function.identifier.shell
+#    ^^ meta.function.parameters.shell
+#      ^ meta.function.shell
+#       ^^^^ meta.function.body.shell meta.block.shell
+#^^^ entity.name.function.shell
+#    ^ punctuation.section.parameters.begin.shell
+#     ^ punctuation.section.parameters.end.shell
+#       ^ punctuation.section.block.begin.shell
+#          ^ punctuation.section.block.end.shell
 
 function foo
 #^^^^^^^^^^^^ source.shell - meta.function meta.function
@@ -12622,6 +12650,10 @@ typeset -f _init_completion > /dev/null && complete -F _upto upto
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.shell - meta.conditional
 
 # <- - meta.compound
+
+[ () ]
+# <- - meta.conditional - support.function
+#^^^^^ - meta.conditional
 
 [ ; cmd ]   # terminated by `;`
 # <- meta.compound.conditional.shell punctuation.section.compound.begin.shell

--- a/ShellScript/Bash/tests/syntax_test_scope.bash
+++ b/ShellScript/Bash/tests/syntax_test_scope.bash
@@ -5007,6 +5007,14 @@ test $me -eq ~/~foo
 #           ^ meta.string.regexp.shell meta.interpolation.tilde.shell variable.language.tilde.shell
 #            ^^^^^ meta.string.regexp.shell string.unquoted.shell - meta.interpolation.tilde
 
+[[ $me =~ ~/~foo ]]
+#         ^ meta.string.regexp.shell meta.interpolation.tilde.shell variable.language.tilde.shell
+#          ^^^^^ meta.string.regexp.shell string.unquoted.shell - meta.interpolation.tilde
+
+[[ ( $me =~ ~/~foo ) ]]
+#           ^ meta.string.regexp.shell meta.interpolation.tilde.shell variable.language.tilde.shell
+#            ^^^^^ meta.string.regexp.shell string.unquoted.shell - meta.interpolation.tilde
+
 ~/.bin/~app
 # <- meta.function-call.identifier.shell meta.interpolation.tilde.shell variable.language.tilde.shell - variable.function
 #^^^^^^^^^^ meta.function-call.identifier.shell variable.function.shell

--- a/ShellScript/Bash/tests/syntax_test_scope.bash
+++ b/ShellScript/Bash/tests/syntax_test_scope.bash
@@ -8903,14 +8903,16 @@ stash) || true)
 
 [[ abc == ^abc|bca$ ]]
 #^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
-#         ^^^^^^^^^ meta.string.regexp.shell - keyword
-#             ^ invalid.illegal.unexpected-token.shell
+#         ^^^^ meta.string.regexp.shell string.unquoted.shell - keyword
+#             ^ invalid.illegal.unexpected-token.shell - meta.string
+#              ^^^^ meta.string.glob.shell string.unquoted.shell
 #                   ^^ punctuation.section.compound.end.shell
 
 [[ abc == ^abc&bca$ ]]
 #^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
-#         ^^^^^^^^^ meta.string.regexp.shell - keyword
-#             ^ invalid.illegal.unexpected-token.shell
+#         ^^^^ meta.string.regexp.shell string.unquoted.shell - keyword
+#             ^ invalid.illegal.unexpected-token.shell - meta.string
+#              ^^^^ meta.string.glob.shell string.unquoted.shell
 #                   ^^ punctuation.section.compound.end.shell
 
 [[ a\$b*c == a'$b*'? ]]
@@ -9355,8 +9357,9 @@ stash) || true)
 [[ "${foo}" =~ bar&baz ]]
 #^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
 #^^^^^^^^^^^^^^ - meta.string.regexp.shell
-#              ^^^^^^^ meta.string.regexp.shell - meta.interpolation
-#                     ^^^ - meta.string.regexp.shell
+#              ^^^ meta.string.regexp.shell - meta.interpolation
+#                 ^ - meta.string
+#                  ^^^ meta.string.glob.shell - meta.interpolation
 #           ^^ keyword.operator.comparison.shell
 #                 ^ invalid.illegal.unexpected-token.shell
 
@@ -9512,7 +9515,7 @@ stash) || true)
 
 [[ $foo =~ ) ]]
 #^^^^^^^^^^^^^^ meta.compound.conditional.shell
-#          ^ meta.string.regexp.shell invalid.illegal.stray.regexp.shell
+#          ^ invalid.illegal.stray.shell
 
 [[ $foo =~ ( ) ]]
 #^^^^^^^^^^ meta.compound.conditional.shell - meta.string.regexp - meta.group

--- a/ShellScript/Bash/tests/syntax_test_scope.bash
+++ b/ShellScript/Bash/tests/syntax_test_scope.bash
@@ -2678,6 +2678,30 @@ done
 #               ^^ keyword.operator.logical.shell
 #                       ^^ punctuation.section.compound.end.shell
 
+[[ ((  ) ) ]]
+#^^ meta.compound.conditional.shell - meta.group
+#  ^ meta.compound.conditional.shell meta.group.shell - meta.group meta.group
+#   ^^^^ meta.compound.conditional.shell meta.group.shell meta.group.shell
+#       ^^ meta.compound.conditional.shell meta.group.shell - meta.group meta.group
+#         ^^^ meta.compound.conditional.shell - meta.group
+#^ punctuation.section.compound.begin.shell
+#  ^^ punctuation.section.group.begin.shell
+#      ^ punctuation.section.group.end.shell
+#        ^ punctuation.section.group.end.shell
+#          ^^ punctuation.section.compound.end.shell
+
+[[ ( (  )) ]]
+#^^ meta.compound.conditional.shell - meta.group
+#  ^^ meta.compound.conditional.shell meta.group.shell - meta.group meta.group
+#    ^^^^ meta.compound.conditional.shell meta.group.shell meta.group.shell
+#        ^ meta.compound.conditional.shell meta.group.shell - meta.group meta.group
+#         ^^^ meta.compound.conditional.shell - meta.group
+#^ punctuation.section.compound.begin.shell
+#  ^ punctuation.section.group.begin.shell
+#    ^ punctuation.section.group.begin.shell
+#       ^^ punctuation.section.group.end.shell
+#          ^^ punctuation.section.compound.end.shell
+
 [[ expr && ( expr || expr ) ]]
 # <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
@@ -2688,6 +2712,26 @@ done
 #                 ^^ keyword.operator.logical.shell
 #                         ^ punctuation.section.group.end.shell
 #                           ^^ punctuation.section.compound.end.shell
+
+[[ (expr && ( expr || !( expr && expr ))) ]]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^ meta.compound.conditional.shell - meta.group
+#  ^^^^^^^^^ meta.compound.conditional.shell meta.group.shell - meta.group meta.group
+#           ^^^^^^^^^^^ meta.compound.conditional.shell meta.group.shell meta.group.shell - meta.group meta.group meta.group
+#                      ^^^^^^^^^^^^^^^^ meta.compound.conditional.shell meta.group.shell meta.group.shell meta.group.shell
+#                                      ^ meta.compound.conditional.shell meta.group.shell meta.group.shell - meta.group meta.group meta.group
+#                                       ^ meta.compound.conditional.shell meta.group.shell - meta.group meta.group
+#                                        ^^^ meta.compound.conditional.shell - meta.group
+#                                           ^ - meta.compound
+#^ punctuation.section.compound.begin.shell
+#        ^^ keyword.operator.logical.shell
+#           ^ punctuation.section.group.begin.shell
+#                  ^^ keyword.operator.logical.shell
+#                     ^ keyword.operator.logical.shell
+#                      ^ punctuation.section.group.begin.shell
+#                             ^^ keyword.operator.logical.shell
+#                                     ^^^ punctuation.section.group.end.shell
+#                                         ^^ punctuation.section.compound.end.shell
 
 [[ expr -a expr -o expr ]]    # -a and -o arguments have no meaning
 #^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
@@ -2858,6 +2902,36 @@ done
 #                                             ^^ keyword.operator.comparison.shell
 #                                                ^^^ meta.string.regexp.shell
 #                                                    ^^ punctuation.section.compound.end.shell
+
+[[ ! ((( $foo == 'bar' ) || $foo == "baz" ) && ($bar == baz)) ]]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^ meta.compound.conditional.shell - meta.group
+#    ^ meta.compound.conditional.shell meta.group.shell - meta.group meta.group
+#     ^ meta.compound.conditional.shell meta.group.shell meta.group.shell - meta.group meta.group meta.group
+#      ^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell meta.group.shell meta.group.shell meta.group.shell
+#                       ^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell meta.group.shell meta.group.shell - meta.group meta.group meta.group
+#                                          ^^^^ meta.compound.conditional.shell meta.group.shell - meta.group meta.group
+#                                              ^^^^^^^^^^^^^ meta.compound.conditional.shell meta.group.shell meta.group.shell
+#                                                           ^ meta.compound.conditional.shell meta.group.shell - meta.group meta.group
+#                                                            ^^^ meta.compound.conditional.shell - meta.group
+#                                                               ^ - meta.compound
+#    ^^^ punctuation.section.group.begin.shell
+#        ^^^^ variable.other.readwrite.shell
+#             ^^ keyword.operator.comparison.shell
+#                ^^^^^ meta.string.regexp.shell
+#                      ^ punctuation.section.group.end.shell
+#                        ^^ keyword.operator.logical.shell
+#                           ^^^^ variable.other.readwrite.shell
+#                                ^^ keyword.operator.comparison.shell
+#                                   ^^^^^ meta.string.regexp.shell
+#                                         ^ punctuation.section.group.end.shell
+#                                           ^^ keyword.operator.logical.shell
+#                                              ^ punctuation.section.group.begin.shell
+#                                               ^^^^ variable.other.readwrite.shell
+#                                                    ^^ keyword.operator.comparison.shell
+#                                                       ^^^ meta.string.regexp.shell
+#                                                          ^^ punctuation.section.group.end.shell
+#                                                             ^^ punctuation.section.compound.end.shell
 
 
 ###############################################################################
@@ -8881,23 +8955,30 @@ stash) || true)
 #  ^^^^^^^^^^ meta.compound.conditional.shell meta.group.shell - meta.string.regexp
 #            ^ meta.compound.conditional.shell meta.group.shell meta.string.regexp.shell
 #             ^ meta.compound.conditional.shell meta.group.shell - meta.string.regexp invalid.illegal.unexpected-token.shell
+   )
+#^^^ meta.compound.conditional.shell meta.group.shell
+#  ^ punctuation.section.group.end.shell
+#   ^ meta.compound.conditional.shell - meta.group
+]]
+# <- meta.compound.conditional.shell punctuation.section.compound.end.shell
+#^ meta.compound.conditional.shell punctuation.section.compound.end.shell
+# ^ - meta.compound
 
 [[ ( $foo == *\
-   [^0-9]? ) ]]   # note: line continuation is only valid without leading whitespace, but we ignore it
+[^0-9]? ) ]]   # note: line continuation is only valid without leading whitespace, but we ignore it
 # <- meta.compound.conditional.shell meta.group.shell meta.string.regexp.shell
-#^^ meta.compound.conditional.shell meta.group.shell meta.string.regexp.shell - meta.set
-#  ^^^^^^ meta.compound.conditional.shell meta.group.shell meta.string.regexp.shell meta.set.regexp.shell
-#        ^ meta.compound.conditional.shell meta.group.shell meta.string.regexp.shell - meta.set
-#         ^^ meta.compound.conditional.shell meta.group.shell - meta.string.regexp
-#           ^^^ meta.compound.conditional.shell - meta.group
-#            ^^ punctuation.section.compound.end.shell
+#^^^^^ meta.compound.conditional.shell meta.group.shell meta.string.regexp.shell meta.set.regexp.shell
+#     ^ meta.compound.conditional.shell meta.group.shell meta.string.regexp.shell - meta.set
+#      ^^ meta.compound.conditional.shell meta.group.shell - meta.string.regexp
+#        ^^^ meta.compound.conditional.shell - meta.group
+#         ^^ punctuation.section.compound.end.shell
 
-[[ ( $foo == ? ]]
+[[ ( $foo == ? ]] # incomplete group
 #^^ meta.compound.conditional.shell - meta.group
 #  ^^^^^^^^^^ meta.compound.conditional.shell meta.group.shell - meta.string.regexp
 #            ^ meta.compound.conditional.shell meta.group.shell meta.string.regexp.shell
-#             ^^^ meta.compound.conditional.shell meta.group.shell - meta.string.regexp
-#              ^^ invalid.illegal.unexpected-token.shell
+#             ^^^ meta.compound.conditional.shell - meta.group - meta.string.regexp
+#              ^^ punctuation.section.compound.end.shell
 
 [[ ( $foo == ? ]]
    [^0-9]+ ) ]]
@@ -9389,21 +9470,29 @@ stash) || true)
 #  ^^^^^^^^^^ meta.compound.conditional.shell meta.group.shell - meta.string.regexp
 #            ^ meta.compound.conditional.shell meta.group.shell meta.string.regexp.shell
 #             ^ meta.compound.conditional.shell meta.group.shell - meta.string.regexp invalid.illegal.unexpected-token.shell
+   )
+#^^^ meta.compound.conditional.shell meta.group.shell
+#  ^ punctuation.section.group.end.shell
+#   ^ meta.compound.conditional.shell - meta.group
+]]
+# <- meta.compound.conditional.shell punctuation.section.compound.end.shell
+#^ meta.compound.conditional.shell punctuation.section.compound.end.shell
+# ^ - meta.compound
 
 [[ ( $foo =~ ^\
-   [^0-9]+ ) ]]
+[^0-9]+ ) ]]
 # <- meta.compound.conditional.shell meta.group.shell meta.string.regexp.shell
-#^^^^^^^^^ meta.compound.conditional.shell meta.group.shell meta.string.regexp.shell
-#         ^^ meta.compound.conditional.shell meta.group.shell - meta.string.regexp
-#           ^^^ meta.compound.conditional.shell - meta.group
-#            ^^ punctuation.section.compound.end.shell
+#^^^^^^ meta.compound.conditional.shell meta.group.shell meta.string.regexp.shell
+#      ^^ meta.compound.conditional.shell meta.group.shell - meta.string.regexp
+#        ^^^ meta.compound.conditional.shell - meta.group
+#         ^^ punctuation.section.compound.end.shell
 
 [[ ( $foo =~ ^ ]]
 #^^ meta.compound.conditional.shell - meta.group
 #  ^^^^^^^^^^ meta.compound.conditional.shell meta.group.shell - meta.string.regexp
 #            ^ meta.compound.conditional.shell meta.group.shell meta.string.regexp.shell
-#             ^^^ meta.compound.conditional.shell meta.group.shell - meta.string.regexp
-#              ^^ invalid.illegal.unexpected-token.shell
+#             ^^^ meta.compound.conditional.shell - meta.group - meta.string.regexp
+#              ^^ punctuation.section.compound.end.shell
 
 [[ ( $foo =~ ^ ]]
    [^0-9]+ ) ]]

--- a/ShellScript/Bash/tests/syntax_test_scope.bash
+++ b/ShellScript/Bash/tests/syntax_test_scope.bash
@@ -1847,90 +1847,14 @@ if !cmd
 # <- variable.language.history.shell punctuation.definition.history.shell
 #^^ variable.language.history.shell
 
-[[ ]]
-# <- punctuation.section.compound.begin.shell
-#^ punctuation.section.compound.begin.shell
-#  ^^ punctuation.section.compound.end.shell
-
-[[
-]]
-# <- meta.compound.conditional.shell punctuation.section.compound.end.shell
-#^ meta.compound.conditional.shell punctuation.section.compound.end.shell
-
-! [[ ]]
-# <- keyword.operator.logical.shell
-# ^^ punctuation.section.compound.begin.shell
-#    ^^ punctuation.section.compound.end.shell
-
-![[ ]]
-# <- punctuation.definition.history.shell
-#^^^^^ meta.compound.conditional.shell
-#^^ punctuation.section.compound.begin.shell
-#   ^^ punctuation.section.compound.end.shell
-
-[[ ! ($line == ^0[1-9]$) ]]
-# <- meta.compound.conditional.shell - meta.group
-#^^^^ meta.compound.conditional.shell - meta.group
-#    ^^^^^^^^^^ meta.compound.conditional.shell meta.group.shell - meta.string.regexp
-#              ^^^^^^^^ meta.compound.conditional.shell meta.group.shell meta.string.regexp.shell
-#                      ^ meta.compound.conditional.shell meta.group.shell - meta.string
-#                       ^^^ meta.compound.conditional.shell - meta.group
-#
-
-[[ ! ($line != \() ]]
-# <- meta.compound.conditional.shell - meta.group
-#^^^^ meta.compound.conditional.shell - meta.group
-#    ^^^^^^^^^^ meta.compound.conditional.shell meta.group.shell - meta.string.regexp
-#              ^^ meta.compound.conditional.shell meta.group.shell meta.string.regexp.shell constant.character.escape.shell
-#                ^ meta.compound.conditional.shell meta.group.shell - meta.string
-#                 ^^^ meta.compound.conditional.shell - meta.group
-#
-
-[[ '-e' == -e ]]   # -e undergoes pattern matching on the right
-#  ^^^^ meta.string.glob.shell string.quoted.single.shell
-#       ^^ keyword.operator.comparison.shell
-#          ^^ meta.compound.conditional.shell meta.string.regexp.shell string.unquoted.shell - variable
-
-[[ -e == -e ]]     # a syntax error in bash but allowed in zsh
-#  ^^ meta.string.glob.shell string.unquoted.shell - variable
-#     ^^ keyword.operator.comparison.shell
-#        ^^ meta.compound.conditional.shell meta.string.regexp.shell string.unquoted.shell - variable
-
-[[ $foo == 'bar' || $foo == "baz" && $bar == baz ]]
-# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
-#  ^^^^ variable.other.readwrite.shell
-#       ^^ keyword.operator.comparison.shell
-#          ^^^^^ meta.string.regexp.shell
-#                ^^ keyword.operator.logical.shell
-#                   ^^^^ variable.other.readwrite.shell
-#                        ^^ keyword.operator.comparison.shell
-#                           ^^^^^ meta.string.regexp.shell
-#                                 ^^ keyword.operator.logical.shell
-#                                    ^^^^ variable.other.readwrite.shell
-#                                         ^^ keyword.operator.comparison.shell
-#                                            ^^^ meta.string.regexp.shell
-#                                                ^^ punctuation.section.compound.end.shell
-
-[[ ( $foo == 'bar' || $foo == "baz" ) && $bar == baz ]]
-# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
-#^^ meta.compound.conditional.shell - meta.group
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell meta.group.shell
-#                                    ^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell - meta.group
-#  ^ punctuation.section.group.begin.shell
-#    ^^^^ variable.other.readwrite.shell
-#         ^^ keyword.operator.comparison.shell
-#            ^^^^^ meta.string.regexp.shell
-#                  ^^ keyword.operator.logical.shell
-#                     ^^^^ variable.other.readwrite.shell
-#                          ^^ keyword.operator.comparison.shell
-#                             ^^^^^ meta.string.regexp.shell
-#                                   ^ punctuation.section.group.end.shell
-#                                     ^^ keyword.operator.logical.shell
-#                                        ^^^^ variable.other.readwrite.shell
-#                                             ^^ keyword.operator.comparison.shell
-#                                                ^^^ meta.string.regexp.shell
-#                                                    ^^ punctuation.section.compound.end.shell
+if cmd ; then cmd ; fi
+#^ keyword.control.conditional.if.shell
+#  ^^^ meta.function-call.identifier.shell meta.command.shell variable.function.shell
+#      ^ punctuation.terminator.statement.shell
+#        ^^^^ keyword.control.conditional.then.shell
+#             ^^^ meta.function-call.identifier.shell meta.command.shell variable.function.shell
+#                 ^ punctuation.terminator.statement.shell
+#                   ^^ keyword.control.conditional.endif.shell
 
 if [[ expr ]] && [[ expr ]] || [[ expr ]] ; then cmd ; fi
 #  ^^^^^^^^^^ meta.compound.conditional.shell
@@ -2623,6 +2547,308 @@ do
 #      ^ punctuation.terminator.statement.shell
 done
 # <- keyword.control.loop.end.shell
+
+
+###############################################################################
+# 3.2.5 Compound Commands                                                     #
+# 3.2.5.2 Conditional Constructs (( ... ))                                    #
+# https://www.gnu.org/software/bash/manual/bash.html                          #
+###############################################################################
+
+((  ))
+# <- meta.compound.arithmetic.shell punctuation.section.compound.begin.shell
+#^^^^^ meta.compound.arithmetic.shell
+#^ punctuation.section.compound.begin.shell
+#   ^^ punctuation.section.compound.end.shell
+#     ^ - meta.compound
+
+((
+))
+# <- meta.compound.arithmetic.shell punctuation.section.compound.end.shell
+#^ meta.compound.arithmetic.shell punctuation.section.compound.end.shell
+# ^ - meta.compound
+
+!(( ))
+# <- punctuation.definition.history.shell - meta.compound
+#^^^^^ meta.compound.arithmetic.shell
+#^^ punctuation.section.compound.begin.shell
+#   ^^ punctuation.section.compound.end.shell
+
+! (( ))
+# <- - meta.compound
+#^ - meta.compound
+# ^^^^^ meta.compound.arithmetic.shell
+# <- keyword.operator.logical.shell
+# ^^ punctuation.section.compound.begin.shell
+#    ^^ punctuation.section.compound.end.shell
+
+(( expr )) && (( expr )) || (( expr )) && cmd;
+# <- meta.compound.arithmetic.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^ meta.compound.arithmetic.shell
+#^ punctuation.section.compound.begin.shell
+#       ^^ punctuation.section.compound.end.shell
+#          ^^ keyword.operator.logical.shell
+#             ^^^^^^^^^^ meta.compound.arithmetic.shell
+#             ^^ punctuation.section.compound.begin.shell
+#                     ^^ punctuation.section.compound.end.shell
+#                        ^^ keyword.operator.logical.shell
+#                           ^^^^^^^^^^ meta.compound.arithmetic.shell
+#                           ^^ punctuation.section.compound.begin.shell
+#                                   ^^ punctuation.section.compound.end.shell
+#                                      ^^ keyword.operator.logical.shell
+#                                         ^^^ meta.function-call.identifier.shell meta.command.shell variable.function.shell
+
+(( expr && expr || expr ))
+# <- meta.compound.arithmetic.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.arithmetic.shell
+#^ punctuation.section.compound.begin.shell
+#       ^^ keyword.operator.logical.shell
+#               ^^ keyword.operator.logical.shell
+#                       ^^ punctuation.section.compound.end.shell
+
+(( expr && ( expr || expr ) ))
+# <- meta.compound.arithmetic.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.arithmetic.shell
+#          ^^^^^^^^^^^^^^^^ meta.group.shell
+#^ punctuation.section.compound.begin.shell
+#       ^^ keyword.operator.logical.shell
+#          ^ punctuation.section.group.begin.shell
+#                 ^^ keyword.operator.logical.shell
+#                         ^ punctuation.section.group.end.shell
+#                           ^^ punctuation.section.compound.end.shell
+
+
+###############################################################################
+# 3.2.5 Compound Commands                                                     #
+# 3.2.5.2 Conditional Constructs [[ ... ]]                                    #
+# https://www.gnu.org/software/bash/manual/bash.html#index-_005b_005b         #
+###############################################################################
+
+[[ ]]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^ meta.compound.conditional.shell
+#^ punctuation.section.compound.begin.shell
+#  ^^ punctuation.section.compound.end.shell
+#    ^ - meta.compound
+
+[[
+]]
+# <- meta.compound.conditional.shell punctuation.section.compound.end.shell
+#^ meta.compound.conditional.shell punctuation.section.compound.end.shell
+
+![[ ]]
+# <- punctuation.definition.history.shell - meta.compound
+#^^^^^ meta.compound.conditional.shell
+#^^ punctuation.section.compound.begin.shell
+#   ^^ punctuation.section.compound.end.shell
+
+! [[ ]]
+# <- - meta.compound
+#^ - meta.compound
+# ^^^^^ meta.compound.conditional.shell
+# <- keyword.operator.logical.shell
+# ^^ punctuation.section.compound.begin.shell
+#    ^^ punctuation.section.compound.end.shell
+
+
+## Logical Operators
+## -----------------
+
+[[ expr ]] && [[ expr ]] || [[ expr ]] && cmd;
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^ meta.compound.conditional.shell
+#^ punctuation.section.compound.begin.shell
+#       ^^ punctuation.section.compound.end.shell
+#          ^^ keyword.operator.logical.shell
+#             ^^^^^^^^^^ meta.compound.conditional.shell
+#             ^^ punctuation.section.compound.begin.shell
+#                     ^^ punctuation.section.compound.end.shell
+#                        ^^ keyword.operator.logical.shell
+#                           ^^^^^^^^^^ meta.compound.conditional.shell
+#                           ^^ punctuation.section.compound.begin.shell
+#                                   ^^ punctuation.section.compound.end.shell
+#                                      ^^ keyword.operator.logical.shell
+#                                         ^^^ meta.function-call.identifier.shell meta.command.shell variable.function.shell
+
+[[ expr && expr || expr ]]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#^ punctuation.section.compound.begin.shell
+#       ^^ keyword.operator.logical.shell
+#               ^^ keyword.operator.logical.shell
+#                       ^^ punctuation.section.compound.end.shell
+
+[[ expr && ( expr || expr ) ]]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#          ^^^^^^^^^^^^^^^^ meta.group.shell
+#^ punctuation.section.compound.begin.shell
+#       ^^ keyword.operator.logical.shell
+#          ^ punctuation.section.group.begin.shell
+#                 ^^ keyword.operator.logical.shell
+#                         ^ punctuation.section.group.end.shell
+#                           ^^ punctuation.section.compound.end.shell
+
+
+## File Comparisons
+## ----------------
+
+[[ file1 -ef file2 ]]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#  ^^^^^ meta.string.glob.shell string.unquoted.shell
+#        ^^^ keyword.operator.comparison.shell
+#            ^^^^^ meta.string.glob.shell string.unquoted.shell
+#                  ^^ punctuation.section.compound.end.shell
+
+[[ file1 -nt file2 ]]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#  ^^^^^ meta.string.glob.shell string.unquoted.shell
+#        ^^^ keyword.operator.comparison.shell
+#            ^^^^^ meta.string.glob.shell string.unquoted.shell
+#                  ^^ punctuation.section.compound.end.shell
+
+[[ file1 -ot file2 ]]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#  ^^^^^ meta.string.glob.shell string.unquoted.shell
+#        ^^^ keyword.operator.comparison.shell
+#            ^^^^^ meta.string.glob.shell string.unquoted.shell
+#                  ^^ punctuation.section.compound.end.shell
+
+
+## String Comparison Operators
+## ---------------------------
+
+[[ ! str != str ]]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#  ^ keyword.operator.logical.shell
+#    ^^^ meta.string.glob.shell string.unquoted.shell
+#        ^^ keyword.operator.comparison.shell
+#           ^^^ meta.string.regexp.shell string.unquoted.shell
+#               ^ punctuation.section.compound.end.shell
+
+[[ str != str ]]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#  ^^^ meta.string.glob.shell string.unquoted.shell
+#      ^^ keyword.operator.comparison.shell
+#         ^^^ meta.string.regexp.shell string.unquoted.shell
+#             ^ punctuation.section.compound.end.shell
+
+[[ str == str ]]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#  ^^^ meta.string.glob.shell string.unquoted.shell
+#      ^^ keyword.operator.comparison.shell
+#         ^^^ meta.string.regexp.shell string.unquoted.shell
+#             ^ punctuation.section.compound.end.shell
+
+[[ str = str ]]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#  ^^^ meta.string.glob.shell string.unquoted.shell
+#      ^ keyword.operator.comparison.shell
+#        ^^^ meta.string.regexp.shell string.unquoted.shell
+#            ^ punctuation.section.compound.end.shell
+
+[[ str < str ]]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#  ^^^ meta.string.glob.shell string.unquoted.shell
+#      ^ keyword.operator.comparison.shell
+#        ^^^ meta.string.glob.shell string.unquoted.shell
+#            ^ punctuation.section.compound.end.shell
+
+[[ str > str ]]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#  ^^^ meta.string.glob.shell string.unquoted.shell
+#      ^ keyword.operator.comparison.shell
+#        ^^^ meta.string.glob.shell string.unquoted.shell
+#            ^ punctuation.section.compound.end.shell
+
+[[ str >= str ]]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#  ^^^ meta.string.glob.shell string.unquoted.shell
+#      ^^ keyword.operator.comparison.shell
+#         ^^^ meta.string.glob.shell string.unquoted.shell
+#             ^ punctuation.section.compound.end.shell
+
+[[ str <= str ]]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#  ^^^ meta.string.glob.shell string.unquoted.shell
+#      ^^ keyword.operator.comparison.shell
+#         ^^^ meta.string.glob.shell string.unquoted.shell
+#             ^ punctuation.section.compound.end.shell
+
+[[ -e == -e ]]     # a syntax error in bash but allowed in zsh
+#  ^^ meta.string.glob.shell string.unquoted.shell - variable
+#     ^^ keyword.operator.comparison.shell
+#        ^^ meta.string.regexp.shell string.unquoted.shell - variable
+
+[[ '-e' == -e ]]   # -e undergoes pattern matching on the right
+#  ^^^^ meta.string.glob.shell string.quoted.single.shell
+#       ^^ keyword.operator.comparison.shell
+#          ^^ meta.string.regexp.shell string.unquoted.shell - variable
+
+[[ ! ($foo == pat) ]]
+# <- meta.compound.conditional.shell - meta.group
+#^^^^ meta.compound.conditional.shell - meta.group
+#    ^^^^^^^^^ meta.compound.conditional.shell meta.group.shell - meta.string.regexp
+#             ^^^ meta.compound.conditional.shell meta.group.shell meta.string.regexp.shell
+#                ^ meta.compound.conditional.shell meta.group.shell - meta.string
+#                 ^^^ meta.compound.conditional.shell - meta.group
+
+[[ ! ($foo != \() ]]
+# <- meta.compound.conditional.shell - meta.group
+#^^^^ meta.compound.conditional.shell - meta.group
+#    ^ meta.compound.conditional.shell meta.group.shell - meta.string
+#     ^^^^ meta.compound.conditional.shell meta.group.shell meta.string.glob.shell meta.interpolation.parameter.shell variable.other.readwrite.shell
+#         ^^^^ meta.compound.conditional.shell meta.group.shell - meta.string
+#             ^^ meta.compound.conditional.shell meta.group.shell meta.string.regexp.shell constant.character.escape.shell
+#               ^ meta.compound.conditional.shell meta.group.shell - meta.string
+#                ^^^ meta.compound.conditional.shell - meta.group
+
+[[ $foo == 'bar' || $foo == "baz" && $bar == baz ]]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#  ^^^^ variable.other.readwrite.shell
+#       ^^ keyword.operator.comparison.shell
+#          ^^^^^ meta.string.regexp.shell
+#                ^^ keyword.operator.logical.shell
+#                   ^^^^ variable.other.readwrite.shell
+#                        ^^ keyword.operator.comparison.shell
+#                           ^^^^^ meta.string.regexp.shell
+#                                 ^^ keyword.operator.logical.shell
+#                                    ^^^^ variable.other.readwrite.shell
+#                                         ^^ keyword.operator.comparison.shell
+#                                            ^^^ meta.string.regexp.shell
+#                                                ^^ punctuation.section.compound.end.shell
+
+[[ ( $foo == 'bar' || $foo == "baz" ) && $bar == baz ]]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^ meta.compound.conditional.shell - meta.group
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell meta.group.shell
+#                                    ^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell - meta.group
+#  ^ punctuation.section.group.begin.shell
+#    ^^^^ variable.other.readwrite.shell
+#         ^^ keyword.operator.comparison.shell
+#            ^^^^^ meta.string.regexp.shell
+#                  ^^ keyword.operator.logical.shell
+#                     ^^^^ variable.other.readwrite.shell
+#                          ^^ keyword.operator.comparison.shell
+#                             ^^^^^ meta.string.regexp.shell
+#                                   ^ punctuation.section.group.end.shell
+#                                     ^^ keyword.operator.logical.shell
+#                                        ^^^^ variable.other.readwrite.shell
+#                                             ^^ keyword.operator.comparison.shell
+#                                                ^^^ meta.string.regexp.shell
+#                                                    ^^ punctuation.section.compound.end.shell
 
 
 ###############################################################################

--- a/ShellScript/Zsh.sublime-syntax
+++ b/ShellScript/Zsh.sublime-syntax
@@ -562,6 +562,17 @@ contexts:
     - match: \#{1,2}
       scope: keyword.operator.quantifier.regexp.shell.zsh
 
+###[ POSIX EXTENDED REGULAR EXPRESSIONS ]######################################
+
+  eregexp-main-content:
+    # ZSH doesn't allow alternation operator in top-level patterns
+    - include: eregexp-quantifiers
+    - include: string-unquoted-content
+    - include: eregexp-charsets
+    - include: eregexp-groups
+    - include: eregexp-anchors
+    - include: eregexp-literals
+
 ###[ ARITHMETIC EXPANSIONS ]###################################################
 
   arithmetic-expansions:

--- a/ShellScript/Zsh/tests/syntax_test_scope.zsh
+++ b/ShellScript/Zsh/tests/syntax_test_scope.zsh
@@ -1774,6 +1774,449 @@ ip=10.10.20.14
 
 
 ###############################################################################
+# 12 Conditional Expressions                                                  #
+# https://zsh.sourceforge.io/Doc/Release/Conditional-Expressions.html         #
+###############################################################################
+
+
+[[
+]]
+# <- meta.compound.conditional.shell punctuation.section.compound.end.shell
+#^ meta.compound.conditional.shell punctuation.section.compound.end.shell
+
+![[ ]]
+# <- punctuation.definition.history.shell - meta.compound
+#^^^^^ meta.compound.conditional.shell
+#^^ punctuation.section.compound.begin.shell
+#   ^^ punctuation.section.compound.end.shell
+
+! [[ ]]
+# <- - meta.compound
+#^ - meta.compound
+# ^^^^^ meta.compound.conditional.shell
+# <- keyword.operator.logical.shell
+# ^^ punctuation.section.compound.begin.shell
+#    ^^ punctuation.section.compound.end.shell
+
+
+## Logical Operators
+## -----------------
+
+[[ expr ]] && [[ expr ]] || [[ expr ]] && cmd;
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^ meta.compound.conditional.shell
+#^ punctuation.section.compound.begin.shell
+#       ^^ punctuation.section.compound.end.shell
+#          ^^ keyword.operator.logical.shell
+#             ^^^^^^^^^^ meta.compound.conditional.shell
+#             ^^ punctuation.section.compound.begin.shell
+#                     ^^ punctuation.section.compound.end.shell
+#                        ^^ keyword.operator.logical.shell
+#                           ^^^^^^^^^^ meta.compound.conditional.shell
+#                           ^^ punctuation.section.compound.begin.shell
+#                                   ^^ punctuation.section.compound.end.shell
+#                                      ^^ keyword.operator.logical.shell
+#                                         ^^^ meta.function-call.identifier.shell meta.command.shell variable.function.shell
+
+[[ expr && expr || expr ]]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#^ punctuation.section.compound.begin.shell
+#       ^^ keyword.operator.logical.shell
+#               ^^ keyword.operator.logical.shell
+#                       ^^ punctuation.section.compound.end.shell
+
+[[ ((  ) ) ]]
+#^^ meta.compound.conditional.shell - meta.group
+#  ^ meta.compound.conditional.shell meta.group.shell - meta.group meta.group
+#   ^^^^ meta.compound.conditional.shell meta.group.shell meta.group.shell
+#       ^^ meta.compound.conditional.shell meta.group.shell - meta.group meta.group
+#         ^^^ meta.compound.conditional.shell - meta.group
+#^ punctuation.section.compound.begin.shell
+#  ^^ punctuation.section.group.begin.shell
+#      ^ punctuation.section.group.end.shell
+#        ^ punctuation.section.group.end.shell
+#          ^^ punctuation.section.compound.end.shell
+
+[[ ( (  )) ]]
+#^^ meta.compound.conditional.shell - meta.group
+#  ^^ meta.compound.conditional.shell meta.group.shell - meta.group meta.group
+#    ^^^^ meta.compound.conditional.shell meta.group.shell meta.group.shell
+#        ^ meta.compound.conditional.shell meta.group.shell - meta.group meta.group
+#         ^^^ meta.compound.conditional.shell - meta.group
+#^ punctuation.section.compound.begin.shell
+#  ^ punctuation.section.group.begin.shell
+#    ^ punctuation.section.group.begin.shell
+#       ^^ punctuation.section.group.end.shell
+#          ^^ punctuation.section.compound.end.shell
+
+[[ expr && ( expr || expr ) ]]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#          ^^^^^^^^^^^^^^^^ meta.group.shell
+#^ punctuation.section.compound.begin.shell
+#       ^^ keyword.operator.logical.shell
+#          ^ punctuation.section.group.begin.shell
+#                 ^^ keyword.operator.logical.shell
+#                         ^ punctuation.section.group.end.shell
+#                           ^^ punctuation.section.compound.end.shell
+
+[[ (expr && ( expr || !( expr && expr ))) ]]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^ meta.compound.conditional.shell - meta.group
+#  ^^^^^^^^^ meta.compound.conditional.shell meta.group.shell - meta.group meta.group
+#           ^^^^^^^^^^^ meta.compound.conditional.shell meta.group.shell meta.group.shell - meta.group meta.group meta.group
+#                      ^^^^^^^^^^^^^^^^ meta.compound.conditional.shell meta.group.shell meta.group.shell meta.group.shell
+#                                      ^ meta.compound.conditional.shell meta.group.shell meta.group.shell - meta.group meta.group meta.group
+#                                       ^ meta.compound.conditional.shell meta.group.shell - meta.group meta.group
+#                                        ^^^ meta.compound.conditional.shell - meta.group
+#                                           ^ - meta.compound
+#^ punctuation.section.compound.begin.shell
+#        ^^ keyword.operator.logical.shell
+#           ^ punctuation.section.group.begin.shell
+#                  ^^ keyword.operator.logical.shell
+#                     ^ keyword.operator.logical.shell
+#                      ^ punctuation.section.group.begin.shell
+#                             ^^ keyword.operator.logical.shell
+#                                     ^^^ punctuation.section.group.end.shell
+#                                         ^^ punctuation.section.compound.end.shell
+
+[[ expr -a expr -o expr ]]    # -a and -o arguments have no meaning
+#^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#  ^^^^ meta.string.glob.shell string.unquoted.shell
+#       ^^ - keyword.operator
+#          ^^^^ meta.string.glob.shell string.unquoted.shell
+#               ^^ - keyword.operator
+#                  ^^^^ meta.string.glob.shell string.unquoted.shell
+#                       ^ punctuation.section.compound.end.shell
+
+
+## File Comparisons
+## ----------------
+
+[[ file1 -ef file2 ]]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#  ^^^^^ meta.string.glob.shell string.unquoted.shell
+#        ^^^ keyword.operator.comparison.shell
+#            ^^^^^ meta.string.glob.shell string.unquoted.shell
+#                  ^^ punctuation.section.compound.end.shell
+
+[[ file1 -nt file2 ]]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#  ^^^^^ meta.string.glob.shell string.unquoted.shell
+#        ^^^ keyword.operator.comparison.shell
+#            ^^^^^ meta.string.glob.shell string.unquoted.shell
+#                  ^^ punctuation.section.compound.end.shell
+
+[[ file1 -ot file2 ]]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#  ^^^^^ meta.string.glob.shell string.unquoted.shell
+#        ^^^ keyword.operator.comparison.shell
+#            ^^^^^ meta.string.glob.shell string.unquoted.shell
+#                  ^^ punctuation.section.compound.end.shell
+
+
+## String Comparison Operators
+## ---------------------------
+
+[[ ! str != str ]]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#  ^ keyword.operator.logical.shell
+#    ^^^ meta.string.glob.shell string.unquoted.shell
+#        ^^ keyword.operator.comparison.shell
+#           ^^^ meta.string.glob.shell string.unquoted.shell
+#               ^ punctuation.section.compound.end.shell
+
+[[ str != str ]]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#  ^^^ meta.string.glob.shell string.unquoted.shell
+#      ^^ keyword.operator.comparison.shell
+#         ^^^ meta.string.glob.shell string.unquoted.shell
+#             ^ punctuation.section.compound.end.shell
+
+[[ str == str ]]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#  ^^^ meta.string.glob.shell string.unquoted.shell
+#      ^^ keyword.operator.comparison.shell
+#         ^^^ meta.string.glob.shell string.unquoted.shell
+#             ^ punctuation.section.compound.end.shell
+
+[[ str = str ]]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#  ^^^ meta.string.glob.shell string.unquoted.shell
+#      ^ keyword.operator.comparison.shell
+#        ^^^ meta.string.glob.shell string.unquoted.shell
+#            ^ punctuation.section.compound.end.shell
+
+[[ str < str ]]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#  ^^^ meta.string.glob.shell string.unquoted.shell
+#      ^ keyword.operator.comparison.shell
+#        ^^^ meta.string.glob.shell string.unquoted.shell
+#            ^ punctuation.section.compound.end.shell
+
+[[ str > str ]]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#  ^^^ meta.string.glob.shell string.unquoted.shell
+#      ^ keyword.operator.comparison.shell
+#        ^^^ meta.string.glob.shell string.unquoted.shell
+#            ^ punctuation.section.compound.end.shell
+
+[[ str >= str ]]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#  ^^^ meta.string.glob.shell string.unquoted.shell
+#      ^^ keyword.operator.comparison.shell
+#         ^^^ meta.string.glob.shell string.unquoted.shell
+#             ^ punctuation.section.compound.end.shell
+
+[[ str <= str ]]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#  ^^^ meta.string.glob.shell string.unquoted.shell
+#      ^^ keyword.operator.comparison.shell
+#         ^^^ meta.string.glob.shell string.unquoted.shell
+#             ^ punctuation.section.compound.end.shell
+
+[[ -e == -e ]]     # a syntax error in bash but allowed in zsh
+#  ^^ meta.string.glob.shell string.unquoted.shell - variable
+#     ^^ keyword.operator.comparison.shell
+#        ^^ meta.string.glob.shell string.unquoted.shell - variable
+
+[[ '-e' == -e ]]   # -e undergoes pattern matching on the right
+#  ^^^^ meta.string.glob.shell string.quoted.single.shell
+#       ^^ keyword.operator.comparison.shell
+#          ^^ meta.string.glob.shell string.unquoted.shell - variable
+
+[[ ! ($foo == pat) ]]
+# <- meta.compound.conditional.shell - meta.group
+#^^^^ meta.compound.conditional.shell - meta.group
+#    ^ meta.compound.conditional.shell meta.group.shell - meta.string
+#     ^^^^ meta.compound.conditional.shell meta.group.shell meta.string.glob.shell meta.interpolation.parameter.shell variable.other.readwrite.shell
+#         ^^^^ meta.compound.conditional.shell meta.group.shell - meta.string
+#             ^^^ meta.compound.conditional.shell meta.group.shell meta.string.glob.shell
+#                ^ meta.compound.conditional.shell meta.group.shell - meta.string
+#                 ^^^ meta.compound.conditional.shell - meta.group
+
+[[ ! ($foo != \() ]]
+# <- meta.compound.conditional.shell - meta.group
+#^^^^ meta.compound.conditional.shell - meta.group
+#    ^ meta.compound.conditional.shell meta.group.shell - meta.string
+#     ^^^^ meta.compound.conditional.shell meta.group.shell meta.string.glob.shell meta.interpolation.parameter.shell variable.other.readwrite.shell
+#         ^^^^ meta.compound.conditional.shell meta.group.shell - meta.string
+#             ^^ meta.compound.conditional.shell meta.group.shell meta.string.glob.shell constant.character.escape.shell
+#               ^ meta.compound.conditional.shell meta.group.shell - meta.string
+#                ^^^ meta.compound.conditional.shell - meta.group
+
+[[ $foo == 'bar' || $foo == "baz" && $bar == baz ]]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#  ^^^^ variable.other.readwrite.shell
+#       ^^ keyword.operator.comparison.shell
+#          ^^^^^ meta.string.glob.shell
+#                ^^ keyword.operator.logical.shell
+#                   ^^^^ variable.other.readwrite.shell
+#                        ^^ keyword.operator.comparison.shell
+#                           ^^^^^ meta.string.glob.shell
+#                                 ^^ keyword.operator.logical.shell
+#                                    ^^^^ variable.other.readwrite.shell
+#                                         ^^ keyword.operator.comparison.shell
+#                                            ^^^ meta.string.glob.shell
+#                                                ^^ punctuation.section.compound.end.shell
+
+[[ ( $foo == 'bar' || $foo == "baz" ) && $bar == baz ]]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^ meta.compound.conditional.shell - meta.group
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell meta.group.shell
+#                                    ^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell - meta.group
+#  ^ punctuation.section.group.begin.shell
+#    ^^^^ variable.other.readwrite.shell
+#         ^^ keyword.operator.comparison.shell
+#            ^^^^^ meta.string.glob.shell
+#                  ^^ keyword.operator.logical.shell
+#                     ^^^^ variable.other.readwrite.shell
+#                          ^^ keyword.operator.comparison.shell
+#                             ^^^^^ meta.string.glob.shell
+#                                   ^ punctuation.section.group.end.shell
+#                                     ^^ keyword.operator.logical.shell
+#                                        ^^^^ variable.other.readwrite.shell
+#                                             ^^ keyword.operator.comparison.shell
+#                                                ^^^ meta.string.glob.shell
+#                                                    ^^ punctuation.section.compound.end.shell
+
+[[ ! ((( $foo == 'bar' ) || $foo == "baz" ) && ($bar == baz)) ]]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^ meta.compound.conditional.shell - meta.group
+#    ^ meta.compound.conditional.shell meta.group.shell - meta.group meta.group
+#     ^ meta.compound.conditional.shell meta.group.shell meta.group.shell - meta.group meta.group meta.group
+#      ^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell meta.group.shell meta.group.shell meta.group.shell
+#                       ^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell meta.group.shell meta.group.shell - meta.group meta.group meta.group
+#                                          ^^^^ meta.compound.conditional.shell meta.group.shell - meta.group meta.group
+#                                              ^^^^^^^^^^^^^ meta.compound.conditional.shell meta.group.shell meta.group.shell
+#                                                           ^ meta.compound.conditional.shell meta.group.shell - meta.group meta.group
+#                                                            ^^^ meta.compound.conditional.shell - meta.group
+#                                                               ^ - meta.compound
+#    ^^^ punctuation.section.group.begin.shell
+#        ^^^^ variable.other.readwrite.shell
+#             ^^ keyword.operator.comparison.shell
+#                ^^^^^ meta.string.glob.shell
+#                      ^ punctuation.section.group.end.shell
+#                        ^^ keyword.operator.logical.shell
+#                           ^^^^ variable.other.readwrite.shell
+#                                ^^ keyword.operator.comparison.shell
+#                                   ^^^^^ meta.string.glob.shell
+#                                         ^ punctuation.section.group.end.shell
+#                                           ^^ keyword.operator.logical.shell
+#                                              ^ punctuation.section.group.begin.shell
+#                                               ^^^^ variable.other.readwrite.shell
+#                                                    ^^ keyword.operator.comparison.shell
+#                                                       ^^^ meta.string.glob.shell
+#                                                          ^^ punctuation.section.group.end.shell
+#                                                             ^^ punctuation.section.compound.end.shell
+
+
+## ZSH specific behavior
+## ----------------------
+
+[[ <1-2>str1 < <1-2>str2 ]] # verify `<` vs. `<1-2>str2`
+#^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#^ punctuation.section.compound.begin.shell
+#  ^^^^^ meta.string.glob.shell meta.range.shell.zsh - string
+#       ^^^^ meta.string.glob.shell string.unquoted.shell
+#            ^ keyword.operator.comparison.shell
+#              ^^^^^ meta.string.glob.shell meta.range.shell.zsh - string
+#                   ^^^^ meta.string.glob.shell string.unquoted.shell
+#                        ^^ punctuation.section.compound.end.shell
+
+[[ $foo == bar&baz ]]       # top-level `&` not valid in ZSH or Bash
+#^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#^ punctuation.section.compound.begin.shell
+#  ^^^^ meta.string.glob.shell meta.interpolation.parameter.shell variable.other.readwrite.shell
+#  ^ punctuation.definition.variable.shell
+#       ^^ keyword.operator.comparison.shell
+#          ^^^ meta.string.glob.shell string.unquoted.shell
+#             ^ invalid.illegal.unexpected-token.shell
+#              ^^^ meta.string.glob.shell string.unquoted.shell
+#                  ^^ punctuation.section.compound.end.shell
+
+[[ $foo == bar|baz ]]       # top-level `|` not valid in ZSH or Bash
+#^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#^ punctuation.section.compound.begin.shell
+#  ^^^^ meta.string.glob.shell meta.interpolation.parameter.shell variable.other.readwrite.shell
+#  ^ punctuation.definition.variable.shell
+#       ^^ keyword.operator.comparison.shell
+#          ^^^ meta.string.glob.shell string.unquoted.shell
+#             ^ invalid.illegal.unexpected-token.shell
+#              ^^^ meta.string.glob.shell string.unquoted.shell
+#                  ^^ punctuation.section.compound.end.shell
+
+
+## Extended Regular Expressions
+## ----------------------------
+
+[[ $foo =~ bar && baz =~ buz || $foo =~ baz ]]
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#^ punctuation.section.compound.begin.shell
+#  ^^^^ meta.string.glob.shell meta.interpolation.parameter.shell variable.other.readwrite.shell
+#  ^ punctuation.definition.variable.shell
+#       ^^ keyword.operator.comparison.shell
+#          ^^^ meta.string.regexp.shell string.unquoted.shell
+#              ^^ keyword.operator.logical.shell
+#                 ^^^ meta.string.glob.shell string.unquoted.shell
+#                     ^^ keyword.operator.comparison.shell
+#                        ^^^ meta.string.regexp.shell string.unquoted.shell
+#                            ^^ keyword.operator.logical.shell
+#                               ^^^^ meta.string.glob.shell meta.interpolation.parameter.shell variable.other.readwrite.shell
+#                               ^ punctuation.definition.variable.shell
+#                                    ^^ keyword.operator.comparison.shell
+#                                       ^^^ meta.string.regexp.shell string.unquoted.shell
+#                                           ^^ punctuation.section.compound.end.shell
+
+
+## Arithmetic Comparisons
+## ----------------------
+
+[[ arg+1 -lt 2+a+(5-b) ]]   # arithmetic comparison
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^ meta.compound.conditional.shell - meta.arithmetic
+#  ^^^^^ meta.compound.conditional.shell meta.arithmetic.shell
+#       ^^^^^ meta.compound.conditional.shell - meta.arithmetic
+#            ^^^^ meta.compound.conditional.shell meta.arithmetic.shell - meta.group
+#                ^^^^^ meta.compound.conditional.shell meta.arithmetic.shell meta.group.shell
+#                     ^^^ meta.compound.conditional.shell - meta.arithmetic
+#  ^^^ variable.other.readwrite.shell
+#        ^^^ keyword.operator.comparison.shell
+#            ^ meta.number.integer.decimal.shell constant.numeric.value.shell
+#             ^ keyword.operator.arithmetic.shell
+#              ^ variable.other.readwrite.shell
+#               ^ keyword.operator.arithmetic.shell
+#                ^ punctuation.section.group.begin.shell
+#                  ^ keyword.operator.arithmetic.shell
+#                   ^ variable.other.readwrite.shell
+#                    ^ punctuation.section.group.end.shell
+#                      ^^ punctuation.section.compound.end.shell
+
+[[ "c + $d" -eq "1 * ( a % ( b * 5) )" ]]   # quoted arithmetic comparison
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#  ^^^^^^^^ meta.quoted.shell meta.arithmetic.shell
+#          ^^^^^ - meta.arithmetic
+#               ^^^^^ meta.quoted.shell meta.arithmetic.shell - meta.group
+#                    ^^^^^^ meta.quoted.shell meta.arithmetic.shell meta.group.shell - meta.group meta.group
+#                          ^^^^^^^^ meta.quoted.shell meta.arithmetic.shell meta.group.shell meta.group.shell
+#                                  ^^ meta.quoted.shell meta.arithmetic.shell meta.group.shell - meta.group meta.group
+#                                    ^ meta.quoted.shell meta.arithmetic.shell - meta.group
+#                                     ^^ - meta.arithmetic
+#  ^ punctuation.definition.quoted.begin.shell
+#   ^ variable.other.readwrite.shell
+#     ^ keyword.operator.arithmetic.shell
+#       ^^ meta.interpolation.parameter.shell variable.other.readwrite.shell
+#       ^ punctuation.definition.variable.shell
+#         ^ punctuation.definition.quoted.end.shell
+#           ^^^ keyword.operator.comparison.shell
+#               ^ punctuation.definition.quoted.begin.shell
+#                ^ meta.number.integer.decimal.shell constant.numeric.value.shell
+#                  ^ keyword.operator.arithmetic.shell
+#                    ^ punctuation.section.group.begin.shell
+#                      ^ variable.other.readwrite.shell
+#                        ^ keyword.operator.arithmetic.shell
+#                          ^ punctuation.section.group.begin.shell
+#                            ^ variable.other.readwrite.shell
+#                              ^ keyword.operator.arithmetic.shell
+#                                ^ meta.number.integer.decimal.shell constant.numeric.value.shell
+#                                 ^ punctuation.section.group.end.shell
+#                                   ^ punctuation.section.group.end.shell
+#                                    ^ punctuation.definition.quoted.end.shell
+#                                      ^^ punctuation.section.compound.end.shell
+
+[[ -eq -ge -eq -eq -eq -eq ]]  # operators like `-eq` appear only on certain positions
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#^ punctuation.section.compound.begin.shell
+#  ^^^ meta.arithmetic.shell
+#  ^ keyword.operator.arithmetic.shell
+#   ^^ variable.other.readwrite.shell
+#      ^^^ keyword.operator.comparison.shell
+#          ^^^ meta.arithmetic.shell
+#          ^ keyword.operator.arithmetic.shell
+#           ^^ variable.other.readwrite.shell
+#              ^^^ meta.arithmetic.shell
+#              ^ keyword.operator.arithmetic.shell
+#               ^^ variable.other.readwrite.shell
+#                  ^^^ keyword.operator.comparison.shell
+#                      ^ keyword.operator.arithmetic.shell
+#                       ^^ variable.other.readwrite.shell
+#                          ^^ punctuation.section.compound.end.shell
+
+
+###############################################################################
 # 14.3 Parameter Expansion                                                    #
 # https://zsh.sourceforge.io/Doc/Release/Expansion.html#Parameter-Expansion   #
 ###############################################################################
@@ -5117,17 +5560,62 @@ esac
 
 # glob in test expressions
 
+[[ $foo < <1-2>bar || $foo < b<1-2>r || $foo < bar<1-2> || $foo < b<a>r ]]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#                                                                         ^ - meta.compound
+#       ^ keyword.operator.comparison.shell
+#         ^^^^^ meta.string.glob.shell meta.range.shell.zsh
+#              ^^^ meta.string.glob.shell string.unquoted.shell
+#                          ^ keyword.operator.comparison.shell
+#                            ^ meta.string.glob.shell string.unquoted.shell
+#                             ^^^^^ meta.string.glob.shell meta.range.shell.zsh
+#                                  ^ meta.string.glob.shell string.unquoted.shell
+#                                            ^ keyword.operator.comparison.shell
+#                                              ^^^ meta.string.glob.shell string.unquoted.shell
+#                                                 ^^^^^ meta.string.glob.shell meta.range.shell.zsh
+#                                                               ^ keyword.operator.comparison.shell
+#                                                                 ^ meta.string.glob.shell string.unquoted.shell
+#                                                                  ^ keyword.operator.comparison.shell
+#                                                                   ^ meta.string.glob.shell string.unquoted.shell
+#                                                                    ^ invalid.illegal.unexpected-token.shell
+#                                                                     ^ meta.string.glob.shell string.unquoted.shell
+
+[[ $foo <= <1-2>bar || $foo <= b<1-2>r || $foo <= bar<1-2> || $foo <= b<a>r ]]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#                                                                             ^ - meta.compound
+#          ^^^^^ meta.string.glob.shell meta.range.shell.zsh
+#               ^^^ meta.string.glob.shell string.unquoted.shell
+#                              ^ meta.string.glob.shell string.unquoted.shell
+#                               ^^^^^ meta.string.glob.shell meta.range.shell.zsh
+#                                    ^ meta.string.glob.shell string.unquoted.shell
+#                                                 ^^^ meta.string.glob.shell string.unquoted.shell
+#                                                    ^^^^^ meta.string.glob.shell meta.range.shell.zsh
+
+[[ $foo >= <1-2>bar || $foo >= b<1-2>r || $foo >= bar<1-2> || $foo >= b<a>r ]]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#                                                                             ^ - meta.compound
+#          ^^^^^ meta.string.glob.shell meta.range.shell.zsh
+#               ^^^ meta.string.glob.shell string.unquoted.shell
+#                              ^ meta.string.glob.shell string.unquoted.shell
+#                               ^^^^^ meta.string.glob.shell meta.range.shell.zsh
+#                                    ^ meta.string.glob.shell string.unquoted.shell
+#                                                 ^^^ meta.string.glob.shell string.unquoted.shell
+#                                                    ^^^^^ meta.string.glob.shell meta.range.shell.zsh
+
 [[ $foo == <1-2>bar || $foo == b<1-2>r || $foo == bar<1-2> || $foo == b<a>r ]]
 # <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
 #                                                                             ^ - meta.compound
-#          ^^^^^ meta.string.regexp.shell meta.range.shell.zsh
-#               ^^^ meta.string.regexp.shell string.unquoted.shell
-#                              ^ meta.string.regexp.shell string.unquoted.shell
-#                               ^^^^^ meta.string.regexp.shell meta.range.shell.zsh
-#                                    ^ meta.string.regexp.shell string.unquoted.shell
-#                                                 ^^^ meta.string.regexp.shell string.unquoted.shell
-#                                                    ^^^^^ meta.string.regexp.shell meta.range.shell.zsh
+#          ^^^^^ meta.string.glob.shell meta.range.shell.zsh
+#               ^^^ meta.string.glob.shell string.unquoted.shell
+#                              ^ meta.string.glob.shell string.unquoted.shell
+#                               ^^^^^ meta.string.glob.shell meta.range.shell.zsh
+#                                    ^ meta.string.glob.shell string.unquoted.shell
+#                                                 ^^^ meta.string.glob.shell string.unquoted.shell
+#                                                    ^^^^^ meta.string.glob.shell meta.range.shell.zsh
 
 [[ ( $foo == <1-2>bar ) || ( $foo == b<1-2>r ) || ( $foo == bar<1-2> ) || ( $foo == b<a>r ) ]]
 # <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
@@ -5141,25 +5629,25 @@ esac
 #                                                                         ^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell meta.group.shell
 #                                                                                          ^^^ meta.compound.conditional.shell - meta.group
 #                                                                                             ^ - meta.compound
-#            ^^^^^ meta.string.regexp.shell meta.range.shell.zsh
-#                 ^^^ meta.string.regexp.shell string.unquoted.shell
-#                                    ^ meta.string.regexp.shell string.unquoted.shell
-#                                     ^^^^^ meta.string.regexp.shell meta.range.shell.zsh
-#                                          ^ meta.string.regexp.shell string.unquoted.shell
-#                                                           ^^^ meta.string.regexp.shell string.unquoted.shell
-#                                                              ^^^^^ meta.string.regexp.shell meta.range.shell.zsh
+#            ^^^^^ meta.string.glob.shell meta.range.shell.zsh
+#                 ^^^ meta.string.glob.shell string.unquoted.shell
+#                                    ^ meta.string.glob.shell string.unquoted.shell
+#                                     ^^^^^ meta.string.glob.shell meta.range.shell.zsh
+#                                          ^ meta.string.glob.shell string.unquoted.shell
+#                                                           ^^^ meta.string.glob.shell string.unquoted.shell
+#                                                              ^^^^^ meta.string.glob.shell meta.range.shell.zsh
 
 [[ $foo == (<1-2>bar) || $foo == (b<1-2>r) || $foo == (bar<1-2>) || $foo == (b<a>r) ]]
 # <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
 #                                                                                     ^ - meta.compound
-#           ^^^^^ meta.string.regexp.shell meta.range.shell.zsh
-#                ^^^ meta.string.regexp.shell string.unquoted.shell
-#                                 ^ meta.string.regexp.shell string.unquoted.shell
-#                                  ^^^^^ meta.string.regexp.shell meta.range.shell.zsh
-#                                       ^ meta.string.regexp.shell string.unquoted.shell
-#                                                      ^^^ meta.string.regexp.shell string.unquoted.shell
-#                                                         ^^^^^ meta.string.regexp.shell meta.range.shell.zsh
+#           ^^^^^ meta.string.glob.shell meta.range.shell.zsh
+#                ^^^ meta.string.glob.shell string.unquoted.shell
+#                                 ^ meta.string.glob.shell string.unquoted.shell
+#                                  ^^^^^ meta.string.glob.shell meta.range.shell.zsh
+#                                       ^ meta.string.glob.shell string.unquoted.shell
+#                                                      ^^^ meta.string.glob.shell string.unquoted.shell
+#                                                         ^^^^^ meta.string.glob.shell meta.range.shell.zsh
 
 [[ ( $foo == (<1-2>bar) ) || ( $foo == (b<1-2>r) ) || ( $foo == (bar<1-2>) ) || ( $foo == (b<a>r) ) ]]
 # <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
@@ -5173,13 +5661,13 @@ esac
 #                                                                               ^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell meta.group.shell
 #                                                                                                ^^^^^ meta.compound.conditional.shell - meta.group
 #                                                                                                     ^ - meta.compound
-#             ^^^^^ meta.string.regexp.shell meta.range.shell.zsh
-#                  ^^^ meta.string.regexp.shell string.unquoted.shell
-#                                       ^ meta.string.regexp.shell string.unquoted.shell
-#                                        ^^^^^ meta.string.regexp.shell meta.range.shell.zsh
-#                                             ^ meta.string.regexp.shell string.unquoted.shell
-#                                                                ^^^ meta.string.regexp.shell string.unquoted.shell
-#                                                                   ^^^^^ meta.string.regexp.shell meta.range.shell.zsh
+#             ^^^^^ meta.string.glob.shell meta.range.shell.zsh
+#                  ^^^ meta.string.glob.shell string.unquoted.shell
+#                                       ^ meta.string.glob.shell string.unquoted.shell
+#                                        ^^^^^ meta.string.glob.shell meta.range.shell.zsh
+#                                             ^ meta.string.glob.shell string.unquoted.shell
+#                                                                ^^^ meta.string.glob.shell string.unquoted.shell
+#                                                                   ^^^^^ meta.string.glob.shell meta.range.shell.zsh
 
 
 ## no glob ranges
@@ -5662,8 +6150,14 @@ a=(/*(D))   # bare qualifiers are valid in arrays
 #       ^^^^^ meta.interpolation.parameter.shell meta.string.regexp.shell string.unquoted.shell - meta.modifier
 #             ^^^^^ meta.interpolation.parameter.shell meta.string.shell string.unquoted.shell
 
+test $var == ~/*(D)     # bare qualifiers can be appear in test arguments, but cause "too many arguments error"
+#            ^^^ meta.string.glob.shell - meta.modifier
+#               ^^^ meta.string.glob.shell meta.modifier.glob.shell.zsh
+#               ^ punctuation.definition.modifier.begin.shell.zsh
+#                ^ storage.modifier.glob.shell.zsh
+#                 ^ punctuation.definition.modifier.end.shell.zsh
 
-[ $var == ~/*(D) ]      # bare qualifiers can be appear in builtin tests but cause "too many arguments error"
+[ $var == ~/*(D) ]      # bare qualifiers can be appear in builtin tests, but cause "too many arguments error"
 #         ^^^ meta.string.glob.shell - meta.modifier
 #            ^^^ meta.string.glob.shell meta.modifier.glob.shell.zsh
 #            ^ punctuation.definition.modifier.begin.shell.zsh
@@ -5671,30 +6165,27 @@ a=(/*(D))   # bare qualifiers are valid in arrays
 #              ^ punctuation.definition.modifier.end.shell.zsh
 #                ^ punctuation.section.compound.end.shell
 
-[[ -f ~/*(D) ]]         # bare qualifiers are valid in compound test expressions
-#     ^^^ meta.string.glob.shell - meta.modifier
-#        ^^^ meta.string.glob.shell meta.modifier.glob.shell.zsh
-#        ^ punctuation.definition.modifier.begin.shell.zsh
-#         ^ storage.modifier.glob.shell.zsh
-#          ^ punctuation.definition.modifier.end.shell.zsh
-#            ^^ punctuation.section.compound.end.shell
+[[ -f ~/*(D) ]]         # bare qualifiers are not valid in compound test expressions
+#     ^^^^^^ meta.string.glob.shell - meta.modifier
 
 [[ ! (-f ~/*(D)) ]]     # bare qualifiers are valid in compound test expressions
 #    ^^^^^^^^^^^ meta.group.shell
-#        ^^^ meta.string.glob.shell - meta.modifier
-#           ^^^ meta.string.glob.shell meta.modifier.glob.shell.zsh
-#           ^ punctuation.definition.modifier.begin.shell.zsh
-#            ^ storage.modifier.glob.shell.zsh
-#             ^ punctuation.definition.modifier.end.shell.zsh
-#                ^^ punctuation.section.compound.end.shell
+#        ^^^^^^ meta.string.glob.shell - meta.modifier
+
+[[ ~/*(D) == $var ]]    # bare qualifiers not valid in compound test expressions
+#  ^^^^^^ meta.string.glob.shell - meta.modifier
+
+[[ (~/*(D) == $var) ]]  # bare qualifiers not valid in compound test expressions
+#  ^^^^^^^^^^^^^^^^ meta.group.shell
+#   ^^^^^^ meta.string.glob.shell - meta.modifier
 
 [[ $var == ~/*(D) ]]    # bare qualifiers are not matched after pattern matching operators
-#          ^^^^^^ meta.string.regexp.shell - meta.modifier
+#          ^^^^^^ meta.string.glob.shell - meta.modifier
 #                 ^^ punctuation.section.compound.end.shell
 
 [[ ($var != ~/*(D)) ]]  # bare qualifiers are not matched after pattern matching operators
 #  ^^^^^^^^^^^^^^^^ meta.group.shell
-#           ^^^^^^ meta.string.regexp.shell - meta.modifier
+#           ^^^^^^ meta.string.glob.shell - meta.modifier
 #                   ^^ punctuation.section.compound.end.shell
 
 [[ $var =~ ~/*(D) ]]    # bare qualifiers are not matched after pattern matching operators
@@ -8382,3 +8873,294 @@ var[1]=Hello
 mapfile # mapfile is not a known/built-in command in ZSH
 # <- meta.function-call.identifier.shell variable.function.shell - support.function
 #^^^^^^ meta.function-call.identifier.shell variable.function.shell - support.function
+
+
+##############################################################################
+# 17 "[ ... ]" Shell Builtin Command
+##############################################################################
+
+![ ]
+# <- punctuation.definition.history.shell
+#^ punctuation.section.compound.begin.shell
+#  ^ punctuation.section.compound.end.shell
+
+! [ ]
+# <- keyword.operator.logical.shell
+# ^ punctuation.section.compound.begin.shell
+#   ^ punctuation.section.compound.end.shell
+
+[  ]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^ meta.compound.conditional.shell
+#  ^ punctuation.section.compound.end.shell
+
+[
+]
+# <- - meta.conditional - support.function
+
+[ \
+]
+# <- meta.compound.conditional.shell punctuation.section.compound.end.shell
+
+[ # comment ]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^ - meta.conditional - comment
+# ^^^^^^^^^^^^ comment.line.number-sign.shell - meta.conditional
+
+[ ; cmd ]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^ - meta.conditional
+# ^ punctuation.terminator.statement.shell
+#   ^^^ variable.function.shell
+#       ^ string.unquoted.shell
+
+[ && cmd ]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^ - meta.conditional
+# ^^ keyword.operator.logical.shell
+#    ^^^ variable.function.shell
+#        ^ string.unquoted.shell
+
+[ || cmd ]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^ - meta.conditional
+# ^^ keyword.operator.logical.shell
+#    ^^^ variable.function.shell
+#        ^ string.unquoted.shell
+
+[ >str ]    # may contain redirections
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^ meta.compound.conditional.shell
+# ^^^^ meta.redirection.shell
+# ^ keyword.operator.assignment.redirection.shell
+#  ^^^ string.unquoted.shell
+#      ^ punctuation.section.compound.end.shell
+
+[ <str ]    # may contain redirections
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^ meta.compound.conditional.shell
+# ^^^^ meta.redirection.shell
+# ^ keyword.operator.assignment.redirection.shell
+#  ^^^ string.unquoted.shell
+#      ^ punctuation.section.compound.end.shell
+
+[ >>cmd ]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^ meta.compound.conditional.shell
+# ^^^^^ meta.redirection.shell
+# ^^ keyword.operator.assignment.redirection.shell
+#   ^^^ string.unquoted.shell
+#       ^ punctuation.section.compound.end.shell
+
+# heredocs causing issues, but no way around it
+[ <<cmd ]  # <- ] should close the conditional
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^ meta.compound.conditional.shell
+# ^^ keyword.operator.assignment.redirection.shell
+#   ^^^ meta.tag.heredoc.begin.shell entity.name.tag.heredoc.shell
+cmd
+# <- meta.tag.heredoc.end.shell entity.name.tag.heredoc.shell
+
+
+## Test Expressions
+## ----------------
+
+[ -f file ]         # true if file exists.
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^ meta.compound.conditional.shell
+
+[ -v varname ]      # true if shell variable varname is set.
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^ meta.compound.conditional.shell
+
+
+## Logical Operators
+## -----------------
+
+[ expr -a expr -o expr ]
+#^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+# ^^^^ meta.string.glob.shell string.unquoted.shell
+#      ^^ keyword.operator.logical.shell
+#         ^^^^ meta.string.glob.shell string.unquoted.shell
+#              ^^ keyword.operator.logical.shell
+#                 ^^^^ meta.string.glob.shell string.unquoted.shell
+#                      ^ punctuation.section.compound.end.shell
+
+[ $var = true -a $var != false ]
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+# ^^^^ meta.string.glob.shell meta.interpolation.parameter.shell variable.other.readwrite.shell
+# ^ punctuation.definition.variable.shell
+#      ^ keyword.operator.comparison.shell
+#        ^^^^ constant.language.boolean.true.shell
+#             ^^ keyword.operator.logical.shell
+#                ^^^^ meta.string.glob.shell meta.interpolation.parameter.shell variable.other.readwrite.shell
+#                ^ punctuation.definition.variable.shell
+#                     ^^ keyword.operator.comparison.shell
+#                        ^^^^^ constant.language.boolean.false.shell
+#                              ^ punctuation.section.compound.end.shell
+
+
+## File Comparisons
+## ----------------
+
+[ file1 -ef file2 ] # true if file1 and file2 exist and refer to the same file.
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+# ^^^^^ meta.string.glob.shell string.unquoted.shell
+#       ^^^ keyword.operator.comparison.shell
+#           ^^^^^ meta.string.glob.shell string.unquoted.shell
+#                 ^ punctuation.section.compound.end.shell
+
+[ file1 -nt file2 ] # true if file1 exists and is newer than file2.
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+# ^^^^^ meta.string.glob.shell string.unquoted.shell
+#       ^^^ keyword.operator.comparison.shell
+#           ^^^^^ meta.string.glob.shell string.unquoted.shell
+#                 ^ punctuation.section.compound.end.shell
+
+[ file1 -ot file2 ] # true if file1 exists and is older than file2.
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+# ^^^^^ meta.string.glob.shell string.unquoted.shell
+#       ^^^ keyword.operator.comparison.shell
+#           ^^^^^ meta.string.glob.shell string.unquoted.shell
+#                 ^ punctuation.section.compound.end.shell
+
+
+## String Comparison Operators
+## ---------------------------
+
+[ ! str != str ]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+# ^ keyword.operator.logical.shell
+#   ^^^ meta.string.glob.shell string.unquoted.shell
+#       ^^ keyword.operator.comparison.shell
+#          ^^^ meta.string.glob.shell string.unquoted.shell
+#              ^ punctuation.section.compound.end.shell
+
+[ str != str ]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^ meta.compound.conditional.shell
+# ^^^ meta.string.glob.shell string.unquoted.shell
+#     ^^ keyword.operator.comparison.shell
+#        ^^^ meta.string.glob.shell string.unquoted.shell
+#            ^ punctuation.section.compound.end.shell
+
+[ str == str ]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^ meta.compound.conditional.shell
+# ^^^ meta.string.glob.shell string.unquoted.shell
+#     ^^ keyword.operator.comparison.shell
+#        ^^^ meta.string.glob.shell string.unquoted.shell
+#            ^ punctuation.section.compound.end.shell
+
+[ str = str ]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^ meta.compound.conditional.shell
+# ^^^ meta.string.glob.shell string.unquoted.shell
+#     ^ keyword.operator.comparison.shell
+#       ^^^ meta.string.glob.shell string.unquoted.shell
+#           ^ punctuation.section.compound.end.shell
+
+[ str < str ]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^ meta.compound.conditional.shell
+# ^^^ meta.string.glob.shell string.unquoted.shell
+#     ^ keyword.operator.comparison.shell
+#       ^^^ meta.string.glob.shell string.unquoted.shell
+#           ^ punctuation.section.compound.end.shell
+
+[ str > str ]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^ meta.compound.conditional.shell
+# ^^^ meta.string.glob.shell string.unquoted.shell
+#     ^ keyword.operator.comparison.shell
+#       ^^^ meta.string.glob.shell string.unquoted.shell
+#           ^ punctuation.section.compound.end.shell
+
+[ <in1 < <in2 ]
+#^^^^^^^^^^^^^^ meta.compound.conditional.shell
+# ^^^^ meta.redirection.shell
+# ^ keyword.operator.assignment.redirection.shell
+#  ^^^ meta.string.glob.shell string.unquoted.shell
+#      ^ keyword.operator.comparison.shell
+#        ^^^^ meta.redirection.shell
+#        ^ keyword.operator.assignment.redirection.shell
+#         ^^^ meta.string.glob.shell string.unquoted.shell
+#             ^ punctuation.section.compound.end.shell
+
+[ str1<1-2> < <1-2>str2 ]
+#^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+# ^^^^ meta.string.glob.shell string.unquoted.shell
+#     ^^^^^ meta.string.glob.shell meta.range.shell.zsh - string
+#           ^ keyword.operator.comparison.shell
+#             ^^^^^ meta.string.glob.shell meta.range.shell.zsh - string
+#                  ^^^^ meta.string.glob.shell string.unquoted.shell
+#                       ^ punctuation.section.compound.end.shell
+
+[ <1-2>str1 < <1-2>str2 ]
+#^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+# ^^^^^ meta.string.glob.shell meta.range.shell.zsh - string
+#      ^^^^ meta.string.glob.shell string.unquoted.shell
+#           ^ keyword.operator.comparison.shell
+#             ^^^^^ meta.string.glob.shell meta.range.shell.zsh - string
+#                  ^^^^ meta.string.glob.shell string.unquoted.shell
+#                       ^ punctuation.section.compound.end.shell
+
+
+## Invalid Comparison Operators
+## ----------------------------
+
+[ str >= str ]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^ meta.compound.conditional.shell
+# ^^^ meta.string.glob.shell string.unquoted.shell
+#     ^^ invalid.illegal.operator.shell
+#        ^^^ meta.string.glob.shell string.unquoted.shell
+#            ^ punctuation.section.compound.end.shell
+
+[ str <= str ]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^ meta.compound.conditional.shell
+# ^^^ meta.string.glob.shell string.unquoted.shell
+#     ^^ invalid.illegal.operator.shell
+#        ^^^ meta.string.glob.shell string.unquoted.shell
+#            ^ punctuation.section.compound.end.shell
+
+[ str =~ str ]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^^^^ meta.compound.conditional.shell
+# ^^^ meta.string.glob.shell string.unquoted.shell
+#     ^^ invalid.illegal.operator.shell
+#        ^^^ meta.string.glob.shell string.unquoted.shell
+#            ^ punctuation.section.compound.end.shell
+
+
+## Integer Comparisons
+## -------------------
+
+[ a -eq 5 ]     # integer comparison
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^ meta.compound.conditional.shell
+# ^ meta.arithmetic.shell variable.other.readwrite.shell
+#   ^^^ keyword.operator.comparison.shell
+#       ^ meta.arithmetic.shell meta.number.integer.decimal.shell constant.numeric.value.shell
+#         ^ punctuation.section.compound.end.shell
+
+[ 4 -lt a ]     # integer comparison
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^ meta.compound.conditional.shell
+# ^ meta.arithmetic.shell meta.number.integer.decimal.shell constant.numeric.value.shell
+#   ^^^ keyword.operator.comparison.shell
+#       ^ meta.arithmetic.shell variable.other.readwrite.shell
+#         ^ punctuation.section.compound.end.shell
+
+[ a -gt b ]     # integer comparison
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^^^^ meta.compound.conditional.shell
+# ^ meta.arithmetic.shell variable.other.readwrite.shell
+#   ^^^ keyword.operator.comparison.shell
+#       ^ meta.arithmetic.shell variable.other.readwrite.shell
+#         ^ punctuation.section.compound.end.shell

--- a/ShellScript/Zsh/tests/syntax_test_scope.zsh
+++ b/ShellScript/Zsh/tests/syntax_test_scope.zsh
@@ -1778,6 +1778,12 @@ ip=10.10.20.14
 # https://zsh.sourceforge.io/Doc/Release/Conditional-Expressions.html         #
 ###############################################################################
 
+[[ ]]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^ meta.compound.conditional.shell
+#^ punctuation.section.compound.begin.shell
+#  ^^ punctuation.section.compound.end.shell
+#    ^ - meta.compound
 
 [[
 ]]
@@ -1797,6 +1803,39 @@ ip=10.10.20.14
 # <- keyword.operator.logical.shell
 # ^^ punctuation.section.compound.begin.shell
 #    ^^ punctuation.section.compound.end.shell
+
+[[ () ]]
+# <- meta.compound.conditional.shell punctuation.section.compound.begin.shell
+#^^^^^^^ meta.compound.conditional.shell
+#^ punctuation.section.compound.begin.shell
+#  ^^ meta.group.shell
+#  ^ punctuation.section.group.begin.shell
+#   ^ punctuation.section.group.end.shell
+#     ^^ punctuation.section.compound.end.shell
+
+[[ ((  ) ) ]]
+#^^ meta.compound.conditional.shell - meta.group
+#  ^ meta.compound.conditional.shell meta.group.shell - meta.group meta.group
+#   ^^^^ meta.compound.conditional.shell meta.group.shell meta.group.shell
+#       ^^ meta.compound.conditional.shell meta.group.shell - meta.group meta.group
+#         ^^^ meta.compound.conditional.shell - meta.group
+#^ punctuation.section.compound.begin.shell
+#  ^^ punctuation.section.group.begin.shell
+#      ^ punctuation.section.group.end.shell
+#        ^ punctuation.section.group.end.shell
+#          ^^ punctuation.section.compound.end.shell
+
+[[ ( (  )) ]]
+#^^ meta.compound.conditional.shell - meta.group
+#  ^^ meta.compound.conditional.shell meta.group.shell - meta.group meta.group
+#    ^^^^ meta.compound.conditional.shell meta.group.shell meta.group.shell
+#        ^ meta.compound.conditional.shell meta.group.shell - meta.group meta.group
+#         ^^^ meta.compound.conditional.shell - meta.group
+#^ punctuation.section.compound.begin.shell
+#  ^ punctuation.section.group.begin.shell
+#    ^ punctuation.section.group.begin.shell
+#       ^^ punctuation.section.group.end.shell
+#          ^^ punctuation.section.compound.end.shell
 
 
 ## Logical Operators
@@ -1825,30 +1864,6 @@ ip=10.10.20.14
 #       ^^ keyword.operator.logical.shell
 #               ^^ keyword.operator.logical.shell
 #                       ^^ punctuation.section.compound.end.shell
-
-[[ ((  ) ) ]]
-#^^ meta.compound.conditional.shell - meta.group
-#  ^ meta.compound.conditional.shell meta.group.shell - meta.group meta.group
-#   ^^^^ meta.compound.conditional.shell meta.group.shell meta.group.shell
-#       ^^ meta.compound.conditional.shell meta.group.shell - meta.group meta.group
-#         ^^^ meta.compound.conditional.shell - meta.group
-#^ punctuation.section.compound.begin.shell
-#  ^^ punctuation.section.group.begin.shell
-#      ^ punctuation.section.group.end.shell
-#        ^ punctuation.section.group.end.shell
-#          ^^ punctuation.section.compound.end.shell
-
-[[ ( (  )) ]]
-#^^ meta.compound.conditional.shell - meta.group
-#  ^^ meta.compound.conditional.shell meta.group.shell - meta.group meta.group
-#    ^^^^ meta.compound.conditional.shell meta.group.shell meta.group.shell
-#        ^ meta.compound.conditional.shell meta.group.shell - meta.group meta.group
-#         ^^^ meta.compound.conditional.shell - meta.group
-#^ punctuation.section.compound.begin.shell
-#  ^ punctuation.section.group.begin.shell
-#    ^ punctuation.section.group.begin.shell
-#       ^^ punctuation.section.group.end.shell
-#          ^^ punctuation.section.compound.end.shell
 
 [[ expr && ( expr || expr ) ]]
 # <- meta.compound.conditional.shell punctuation.section.compound.begin.shell

--- a/ShellScript/Zsh/tests/syntax_test_scope.zsh
+++ b/ShellScript/Zsh/tests/syntax_test_scope.zsh
@@ -2141,6 +2141,28 @@ ip=10.10.20.14
 #                                       ^^^ meta.string.regexp.shell string.unquoted.shell
 #                                           ^^ punctuation.section.compound.end.shell
 
+[[ $var =~ bar&baz ]]   # top-level `&` not valid in ZSH or Bash
+#^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#^ punctuation.section.compound.begin.shell
+#  ^^^^ meta.string.glob.shell meta.interpolation.parameter.shell variable.other.readwrite.shell
+#  ^ punctuation.definition.variable.shell
+#       ^^ keyword.operator.comparison.shell
+#          ^^^ meta.string.regexp.shell string.unquoted.shell
+#             ^ invalid.illegal.unexpected-token.shell
+#              ^^^ meta.string.glob.shell string.unquoted.shell
+#                  ^^ punctuation.section.compound.end.shell
+
+[[ $var =~ bar|baz ]]   # top-level `|` not valid in ZSH (but in Bash)
+#^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#^ punctuation.section.compound.begin.shell
+#  ^^^^ meta.string.glob.shell meta.interpolation.parameter.shell variable.other.readwrite.shell
+#  ^ punctuation.definition.variable.shell
+#       ^^ keyword.operator.comparison.shell
+#          ^^^ meta.string.regexp.shell string.unquoted.shell
+#             ^ invalid.illegal.unexpected-token.shell
+#              ^^^ meta.string.glob.shell string.unquoted.shell
+#                  ^^ punctuation.section.compound.end.shell
+
 
 ## Arithmetic Comparisons
 ## ----------------------


### PR DESCRIPTION
Addresses #4272 / no bare glob qualifiers in compound tests

This PR refactors built-in `test ...` and `[ ... ]` as well as compound `[[ ... ]]` test expressions to apply more detailed parsing rules, which follow more closely closely to language specifications and shell parsing behavior.

This fixes various edge cases and enables more fine gained and accurate highlighting.

Parsing performance isn't affected by this change, syntax cache size is also nearly unchanged.

For details, please refer to commit messages.

Some highlights:

- highlight math expressions before and after `-eq` and friends

  ![grafik](https://github.com/user-attachments/assets/d98fa586-7533-4371-a357-b9959362da11)
   
- support some of Bash/Zsh's insanity

  ![grafik](https://github.com/user-attachments/assets/778acd0a-507e-45ce-a92b-164c1c120d98)

- compare two redirections

  ![grafik](https://github.com/user-attachments/assets/8174b8bf-0187-4803-9ffd-95b644930d73)

- fix arbitrarily nested groups in expressions

  ![grafik](https://github.com/user-attachments/assets/8175b83d-4a86-4de7-b0fc-1c13d4e36226)

  ![grafik](https://github.com/user-attachments/assets/f5ff9713-d85e-4373-a814-404cbc045b9c)

- no bare globs in compound tests

  ![grafik](https://github.com/user-attachments/assets/6f863587-1905-4b64-a31b-a1d6cc31f2b8)

  ![grafik](https://github.com/user-attachments/assets/c54e7780-eb89-471b-9dc3-ddfc9a266e2e)

- various other fixes