### PR TITLE
[ZSH] Ensure balanced braces in shell words

### DIFF
--- a/ShellScript/Zsh.sublime-syntax
+++ b/ShellScript/Zsh.sublime-syntax
@@ -432,6 +432,16 @@ contexts:
 
 ###[ REDIRECTIONS AND HEREDOCS ]###############################################
 
+  here-string-body:
+    - meta_prepend: true
+    - match: \{
+      push: zsh-here-string-braces-body
+
+  zsh-here-string-braces-body:
+    - meta_include_prototype: false
+    - include: brace-end
+    - include: here-string-body
+
   redirection-input:
     # This context consumes patterns beginning with glob ranges (e.g.: `<1-20>`)
     # or input redirection (e.g.: <"/path/file").
@@ -532,6 +542,17 @@ contexts:
     - include: variable-expansions
     - include: immediately-pop
 
+  literal-unquoted-content:
+    - meta_append: true
+    - match: \{
+      push: zsh-literal-braces-body
+
+  zsh-literal-braces-body:
+    - meta_include_prototype: false
+    - include: brace-end
+    - include: literal-unquoted-content
+    - include: word-end
+
 ###[ STRING PATH PATTERN MATCHING ]############################################
 
   group-path-pattern-body:
@@ -542,17 +563,43 @@ contexts:
     - meta_prepend: true
     - include: zsh-string-glob-ranges
 
+  string-path-pattern-content:
+    - meta_append: true
+    - match: \{
+      push: zsh-string-path-pattern-braces-body
+
+  zsh-string-path-pattern-braces-body:
+    - meta_include_prototype: false
+    - include: brace-end
+    - include: string-path-pattern-content
+    - include: word-end
+
 ###[ PATH PATTERN MATCHING ]###################################################
 
   path-pattern-content:
-    - meta_prepend: true
+    - meta_append: true
     - include: zsh-string-glob-ranges
+    - match: \{
+      push: zsh-path-pattern-braces-body
+
+  zsh-path-pattern-braces-body:
+    - meta_include_prototype: false
+    - include: brace-end
+    - include: path-pattern-content
+    - include: word-end
 
 ###[ SHELL PATTERN MATCHING ]##################################################
 
   pattern-main-content:
-    - meta_prepend: true
-    - include: zsh-string-glob-ranges
+    - meta_append: true
+    - match: \{
+      push: zsh-pattern-brace-body
+
+  zsh-pattern-brace-body:
+    - meta_include_prototype: false
+    - include: brace-end
+    - include: pattern-main-content
+    - include: word-end
 
   pattern-groups:
     - include: zsh-glob-flags
@@ -572,9 +619,17 @@ contexts:
       scope: punctuation.section.group.begin.regexp.shell
       push: pattern-group-body
 
-  pattern-group-body:
+  pattern-group-content:
     - meta_append: true
+    - match: \{
+      push: zsh-pattern-group-braces-body
     - include: pipesep-pop
+
+  zsh-pattern-group-braces-body:
+    - meta_include_prototype: false
+    - include: brace-end
+    - include: pattern-group-content
+    - include: word-end
 
   pattern-common:
     - meta_prepend: true
@@ -594,6 +649,26 @@ contexts:
     - include: eregexp-groups
     - include: eregexp-anchors
     - include: eregexp-literals
+    - match: \{
+      push: zsh-eregexp-brace-body
+
+  zsh-eregexp-brace-body:
+    - meta_include_prototype: false
+    - include: brace-end
+    - include: eregexp-main-content
+    - include: word-end
+
+  eregexp-group-content:
+    - meta_append: true
+    - match: \{
+      push: zsh-eregexp-group-braces-body
+    - include: pipesep-pop
+
+  zsh-eregexp-group-braces-body:
+    - meta_include_prototype: false
+    - include: brace-end
+    - include: eregexp-group-content
+    - include: word-end
 
 ###[ ARITHMETIC EXPANSIONS ]###################################################
 
@@ -611,6 +686,17 @@ contexts:
       scope: punctuation.section.interpolation.end.shell.zsh
       pop: 1
     - include: expression-content
+
+###[ BRACE EXPANSIONS ]########################################################
+
+  brace-interpolations:
+    # 1. use branching as valid brace expansions must not exceed word boundaries
+    # 2. exclude `brace-interpolation-fallback` as it is handled by balancers
+    - match: (?={)
+      branch_point: brace-interpolation
+      branch:
+        - brace-interpolation-sequence
+        - brace-interpolation-series
 
 ###[ PARAMETER EXPANSIONS ]####################################################
 
@@ -712,6 +798,16 @@ contexts:
         - parameter-expansion-pattern
         - maybe-tilde-interpolation
 
+  parameter-expansion-pattern:
+    - meta_append: true
+    - match: \{
+      push: zsh-parameter-expansion-pattern-braces-body
+
+  zsh-parameter-expansion-pattern-braces-body:
+    - meta_include_prototype: false
+    - include: brace-end
+    - include: parameter-expansion-pattern
+
   parameter-expansion-pattern-groups:
     - include: zsh-glob-flags
     - include: zsh-parameter-glob-ranges
@@ -719,6 +815,26 @@ contexts:
     - match: \(
       scope: punctuation.section.group.begin.regexp.shell
       push: parameter-expansion-pattern-group-body
+
+  parameter-expansion-pattern-group-content:
+    - meta_append: true
+    - match: \{
+      push: zsh-parameter-expansion-pattern-group-braces-body
+
+  zsh-parameter-expansion-pattern-group-braces-body:
+    - meta_include_prototype: false
+    - include: brace-end
+    - include: parameter-expansion-pattern-group-content
+
+  parameter-expansion-string:
+    - meta_append: true
+    - match: \{
+      push: zsh-parameter-expansion-string-braces-body
+
+  zsh-parameter-expansion-string-braces-body:
+    - meta_include_prototype: false
+    - include: brace-end
+    - include: parameter-expansion-string
 
   zsh-parameter-flags:
     # 14.3.1 Parameter Expansion Flags
@@ -1476,6 +1592,12 @@ contexts:
       scope: punctuation.definition.quoted.end.shell.zsh
       pop: 1
     - include: string-prototype
+
+###[ PROTOTYPES ]##############################################################
+
+  brace-end:
+    - match: \}
+      pop: 1
 
 ###[ VARIABLES ]###############################################################
 

--- a/ShellScript/Zsh/tests/syntax_test_scope.zsh
+++ b/ShellScript/Zsh/tests/syntax_test_scope.zsh
@@ -1015,6 +1015,15 @@ if opam upgrade --check; then
 fi
 # <- keyword.control.conditional.endif.shell - string
 
+cat <<<{{str\}{{str}}}str}}     # ensure balanced braces in unquoted strings
+#^^ meta.function-call.identifier.shell meta.command.shell variable.function.shell
+#  ^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell
+#   ^^^ meta.redirection.shell - meta.string - string
+#      ^^^^^^^^^^^^^^^^^^^ meta.redirection.shell meta.string.herestring.shell string.unquoted.shell
+#   ^^^ keyword.operator.assignment.herestring.shell
+#           ^^ constant.character.escape.shell
+#                         ^ invalid.illegal.stray.shell - meta.redirection - meta.string
+
 
 ###############################################################################
 # 8 Command Execution                                                         #
@@ -1044,6 +1053,10 @@ cmd
 # ^ punctuation.separator.path.shell
 #  ^ - constant
 #      ^ punctuation.separator.path.shell
+
+co{{mm{and}}}}  # verify balanced braces in command names (ZSH only)
+#^^^^^^^^^^^^ meta.function-call.identifier.shell meta.command.shell variable.function.shell
+#            ^ invalid.illegal.stray.shell
 
 
 ###############################################################################
@@ -1310,6 +1323,18 @@ function 'foo() \($bar\)[ba-z]'() { : }  # nonsense just to verify theoretical r
 #                                 ^ punctuation.section.block.begin.shell
 #                                   ^ meta.function-call.identifier.shell meta.command.shell support.function.shell
 #                                     ^ punctuation.section.block.end.shell
+
+function co{{mm{and}}}() {}
+#^^^^^^^^ meta.function.shell
+#^^^^^^^ keyword.declaration.function.shell
+#        ^^^^^^^^^^^^^ meta.function.identifier.shell entity.name.function.shell
+#                     ^^ meta.function.parameters.shell
+#                     ^ punctuation.section.parameters.begin.shell
+#                      ^ punctuation.section.parameters.end.shell
+#                       ^ meta.function.shell
+#                        ^^ meta.function.body.shell meta.block.shell
+#                        ^ punctuation.section.block.begin.shell
+#                         ^ punctuation.section.block.end.shell
 
 function foo bar() { : }
 # <- meta.function.shell keyword.declaration.function.shell
@@ -2377,6 +2402,21 @@ ip=10.10.20.14
 #              ^^^ meta.string.glob.shell string.unquoted.shell
 #                  ^^ punctuation.section.compound.end.shell
 
+[[ $foo == co{{mm{[a-d]?}}}{} ]]
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#^ punctuation.section.compound.begin.shell
+#  ^^^^ meta.string.glob.shell meta.interpolation.parameter.shell variable.other.readwrite.shell
+#  ^ punctuation.definition.variable.shell
+#       ^^ keyword.operator.comparison.shell
+#          ^^^^^^^^^^^^^^^^^^ meta.string.glob.shell string.unquoted.shell
+#                 ^^^^^ meta.set.regexp.shell
+#                 ^ punctuation.definition.set.begin.regexp.shell
+#                  ^^^ constant.other.range.regexp.shell
+#                   ^ punctuation.separator.sequence.regexp.shell
+#                     ^ punctuation.definition.set.end.regexp.shell
+#                      ^ constant.other.wildcard.questionmark.shell
+#                             ^^ punctuation.section.compound.end.shell
+
 
 ## Extended Regular Expressions
 ## ----------------------------
@@ -2420,6 +2460,22 @@ ip=10.10.20.14
 #             ^ invalid.illegal.unexpected-token.shell
 #              ^^^ meta.string.glob.shell string.unquoted.shell
 #                  ^^ punctuation.section.compound.end.shell
+
+[[ $var =~ co{{mm{[a-d]?}}}} ]]
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
+#^ punctuation.section.compound.begin.shell
+#  ^^^^ meta.string.glob.shell meta.interpolation.parameter.shell variable.other.readwrite.shell
+#  ^ punctuation.definition.variable.shell
+#       ^^ keyword.operator.comparison.shell
+#          ^^^^^^^^^^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#                 ^^^^^ meta.set.regexp.shell
+#                 ^ punctuation.definition.set.begin.regexp.shell
+#                  ^^^ constant.other.range.regexp.shell
+#                   ^ punctuation.separator.sequence.regexp.shell
+#                     ^ punctuation.definition.set.end.regexp.shell
+#                      ^ keyword.operator.quantifier.regexp.shell
+#                          ^ invalid.illegal.stray.shell - meta.string - string
+#                            ^^ punctuation.section.compound.end.shell
 
 
 ## Arithmetic Comparisons
@@ -4003,6 +4059,24 @@ ip=10.10.20.14
 #            ^ meta.string.regexp.shell string.unquoted.shell
 #             ^ punctuation.section.interpolation.end.shell
 
+: ${${var%{p}}#{q}}  # Ensure balanced braces (ZSH only)
+# ^^ meta.interpolation.parameter.shell
+#   ^^^^^^^^^^ meta.interpolation.parameter.shell meta.interpolation.parameter.shell
+#             ^^^^^ meta.interpolation.parameter.shell
+#                  ^ - meta.interpolation
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#   ^ punctuation.definition.variable.shell
+#    ^ punctuation.section.interpolation.begin.shell
+#     ^^^ variable.other.readwrite.shell
+#        ^ keyword.operator.expansion.shell
+#         ^^^ meta.string.regexp.shell string.unquoted.shell
+#            ^ punctuation.section.interpolation.end.shell
+#             ^ keyword.operator.expansion.shell
+#              ^^^ meta.string.regexp.shell string.unquoted.shell
+#                 ^ punctuation.section.interpolation.end.shell
+
+
 ################################
 # ${parameter/pattern/word}
 
@@ -4331,6 +4405,15 @@ a\/b/c/d}
 #          ^ keyword.operator.substitution.shell
 #              ^ punctuation.section.interpolation.end.shell
 
+: ${foo//{\}}/foo}  # brace are balanced in patterns (ZSH only)
+# ^^^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#      ^^ keyword.operator.substitution.shell
+#         ^^ constant.character.escape.shell
+#            ^ keyword.operator.substitution.shell
+#                ^ punctuation.section.interpolation.end.shell
+
 : ${foo//:/[}]
 # ^^^^^^^^^^^ meta.interpolation.parameter.shell
 #          ^^^ - meta.string.regexp - meta.set
@@ -4353,6 +4436,18 @@ a\/b/c/d}
 #          ^^^^ - meta.string.regexp - meta.set - punctuation
 #           ^^ constant.character.escape.shell
 #              ^ punctuation.section.interpolation.end.shell
+
+: ${foo//:/[{\}}]} # brace are balanced in plain strings (ZSH only)
+# ^^^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
+#                 ^ - meta.interpolation
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#   ^^^ variable.other.readwrite.shell
+#      ^^ keyword.operator.substitution.shell
+#         ^ keyword.operator.substitution.shell
+#          ^^^^^^ - meta.string.regexp - meta.set - punctuation
+#            ^^ constant.character.escape.shell
+#                ^ punctuation.section.interpolation.end.shell
 
 : ${foo//[a-/\}} # incomplete charset
 # ^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
@@ -4449,6 +4544,23 @@ a\/b/c/d}
 #           ^ keyword.operator.substitution.shell
 #            ^^^^ meta.string.glob.shell string.unquoted.shell - keyword - punctuation
 #                ^ punctuation.section.interpolation.end.shell
+
+: ${foo/{{\}[a-z]}({b[a-z]} | ({{([0-9])}}))}/[]]{{\}}}}  # advanced brace balancing in patterns (ZSH only)
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell
+#       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#         ^^ constant.character.escape.shell
+#           ^^^^^ meta.set.regexp.shell
+#                 ^^^^^^^^^^^^ meta.group.regexp.shell - meta.group meta.group
+#                    ^^^^^ meta.set.regexp.shell
+#                           ^ keyword.operator.alternation.regexp.shell
+#                             ^^^ meta.group.regexp.shell meta.group.regexp.shell - meta.group meta.group meta.group
+#                                ^^^^^^^ meta.group.regexp.shell meta.group.regexp.shell meta.group.regexp.shell
+#                                 ^^^^^ meta.set.regexp.shell
+#                                       ^^^ meta.group.regexp.shell meta.group.regexp.shell - meta.group meta.group meta.group
+#                                          ^ meta.group.regexp.shell - meta.group meta.group
+#                                            ^ keyword.operator.substitution.shell
+#                                             ^^^^^^^^^ meta.string.shell string.unquoted.shell
+#                                                      ^ punctuation.section.interpolation.end.shell
 
 # tilde expansion in pattern
 
@@ -4960,22 +5072,59 @@ any --arg{1,2,3} ={1,2,3}
 
 # invalid brace expansions due to whitespace
 
-: {} {*} {1} {a} {foo} {'bar'} {"baz"}
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.interpolation
+: {} {*} {1} {a} {foo} {'bar'} {"baz"} {{} {}}
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.interpolation
+# ^^ meta.string.glob.shell string.unquoted.shell
+#    ^^^ meta.string.glob.shell string.unquoted.shell
+#     ^ constant.other.wildcard.asterisk.shell
+#        ^^^ meta.string.glob.shell string.unquoted.shell
+#            ^^^ meta.string.glob.shell string.unquoted.shell
+#                ^^^^^ meta.string.glob.shell string.unquoted.shell
+#                      ^^^^^^^ meta.string.glob.shell
+#                      ^ string.unquoted.shell
+#                       ^^^^^ string.quoted.single.shell
+#                       ^ punctuation.definition.string.begin.shell
+#                           ^ punctuation.definition.string.end.shell
+#                            ^ string.unquoted.shell
+#                              ^^^^^^^ meta.string.glob.shell
+#                              ^ string.unquoted.shell
+#                               ^^^^^ string.quoted.double.shell
+#                               ^ punctuation.definition.string.begin.shell
+#                                   ^ punctuation.definition.string.end.shell
+#                                    ^ string.unquoted.shell
+#                                      ^^^ meta.string.glob.shell string.unquoted.shell
+#                                          ^^ meta.string.glob.shell string.unquoted.shell
+#                                            ^ invalid.illegal.stray.shell
 
-: { 1..9} {1..9 } {1.. 9} {1 ..9} {a, b, c}
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.interpolation
+: {f{o} {"b}r"} {{foo}bar}}
+# ^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.interpolation
+# ^^^^^ meta.string.glob.shell string.unquoted.shell
+#      ^ - meta.string - string
+#       ^^^^^^^ meta.string.glob.shell
+#       ^ string.unquoted.shell
+#        ^^^^^ string.quoted.double.shell
+#        ^ punctuation.definition.string.begin.shell
+#            ^ punctuation.definition.string.end.shell
+#             ^ string.unquoted.shell
+#              ^ - meta.string - string
+#               ^^^^^^^^^^ meta.string.glob.shell string.unquoted.shell
+#                         ^ invalid.illegal.stray.shell - meta.string - string
 
-: {1..&} {1..|} {1..<} {1..>} {(..)} {a..)}
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.interpolation
+: { 1..9} : {1..9 } : {1.. 9} : {1 ..9} : {a, b, c}
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.interpolation
+
+: {1..&} : {1..|} : {1..<} : {1..>} : {(..)} : {a..)}
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.interpolation
 
 : {a..z\
   ..2}
-#^^^^^ - meta.interpolation
+# ^^^ meta.string.glob.shell string.unquoted.shell - meta.interpolation
+#    ^ invalid.illegal.stray.shell - meta.string - string - meta.interpolation
 
 : {foo\
   bar,baz}
-#^^^^^^^^^^ - meta.interpolation
+# ^^^^^^^ meta.string.glob.shell string.unquoted.shell - meta.interpolation
+#        ^ invalid.illegal.stray.shell - meta.string - string - meta.interpolation
 
 : '{foo,bar,baz}' '{1..10}'
 # ^^^^^^^^^^^^^^^ meta.string.glob.shell string.quoted.single.shell - meta.interpolation


### PR DESCRIPTION
Addresses #4244 issue 9

This PR pushes dedicated contexts onto stack to ensure braces are balanced in shell words, thus `hello{world}` is consumed as single word without final `}` being scoped stray.

Note:

ZSH treats `{` and `}` as "metachar", which terminate shell words. Additionally it tracks balanced braces within words. Thus `Hello{world}` is a single word, but final closing brace in `Hello{world}}` is stray.

This rule has already been applied to glob flags/qualifiers and subscripts. This commit extends implementation to all other shell word handling contexts.