### PR TITLE
[ShellScript] Improve arithmetic words

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -1753,29 +1753,13 @@ contexts:
     - include: else-pop
 
   arithmetic-word:
-    # A `word` which is interpreted as arithmetic expression
-    - match: \"
-      scope: punctuation.definition.quoted.begin.shell
-      set: arithmetic-word-double-quoted-body
-    - match: \'
-      scope: punctuation.definition.quoted.begin.shell
-      set: arithmetic-word-single-quoted-body
+    - meta_include_prototype: false
     - match: '{{word_begin}}'
-      set: arithmetic-word-unquoted-body
+      set: arithmetic-word-body
 
-  arithmetic-word-double-quoted-body:
-    - meta_scope: meta.quoted.shell meta.arithmetic.shell
-    - include: expression-double-quoted-body
-
-  arithmetic-word-single-quoted-body:
-    - meta_scope: meta.quoted.shell meta.arithmetic.shell
-    - include: expression-single-quoted-body
-
-  arithmetic-word-unquoted-body:
+  arithmetic-word-body:
     - meta_scope: meta.arithmetic.shell
-    - include: expression-groups
-    - include: expression-common
-    - include: expression-illegals
+    - include: expression-content
     - include: word-end
 
   expression-content:
@@ -1790,6 +1774,7 @@ contexts:
     - include: expression-common
 
   expression-double-quoted-body:
+    - meta_scope: meta.quoted.shell
     - match: \"
       scope: punctuation.definition.quoted.end.shell
       pop: 1
@@ -1814,6 +1799,7 @@ contexts:
     - include: expression-illegals
 
   expression-single-quoted-body:
+    - meta_scope: meta.quoted.shell
     - match: \'
       scope: punctuation.definition.quoted.end.shell
       pop: 1

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -728,7 +728,28 @@ contexts:
       branch_point: cmd-compound-test-comparison
       branch:
         - cmd-compound-test-string-comparison  # note: try string comparison first as it is more likely
-        - arithmetic-comparison
+        - cmd-compound-test-arithmetic-comparison
+
+  cmd-compound-test-arithmetic-comparison:
+    - meta_include_prototype: false
+    - match: ''
+      set:
+        - cmd-compound-test-arithmetic-word
+        - cmd-compound-test-arithmetic-operator
+        - arithmetic-word-body
+
+  cmd-compound-test-arithmetic-operator:
+    - meta_include_prototype: false
+    - match: '{{arithmetic_comparison_operators}}'
+      scope: keyword.operator.comparison.shell
+      pop: 1
+    - include: comments
+    - include: else-pop
+
+  cmd-compound-test-arithmetic-word:
+    - meta_include_prototype: false
+    - include: comments
+    - include: arithmetic-word
 
   cmd-compound-test-string-comparison:
     # comparison like `string < string` or `string =~ pattern`
@@ -832,8 +853,28 @@ contexts:
     - match: '{{word_begin}}'
       branch_point: cmd-test-comparison
       branch:
-        - cmd-test-string-comparison   # note: try string comparison first as it is more likely
-        - arithmetic-comparison        # note: built-in tests only support basic integer expressions
+        - cmd-test-string-comparison      # note: try string comparison first as it is more likely
+        - cmd-test-arithmetic-comparison  # note: built-in tests only support basic integer expressions
+
+  cmd-test-arithmetic-comparison:
+    - meta_include_prototype: false
+    - match: ''
+      set:
+        - cmd-test-arithmetic-word
+        - cmd-test-arithmetic-operator
+        - arithmetic-word-body
+
+  cmd-test-arithmetic-operator:
+    - meta_include_prototype: false
+    - match: '{{arithmetic_comparison_operators}}'
+      scope: keyword.operator.comparison.shell
+      pop: 1
+    - include: eoc-pop
+
+  cmd-test-arithmetic-word:
+    - meta_include_prototype: false
+    - include: eoc-pop
+    - include: arithmetic-word
 
   cmd-test-string-comparison:
     # comparison like `string < string` or `string =~ pattern`
@@ -1735,22 +1776,6 @@ contexts:
     - include: string-interpolations
 
 ###[ ARITHMETIC EXPRESSIONS ]##################################################
-
-  arithmetic-comparison:
-    # arithmetic comparison like `1+2 -eq 2+1`
-    - meta_include_prototype: false
-    - match: ''
-      set:
-        - arithmetic-operator
-        - arithmetic-word
-
-  arithmetic-operator:
-    - meta_include_prototype: false
-    - match: '{{arithmetic_comparison_operators}}'
-      scope: keyword.operator.comparison.shell
-      set: arithmetic-word
-    - include: comments
-    - include: else-pop
 
   arithmetic-word:
     - meta_include_prototype: false

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -395,11 +395,13 @@ contexts:
     - match: (?=\))
       fail: cmd-arithmetic
     - include: expression-content
+    - include: expression-illegals
 
   cmd-arithmetic-args:
     - meta_content_scope: meta.function-call.arguments.shell meta.arithmetic.shell
     - include: cmd-args-end
     - include: expression-content
+    - include: expression-illegals
 
 ###[ COMMAND BUILTINS ]########################################################
 
@@ -1786,7 +1788,6 @@ contexts:
       push: expression-single-quoted-body
     - include: expression-groups
     - include: expression-common
-    - include: expression-illegals
 
   expression-double-quoted-body:
     - match: \"
@@ -2812,6 +2813,7 @@ contexts:
     - match: (?=\))
       fail: arithmetic-expansion
     - include: expression-content
+    - include: expression-illegals
 
 ###[ BRACE EXPANSIONS ]########################################################
 
@@ -3129,6 +3131,7 @@ contexts:
     - meta_content_scope: meta.arithmetic.shell
     - include: parameter-expansion-end
     - include: expression-content
+    - include: expression-illegals
 
   parameter-expansion-substitution-pattern:
     # [3.5.8.1] Pattern Matching in parameter expansions' substitutions

--- a/ShellScript/Bash/tests/syntax_test_scope.bash
+++ b/ShellScript/Bash/tests/syntax_test_scope.bash
@@ -2971,15 +2971,17 @@ done
 #                    ^ punctuation.section.group.end.shell
 #                      ^^ punctuation.section.compound.end.shell
 
-[[ "c + $d" -eq "1 * ( a % ( b * 5) )" ]]
+[[ "c"+"$d" -eq "1 * ( a % ( b * 5) )" ]]
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
-#  ^^^^^^^^ meta.quoted.shell meta.arithmetic.shell
+#  ^^^ meta.arithmetic.shell meta.quoted.shell
+#     ^ meta.arithmetic.shell - meta.quoted
+#      ^^^ meta.arithmetic.shell meta.quoted.shell
 #          ^^^^^ - meta.arithmetic
-#               ^^^^^ meta.quoted.shell meta.arithmetic.shell - meta.group
-#                    ^^^^^^ meta.quoted.shell meta.arithmetic.shell meta.group.shell - meta.group meta.group
-#                          ^^^^^^^^ meta.quoted.shell meta.arithmetic.shell meta.group.shell meta.group.shell
-#                                  ^^ meta.quoted.shell meta.arithmetic.shell meta.group.shell - meta.group meta.group
-#                                    ^ meta.quoted.shell meta.arithmetic.shell - meta.group
+#               ^^^^^ meta.arithmetic.shell meta.quoted.shell - meta.group
+#                    ^^^^^^ meta.arithmetic.shell meta.quoted.shell meta.group.shell - meta.group meta.group
+#                          ^^^^^^^^ meta.arithmetic.shell meta.quoted.shell meta.group.shell meta.group.shell
+#                                  ^^ meta.arithmetic.shell meta.quoted.shell meta.group.shell - meta.group meta.group
+#                                    ^ meta.arithmetic.shell meta.quoted.shell - meta.group
 #                                     ^^ - meta.arithmetic
 #  ^ punctuation.definition.quoted.begin.shell
 #   ^ variable.other.readwrite.shell

--- a/ShellScript/Bash/tests/syntax_test_scope.bash
+++ b/ShellScript/Bash/tests/syntax_test_scope.bash
@@ -3023,6 +3023,47 @@ done
 #                       ^^ variable.other.readwrite.shell
 #                          ^^ punctuation.section.compound.end.shell
 
+## multi-line arithmetic comparisons
+
+[[
+    # comment
+#   ^^^^^^^^^^ meta.compound.conditional.shell comment.line.number-sign.shell
+    "a"+"b"+(
+#^^^ meta.compound.conditional.shell - meta.arithmetic
+#   ^^^^^^^^^^ meta.compound.conditional.shell meta.arithmetic.shell
+#   ^^^ meta.quoted.shell
+#   ^ punctuation.definition.quoted.begin.shell
+#    ^ variable.other.readwrite.shell
+#     ^ punctuation.definition.quoted.end.shell
+#      ^ keyword.operator.arithmetic.shell
+#       ^^^ meta.quoted.shell
+#       ^ punctuation.definition.quoted.begin.shell
+#        ^ variable.other.readwrite.shell
+#         ^ punctuation.definition.quoted.end.shell
+#          ^ keyword.operator.arithmetic.shell
+#           ^  punctuation.section.group.begin.shell
+
+    # not a comment
+#   ^^^^^^^^^^^^^^^^ - comment
+    1
+#   ^ constant.numeric.value.shell
+    )
+# ^^^ meta.compound.conditional.shell meta.arithmetic.shell meta.group.shell
+#   ^ punctuation.section.group.end.shell
+    # comment
+#   ^^^^^^^^^^ meta.compound.conditional.shell comment.line.number-sign.shell
+    -lt
+#^^^^^^ meta.compound.conditional.shell
+#   ^^^ keyword.operator.comparison.shell
+    # comment
+#   ^^^^^^^^^^ meta.compound.conditional.shell comment.line.number-sign.shell
+    5
+#^^^^ meta.compound.conditional.shell
+#   ^ meta.arithmetic.shell meta.number.integer.decimal.shell constant.numeric.value.shell
+    # comment
+#   ^^^^^^^^^^ meta.compound.conditional.shell comment.line.number-sign.shell
+]]
+
 
 ###############################################################################
 # 3.2.5 Compound Commands                                                     #
@@ -13084,6 +13125,25 @@ doc
 #                     ^ keyword.operator.arithmetic.shell
 #                      ^^ variable.other.readwrite.shell
 #                         ^ punctuation.section.compound.end.shell
+
+## arithmetic multi-line test expressions
+
+[ 4 \
+  -lt \
+# ^^^ keyword.operator.comparison.shell
+#     ^ punctuation.separator.continuation.line.shell
+
+[ 4 \
+  -lt \
+  a \
+# ^ meta.arithmetic.shell variable.other.readwrite.shell
+#   ^ punctuation.separator.continuation.line.shell
+
+[ 4 \
+  -lt \
+  a \
+]
+# <- meta.compound.conditional.shell punctuation.section.compound.end.shell
 
 
 ###############################################################################

--- a/ShellScript/Zsh.sublime-syntax
+++ b/ShellScript/Zsh.sublime-syntax
@@ -686,6 +686,7 @@ contexts:
       scope: punctuation.section.interpolation.end.shell.zsh
       pop: 1
     - include: expression-content
+    - include: expression-illegals
 
 ###[ BRACE EXPANSIONS ]########################################################
 
@@ -1187,6 +1188,7 @@ contexts:
       pop: 1
     - include: line-continuations
     - include: expression-content
+    - include: expression-illegals
 
   zsh-qualifier-fspec:
     # credentials given as octal number without base
@@ -1361,7 +1363,7 @@ contexts:
       set: zsh-modifier-expression-paren-body
     - match: '{{glob_string_quote}}'
       scope: meta.quoted.glob.shell.zsh punctuation.definition.quoted.begin.shell.zsh
-      embed: expression-content
+      embed: zsh-modifier-expression-content
       embed_scope: meta.quoted.glob.shell.zsh meta.arithmetic.shell
       escape: \1
       escape_captures:
@@ -1376,7 +1378,7 @@ contexts:
     - match: \>
       scope: punctuation.definition.quoted.end.shell.zsh
       pop: 1
-    - include: expression-content
+    - include: zsh-modifier-expression-content
 
   zsh-modifier-expression-brace-body:
     - meta_include_prototype: false
@@ -1385,7 +1387,7 @@ contexts:
     - match: \}
       scope: punctuation.definition.quoted.end.shell.zsh
       pop: 1
-    - include: expression-content
+    - include: zsh-modifier-expression-content
 
   zsh-modifier-expression-bracket-body:
     - meta_include_prototype: false
@@ -1394,7 +1396,7 @@ contexts:
     - match: \]
       scope: punctuation.definition.quoted.end.shell.zsh
       pop: 1
-    - include: expression-content
+    - include: zsh-modifier-expression-content
 
   zsh-modifier-expression-paren-body:
     - meta_include_prototype: false
@@ -1403,7 +1405,11 @@ contexts:
     - match: \)
       scope: punctuation.definition.quoted.end.shell.zsh
       pop: 1
+    - include: zsh-modifier-expression-content
+
+  zsh-modifier-expression-content:
     - include: expression-content
+    - include: expression-illegals
 
 ###[ ZSH MODIFIER INTERPOLATED STRINGS ]#######################################
 


### PR DESCRIPTION
This PR...

1. separates `expression-illegals` from `expression-content` as preparation for 2.) and future changes
2. implements `arithmetic-word` like `string-path-pattern` with regards to word boundaries and quotation handling, as both share same rules with regards to shell words and quotations
3. fixes arithmetic multi-line comparisons in built-in and compound test expressions.