### PR TITLE
[ShellScript] Add missing parameter expansion substitution operator

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -3048,11 +3048,11 @@ contexts:
     - meta_include_prototype: false
     # Expansion result is used as new parameter name to expand
     # Adds a level of indirection to name resolution
-    - match: \!(?![/%,:=^}]|[-+?@][^}])
+    - match: \!(?![/%,~:=^}]|[-+?@][^}])
       scope: keyword.operator.expansion.indirection.shell
       pop: 1
     # Length of var in words (array) or bytes
-    - match: \#(?![/%,:=^}]|[-+?@#][^}])
+    - match: \#(?![/%,~:=^}]|[-+?@#][^}])
       scope: keyword.operator.expansion.length.shell
       pop: 1
     - include: line-continuations
@@ -3063,10 +3063,10 @@ contexts:
     - match: \d+
       scope: variable.language.positional.shell
       pop: 1
-    - match: '{{builtin_variables}}(?=[-+*/%?,:=#^@}\[])'
+    - match: '{{builtin_variables}}(?=[-+*/%?,~:=#^@}\[])'
       scope: variable.language.builtin.shell
       pop: 1
-    - match: '{{special_variables}}(?=[-+*/%?,:=#^@}\[])'
+    - match: '{{special_variables}}(?=[-+*/%?,~:=#^@}\[])'
       scope: variable.language.special.shell
       pop: 1
     - match: ''
@@ -3108,15 +3108,20 @@ contexts:
     # ${parameter##pattern}
     # ${parameter%pattern}
     # ${parameter%%pattern}
-    # ${parameter^pattern}
-    # ${parameter^^pattern}
-    # ${parameter,pattern}
-    # ${parameter,,pattern}
-    - match: (?:##?|%%?|\^\^?|,,?)
+    - match: (?:##?|%%?)
       scope: keyword.operator.expansion.shell
       set:
         - parameter-expansion-pattern
         - maybe-tilde-interpolation
+    # ${parameter^pattern}
+    # ${parameter^^pattern}
+    # ${parameter,pattern}
+    # ${parameter,,pattern}
+    # ${parameter~pattern}
+    # ${parameter~~pattern}
+    - match: (?:\^\^?|,,?|~~?)
+      scope: keyword.operator.expansion.shell
+      set: parameter-expansion-pattern
 
   parameter-expansion-substr-start:
     - meta_content_scope: meta.arithmetic.shell

--- a/ShellScript/Bash/tests/syntax_test_scope.bash
+++ b/ShellScript/Bash/tests/syntax_test_scope.bash
@@ -8023,20 +8023,16 @@ a\/b/c/d}
 #           ^ punctuation.section.interpolation.end.shell
 #             ^ comment.line punctuation
 
-: ${foo,~+/*bar}
-# ^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
+: ${foo,~}
+# ^^^^^^^^ meta.interpolation.parameter.shell
 #      ^ keyword.operator.expansion.shell
-#       ^^ meta.string.regexp.shell meta.interpolation.tilde.shell variable.language.tilde.shell
-#         ^^^^^ meta.interpolation.parameter.shell meta.string.regexp.shell string.unquoted.shell
-#          ^ constant.other.wildcard.asterisk.shell
-#              ^ punctuation.section.interpolation.end.shell
+#       ^ meta.string.regexp.shell string.unquoted.shell
+#        ^ punctuation.section.interpolation.end.shell
 
-: ${foo,m~+/*bar}
-# ^^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
+: ${foo,[abx]}
+# ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #      ^ keyword.operator.expansion.shell
-#       ^^^^^^^^ meta.string.regexp.shell
-#        ^^ - variable
-#           ^ constant.other.wildcard.asterisk.shell
+#       ^^^^^ meta.string.regexp.shell string.unquoted.shell meta.set.regexp.shell
 
 ################################
 # ${parameter,,pattern}
@@ -8159,20 +8155,16 @@ a\/b/c/d}
 #           ^^^^^^^ meta.string.regexp.shell
 #                  ^ punctuation.section.interpolation.end.shell
 
-: ${foo,,~+/*bar}
-# ^^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
+: ${foo,,~}
+# ^^^^^^^^^ meta.interpolation.parameter.shell
 #      ^^ keyword.operator.expansion.shell
-#        ^^^^^^^ meta.string.regexp.shell
-#        ^^ variable.language.tilde.shell
-#           ^ constant.other.wildcard.asterisk.shell
-#               ^ punctuation.section.interpolation.end.shell
+#        ^ meta.string.regexp.shell string.unquoted.shell
+#         ^ punctuation.section.interpolation.end.shell
 
-: ${foo,,m~+/*bar}
-# ^^^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
+: ${foo,,[abx]}
+# ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #      ^^ keyword.operator.expansion.shell
-#        ^^^^^^^^ meta.string.regexp.shell
-#         ^^ - variable
-#            ^ constant.other.wildcard.asterisk.shell
+#        ^^^^^ meta.string.regexp.shell string.unquoted.shell meta.set.regexp.shell
 
 ################################
 # ${parameter^pattern}
@@ -8310,20 +8302,16 @@ a\/b/c/d}
 #           ^ punctuation.section.interpolation.end.shell
 #             ^ comment.line punctuation
 
-: ${foo^~+/*bar}
-# ^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
+: ${foo^~}
+# ^^^^^^^^ meta.interpolation.parameter.shell
 #      ^ keyword.operator.expansion.shell
-#       ^^ meta.string.regexp.shell meta.interpolation.tilde.shell variable.language.tilde.shell
-#         ^^^^^ meta.interpolation.parameter.shell meta.string.regexp.shell string.unquoted.shell
-#          ^ constant.other.wildcard.asterisk.shell
-#              ^ punctuation.section.interpolation.end.shell
+#       ^ meta.string.regexp.shell string.unquoted.shell
+#        ^ punctuation.section.interpolation.end.shell
 
-: ${foo^m~+/*bar}
-# ^^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
+: ${foo^[abx]}
+# ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #      ^ keyword.operator.expansion.shell
-#       ^^^^^^^^ meta.string.regexp.shell
-#        ^^ - variable
-#           ^ constant.other.wildcard.asterisk.shell
+#       ^^^^^ meta.string.regexp.shell string.unquoted.shell meta.set.regexp.shell
 
 ################################
 # ${parameter^^pattern}
@@ -8446,20 +8434,294 @@ a\/b/c/d}
 #           ^^^^^^^ meta.string.regexp.shell
 #                  ^ punctuation.section.interpolation.end.shell
 
-: ${foo^^~+/*bar}
-# ^^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
+: ${foo^^~}
+# ^^^^^^^^^ meta.interpolation.parameter.shell
 #      ^^ keyword.operator.expansion.shell
+#        ^ meta.string.regexp.shell string.unquoted.shell
+#         ^ punctuation.section.interpolation.end.shell
+
+: ${foo^^[abx]}
+# ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
+#      ^^ keyword.operator.expansion.shell
+#        ^^^^^ meta.string.regexp.shell string.unquoted.shell meta.set.regexp.shell
+
+################################
+# ${parameter~pattern}
+
+: ${@~pattern}
+# ^^^^^^^^^^^^ meta.interpolation.parameter.shell
+#   ^ variable.language.special.shell
+#    ^ keyword.operator.expansion.shell
+#     ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+
+: ${*~pattern}
+# ^^^^^^^^^^^^ meta.interpolation.parameter.shell
+#   ^ variable.language.special.shell
+#    ^ keyword.operator.expansion.shell
+#     ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+
+: ${#~pattern}
+# ^^^^^^^^^^^^ meta.interpolation.parameter.shell
+#   ^ variable.language.special.shell
+#    ^ keyword.operator.expansion.shell
+#     ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+
+: ${?~pattern}
+# ^^^^^^^^^^^^ meta.interpolation.parameter.shell
+#   ^ variable.language.special.shell
+#    ^ keyword.operator.expansion.shell
+#     ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+
+: ${$~pattern}
+# ^^^^^^^^^^^^ meta.interpolation.parameter.shell
+#   ^ variable.language.special.shell
+#    ^ keyword.operator.expansion.shell
+#     ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+
+: ${-~pattern}
+# ^^^^^^^^^^^^ meta.interpolation.parameter.shell
+#   ^ variable.language.special.shell
+#    ^ keyword.operator.expansion.shell
+#     ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+
+: ${!~pattern}
+# ^^^^^^^^^^^^ meta.interpolation.parameter.shell
+#   ^ variable.language.special.shell
+#    ^ keyword.operator.expansion.shell
+#     ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+
+: ${_~pattern}
+# ^^^^^^^^^^^^ meta.interpolation.parameter.shell
+#   ^ variable.language.builtin.shell
+#    ^ keyword.operator.expansion.shell
+#     ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+
+: ${foo~}
+# ^^^^^^^ meta.interpolation.parameter.shell
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#      ^ keyword.operator.expansion.shell
+#       ^ punctuation.section.interpolation.end.shell
+
+: ${foo~pattern}
+# ^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#      ^ keyword.operator.expansion.shell
+#       ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#              ^ punctuation.section.interpolation.end.shell
+
+: ${foo@~pattern}
+# ^^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#   ^^^ variable.other.readwrite.shell
+#      ^ variable.language.special.shell
+#       ^ keyword.operator.expansion.shell
 #        ^^^^^^^ meta.string.regexp.shell
-#        ^^ variable.language.tilde.shell
-#           ^ constant.other.wildcard.asterisk.shell
 #               ^ punctuation.section.interpolation.end.shell
 
-: ${foo^^m~+/*bar}
+: ${foo*~pattern}
+# ^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#   ^^^ variable.other.readwrite.shell
+#      ^ variable.language.special.shell
+#       ^ keyword.operator.expansion.shell
+#        ^^^^^^^ meta.string.regexp.shell
+#               ^ punctuation.section.interpolation.end.shell
+
+: ${foo[@]~pattern}
+# ^^^^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#   ^^^ variable.other.readwrite.shell
+#      ^^^ meta.item-access.shell
+#      ^ punctuation.section.item-access.begin.shell
+#       ^ variable.language.array.shell
+#        ^ punctuation.section.item-access.end.shell
+#         ^ keyword.operator.expansion.shell
+#          ^^^^^^^ meta.string.regexp.shell
+#                 ^ punctuation.section.interpolation.end.shell
+
+: ${foo[@]~pattern}
+# ^^^^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#   ^^^ variable.other.readwrite.shell
+#      ^^^ meta.item-access.shell
+#      ^ punctuation.section.item-access.begin.shell
+#       ^ variable.language.array.shell
+#        ^ punctuation.section.item-access.end.shell
+#         ^ keyword.operator.expansion.shell
+#          ^^^^^^^ meta.string.regexp.shell
+#                 ^ punctuation.section.interpolation.end.shell
+
+: ${foo~ #pattern} # comment
 # ^^^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#      ^ keyword.operator.expansion.shell
+#       ^^^^^^^^^ meta.string.regexp.shell
+#        ^ - comment - keyword
+#                ^ punctuation.section.interpolation.end.shell
+#                  ^^^^^^^^^^ comment.line.number-sign.shell
+
+: ${foo~ #} # hello
+#      ^ keyword.operator.expansion.shell
+#       ^^ meta.string.regexp.shell
+#        ^ - comment.line
+#         ^ punctuation.section.interpolation.end.shell
+#           ^ comment.line punctuation
+
+: ${foo~\ \#} # hello
+#      ^ keyword.operator.expansion.shell
+#       ^^^^ meta.string.regexp.shell constant.character.escape.shell
+#          ^ - comment.line
+#           ^ punctuation.section.interpolation.end.shell
+#             ^ comment.line punctuation
+
+: ${foo~~}
+# ^^^^^^^^ meta.interpolation.parameter.shell
+#      ^^ keyword.operator.expansion.shell
+#        ^ punctuation.section.interpolation.end.shell
+
+: ${foo~[abx]}
+# ^^^^^^^^^^^^ meta.interpolation.parameter.shell
+#      ^ keyword.operator.expansion.shell
+#       ^^^^^ meta.string.regexp.shell string.unquoted.shell meta.set.regexp.shell
+
+################################
+# ${parameter~~pattern}
+
+: ${@~~pattern}
+# ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
+#   ^ variable.language.special.shell
+#    ^^ keyword.operator.expansion.shell
+#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+
+: ${*~~pattern}
+# ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
+#   ^ variable.language.special.shell
+#    ^^ keyword.operator.expansion.shell
+#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+
+: ${#~~pattern}
+# ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
+#   ^ variable.language.special.shell
+#    ^^ keyword.operator.expansion.shell
+#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+
+: ${?~~pattern}
+# ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
+#   ^ variable.language.special.shell
+#    ^^ keyword.operator.expansion.shell
+#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+
+: ${$~~pattern}
+# ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
+#   ^ variable.language.special.shell
+#    ^^ keyword.operator.expansion.shell
+#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+
+: ${-~~pattern}
+# ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
+#   ^ variable.language.special.shell
+#    ^^ keyword.operator.expansion.shell
+#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+
+: ${!~~pattern}
+# ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
+#   ^ variable.language.special.shell
+#    ^^ keyword.operator.expansion.shell
+#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+
+: ${_~~pattern}
+# ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
+#   ^ variable.language.builtin.shell
+#    ^^ keyword.operator.expansion.shell
+#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+
+: ${foo~~}
+# ^^^^^^^^ meta.interpolation.parameter.shell
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#      ^^ keyword.operator.expansion.shell
+#        ^ punctuation.section.interpolation.end.shell
+
+: ${foo~~pattern}
+# ^^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#      ^^ keyword.operator.expansion.shell
+#        ^^^^^^^ meta.string.regexp.shell
+#               ^ punctuation.section.interpolation.end.shell
+
+: ${foo~~~pattern}
+# ^^^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
 #      ^^ keyword.operator.expansion.shell
 #        ^^^^^^^^ meta.string.regexp.shell
-#         ^^ - variable
-#            ^ constant.other.wildcard.asterisk.shell
+#        ^ - keyword
+#                ^ punctuation.section.interpolation.end.shell
+
+: ${foo@~~pattern}
+# ^^^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#   ^^^ variable.other.readwrite.shell
+#      ^ variable.language.special.shell
+#       ^^ keyword.operator.expansion.shell
+#         ^^^^^^^ meta.string.regexp.shell
+#                ^ punctuation.section.interpolation.end.shell
+
+: ${foo*~~pattern}
+# ^^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#   ^^^ variable.other.readwrite.shell
+#      ^ variable.language.special.shell
+#       ^^ keyword.operator.expansion.shell
+#         ^^^^^^^ meta.string.regexp.shell
+#                ^ punctuation.section.interpolation.end.shell
+
+: ${foo[@]~~pattern}
+# ^^^^^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#   ^^^ variable.other.readwrite.shell
+#      ^^^ meta.item-access.shell
+#      ^ punctuation.section.item-access.begin.shell
+#       ^ variable.language.array.shell
+#        ^ punctuation.section.item-access.end.shell
+#         ^^ keyword.operator.expansion.shell
+#           ^^^^^^^ meta.string.regexp.shell
+#                  ^ punctuation.section.interpolation.end.shell
+
+: ${foo[@]~~pattern}
+# ^^^^^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#   ^^^ variable.other.readwrite.shell
+#      ^^^ meta.item-access.shell
+#      ^ punctuation.section.item-access.begin.shell
+#       ^ variable.language.array.shell
+#        ^ punctuation.section.item-access.end.shell
+#         ^^ keyword.operator.expansion.shell
+#           ^^^^^^^ meta.string.regexp.shell
+#                  ^ punctuation.section.interpolation.end.shell
+
+: ${foo~~~}
+# ^^^^^^^^^ meta.interpolation.parameter.shell
+#      ^^ keyword.operator.expansion.shell
+#        ^ meta.string.regexp.shell string.unquoted.shell
+#         ^ punctuation.section.interpolation.end.shell
+
+: ${foo~~[abx]}
+# ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
+#      ^^ keyword.operator.expansion.shell
+#        ^^^^^ meta.string.regexp.shell string.unquoted.shell meta.set.regexp.shell
 
 ################################
 # ${parameter@operator}

--- a/ShellScript/Zsh.sublime-syntax
+++ b/ShellScript/Zsh.sublime-syntax
@@ -793,15 +793,14 @@ contexts:
     - match: :(?:[*|]|\^\^?)
       scope: keyword.operator.arithmetic.shell
       set: zsh-parameter-array-name
+    # ${parameter:#pattern}
     # ${parameter::=pattern}
-    # $parameter if non-null, else str and set parameter to it.
     - match: :(?:#|:=)
       scope: keyword.operator.assignment.shell.zsh
       set:
         - parameter-expansion-pattern
         - maybe-tilde-interpolation
     # ${parameter:/pattern/word}
-    # Substitute <pattern> with <word>, if pattern match the whole value of <parameter>.
     - match: :/
       scope: keyword.operator.substitution.shell
       set:

--- a/ShellScript/Zsh.sublime-syntax
+++ b/ShellScript/Zsh.sublime-syntax
@@ -784,19 +784,34 @@ contexts:
     - include: immediately-pop
 
   parameter-expansion-modifier:
-    # 14.3 Parameter Expansion
     - meta_prepend: true
-    # $var if non-null, else str and set var to it
-    - match: ::=
+    # 14.3 Parameter Expansion
+    # ${parameter:|arrayname}
+    # ${parameter:*arrayname}
+    # ${parameter:^arrayname}
+    # ${parameter:^^arrayname}
+    - match: :(?:[*|]|\^\^?)
+      scope: keyword.operator.arithmetic.shell
+      set: zsh-parameter-array-name
+    # ${parameter::=pattern}
+    # $parameter if non-null, else str and set parameter to it.
+    - match: :(?:#|:=)
       scope: keyword.operator.assignment.shell.zsh
       set:
         - parameter-expansion-pattern
         - maybe-tilde-interpolation
-    - match: :#
-      scope: keyword.operator.assignment.shell.zsh
+    # ${parameter:/pattern/word}
+    # Substitute <pattern> with <word>, if pattern match the whole value of <parameter>.
+    - match: :/
+      scope: keyword.operator.substitution.shell
       set:
-        - parameter-expansion-pattern
+        - parameter-expansion-substitution-pattern
         - maybe-tilde-interpolation
+
+  zsh-parameter-array-name:
+    - meta_content_scope: variable.other.readwrite.shell
+    - include: parameter-expansion-end
+    - include: literal-unquoted-content
 
   parameter-expansion-pattern:
     - meta_append: true

--- a/ShellScript/Zsh.sublime-syntax
+++ b/ShellScript/Zsh.sublime-syntax
@@ -806,6 +806,12 @@ contexts:
       set:
         - parameter-expansion-substitution-pattern
         - maybe-tilde-interpolation
+    # Legal in Bash, but illegal in Zsh
+    # ${parameter~pattern}
+    # ${parameter~~pattern}
+    - match: ~~?
+      scope: invalid.illegal.unexpacted-token.shell
+      set: parameter-expansion-pattern
 
   zsh-parameter-array-name:
     - meta_content_scope: variable.other.readwrite.shell

--- a/ShellScript/Zsh/tests/syntax_test_scope.zsh
+++ b/ShellScript/Zsh/tests/syntax_test_scope.zsh
@@ -4012,6 +4012,60 @@ ip=10.10.20.14
 #        ^^^ meta.string.regexp.shell
 #           ^ punctuation.section.interpolation.end.shell
 
+: ${var^pat}    # upper case all chars matching `pat`
+# ^^^^^^^^^^ meta.interpolation.parameter.shell
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#   ^^^ variable.other.readwrite.shell
+#      ^ keyword.operator.expansion.shell
+#       ^^^ meta.string.regexp.shell string.unquoted.shell
+#          ^ punctuation.section.interpolation.end.shell
+
+: ${var^^pat}   # upper case all chars matching `pat`
+# ^^^^^^^^^^ meta.interpolation.parameter.shell
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#   ^^^ variable.other.readwrite.shell
+#      ^^ keyword.operator.expansion.shell
+#        ^^^ meta.string.regexp.shell string.unquoted.shell
+#           ^ punctuation.section.interpolation.end.shell
+
+: ${var,pat}    # lower case all chars matching `pat`
+# ^^^^^^^^^^ meta.interpolation.parameter.shell
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#   ^^^ variable.other.readwrite.shell
+#      ^ keyword.operator.expansion.shell
+#       ^^^ meta.string.regexp.shell string.unquoted.shell
+#          ^ punctuation.section.interpolation.end.shell
+
+: ${var,,pat}   # lower case all chars matching `pat`
+# ^^^^^^^^^^ meta.interpolation.parameter.shell
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#   ^^^ variable.other.readwrite.shell
+#      ^^ keyword.operator.expansion.shell
+#        ^^^ meta.string.regexp.shell string.unquoted.shell
+#           ^ punctuation.section.interpolation.end.shell
+
+: ${var~pat}    # toggle case all chars matching `pat` (Bash only)
+# ^^^^^^^^^^ meta.interpolation.parameter.shell
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#   ^^^ variable.other.readwrite.shell
+#      ^ invalid.illegal.unexpacted-token.shell
+#       ^^^ meta.string.regexp.shell string.unquoted.shell
+#          ^ punctuation.section.interpolation.end.shell
+
+: ${var~~pat}   # toggle case all chars matching `pat` (Bash only)
+# ^^^^^^^^^^ meta.interpolation.parameter.shell
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#   ^^^ variable.other.readwrite.shell
+#      ^^ invalid.illegal.unexpacted-token.shell
+#        ^^^ meta.string.regexp.shell string.unquoted.shell
+#           ^ punctuation.section.interpolation.end.shell
+
 : ${var:#pat}    # $var unless pat matches, then empty
 # ^^^^^^^^^^ meta.interpolation.parameter.shell
 # ^ punctuation.definition.variable.shell

--- a/ShellScript/Zsh/tests/syntax_test_scope.zsh
+++ b/ShellScript/Zsh/tests/syntax_test_scope.zsh
@@ -4022,7 +4022,7 @@ ip=10.10.20.14
 #           ^ punctuation.section.interpolation.end.shell
 
 : ${var:|arr}    # Remove all elements of array `arr` from `var`.
-#^^^^^^^^^^^^ meta.function-call.arguments.shell
+# ^^^^^^^^^^^ meta.interpolation.parameter.shell
 # ^ punctuation.definition.variable.shell
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^^^ variable.other.readwrite.shell
@@ -4031,7 +4031,7 @@ ip=10.10.20.14
 #           ^ punctuation.section.interpolation.end.shell
 
 : ${var:*arr}    # Retain all elements which appear in both arrays `var` and `arr`.
-#^^^^^^^^^^^^ meta.function-call.arguments.shell
+# ^^^^^^^^^^^ meta.interpolation.parameter.shell
 # ^ punctuation.definition.variable.shell
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^^^ variable.other.readwrite.shell
@@ -4040,7 +4040,7 @@ ip=10.10.20.14
 #           ^ punctuation.section.interpolation.end.shell
 
 : ${var:^arr}    # Zip arrays `var` and `arr`.
-#^^^^^^^^^^^^ meta.function-call.arguments.shell
+# ^^^^^^^^^^^ meta.interpolation.parameter.shell
 # ^ punctuation.definition.variable.shell
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^^^ variable.other.readwrite.shell
@@ -4049,7 +4049,7 @@ ip=10.10.20.14
 #           ^ punctuation.section.interpolation.end.shell
 
 : ${var:^^arr}   # Zip arrays `var` and `arr`.
-#^^^^^^^^^^^^^ meta.function-call.arguments.shell
+# ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 # ^ punctuation.definition.variable.shell
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^^^ variable.other.readwrite.shell

--- a/ShellScript/Zsh/tests/syntax_test_scope.zsh
+++ b/ShellScript/Zsh/tests/syntax_test_scope.zsh
@@ -4021,6 +4021,42 @@ ip=10.10.20.14
 #        ^^^ meta.string.glob.shell string.unquoted.shell
 #           ^ punctuation.section.interpolation.end.shell
 
+: ${var:|arr}    # Remove all elements of array `arr` from `var`.
+#^^^^^^^^^^^^ meta.function-call.arguments.shell
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#   ^^^ variable.other.readwrite.shell
+#      ^^ keyword.operator.arithmetic.shell
+#        ^^^ variable.other.readwrite.shell
+#           ^ punctuation.section.interpolation.end.shell
+
+: ${var:*arr}    # Retain all elements which appear in both arrays `var` and `arr`.
+#^^^^^^^^^^^^ meta.function-call.arguments.shell
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#   ^^^ variable.other.readwrite.shell
+#      ^^ keyword.operator.arithmetic.shell
+#        ^^^ variable.other.readwrite.shell
+#           ^ punctuation.section.interpolation.end.shell
+
+: ${var:^arr}    # Zip arrays `var` and `arr`.
+#^^^^^^^^^^^^ meta.function-call.arguments.shell
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#   ^^^ variable.other.readwrite.shell
+#      ^^ keyword.operator.arithmetic.shell
+#        ^^^ variable.other.readwrite.shell
+#           ^ punctuation.section.interpolation.end.shell
+
+: ${var:^^arr}   # Zip arrays `var` and `arr`.
+#^^^^^^^^^^^^^ meta.function-call.arguments.shell
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#   ^^^ variable.other.readwrite.shell
+#      ^^^ keyword.operator.arithmetic.shell
+#         ^^^ variable.other.readwrite.shell
+#            ^ punctuation.section.interpolation.end.shell
+
 : ${var/p/r}     # One occurrence of p replaced by r
 # ^^^^^^^^^^ meta.interpolation.parameter.shell
 # ^ punctuation.definition.variable.shell
@@ -4033,6 +4069,17 @@ ip=10.10.20.14
 #          ^ punctuation.section.interpolation.end.shell
 
 : ${var//p/r}    # All occurrences of p replaced by r
+# ^^^^^^^^^^^ meta.interpolation.parameter.shell
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#   ^^^ variable.other.readwrite.shell
+#      ^^ keyword.operator.substitution.shell
+#        ^ meta.string.regexp.shell string.unquoted.shell
+#         ^ keyword.operator.substitution.shell
+#          ^ meta.string.glob.shell string.unquoted.shell
+#           ^ punctuation.section.interpolation.end.shell
+
+: ${var:/p/r}    # All p replaced by r if p matches var
 # ^^^^^^^^^^^ meta.interpolation.parameter.shell
 # ^ punctuation.definition.variable.shell
 #  ^ punctuation.section.interpolation.begin.shell


### PR DESCRIPTION
Resolves #4301

This PR adds support for

1. zsh specific array arithmetic

    - ${name:|arrayname}
    - ${name:*arrayname}
    - ${name:^arrayname}
    - ${name:^^arrayname}

2. zsh specific substitution operator `:/`

   - ${parameter:/pattern/repl}

3. bash specific case toggle operator `~` and `~~`

   - ${parameter~pattern}
   - ${parameter~~pattern}
   
   see: https://flokoe.github.io/bash-hackers-wiki/syntax/pe/#case-modification

4. removes tilde expansion in case conversion patterns 