### PR TITLE
[ShellScript] Adjust built-in command and variable completions

### DIFF
--- a/ShellScript/Bash/Builtin Command Names.sublime-completions
+++ b/ShellScript/Bash/Builtin Command Names.sublime-completions
@@ -12,6 +12,11 @@
 			"details": "bash built-in",
 		},
 		{
+			"trigger": "compopt",
+			"kind": ["function", "f", "command"],
+			"details": "bash built-in",
+		},
+		{
 			"trigger": "help",
 			"kind": ["function", "f", "command"],
 			"details": "bash built-in",

--- a/ShellScript/Bash/Variable Names.sublime-completions
+++ b/ShellScript/Bash/Variable Names.sublime-completions
@@ -316,6 +316,5 @@
             "kind": "variable",
             "details": "bash built-in variable",
         },
-        
     ]
 }

--- a/ShellScript/Bash/Variables.sublime-completions
+++ b/ShellScript/Bash/Variables.sublime-completions
@@ -379,6 +379,5 @@
             "kind": "variable",
             "details": "bash built-in variable",
         },
-        
     ]
 }

--- a/ShellScript/Shell/Builtin Command Names.sublime-completions
+++ b/ShellScript/Shell/Builtin Command Names.sublime-completions
@@ -27,6 +27,16 @@
 			"details": "shell built-in",
 		},
 		{
+			"trigger": "compgen",
+			"kind": ["function", "f", "command"],
+			"details": "shell built-in",
+		},
+		{
+			"trigger": "complete",
+			"kind": ["function", "f", "command"],
+			"details": "shell built-in",
+		},
+		{
 			"trigger": "continue",
 			"kind": ["function", "f", "command"],
 			"details": "shell built-in",
@@ -35,6 +45,11 @@
 			"trigger": "declare",
 			"kind": ["function", "f", "command"],
 			"details": "shell built-in",
+		},
+		{
+			"trigger": "dirs",
+			"kind": ["function", "f", "command"],
+			"details": "shell built-in"
 		},
 		{
 			"trigger": "echo",
@@ -67,6 +82,16 @@
 			"details": "shell built-in",
 		},
 		{
+			"trigger": "fc",
+			"kind": ["function", "f", "command"],
+			"details": "shell built-in"
+		},
+		{
+			"trigger": "fg",
+			"kind": ["function", "f", "command"],
+			"details": "shell built-in"
+		},
+		{
 			"trigger": "getopts",
 			"kind": ["function", "f", "command"],
 			"details": "shell built-in",
@@ -75,6 +100,11 @@
 			"trigger": "hash",
 			"kind": ["function", "f", "command"],
 			"details": "shell built-in",
+		},
+		{
+			"trigger": "history",
+			"kind": ["function", "f", "command"],
+			"details": "shell built-in"
 		},
 		{
 			"trigger": "let",
@@ -92,9 +122,19 @@
 			"details": "shell built-in",
 		},
 		{
+			"trigger": "popd",
+			"kind": ["function", "f", "command"],
+			"details": "shell built-in"
+		},
+		{
 			"trigger": "printf",
 			"kind": ["function", "f", "command"],
 			"details": "shell built-in",
+		},
+		{
+			"trigger": "pushd",
+			"kind": ["function", "f", "command"],
+			"details": "shell built-in"
 		},
 		{
 			"trigger": "pwd",

--- a/ShellScript/Shell/Variable Names.sublime-completions
+++ b/ShellScript/Shell/Variable Names.sublime-completions
@@ -12,6 +12,11 @@
             "details": "shell built-in variable",
         },
         {
+            "trigger": "EMACS",
+            "kind": "variable",
+            "details": "shell built-in variable",
+        },
+        {
             "trigger": "ENV",
             "kind": "variable",
             "details": "shell built-in variable",
@@ -198,6 +203,11 @@
         },
         {
             "trigger": "TMOUT",
+            "kind": "variable",
+            "details": "shell built-in variable",
+        },
+        {
+            "trigger": "TMPDIR",
             "kind": "variable",
             "details": "shell built-in variable",
         },

--- a/ShellScript/Shell/Variables.sublime-completions
+++ b/ShellScript/Shell/Variables.sublime-completions
@@ -14,6 +14,12 @@
             "details": "shell built-in variable",
         },
         {
+            "trigger": "EMACS",
+            "contents": "\\$EMACS",
+            "kind": "variable",
+            "details": "shell built-in variable",
+        },
+        {
             "trigger": "ENV",
             "contents": "\\$ENV",
             "kind": "variable",
@@ -238,6 +244,12 @@
         {
             "trigger": "TMOUT",
             "contents": "\\$TMOUT",
+            "kind": "variable",
+            "details": "shell built-in variable",
+        },
+        {
+            "trigger": "TMPDIR",
+            "contents": "\\$TMPDIR",
             "kind": "variable",
             "details": "shell built-in variable",
         },

--- a/ShellScript/Zsh/Builtin Command Names.sublime-completions
+++ b/ShellScript/Zsh/Builtin Command Names.sublime-completions
@@ -37,6 +37,11 @@
 			"details": "zsh built-in"
 		},
 		{
+			"trigger": "compadd",
+			"kind": ["function", "f", "command"],
+			"details": "zsh built-in"
+		},
+		{
 			"trigger": "comparguments",
 			"kind": ["function", "f", "command"],
 			"details": "zsh built-in"
@@ -87,11 +92,6 @@
 			"details": "zsh built-in"
 		},
 		{
-			"trigger": "dirs",
-			"kind": ["function", "f", "command"],
-			"details": "zsh built-in"
-		},
-		{
 			"trigger": "disable",
 			"kind": ["function", "f", "command"],
 			"details": "zsh built-in"
@@ -122,16 +122,6 @@
 			"details": "zsh built-in"
 		},
 		{
-			"trigger": "fc",
-			"kind": ["function", "f", "command"],
-			"details": "zsh built-in"
-		},
-		{
-			"trigger": "fg",
-			"kind": ["function", "f", "command"],
-			"details": "zsh built-in"
-		},
-		{
 			"trigger": "float",
 			"kind": ["function", "f", "command"],
 			"details": "zsh built-in"
@@ -148,11 +138,6 @@
 		},
 		{
 			"trigger": "getln",
-			"kind": ["function", "f", "command"],
-			"details": "zsh built-in"
-		},
-		{
-			"trigger": "history",
 			"kind": ["function", "f", "command"],
 			"details": "zsh built-in"
 		},
@@ -187,17 +172,7 @@
 			"details": "zsh built-in"
 		},
 		{
-			"trigger": "popd",
-			"kind": ["function", "f", "command"],
-			"details": "zsh built-in"
-		},
-		{
 			"trigger": "print",
-			"kind": ["function", "f", "command"],
-			"details": "zsh built-in"
-		},
-		{
-			"trigger": "pushd",
 			"kind": ["function", "f", "command"],
 			"details": "zsh built-in"
 		},


### PR DESCRIPTION
This commit adjusts completions to syntax changes by PR #4294 and #4295.

Note: Zsh provides `compgen` and `complete` via library module `bashcompinit` rather than being real built-ins. Despite that implementation detail they are scoped and provided by completions in both Bash and Zsh.