### PR TITLE
[C#] Support `dotnet run script.cs`

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -200,9 +200,6 @@ contexts:
         2: keyword.other.preprocessor.cs
         3: keyword.other.preprocessor.cs
 
-    - match: '!'
-      scope: punctuation.definition.comment.cs
-      set: shebang-body
     - match: (:)(\w+)
       captures:
         1: punctuation.definition.preprocessor.cs

--- a/C#/tests/syntax_test_dotnetrun.cs
+++ b/C#/tests/syntax_test_dotnetrun.cs
@@ -5,9 +5,6 @@
 
 // https://devblogs.microsoft.com/dotnet/announcing-dotnet-run-app/
 
-#!/usr/bin/dotnet run
-#!^^^^^^^^^^^^^^^^^^^ comment.line.shebang.cs
-#!         ^^^^^^^^^^ constant.language.shebang.cs
 #:package Humanizer@2.14.1
 #!^^^^^^^^^^^^^^^^^^^^^^^^ meta.preprocessor.cs
 #!^^^^^^^ variable.language.cs


### PR DESCRIPTION
- support shebangs the same way other syntax definitions do
- improve the preprocessor directive (`preprocessor_option`) context
  - no longer mark anything unexpected as illegal
  - after a colon, scope the following word
  - this ensures it can correctly highlight the following officially supported keywords:
    - `sdk`
    - `package`
    - `property`
  - currently it leaves the text after it unscoped. We can adjust this based on feedback later if necessary.