### PR TITLE
[Python] Add support for PEP723 script metadata

### DIFF
--- a/Python/Embeddings/TOML (for Python).sublime-syntax
+++ b/Python/Embeddings/TOML (for Python).sublime-syntax
@@ -1,0 +1,22 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/syntax.html
+scope: source.toml.embedded.python
+version: 2
+hidden: true
+
+extends: Packages/TOML/TOML.sublime-syntax
+
+contexts:
+
+  prototype:
+    - meta_prepend: true
+    - match: ^\s*(#)[ ]?
+      captures:
+        1: punctuation.definition.comment.python
+
+  string-prototype:
+    - meta_prepend: true
+    - match: ^\s*(#)[ ]?
+      captures:
+        1: punctuation.definition.comment.python

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -368,6 +368,20 @@ contexts:
 ###[ COMMENTS ]###############################################################
 
   comments:
+    # PEP 723 Inline script metadata
+    - match: ^\s*(#)\s+(///)\s+(script)\b
+      scope: comment.line.number-sign.python
+      captures:
+        1: punctuation.definition.comment.python
+        2: punctuation.section.raw.begin.python
+        3: constant.other.lanugage-name.python
+      embed: scope:source.toml.embedded.python#toml
+      embed_scope: comment.line.number-sign.python source.toml.embedded.python
+      escape: ^(?:\s*(#)\s+(///)$\n?|(?!\s*#))
+      escape_captures:
+        0: comment.line.number-sign.python
+        1: punctuation.definition.comment.python
+        2: punctuation.section.raw.end.python
     # Special Sphinx comment syntax to denote documentation
     # https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#directive-autoattribute
     - match: '#:'

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -1,6 +1,25 @@
 # SYNTAX TEST "Packages/Python/Python.sublime-syntax"
 # <- source.python comment.line.number-sign punctuation.definition.comment
 
+# /// script
+# ^^^^^^^^^^^ comment.line.number-sign.python
+# ^^^ punctuation.section.raw.begin.python
+#     ^^^^^^ constant.other.lanugage-name.python
+# requires-python = ">=3.8"
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^ source.toml.embedded.python
+# dependencies = [
+#     "requests",
+#     ^^^^^^^^^^ source.toml.embedded.python meta.mapping.value.toml meta.sequence.array.toml meta.string.toml string.quoted.double.toml
+# ]
+#
+# [tools.black]
+# ^^^^^^^^^^^^^ comment.line.number-sign.python source.toml.embedded.python meta.section.toml meta.brackets.toml
+#
+# ///
+# <- comment.line.number-sign.python punctuation.definition.comment.python
+#^^^^^ comment.line.number-sign.python
+# ^^^ punctuation.section.raw.end.python
+
 r"""This is a syntax test file.
 # <- storage.type.string - comment
 #^^^ comment.block.documentation.python punctuation.definition.comment.begin.python


### PR DESCRIPTION
This PR implements https://peps.python.org/pep-0723.

Highlights script metadata in comments.

```py
# /// script
# requires-python = ">=3.11"
# dependencies = [
#   "requests<3",
#   "rich",
# ]
# ///

import requests
from rich.pretty import pprint

resp = requests.get("https://peps.python.org/api/peps.json")
data = resp.json()
pprint([(k, v["title"]) for k, v in data.items()][:10])
```

![grafik](https://github.com/user-attachments/assets/3c0bc09a-5087-48b8-a888-1bb199ebed3b)
