### PR TITLE
[Git Formats] Refactor git rebase commands

### DIFF
--- a/Git Formats/Git Rebase.sublime-syntax
+++ b/Git Formats/Git Rebase.sublime-syntax
@@ -239,7 +239,7 @@ contexts:
 
   commit-commands:
     # e.g. pick d284bb2 Initial commit
-    - match: ^\s*
+    - match: ^
       push: [commit-subject, commit-hash, commit-command]
 
   commit-command:
@@ -264,32 +264,35 @@ contexts:
     - match: (?:s|squash)\b
       scope: keyword.operator.commit.squash.git.rebase
       pop: 1
-    - include: comments
-    - include: line-end
+    - match: $|(?=#)
+      pop: 1
     - match: \S+
       scope: invalid.illegal.command-expected.git.rebase
       pop: 1
 
   commit-hash:
+    - include: cmd-options
     - match: '{{hash}}' # e.g. d284bb2
       scope: constant.other.hash.git.rebase
       pop: 1
-    - include: cmd-options
-    - include: line-end
+    - match: $|(?=#)
+      pop: 1
     - match: \S+
       scope: invalid.illegal.hash-expected.git.rebase
       pop: 1
 
   commit-subject:
-    - meta_scope: meta.commit.git.rebase
-    - include: line-end
-    - match: (?=\S)  # subject begins with first none whitespace
+    - meta_content_scope: meta.commit.git.rebase
+    # subject comment begins with first none whitespace
+    - match: '{{comment_char}}'
+      scope: punctuation.definition.comment.git.rebase
       set: commit-subject-content
+    - match: (?=\S)
+      set: commit-subject-content
+    - include: line-end
 
   commit-subject-content:
-    - meta_scope: meta.commit.git.rebase
-    - meta_content_scope: meta.subject.git.commit
-    - include: Git Common.sublime-syntax#references
+    - meta_scope: meta.commit.git.rebase comment.line.git.rebase
     - include: line-end
 
   shell-commands:

--- a/Git Formats/Git Rebase.sublime-syntax
+++ b/Git Formats/Git Rebase.sublime-syntax
@@ -20,9 +20,7 @@ contexts:
 
   main:
     - include: comments
-    - include: shell-commands
-    - include: branch-commands
-    - include: commit-commands
+    - include: commands
 
 ###[ COMMENTS ]################################################################
 
@@ -164,8 +162,7 @@ contexts:
     - include: help-cmd-brackets
     - include: help-cmd-parameters
     - include: cmd-options
-    - match: \n
-      pop: 1
+    - include: line-end
 
   help-cmd-brackets:
     - match: \[
@@ -211,91 +208,81 @@ contexts:
 
 ###[ COMMANDS ]################################################################
 
-  branch-commands:
-    - match: ^\s*(l|label)\s+(\S+)
+  commands:
+    # branch commands
+    - match: ^\s*(l|label)\b
       captures:
-        0: meta.branch.label.git.rebase
         1: keyword.other.label.git.rebase
-        2: constant.language.branch-name.git.commit
-    - match: ^\s*(u|update-ref)\s+(\S+)
+      push:
+        - cmd-end
+        - label-ref
+    - match: ^\s*(m|merge)\b
       captures:
-        0: meta.branch.update-ref.git.rebase
-        1: keyword.operator.update-ref.git.rebase
-        2: constant.language.ref.git.commit
-    - match: ^\s*(m|merge)\s+({{option}})\s+({{hash}})\s+(\S+)
-      captures:
-        0: meta.branch.merge.git.rebase
         1: keyword.operator.branch.merge.git.rebase
-        2: variable.parameter.option.git.rebase
-        3: punctuation.definition.variable.git.rebase
-        4: constant.other.hash.git.rebase
-        5: constant.language.branch-name.git.commit
-    - match: ^\s*(t|reset)\s+(?:({{hash}})|(\S+))
+      push:
+        - cmd-end
+        - merge-ref
+        - ref-name
+        - maybe-cmd-options
+    - match: ^\s*(t|reset)\b
       captures:
-        0: meta.branch.reset.git.rebase
         1: keyword.operator.branch.reset.git.rebase
-        2: constant.other.hash.git.rebase
-        3: constant.language.branch-name.git.commit
+      push:
+        - cmd-end
+        - reset-ref
+    - match: ^\s*(u|update-ref)\b
+      captures:
+        1: keyword.operator.update-ref.git.rebase
+      push:
+        - cmd-end
+        - update-ref
 
-  commit-commands:
-    # e.g. pick d284bb2 Initial commit
-    - match: ^
-      push: [commit-subject, commit-hash, commit-command]
+    # commit commands
+    - match: ^\s*(b|break)\b
+      captures:
+        1: keyword.operator.commit.break.git.rebase
+      push:
+        - commit-subject
+        - commit-hash
+    - match: ^\s*(d|drop)\b
+      captures:
+        1: keyword.operator.commit.drop.git.rebase
+      push:
+        - commit-subject
+        - commit-hash
+    - match: ^\s*(e|edit)\b
+      captures:
+        1: keyword.operator.commit.edit.git.rebase
+      push:
+        - commit-subject
+        - commit-hash
+    - match: ^\s*(f|fixup)\b
+      captures:
+        1: keyword.operator.commit.fixup.git.rebase
+      push:
+        - commit-subject
+        - commit-hash
+        - maybe-cmd-options
+    - match: ^\s*(p|pick)\b
+      captures:
+        1: keyword.operator.commit.pick.git.rebase
+      push:
+        - commit-subject
+        - commit-hash
+    - match: ^\s*(r|reword)\b
+      captures:
+        1: keyword.operator.commit.reword.git.rebase
+      push:
+        - commit-subject
+        - commit-hash
+    - match: ^\s*(s|squash)\b
+      captures:
+        1: keyword.operator.commit.squash.git.rebase
+      push:
+        - commit-subject
+        - commit-hash
 
-  commit-command:
-    - match: (?:b|break)\b
-      scope: keyword.operator.commit.break.git.rebase
-      pop: 1
-    - match: (?:d|drop)\b
-      scope: keyword.operator.commit.drop.git.rebase
-      pop: 1
-    - match: (?:e|edit)\b
-      scope: keyword.operator.commit.edit.git.rebase
-      pop: 1
-    - match: (?:f|fixup)\b
-      scope: keyword.operator.commit.fixup.git.rebase
-      pop: 1
-    - match: (?:p|pick)\b
-      scope: keyword.operator.commit.pick.git.rebase
-      pop: 1
-    - match: (?:r|reword)\b
-      scope: keyword.operator.commit.reword.git.rebase
-      pop: 1
-    - match: (?:s|squash)\b
-      scope: keyword.operator.commit.squash.git.rebase
-      pop: 1
-    - match: $|(?=#)
-      pop: 1
-    - match: \S+
-      scope: invalid.illegal.command-expected.git.rebase
-      pop: 1
-
-  commit-hash:
-    - include: cmd-options
-    - match: '{{hash}}' # e.g. d284bb2
-      scope: constant.other.hash.git.rebase
-      pop: 1
-    - match: $|(?=#)
-      pop: 1
-    - match: \S+
-      scope: invalid.illegal.hash-expected.git.rebase
-      pop: 1
-
-  commit-subject:
-    - meta_content_scope: meta.commit.git.rebase
-    # subject comment begins with first none whitespace
-    - match: '{{comment_char}}'
-      scope: punctuation.definition.comment.git.rebase
-      set: commit-subject-content
-    - match: (?=\S)
-      set: commit-subject-content
-    - include: line-end
-
-  commit-subject-content:
-    - meta_scope: meta.commit.git.rebase comment.line.git.rebase
-    - include: line-end
-
-  shell-commands:
+    # shell commands
     - match: ^\s*(x|exec)\b
       captures:
         0: meta.shell.git.rebase
@@ -305,6 +292,68 @@ contexts:
       escape: $\n?
       escape_captures:
         0: meta.shell.git.rebase
+
+  commit-hash:
+    - match: $|(?=#)
+      pop: 1
+    - match: '{{hash}}' # e.g. d284bb2
+      scope: constant.other.hash.git.rebase
+      pop: 1
+    - match: \S+
+      scope: invalid.illegal.hash-expected.git.rebase
+      pop: 1
+
+  commit-subject:
+    - meta_scope: meta.commit.git.rebase
+    - match: '{{comment_char}}'
+      scope: punctuation.definition.comment.git.rebase
+      push: cmd-comment-body
+    - match: (?=\S)
+      push: cmd-comment-body
+    - include: line-end
+
+  cmd-end:
+    - match: '{{comment_char}}'
+      scope: punctuation.definition.comment.git.rebase
+      set: cmd-comment-body
+    - include: line-end
+
+  cmd-comment-body:
+    - meta_scope: comment.line.git.rebase
+    - include: line-end
+
+  label-ref:
+    - meta_scope: meta.branch.label.git.rebase
+    - include: ref-name
+
+  merge-ref:
+    - meta_scope: meta.branch.merge.git.rebase
+    - include: ref-name
+
+  reset-ref:
+    - meta_scope: meta.branch.reset.git.rebase
+    - include: ref-name
+
+  update-ref:
+    - meta_scope: meta.branch.update-ref.git.rebase
+    - include: ref-name
+
+  ref-name:
+    - match: $|(?=#)
+      pop: 1
+    - match: '{{hash}}' # e.g. d284bb2
+      scope: constant.other.hash.git.rebase
+      pop: 1
+    - match: refs/\S+
+      scope: constant.language.ref.git.commit
+      pop: 1
+    - match: \S+
+      scope: constant.language.branch-name.git.commit
+      pop: 1
+
+  maybe-cmd-options:
+    - include: cmd-options
+    - include: else-pop
 
   cmd-options:
     - match: '{{option}}'
@@ -316,4 +365,8 @@ contexts:
 
   line-end:
     - match: $\n?
+      pop: 1
+
+  else-pop:
+    - match: (?=\S)
       pop: 1

--- a/Git Formats/Git Rebase.sublime-syntax
+++ b/Git Formats/Git Rebase.sublime-syntax
@@ -344,12 +344,25 @@ contexts:
     - match: '{{hash}}' # e.g. d284bb2
       scope: constant.other.hash.git.rebase
       pop: 1
-    - match: refs/\S+
-      scope: constant.language.ref.git.commit
-      pop: 1
-    - match: \S+
-      scope: constant.language.branch-name.git.commit
-      pop: 1
+    - match: (?=refs/)
+      push: ref-name-body
+    - match: (?=\S)
+      push: branch-name-body
+
+  branch-name-body:
+    - meta_scope: constant.language.branch-name.git.commit
+    - include: ref-name-body
+
+  ref-name-body:
+    - meta_scope: constant.language.ref.git.commit
+    - match: (?=\s)
+      pop: 2
+    - match: (/)(\.*)
+      captures:
+        1: punctuation.separator.path.git.commit
+        2: invalid.illegal.unexpected-token.git.commit
+    - match: \.(?:\.|(?:lock)?(?=\s))|[:?\[\\^~]
+      scope: invalid.illegal.unexpected-token.git.commit
 
   maybe-cmd-options:
     - include: cmd-options

--- a/Git Formats/tests/syntax_test_git_rebase
+++ b/Git Formats/tests/syntax_test_git_rebase
@@ -16,7 +16,6 @@ reset 9698953 # Fix form submission
 pick d284bb2 Initial commit
 # <- meta.commit
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.commit
-#                           ^ - meta.commit
 # <- keyword.operator.commit.pick
 #^^^ keyword.operator.commit.pick
 #   ^ - storage.type.commit
@@ -27,7 +26,6 @@ pick d284bb2 Initial commit
 p 6746220 Second pick commit # no comment
 # <- meta.commit
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.commit
-#                                         ^ - meta.commit
 # <- keyword.operator.commit.pick
 #^ - keyword.operator.commit
 # ^^^^^^^ constant.other.hash
@@ -38,7 +36,6 @@ p 6746220 Second pick commit # no comment
    p 6746220 Third pick commit # no comment
 # <- meta.commit
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.commit
-#                                            ^ - meta.commit
 # ^ - keyword.operator.commit
 #  ^ keyword.operator.commit.pick
 #   ^ - keyword.operator.commit -constant.other.hash

--- a/Git Formats/tests/syntax_test_git_rebase
+++ b/Git Formats/tests/syntax_test_git_rebase
@@ -52,14 +52,8 @@ p 6746220 Second pick commit # no comment
 #            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.git.rebase
 #                  ^^^^ - keyword
 puck 6746220 Invalid command
-# <- meta.commit
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.commit
-# <- invalid.illegal.command-expected
-#^^^ invalid.illegal.command-expected
-#   ^ - storage.type.commit - invalid
-#    ^^^^^^^ constant.other.hash
-#           ^ - constant - comment
-#            ^^^^^^^^^^^^^^^^ comment.line.git.rebase
+# <- - meta - constant - keyword
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta - constant - keyword
 p 6746x20 Invalid hash # no comment
 # <- meta.commit
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.commit
@@ -69,13 +63,8 @@ p 6746x20 Invalid hash # no comment
 #        ^ - constant - comment
 #         ^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.git.rebase
 a 6746x20 Invalid command and hash # no comment (#403)
-# <- meta.commit
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.commit
-# <- invalid.illegal.command-expected
-#^ - storage.type.commit
-# ^^^^^^^ invalid.illegal.hash-expected
-#        ^ - constant - comment
-#         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.git.rebase
+# <- - meta.commit - constant - keyword
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta - constant - keyword
 l feature/branch-name
 # <- meta.branch.label.git.rebase keyword.other.label.git.rebase
 #^^^^^^^^^^^^^^^^^^^^ meta.branch.label.git.rebase

--- a/Git Formats/tests/syntax_test_git_rebase
+++ b/Git Formats/tests/syntax_test_git_rebase
@@ -144,43 +144,78 @@ l ~/.foo.bar..baz:buuz/.br^an~ch/.br\anch-#name.lock
   # p 6746220 Second pick commit # no comment
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.git.rebase
   b
+# <- meta.commit.git.rebase
+#^^^ meta.commit.git.rebase
 # ^ keyword.operator.commit.break
   break
+# <- meta.commit.git.rebase
+#^^^^^^^ meta.commit.git.rebase
 # ^^^^^ keyword.operator.commit.break
   d d284bb2 Drop commit
+# <- meta.commit.git.rebase
+#^^^^^^^^^^^^^^^^^^^^^^^ meta.commit.git.rebase
 # ^ keyword.operator.commit.drop
 #   ^^^^^^^ constant.other.hash.git.rebase
+#           ^^^^^^^^^^^^ comment.line.git.rebase
   drop d284bb2 Drop commit
+# <- meta.commit.git.rebase
+#^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.commit.git.rebase
 # ^^^^ keyword.operator.commit.drop
 #      ^^^^^^^ constant.other.hash.git.rebase
+#              ^^^^^^^^^^^^ comment.line.git.rebase
   e d284bb2 Edit commit
+# <- meta.commit.git.rebase
+#^^^^^^^^^^^^^^^^^^^^^^^ meta.commit.git.rebase
 # ^ keyword.operator.commit.edit
 #   ^^^^^^^ constant.other.hash.git.rebase
+#           ^^^^^^^^^^^^ comment.line.git.rebase
   edit d284bb2 Edit commit
+# <- meta.commit.git.rebase
+#^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.commit.git.rebase
 # ^^^^ keyword.operator.commit.edit
 #      ^^^^^^^ constant.other.hash.git.rebase
+#              ^^^^^^^^^^^^ comment.line.git.rebase
   f d284bb2 Fixup commit
+# <- meta.commit.git.rebase
+#^^^^^^^^^^^^^^^^^^^^^^^^ meta.commit.git.rebase
 # ^ keyword.operator.commit.fixup
 #   ^^^^^^^ constant.other.hash.git.rebase
+#           ^^^^^^^^^^^^^ comment.line.git.rebase
   fixup d284bb2 Fixup commit
+# <- meta.commit.git.rebase
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.commit.git.rebase
 # ^^^^^ keyword.operator.commit.fixup
 #       ^^^^^^^ constant.other.hash.git.rebase
+#               ^^^^^^^^^^^^^ comment.line.git.rebase
   f -c d284bb2 Fixup commit
+# <- meta.commit.git.rebase
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.commit.git.rebase
 # ^ keyword.operator.commit.fixup
 #   ^^ variable.parameter.option.git.rebase
 #      ^^^^^^^ constant.other.hash.git.rebase
+#              ^^^^^^^^^^^^^ comment.line.git.rebase
   fixup -C d284bb2 Fixup commit
+# <- meta.commit.git.rebase
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.commit.git.rebase
 # ^^^^^ keyword.operator.commit.fixup
 #       ^^ variable.parameter.option.git.rebase
 #          ^^^^^^^ constant.other.hash.git.rebase
+#                  ^^^^^^^^^^^^^ comment.line.git.rebase
   r d284bb2 Reword commit
+# <- meta.commit.git.rebase
+#^^^^^^^^^^^^^^^^^^^^^^^^^ meta.commit.git.rebase
 # ^ keyword.operator.commit.reword
 #   ^^^^^^^ constant.other.hash.git.rebase
+#           ^^^^^^^^^^^^^^ comment.line.git.rebase
   reword d284bb2 Reword commit
+# <- meta.commit.git.rebase
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.commit.git.rebase
 # ^^^^^^ keyword.operator.commit.reword
 #        ^^^^^^^ constant.other.hash.git.rebase
+#                ^^^^^^^^^^^^^^ comment.line.git.rebase
   x git tag -d 0.1.0
-# ^ meta.shell.git.rebase - source.shell
+# <- meta.shell.git.rebase
+#^^ meta.shell.git.rebase - source.shell
 #  ^^^^^^^^^^^^^^^^^ meta.shell.git.rebase source.shell.embedded.git.rebase
 #   ^^^ meta.function-call.identifier.shell
 #      ^^^^^^^^^^^^^ meta.function-call.arguments.shell
@@ -189,7 +224,8 @@ l ~/.foo.bar..baz:buuz/.br^an~ch/.br\anch-#name.lock
 #   ^^^ variable.function.shell
 #           ^^ variable.parameter.option.shell
   exec git tag -d 0.1.0
-# ^^^^ meta.shell.git.rebase - source.shell
+# <- meta.shell.git.rebase
+#^^^^^ meta.shell.git.rebase - source.shell
 #     ^^^^^^^^^^^^^^^^^ meta.shell.git.rebase source.shell.embedded.git.rebase
 #      ^^^ meta.function-call.identifier.shell
 #         ^^^^^^^^^^^^^ meta.function-call.arguments.shell

--- a/Git Formats/tests/syntax_test_git_rebase
+++ b/Git Formats/tests/syntax_test_git_rebase
@@ -20,59 +20,62 @@ pick d284bb2 Initial commit
 #^^^ keyword.operator.commit.pick
 #   ^ - storage.type.commit
 #    ^^^^^^^ constant.other.hash
-#           ^ - constant.other.hash -meta.subject.git.commit
-#            ^^^^^^^^^^^^^^ meta.subject.git.commit
-#                          ^ - meta.subject.git.commit
+#           ^ - constant - comment
+#            ^^^^^^^^^^^^^^^ comment.line.git.rebase
+pick d284bb2 # Initial commit
+# <- meta.commit
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.commit
+# <- keyword.operator.commit.pick
+#^^^ keyword.operator.commit.pick
+#   ^ - storage.type.commit
+#    ^^^^^^^ constant.other.hash
+#           ^ - constant - comment
+#            ^^^^^^^^^^^^^^^^^ comment.line.git.rebase
+#            ^ punctuation.definition.comment.git.rebase
 p 6746220 Second pick commit # no comment
 # <- meta.commit
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.commit
 # <- keyword.operator.commit.pick
 #^ - keyword.operator.commit
 # ^^^^^^^ constant.other.hash
-#        ^ - constant.other.hash -meta.subject.git.commit
-#         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.subject.git.commit
-#                                        ^ - meta.subject.git.commit
+#        ^ - constant - comment
+#         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.git.rebase
 #                ^^^^ - keyword
    p 6746220 Third pick commit # no comment
 # <- meta.commit
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.commit
 # ^ - keyword.operator.commit
 #  ^ keyword.operator.commit.pick
-#   ^ - keyword.operator.commit -constant.other.hash
+#   ^ - keyword.operator.commit - constant
 #    ^^^^^^^ constant.other.hash
-#           ^ - constant.other.hash -meta.subject.git.commit
-#            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.subject.git.commit
-#                                          ^ - meta.subject.git.commit
+#           ^ - constant - comment
+#            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.git.rebase
 #                  ^^^^ - keyword
 puck 6746220 Invalid command
 # <- meta.commit
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.commit
 # <- invalid.illegal.command-expected
 #^^^ invalid.illegal.command-expected
-#   ^ - storage.type.commit -invalid.illegal.command-expected
+#   ^ - storage.type.commit - invalid
 #    ^^^^^^^ constant.other.hash
-#           ^ - constant.other.hash -meta.subject.git.commit
-#            ^^^^^^^^^^^^^^^ meta.subject.git.commit
+#           ^ - constant - comment
+#            ^^^^^^^^^^^^^^^^ comment.line.git.rebase
 p 6746x20 Invalid hash # no comment
 # <- meta.commit
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.commit
 # <- keyword.operator.commit.pick
 #^ - storage.type.commit
 # ^^^^^^^ invalid.illegal.hash-expected
-#        ^ - constant.other.hash -meta.subject.git.commit
-#         ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.subject.git.commit
-#                                  ^ - meta.subject.git.commit
+#        ^ - constant - comment
+#         ^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.git.rebase
 a 6746x20 Invalid command and hash # no comment (#403)
 # <- meta.commit
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.commit
 # <- invalid.illegal.command-expected
 #^ - storage.type.commit
 # ^^^^^^^ invalid.illegal.hash-expected
-#        ^ - constant.other.hash -meta.subject.git.commit
-#         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.subject.git.commit
-#                                                ^ punctuation.definition.reference.issue.git
-#                                                ^^^^ meta.reference.issue.git constant.other.reference.issue.git
-#                                                     ^ - meta.subject.git.commit
+#        ^ - constant - comment
+#         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.git.rebase
 l feature/branch-name
 # <- meta.branch.label.git.rebase keyword.other.label.git.rebase
 #^^^^^^^^^^^^^^^^^^^^ meta.branch.label.git.rebase
@@ -132,24 +135,36 @@ merge -C c7cba2e feature/branch-name # Merge branch 'alicja/loyalty'
 # ^^^^^ keyword.operator.commit.break
   d d284bb2 Drop commit
 # ^ keyword.operator.commit.drop
+#   ^^^^^^^ constant.other.hash.git.rebase
   drop d284bb2 Drop commit
 # ^^^^ keyword.operator.commit.drop
+#      ^^^^^^^ constant.other.hash.git.rebase
   e d284bb2 Edit commit
 # ^ keyword.operator.commit.edit
+#   ^^^^^^^ constant.other.hash.git.rebase
   edit d284bb2 Edit commit
 # ^^^^ keyword.operator.commit.edit
+#      ^^^^^^^ constant.other.hash.git.rebase
   f d284bb2 Fixup commit
 # ^ keyword.operator.commit.fixup
+#   ^^^^^^^ constant.other.hash.git.rebase
   fixup d284bb2 Fixup commit
 # ^^^^^ keyword.operator.commit.fixup
+#       ^^^^^^^ constant.other.hash.git.rebase
   f -c d284bb2 Fixup commit
 # ^ keyword.operator.commit.fixup
+#   ^^ variable.parameter.option.git.rebase
+#      ^^^^^^^ constant.other.hash.git.rebase
   fixup -C d284bb2 Fixup commit
 # ^^^^^ keyword.operator.commit.fixup
+#       ^^ variable.parameter.option.git.rebase
+#          ^^^^^^^ constant.other.hash.git.rebase
   r d284bb2 Reword commit
 # ^ keyword.operator.commit.reword
+#   ^^^^^^^ constant.other.hash.git.rebase
   reword d284bb2 Reword commit
 # ^^^^^^ keyword.operator.commit.reword
+#        ^^^^^^^ constant.other.hash.git.rebase
   x git tag -d 0.1.0
 # ^ meta.shell.git.rebase - source.shell
 #  ^^^^^^^^^^^^^^^^^ meta.shell.git.rebase source.shell.embedded.git.rebase

--- a/Git Formats/tests/syntax_test_git_rebase
+++ b/Git Formats/tests/syntax_test_git_rebase
@@ -69,21 +69,27 @@ l feature/branch-name
 # <- meta.branch.label.git.rebase keyword.other.label.git.rebase
 #^^^^^^^^^^^^^^^^^^^^ meta.branch.label.git.rebase
 # ^^^^^^^^^^^^^^^^^^^ constant.language.branch-name.git.commit
+#        ^ punctuation.separator.path.git.commit
 label feature/branch-name
 # <- meta.branch.label.git.rebase keyword.other.label.git.rebase
 #^^^^^^^^^^^^^^^^^^^^^^^^ meta.branch.label.git.rebase
 #^^^^ keyword.other.label.git.rebase
 #     ^^^^^^^^^^^^^^^^^^^ constant.language.branch-name.git.commit
+#            ^ punctuation.separator.path.git.commit
 update-ref refs/heads/feature-branch
 # <- meta.branch.update-ref.git.rebase keyword.operator.update-ref.git.rebase
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.branch.update-ref.git.rebase
 #^^^^^^^^^ keyword.operator.update-ref.git.rebase
 #          ^^^^^^^^^^^^^^^^^^^^^^^^^ constant.language.ref.git.commit
+#              ^ punctuation.separator.path.git.commit
+#                    ^ punctuation.separator.path.git.commit
 u refs/heads/feature-branch
 # <- meta.branch.update-ref.git.rebase keyword.operator.update-ref.git.rebase
 #^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.branch.update-ref.git.rebase
 # <- keyword.operator.update-ref.git.rebase
-#          ^^^^^^^^^^^^^^^^ constant.language.ref.git.commit
+# ^^^^^^^^^^^^^^^^^^^^^^^^^ constant.language.ref.git.commit
+#     ^ punctuation.separator.path.git.commit
+#           ^ punctuation.separator.path.git.commit
 t onto
 # <- meta.branch.reset.git.rebase keyword.operator.branch.reset.git.rebase
 #^^^^^ meta.branch.reset.git.rebase
@@ -96,6 +102,7 @@ reset onto
 m -c c7cba2e feature/branch-name # Merge branch 'alicja/loyalty'
 # <- meta.branch.merge.git.rebase keyword.operator.branch.merge.git.rebase
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.branch.merge.git.rebase
+#                   ^ punctuation.separator.path.git.commit
 #                               ^ - meta.branch - comment
 #                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.git.rebase
 #                                ^ punctuation.definition.comment.git.rebase
@@ -107,6 +114,7 @@ m -c c7cba2e feature/branch-name # Merge branch 'alicja/loyalty'
 merge -C c7cba2e feature/branch-name # Merge branch 'alicja/loyalty'
 # <- meta.branch.merge.git.rebase keyword.operator.branch.merge.git.rebase
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.branch.merge.git.rebase
+#                       ^ punctuation.separator.path.git.commit
 #                                   ^ - meta.branch - comment
 #                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.git.rebase
 #                                    ^ punctuation.definition.comment.git.rebase
@@ -115,6 +123,23 @@ merge -C c7cba2e feature/branch-name # Merge branch 'alicja/loyalty'
 #     ^ punctuation.definition.variable.git.rebase
 #        ^^^^^^^ constant.other.hash.git.rebase
 #                ^^^^^^^^^^^^^^^^^^^ constant.language.branch-name.git.commit
+
+# highlight illegal reference characters
+l ~/.foo.bar..baz:buuz/.br^an~ch/.br\anch-#name.lock
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.language.branch-name.git.commit
+# ^ invalid.illegal.unexpected-token.git.commit
+#  ^ punctuation.separator.path.git.commit
+#   ^ invalid.illegal.unexpected-token.git.commit
+#           ^^ invalid.illegal.unexpected-token.git.commit
+#                ^ invalid.illegal.unexpected-token.git.commit
+#                     ^ punctuation.separator.path.git.commit
+#                      ^ invalid.illegal.unexpected-token.git.commit
+#                         ^ invalid.illegal.unexpected-token.git.commit
+#                            ^ invalid.illegal.unexpected-token.git.commit
+#                               ^ punctuation.separator.path.git.commit
+#                                ^ invalid.illegal.unexpected-token.git.commit
+#                                   ^ invalid.illegal.unexpected-token.git.commit
+#                                              ^^^^^ invalid.illegal.unexpected-token.git.commit
 
   # p 6746220 Second pick commit # no comment
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.git.rebase


### PR DESCRIPTION
Resolves #4311

This PR overhauls git rebase command related contexts.

1. All use same implementation scheme. 
2. Lines with unknown or invalid commands are no longer highlighted as any assumption about structure may be wrong.
3. A simple command keyword is enough to start highlighting a line, regardless valid arguments being fully present. May improve UX while editing commands.
4. Commit subject text after commands like `pick 12b32` are scoped comment as changing them doesn't effect commit messages when rebasing.
5. Each command line is terminated by a dedicated simple comment context, which ensures not to scope help commands etc. by accident.
6. Reference names' highlighting is extended by scoping `/` path separators and various illegal chars.
