### PR TITLE
[Scala] Fix interpolation not terminated due to if statements

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -1244,12 +1244,8 @@ contexts:
   if-statement:
     - match: '\bif\b'
       scope: keyword.control.flow.scala
-      push:
-        - match: '$'
-          pop: 1
-        - match: '\bthen\b'
-          scope: keyword.control.flow.scala
-        - include: main
+    - match: '\bthen\b'
+      scope: keyword.control.flow.scala
 
   for-comprehension:
     - match: '\bfor\b'

--- a/Scala/tests/syntax_test_scala.scala
+++ b/Scala/tests/syntax_test_scala.scala
@@ -419,6 +419,24 @@ type Foo = Bar[A] forSome { type A }
 //                    ^ variable.other.scala
 //                      ^^ constant.other.formatting.scala
 
+   s"${if (n == 1) "" else "s" }"
+// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.interpolated.scala
+//  ^ punctuation.definition.string.begin.scala
+//   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.interpolation.scala
+//   ^ punctuation.definition.variable.scala
+//    ^ punctuation.section.interpolation.begin.scala
+//     ^^ keyword.control.flow.scala
+//        ^^^^^^^^ meta.group.scala
+//        ^ punctuation.section.group.begin.scala
+//           ^^ keyword.operator.comparison.scala
+//              ^ meta.number.integer.decimal.scala constant.numeric.value.scala
+//               ^ punctuation.section.group.end.scala
+//                 ^^ meta.string.scala string.quoted.double.scala
+//                    ^^^^ keyword.control.flow.scala
+//                         ^^^ meta.string.scala string.quoted.double.scala
+//                             ^ punctuation.section.interpolation.end.scala
+//                              ^ string.quoted.double.scala punctuation.definition.string.end.scala
+
    Unit
 // ^^^^ storage.type.primitive.scala
 


### PR DESCRIPTION
resolves https://forum.sublimetext.com/t/build-4200-syntax-highlighting-for-scala-is-broken/76567

Just highlight `if` and `then` everywhere, without pushing into dedicated context as it seems not needed syntax wise and not special meta scopes are applied.