### PR TITLE
[Rust] Add raw-identifier label and lifetime

### DIFF
--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -20,7 +20,7 @@ variables:
   # consumed, to prevent catastrophic backtracking
   identifier: '(?:(?:r\#)?{{non_raw_ident}}\b)'
   camel_ident: '\b_*[A-Z][a-zA-Z0-9_]*[a-z][a-zA-Z0-9_]*\b'
-  lifetime: '''(?:_|{{non_raw_ident}})(?!\'')\b'
+  lifetime: '''(?:_|{{identifier}})(?!\'')\b'
   escaped_char: '\\([nrt0\"''\\]|x[0-7]\h|u\{(?:\h_*){1,6}\})'
   int_suffixes: '[iu](?:8|16|32|64|128|size)'
   float_suffixes: 'f(32|64)'
@@ -147,7 +147,7 @@ contexts:
 
     - include: terminators
 
-    - match: '(''(?:{{non_raw_ident}}))\s*(:)'
+    - match: '(''(?:{{identifier}}))\s*(:)'
       captures:
         1: entity.name.label.rust
         2: punctuation.separator.rust
@@ -294,7 +294,7 @@ contexts:
         2: storage.modifier.rust
       push: declaration-identifier
 
-    - match: '\b(break|continue)\b(?:\s+(''{{non_raw_ident}}))?'
+    - match: '\b(break|continue)\b(?:\s+(''{{identifier}}))?'
       captures:
         1: keyword.control.rust
         2: entity.name.label.rust

--- a/Rust/tests/syntax_test_control_flow.rs
+++ b/Rust/tests/syntax_test_control_flow.rs
@@ -17,6 +17,7 @@ for i in 1..10 {
 // <- meta.block punctuation.section.block.end
 
 'label_name: loop {
+// <- entity.name.label.rust
 // ^^^^^^^^ entity.name.label
 //         ^ punctuation.separator
 //           ^^^^ keyword.control
@@ -47,6 +48,26 @@ for i in 1..10 {
         continue 'label1;
 //               ^^^^^^^ entity.name.label
 //                      ^ punctuation.terminator
+    }
+}
+
+// raw labels (requires Rust 2021)
+'r#for: for _ in 0..100 {
+// <- entity.name.label.rust
+//^^^^ entity.name.label
+    'r#for : loop {
+//  ^^^^^^ entity.name.label
+//         ^ punctuation.separator
+        'r#for: while true {
+//      ^^^^^^ entity.name.label
+//            ^ punctuation.separator
+            break 'r#for;
+//                ^^^^^^ entity.name.label
+//                      ^ punctuation.terminator
+        }
+        continue 'r#for;
+//               ^^^^^^ entity.name.label
+//                     ^ punctuation.terminator
     }
 }
 


### PR DESCRIPTION
```rust
'r#break: {
    break 'r#break;
}
```

compare: https://doc.rust-lang.org/stable/reference/tokens.html#lifetimes-and-loop-labels