### PR TITLE
[HTML] Fix xml prolog tag scopes

### DIFF
--- a/HTML/HTML (Plain).sublime-syntax
+++ b/HTML/HTML (Plain).sublime-syntax
@@ -236,7 +236,7 @@ contexts:
 ###[ PREPROCESSOR ]###########################################################
 
   preprocessor:
-    - match: (<\?)(xml)
+    - match: (<\?)(xml(?:-{{tag_name_char}}*)?)
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.xml.html
@@ -244,11 +244,10 @@ contexts:
 
   preprocessor-content:
     - meta_scope: meta.tag.preprocessor.xml.html
-    - match: \?>
+    - match: \??>
       scope: punctuation.definition.tag.end.html
       pop: 1
     - include: tag-generic-attribute
-    - include: strings
     - include: merge-conflict-markers
 
 ###[ TAGS ]###################################################################

--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -189,6 +189,10 @@ variables:
 
 contexts:
 
+  preprocessor-content:
+    - meta_prepend: true
+    - include: tag-href-attribute
+
   tag:
     - include: tag-html
     - include: tag-other

--- a/HTML/tests/syntax_test_scope.html
+++ b/HTML/tests/syntax_test_scope.html
@@ -3,6 +3,20 @@
 ## <- meta.tag.preprocessor punctuation.definition.tag.begin
 ##^^^entity.name.tag.xml
 ##                                   ^ punctuation.definition.tag.end
+
+<?xml-model>
+## <- meta.tag.preprocessor.xml.html punctuation.definition.tag.begin.html
+##^^^^^^^^^^ meta.tag.preprocessor.xml.html
+##^^^^^^^^^ entity.name.tag.xml.html
+##         ^ punctuation.definition.tag.end.html
+
+<?xml-model  href="schemas/xhtml-strict.xsd" ?>
+## <- meta.tag.preprocessor.xml.html punctuation.definition.tag.begin.html
+##^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.preprocessor.xml.html
+##^^^^^^^^^ entity.name.tag.xml.html
+##           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.href.html
+##                                           ^^ punctuation.definition.tag.end.html
+
 <!DOCTYPE html SYSTEM "html5.dtd" [ <!-- comment -->
 ## <- meta.tag.sgml.doctype punctuation.definition.tag.begin
 ##^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.sgml.doctype


### PR DESCRIPTION
This commit...

1. adds lazy support for `xml-model`, `xml-stylesheet`, ... prolog tags, primarily because... a) HTML syntax may be used by 3rd-party syntaxes targetting XML processing. b) a prolog tag was found breaking a Markdown document's highlighting.

2. makes prolog tag termination pattern more error resilient by also matching plain `>` as tag close punctuation. This also targets 1b)

3. removes `string` include from prolog tag attributes context, because those behave like normal xml tag attribute contexts - not supporting plain strings.