### PR TITLE
[Markdown] Fix reference definition symbols

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -248,10 +248,10 @@ variables:
       )
     )
 
-  # References and Footnotes
-  # ========================
+  # Footnotes
+  # =========
 
-  blockquote_footnote_end: |-
+  blockquote_footnote_paragraph_end: |-
     (?x: # pop out of this context if one of the following conditions are met:
       ^(?= (?:[ \t]*>)* [ \t]*
         (?: $                           # the line is blank (or only contains whitespace)
@@ -266,7 +266,7 @@ variables:
       )
     )
 
-  footnote_end: |-
+  footnote_paragraph_end: |-
     (?x: # pop out of this context if one of the following conditions are met:
       ^(?= [ \t]*
         (?: $                           # the line is blank (or only contains whitespace)
@@ -283,6 +283,38 @@ variables:
     )
 
   footnote_name: (?:\^(?:\\\]|[^]])+)
+
+  # References
+  # ==========
+
+  blockquote_reference_end: |-
+    (?x: # pop out of this context if one of the following conditions are met:
+      ^(?= (?:[ \t]*>)* [ \t]*
+        (?: $                           # the line is blank (or only contains whitespace)
+        |   {{reference_definition}}    # a reference definition begins the line
+        |   {{atx_heading}}             # an ATX heading begins the line
+        |   {{fenced_code_block}}       # a fenced codeblock begins the line
+        |   {{fenced_div_block}}        # a fenced div block begins the line
+        |   {{thematic_break}}          # line is a thematic beak
+        |   {{list_item}}               # a list item begins the line
+        )
+      )
+    )
+
+  reference_end: |-
+    (?x: # pop out of this context if one of the following conditions are met:
+      ^(?= [ \t]*
+        (?: $                           # the line is blank (or only contains whitespace)
+        |   {{reference_definition}}    # a reference definition begins the line
+        |   {{block_quote}}             # a blockquote begins the line
+        |   {{atx_heading}}             # an ATX heading begins the line
+        |   {{fenced_code_block}}       # a fenced codeblock begins the line
+        |   {{fenced_div_block}}        # a fenced div block begins the line
+        |   {{thematic_break}}          # line is a thematic beak
+        |   {{list_item}}               # a list item begins the line
+        )
+      )
+    )
 
   reference_definition: (?:\[{{reference_name}}\]\:)
   reference_name: (?:(?:\\\]|[^]])+)
@@ -711,9 +743,26 @@ contexts:
     - include: block-quote-footnote-paragraphs
 
   block-quote-footnote-def-end:
-    # A footnote definition is terminated by blocks not indented by at least 4 characters.
-    # Note: The first space after a quotation punctuation is not counted for simplicity reasons.
-    - match: ^(?!(?:[ \t]*>)+[ ](?:\1[ ]{4}|\s*$))
+    # Pop at eol, if next line contains a reference definition, for each
+    # footnote to be indexed individually by separating `meta.link.reference`
+    # scopes from each other.
+    - match: $
+      branch_point: block-quote-footnote-def-continuation
+      branch:
+        - block-quote-footnote-def-continuation
+        - immediately-pop2
+    # A footnote definition is terminated by blocks not indented by at least
+    # 4 characters + 1st first space after quotation punctuation for simplicity.
+    - match: ^(?!(?:[ \t]*>)+(?:[ ]\1[ ]{4}|\s*$))
+      pop: 1
+
+  block-quote-footnote-def-continuation:
+    - meta_include_prototype: false
+    # if line starts with footnote or reference definition,
+    # rollback to previous line and pop footnote contexts.
+    - match: ^(?=(?:[ \t]*>)*[ \t]*{{reference_definition}})
+      fail: block-quote-footnote-def-continuation
+    - match: ^
       pop: 1
 
   block-quote-footnote-paragraphs:
@@ -721,12 +770,25 @@ contexts:
       push: block-quote-footnote-paragraph-body
 
   block-quote-footnote-paragraph-body:
+    - meta_scope: meta.paragraph.markdown
     - include: block-quote-footnote-paragraph-end
     - include: block-quote-punctuations
     - include: footnote-paragraph-common
 
   block-quote-footnote-paragraph-end:
-    - match: '{{blockquote_footnote_end}}'
+    - match: $
+      branch_point: block-quote-footnote-paragraph-continuation
+      branch:
+        - block-quote-footnote-paragraph-continuation
+        - immediately-pop2
+
+  block-quote-footnote-paragraph-continuation:
+    - meta_include_prototype: false
+    # if line terminates the paragraph or footnote definition,
+    # rollback to previous line and pop its contexts.
+    - match: '{{blockquote_footnote_paragraph_end}}'
+      fail: block-quote-footnote-paragraph-continuation
+    - match: ^
       pop: 1
 
   block-quote-link-definitions:
@@ -739,6 +801,7 @@ contexts:
         4: punctuation.separator.key-value.markdown
       push:
         - block-quote-link-def-meta
+        - block-quote-link-def-attr
         - block-quote-link-def-title
         - block-quote-link-def-url
 
@@ -747,25 +810,73 @@ contexts:
     - meta_scope: meta.link.reference.def.markdown
     - include: immediately-pop
 
+  block-quote-link-def-attr:
+    - include: block-quote-punctuations
+    - match: \{
+      scope: punctuation.definition.attributes.begin.markdown
+      set: link-def-attr-body
+    - match: $
+      branch_point: block-quote-link-def-attr-continuation
+      branch:
+        - block-quote-link-def-attr-continuation
+        - immediately-pop2
+    - match: \S.+
+      scope: invalid.illegal.expected-eol.markdown
+
+  block-quote-link-def-attr-continuation:
+    - meta_include_prototype: false
+    # if line doesn't start with attributes block,
+    # rollback to previous line and pop its contexts.
+    - match: ^(?!(?:[ \t]*>)*\s*{)
+      fail: block-quote-link-def-attr-continuation
+    - match: ^
+      pop: 1
+
   block-quote-link-def-title:
-    - include: block-quote-nested-paragraph-end
     - include: block-quote-punctuations
     - include: link-title-begin
+    - match: $
+      branch_point: block-quote-link-def-title-continuation
+      branch:
+        - block-quote-link-def-title-continuation
+        - immediately-pop2
     - include: else-pop
 
+  block-quote-link-def-title-continuation:
+    - meta_include_prototype: false
+    # if line doesn't start with an url description,
+    # rollback to previous line and pop its contexts.
+    - match: ^(?!(?:[ \t]*>)*\s*["'(])
+      fail: block-quote-link-def-title-continuation
+    - match: ^
+      pop: 1
+
   block-quote-link-def-url:
-    - include: block-quote-nested-paragraph-end
     - include: block-quote-punctuations
     - match: <
       scope: punctuation.definition.link.begin.markdown
       set: block-quote-link-def-url-angled
     - match: (?=\S)
       set: link-def-url-unquoted
+    - match: $
+      branch_point: block-quote-link-def-url-continuation
+      branch:
+        - block-quote-link-def-url-continuation
+        - immediately-pop2
 
   block-quote-link-def-url-angled:
     - meta_content_scope: markup.underline.link.markdown
     - include: block-quote-punctuations
     - include: link-url-angled
+
+  block-quote-link-def-url-continuation:
+    - meta_include_prototype: false
+    # if line terminates the reference definition,
+    # rollback to previous line and pop its contexts.
+    - match: '{{blockquote_reference_end}}'
+      fail: block-quote-link-def-url-continuation
+    - match: ^
+      pop: 1
 
 ###[ CONTAINER BLOCKS: BLOCK QUOTES > LIST BLOCKS ]###########################
 
@@ -2399,7 +2510,7 @@ contexts:
 
   footnote-definitions:
     # Markdown Extras Footnotes
-    - match: '([ \t]*)(\[)({{footnote_name}})(\])(:)'
+    - match: ([ \t]*)(\[)({{footnote_name}})(\])(:)
       captures:
         2: punctuation.definition.reference.begin.markdown
         3: entity.name.reference.link.markdown
@@ -2413,7 +2524,24 @@ contexts:
     - include: footnote-paragraphs
 
   footnote-def-end:
+    # Pop at eol, if next line contains a reference definition, for each
+    # footnote to be indexed individually by separating `meta.link.reference`
+    # scopes from each other.
+    - match: $
+      branch_point: footnote-def-end
+      branch:
+        - footnote-def-continuation
+        - immediately-pop2
+    # pop at bol if non-empty line is not indented enough
     - match: ^(?!(?:\1[ ]{4}|\s*$))
+      pop: 1
+
+  footnote-def-continuation:
+    # if line starts with footnote or reference definition,
+    # rollback to previous line and pop footnote contexts.
+    - match: ^(?=[ \t]*{{reference_definition}})
+      fail: footnote-def-end
+    - match: ^
       pop: 1
 
   footnote-paragraphs:
@@ -2421,6 +2549,7 @@ contexts:
       push: footnote-paragraph-body
 
   footnote-paragraph-body:
+    - meta_scope: meta.paragraph.markdown
     - include: footnote-paragraph-end
     - include: footnote-paragraph-common
 
@@ -2431,7 +2560,19 @@ contexts:
     - include: links
 
   footnote-paragraph-end:
-    - match: '{{footnote_end}}'
+    - match: $
+      branch_point: footnote-paragraph-end
+      branch:
+        - footnote-paragraph-continuation
+        - immediately-pop2
+
+  footnote-paragraph-continuation:
+    - meta_include_prototype: false
+    # if line terminates the footnote paragraph,
+    # rollback to previous line and pop its contexts.
+    - match: '{{footnote_paragraph_end}}'
+      fail: footnote-paragraph-end
+    - match: ^
       pop: 1
 
   link-definitions:
@@ -2457,29 +2598,44 @@ contexts:
     - match: \{
       scope: punctuation.definition.attributes.begin.markdown
       set: link-def-attr-body
-    - match: ^(?!\s*{)|(?=\S)
-      pop: 1
+    - match: $
+      branch_point: link-def-attr-continuation
+      branch:
+        - link-def-attr-continuation
+        - immediately-pop2
+    - match: \S.+
+      scope: invalid.illegal.expected-eol.markdown
 
   link-def-attr-body:
     - meta_scope: meta.attributes.markdown
     - include: tag-attributes
 
-  link-def-title:
-    - match: ^(?!\s*["'(])
+  link-def-attr-continuation:
+    - meta_include_prototype: false
+    # if line doesn't start with attributes block,
+    # rollback to previous line and pop its contexts.
+    - match: ^(?!\s*{)
+      fail: link-def-attr-continuation
+    - match: ^
       pop: 1
-    - match: (?=["'(])
-      set:
-        - expect-attr-or-eol
-        - link-title
-    - match: (?=\{)
-      pop: 1
-    - match: \S.+
-      scope: invalid.illegal.expected-eol.markdown
 
-  expect-attr-or-eol:
-    - match: (?=\{)
+  link-def-title:
+    - include: link-title-begin
+    - match: $
+      branch_point: link-def-title-continuation
+      branch:
+        - link-def-title-continuation
+        - immediately-pop2
+    - include: else-pop
+
+  link-def-title-continuation:
+    - meta_include_prototype: false
+    # if line doesn't start with an url description,
+    # rollback to previous line and pop its contexts.
+    - match: ^(?!\s*["'(])
+      fail: link-def-title-continuation
+    - match: ^
       pop: 1
-    - include: expect-eol
 
   link-def-url:
     - match: <
@@ -2487,19 +2643,32 @@ contexts:
       set: link-def-url-angled
     - match: (?=\S)
       set: link-def-url-unquoted
-    - include: paragraph-end
+    - match: $
+      branch_point: link-def-url-continuation
+      branch:
+        - link-def-url-continuation
+        - immediately-pop2
 
   link-def-url-angled:
     - meta_content_scope: markup.underline.link.markdown
     - include: link-url-angled
 
   link-def-url-unquoted:
-    - meta_scope: markup.underline.link.markdown
+    - meta_content_scope: markup.underline.link.markdown
     # URLs are terminated by whitespace or newline in reference definitions
     # Note: \s includes \n
     - match: (?=\s)
       pop: 1
     - include: link-url-common
+
+  link-def-url-continuation:
+    - meta_include_prototype: false
+    # if line terminates the reference definition,
+    # rollback to previous line and pop its contexts.
+    - match: '{{reference_end}}'
+      fail: link-def-url-continuation
+    - match: ^
+      pop: 1
 
 ###[ LEAF BLOCKS: TABLES ]####################################################
 
@@ -3158,11 +3327,26 @@ contexts:
     - include: link-title-common
 
   link-title-common:
-    - match: ^\s*$\n?
-      scope: invalid.illegal.non-terminated.link-title.markdown
-      pop: 1
+    - match: $\n?
+      branch_point: link-title-continuation
+      branch:
+        - link-title-continuation
+        - link-title-termination
     - include: escapes
     - include: html-entities
+
+  link-title-continuation:
+    - meta_include_prototype: false
+    # if line is empty, rollback to previous line and pop its contexts.
+    - match: ^\s*$
+      fail: link-title-continuation
+    - match: ^
+      pop: 1
+
+  link-title-termination:
+    - meta_include_prototype: false
+    - meta_scope: invalid.illegal.non-terminated.link-title.markdown
+    - include: immediately-pop2
 
   link-url-angled:
     - match: \>
@@ -3684,5 +3868,11 @@ contexts:
       scope: invalid.illegal.expected-eol.markdown
 
   immediately-pop:
+    - meta_include_prototype: false
     - match: ''
       pop: 1
+
+  immediately-pop2:
+    - meta_include_prototype: false
+    - match: ''
+      pop: 2

--- a/Markdown/Symbol List - Reference Link.tmPreferences
+++ b/Markdown/Symbol List - Reference Link.tmPreferences
@@ -9,6 +9,7 @@
 		<integer>1</integer>
 		<key>symbolTransformation</key>
 		<string><![CDATA[
+			s/\n(?:\s*>)+//g;   # remove intermediate block quote punctuation
 			s/^\s*//g;			# strip leading whitespace
 			s/\s*$//g; 			# strip all trailing whitespace
 			s/\s+/ /g;			# convert (multiple) whitespace to one space

--- a/Markdown/tests/syntax_test_markdown.md
+++ b/Markdown/tests/syntax_test_markdown.md
@@ -3011,7 +3011,8 @@ Foo
 ### [Foo]
 [foo]: /url
 | <- meta.link.reference.def.markdown punctuation.definition.reference.begin.markdown
-|^^^^^^^^^^^ meta.link.reference.def.markdown
+|^^^^^^^^^^ meta.link.reference.def.markdown
+|          ^ - meta.link
 
 ### [Foo]
 [foo]: /url
@@ -3024,12 +3025,13 @@ Foo
 > [foo]: /url
 | <- markup.quote.markdown punctuation.definition.blockquote.markdown
 |^ markup.quote.markdown - meta.link
-| ^^^^^^^^^^^^ markup.quote.markdown meta.link.reference.def.markdown
+| ^^^^^^^^^^^ markup.quote.markdown meta.link.reference.def.markdown
 | ^ punctuation.definition.reference.begin.markdown
 |  ^^^ entity.name.reference.link.markdown
 |     ^ punctuation.definition.reference.end.markdown
 |      ^ punctuation.separator.key-value.markdown
 |        ^^^^ markup.underline.link.markdown
+|            ^ markup.quote.markdown - meta.link
 
 ## https://custom-tests/link-reference-definitions/with-attributes
 
@@ -3096,15 +3098,16 @@ Foo
 > </url-with
 > -continuation>
 | <- markup.quote.markdown meta.link.reference.def.markdown markup.underline.link.markdown punctuation.definition.blockquote.markdown
-|^^^^^^^^^^^^^^^^ markup.quote.markdown meta.link.reference.def.markdown
-|^^^^^^^^^^^^^^ markup.underline.link.markdown
-|              ^ punctuation.definition.link.end.markdown
+|^^^^^^^^^^^^^^ markup.quote.markdown meta.link.reference.def.markdown markup.underline.link.markdown
+|              ^ markup.quote.markdown meta.link.reference.def.markdown punctuation.definition.link.end.markdown - markup.underline
+|               ^ markup.quote.markdown - meta.link
 
 > [foo]: 
   /url
 | <- markup.quote.markdown - markup.underline - punctuation
 |^ markup.quote.markdown meta.link.reference.def.markdown - markup.underline
 | ^^^^ markup.quote.markdown meta.link.reference.def.markdown markup.underline.link.markdown
+|     ^ markup.quote.markdown - meta.link
 
 > [foo]: 
   /url
@@ -3112,14 +3115,50 @@ Foo
 | <- markup.quote.markdown - meta.string - string - punctuation
 |^ markup.quote.markdown meta.link.reference.def.markdown - meta.string - string
 | ^^^^^^^^^^^^^ markup.quote.markdown meta.link.reference.def.markdown meta.string.title.markdown string.quoted.double.markdown
+|              ^ markup.quote.markdown - meta.link
 
 > [foo]:
   </url-with
   -continuation>
 | <- markup.quote.markdown meta.link.reference.def.markdown markup.underline.link.markdown
-|^^^^^^^^^^^^^^^^ markup.quote.markdown meta.link.reference.def.markdown
-|^^^^^^^^^^^^^^ markup.underline.link.markdown
-|              ^ punctuation.definition.link.end.markdown
+|^^^^^^^^^^^^^^ markup.quote.markdown meta.link.reference.def.markdown markup.underline.link.markdown
+|              ^ markup.quote.markdown meta.link.reference.def.markdown punctuation.definition.link.end.markdown - markup.underline
+|               ^ markup.quote.markdown - meta.link
+
+## https://custom-tests/link-reference-definitions/in-block-quotes-with-attributes
+
+> [link]: /url {#id .class width=30}
+|              ^^^^^^^^^^^^^^^^^^^^^ meta.link.reference.def.markdown meta.attributes.markdown
+
+> [link]: /url (description) {#id .class width=30}
+|                            ^^^^^^^^^^^^^^^^^^^^^ meta.link.reference.def.markdown meta.attributes.markdown
+
+> [link]: /url "description" {#id .class width=30}
+|                            ^^^^^^^^^^^^^^^^^^^^^ meta.link.reference.def.markdown meta.attributes.markdown
+
+> [link]: 
+>   /url 
+>   {#id .class width=30}
+|   ^^^^^^^^^^^^^^^^^^^^^ meta.link.reference.def.markdown meta.attributes.markdown
+
+> [link]: 
+>   /url 
+>
+>   {#id .class width=30}
+|   ^^^^^^^^^^^^^^^^^^^^^ - meta.link - meta.attributes
+
+> [link]: 
+>   /url 
+>   "description" 
+>   {#id .class width=30}
+|   ^^^^^^^^^^^^^^^^^^^^^ meta.link.reference.def.markdown meta.attributes.markdown
+
+> [link]: 
+>   /url 
+>   "description" 
+>
+>   {#id .class width=30}
+|   ^^^^^^^^^^^^^^^^^^^^^ - meta.link - meta.attributes
 
 ## https://custom-tests/link-reference-definitions
 
@@ -3144,7 +3183,7 @@ Foo
 blah
 | <- meta.link.reference.def.markdown string.quoted.other
 
-| <- invalid.illegal.non-terminated.link-title
+| <- meta.link.reference.def.markdown - string
 text
 | <- meta.paragraph - meta.link.reference.def.markdown
 
@@ -3195,6 +3234,8 @@ with a *second* line.
 [^1]:
     And that's the footnote
 with a *second* line.
+| <- meta.link.reference.def.footnote.markdown-extra meta.paragraph.markdown
+|^^^^^^^^^^^^^^^^^^^^ meta.link.reference.def.footnote.markdown-extra meta.paragraph.markdown
 [^2]: second
 | <- meta.link.reference.def.footnote.markdown-extra punctuation.definition.reference.begin.markdown
 |^^^^^^^^^^^^ meta.link.reference.def.footnote.markdown-extra
@@ -3239,20 +3280,20 @@ with a *second* line.
 
 > [^1]:
 >     And that's the footnote.
-> 
+>
 >     That's the *second* paragraph.
 | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown meta.link.reference.def.footnote.markdown-extra
 |                ^^^^^^^^ markup.italic
 
 > [^1]:
 >     And that's the footnote.
-> 
+>
 >    Not a footnote paragraph.
 | <- markup.quote.markdown punctuation.definition.blockquote.markdown - markup.link
 | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.paragraph.markdown - markup.link
 
 >   [^1]: And that's the footnote.
-> 
+>
 >     code block
 | <- markup.quote.markdown punctuation.definition.blockquote.markdown - markup.raw
 |^ markup.quote.markdown - markup.raw
@@ -3260,7 +3301,7 @@ with a *second* line.
 
 > [^1]:
 >     And that's the footnote.
-> 
+>
       That's not a *second* paragraph.
 |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.raw.block.markdown
 
@@ -4319,11 +4360,12 @@ second line
 > 
 >     [ref]: /url
       | <- markup.list.unnumbered.markdown meta.link.reference.def.markdown punctuation.definition.reference.begin.markdown
-      |^^^^^^^^^^^ markup.list.unnumbered.markdown meta.link.reference.def.markdown
+      |^^^^^^^^^^ markup.list.unnumbered.markdown meta.link.reference.def.markdown
       |^^^ entity.name.reference.link.markdown
       |   ^ punctuation.definition.reference.end.markdown
       |    ^ punctuation.separator.key-value.markdown
       |      ^^^^ markup.underline.link.markdown
+      |          ^ markup.quote.markdown markup.list.unnumbered.markdown - meta.link
 >
 >   + sub item [ref]
 >     - sub item [ref]
@@ -4331,11 +4373,12 @@ second line
 >     
 >       [ref]: /url
         | <- markup.list.unnumbered.markdown meta.link.reference.def.markdown punctuation.definition.reference.begin.markdown
-        |^^^^^^^^^^^ markup.list.unnumbered.markdown meta.link.reference.def.markdown
+        |^^^^^^^^^^ markup.list.unnumbered.markdown meta.link.reference.def.markdown
         |^^^ entity.name.reference.link.markdown
         |   ^ punctuation.definition.reference.end.markdown
         |    ^ punctuation.separator.key-value.markdown
         |      ^^^^ markup.underline.link.markdown
+        |          ^ markup.quote.markdown markup.list.unnumbered.markdown - meta.link
 >
 >   + sub item [ref]
 >     - sub item [ref]
@@ -4344,11 +4387,12 @@ second line
 >
 >  [ref]: /url
    | <- markup.list.unnumbered.markdown meta.link.reference.def.markdown punctuation.definition.reference.begin.markdown
-   |^^^^^^^^^^^ markup.list.unnumbered.markdown meta.link.reference.def.markdown
+   |^^^^^^^^^^ markup.list.unnumbered.markdown meta.link.reference.def.markdown
    |^^^ entity.name.reference.link.markdown
    |   ^ punctuation.definition.reference.end.markdown
    |    ^ punctuation.separator.key-value.markdown
    |      ^^^^ markup.underline.link.markdown
+   |          ^ markup.quote.markdown markup.list.unnumbered.markdown - meta.link
 
 ## https://custom-tests/block-quotes/list-blocks/ordered-items-with-reference-definitions
 
@@ -4360,11 +4404,12 @@ second line
 >
 >       [ref]: /url
         | <- markup.list.numbered.markdown meta.link.reference.def.markdown punctuation.definition.reference.begin.markdown
-        |^^^^^^^^^^^ markup.list.numbered.markdown meta.link.reference.def.markdown
+        |^^^^^^^^^^ markup.list.numbered.markdown meta.link.reference.def.markdown
         |^^^ entity.name.reference.link.markdown
         |   ^ punctuation.definition.reference.end.markdown
         |    ^ punctuation.separator.key-value.markdown
         |      ^^^^ markup.underline.link.markdown
+        |          ^ markup.quote.markdown markup.list.numbered.markdown - meta.link
 >
 >    2. sub item [ref]
 >       3. sub item [ref]
@@ -4372,11 +4417,12 @@ second line
 >        
 >          [ref]: /url
            | <- markup.list.numbered.markdown meta.link.reference.def.markdown punctuation.definition.reference.begin.markdown
-           |^^^^^^^^^^^ markup.list.numbered.markdown meta.link.reference.def.markdown
+           |^^^^^^^^^^ markup.list.numbered.markdown meta.link.reference.def.markdown
            |^^^ entity.name.reference.link.markdown
            |   ^ punctuation.definition.reference.end.markdown
            |    ^ punctuation.separator.key-value.markdown
            |      ^^^^ markup.underline.link.markdown
+           |          ^ markup.quote.markdown markup.list.numbered.markdown - meta.link
 >
 >    2. sub item [ref]
 >       3. sub item [ref]
@@ -4385,11 +4431,12 @@ second line
 >          
 >    [ref]: /url
      | <- markup.list.numbered.markdown meta.link.reference.def.markdown punctuation.definition.reference.begin.markdown
-     |^^^^^^^^^^^ markup.list.numbered.markdown meta.link.reference.def.markdown
+     |^^^^^^^^^^ markup.list.numbered.markdown meta.link.reference.def.markdown
      |^^^ entity.name.reference.link.markdown
      |   ^ punctuation.definition.reference.end.markdown
      |    ^ punctuation.separator.key-value.markdown
      |      ^^^^ markup.underline.link.markdown
+     |          ^ markup.quote.markdown markup.list.numbered.markdown - meta.link
 
 ## https://custom-tests/block-quotes/list-blocks/items-with-reference-definitions
 
@@ -4407,6 +4454,7 @@ second line
 |             ^ punctuation.separator.key-value.markdown
 |               ^^^^ markup.underline.link.markdown
 |                    ^^^^^^^^^^^^^ meta.string.title.markdown string.quoted.double.markdown
+|                                 ^ markup.quote.markdown markup.list.numbered.markdown - meta.link
 
 > 1. item
 >    + item
@@ -4418,6 +4466,7 @@ second line
 |^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown meta.link.reference.def.markdown
 |        ^^^^ markup.underline.link.markdown
 |             ^^^^^^^^^^^^^ meta.string.title.markdown string.quoted.double.markdown
+|                          ^ markup.quote.markdown markup.list.numbered.markdown - meta.link
 
 > 1. item
 >    + item
@@ -4429,6 +4478,7 @@ second line
 | <- markup.quote.markdown markup.list.numbered.markdown meta.link.reference.def.markdown punctuation.definition.blockquote.markdown
 |^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown meta.link.reference.def.markdown
 |        ^^^^^^^^^^^^^ meta.string.title.markdown string.quoted.double.markdown
+|                     ^ markup.quote.markdown markup.list.numbered.markdown - meta.link
 
 > 1. item
 >    + item
@@ -4438,9 +4488,9 @@ second line
 >        </url-with
 >        -continuation>
 | <- markup.quote.markdown markup.list.numbered.markdown meta.link.reference.def.markdown markup.underline.link.markdown punctuation.definition.blockquote.markdown
-|^^^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown meta.link.reference.def.markdown
-|^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.markdown
-|                     ^ punctuation.definition.link.end.markdown
+|^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown meta.link.reference.def.markdown markup.underline.link.markdown
+|                     ^ markup.quote.markdown markup.list.numbered.markdown meta.link.reference.def.markdown punctuation.definition.link.end.markdown - markup.underline
+|                      ^ markup.quote.markdown markup.list.numbered.markdown - meta.link
 
 > 1. item
 >    + item
@@ -4452,6 +4502,7 @@ second line
 |^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown meta.link.reference.def.markdown
 |        ^^^^ markup.underline.link.markdown
 |             ^^^^^^^^^^^^^ meta.string.title.markdown string.quoted.double.markdown
+|                          ^ markup.quote.markdown markup.list.numbered.markdown - meta.link
 
 > 1. item
 >    + item
@@ -4463,6 +4514,7 @@ second line
 | <- markup.quote.markdown - meta.string - string - punctuation
 |^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown meta.link.reference.def.markdown
 |        ^^^^^^^^^^^^^ meta.string.title.markdown string.quoted.double.markdown
+|                     ^ markup.quote.markdown markup.list.numbered.markdown - meta.link
 
 > 1. item
 >    + item
@@ -4472,9 +4524,9 @@ second line
          </url-with
          -continuation>
 | <- markup.quote.markdown markup.list.numbered.markdown meta.link.reference.def.markdown markup.underline.link.markdown
-|^^^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown meta.link.reference.def.markdown
-|^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.markdown
-|                     ^ punctuation.definition.link.end.markdown
+|^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown meta.link.reference.def.markdown markup.underline.link.markdown
+|                     ^ markup.quote.markdown markup.list.numbered.markdown meta.link.reference.def.markdown punctuation.definition.link.end.markdown - markup.underline
+|                      ^ markup.quote.markdown markup.list.numbered.markdown - meta.link
 
 ## https://custom-tests/block-quotes/list-blocks/items-with-footnote-definitions
 
@@ -5129,11 +5181,12 @@ So is this, with a empty second item:
 
   [ref]: /url
   | <- markup.list.unnumbered.markdown meta.link.reference.def.markdown punctuation.definition.reference.begin.markdown
-  |^^^^^^^^^^^ markup.list.unnumbered.markdown meta.link.reference.def.markdown
+  |^^^^^^^^^^ markup.list.unnumbered.markdown meta.link.reference.def.markdown
   |^^^ entity.name.reference.link.markdown
   |   ^ punctuation.definition.reference.end.markdown
   |    ^ punctuation.separator.key-value.markdown
   |      ^^^^ markup.underline.link.markdown
+  |          ^ markup.list.unnumbered.markdown - meta.link
 - d
   | <- markup.list.unnumbered.markdown
 
@@ -5588,32 +5641,36 @@ global heading
   
     [ref]: /url
     | <- markup.list.unnumbered.markdown meta.link.reference.def.markdown punctuation.definition.reference.begin.markdown
-    |^^^^^^^^^^^ markup.list.unnumbered.markdown meta.link.reference.def.markdown
+    |^^^^^^^^^^ markup.list.unnumbered.markdown meta.link.reference.def.markdown
     |^^^ entity.name.reference.link.markdown
     |   ^ punctuation.definition.reference.end.markdown
     |    ^ punctuation.separator.key-value.markdown
     |      ^^^^ markup.underline.link.markdown
+    |          ^ markup.list.unnumbered.markdown - meta.link
 
     - sub item [ref]
       |        ^^^^^ markup.list.unnumbered.markdown meta.link.reference.description.markdown
     
       [ref]: /url
       | <- markup.list.unnumbered.markdown meta.link.reference.def.markdown punctuation.definition.reference.begin.markdown
-      |^^^^^^^^^^^ markup.list.unnumbered.markdown meta.link.reference.def.markdown
+      |^^^^^^^^^^ markup.list.unnumbered.markdown meta.link.reference.def.markdown
       |^^^ entity.name.reference.link.markdown
       |   ^ punctuation.definition.reference.end.markdown
       |    ^ punctuation.separator.key-value.markdown
       |      ^^^^ markup.underline.link.markdown
- 
+      |          ^ markup.list.unnumbered.markdown - meta.link
+      
       [ref]:
       /url
       | <- markup.list.unnumbered.markdown meta.link.reference.def.markdown markup.underline.link.markdown
       |^^^ markup.list.unnumbered.markdown meta.link.reference.def.markdown markup.underline.link.markdown
+      |   ^ markup.list.unnumbered.markdown - meta.link
 
       [ref]: /url
       "title"
       | <- markup.list.unnumbered.markdown meta.link.reference.def.markdown meta.string.title.markdown string.quoted.double.markdown
       |^^^^^^ markup.list.unnumbered.markdown meta.link.reference.def.markdown meta.string.title.markdown string.quoted.double.markdown
+      |      ^ markup.list.unnumbered.markdown - meta.link
 
       [ref]: /url
       no title
@@ -5622,11 +5679,12 @@ global heading
 
   [ref]: /url
   | <- markup.list.unnumbered.markdown meta.link.reference.def.markdown punctuation.definition.reference.begin.markdown
-  |^^^^^^^^^^^ markup.list.unnumbered.markdown meta.link.reference.def.markdown
+  |^^^^^^^^^^ markup.list.unnumbered.markdown meta.link.reference.def.markdown
   |^^^ entity.name.reference.link.markdown
   |   ^ punctuation.definition.reference.end.markdown
   |    ^ punctuation.separator.key-value.markdown
   |      ^^^^ markup.underline.link.markdown
+  |          ^ markup.list.unnumbered.markdown - meta.link
 
 1. list item [ref]
    |         ^^^^^ markup.list.numbered.markdown meta.link.reference.description.markdown
@@ -5636,32 +5694,36 @@ global heading
     
       [ref]: /url
       | <- markup.list.numbered.markdown meta.link.reference.def.markdown punctuation.definition.reference.begin.markdown
-      |^^^^^^^^^^^ markup.list.numbered.markdown meta.link.reference.def.markdown
+      |^^^^^^^^^^ markup.list.numbered.markdown meta.link.reference.def.markdown
       |^^^ entity.name.reference.link.markdown
       |   ^ punctuation.definition.reference.end.markdown
       |    ^ punctuation.separator.key-value.markdown
       |      ^^^^ markup.underline.link.markdown
+      |          ^ markup.list.numbered.markdown - meta.link
 
       3. sub item [ref]
          |        ^^^^^ markup.list.numbered.markdown meta.link.reference.description.markdown
        
          [ref]: /url
          | <- markup.list.numbered.markdown meta.link.reference.def.markdown punctuation.definition.reference.begin.markdown
-         |^^^^^^^^^^^ markup.list.numbered.markdown meta.link.reference.def.markdown
+         |^^^^^^^^^^ markup.list.numbered.markdown meta.link.reference.def.markdown
          |^^^ entity.name.reference.link.markdown
          |   ^ punctuation.definition.reference.end.markdown
          |    ^ punctuation.separator.key-value.markdown
          |      ^^^^ markup.underline.link.markdown
+         |          ^ markup.list.numbered.markdown - meta.link
 
          [ref]:
          /url
          | <- markup.list.numbered.markdown meta.link.reference.def.markdown markup.underline.link.markdown
          |^^^ markup.list.numbered.markdown meta.link.reference.def.markdown markup.underline.link.markdown
+         |   ^ markup.list.numbered.markdown - meta.link
 
          [ref]: /url
          "title"
          | <- markup.list.numbered.markdown meta.link.reference.def.markdown meta.string.title.markdown string.quoted.double.markdown
          |^^^^^^ markup.list.numbered.markdown meta.link.reference.def.markdown meta.string.title.markdown string.quoted.double.markdown
+         |      ^ markup.list.numbered.markdown - meta.link
 
          [ref]: /url
          no title
@@ -5670,11 +5732,12 @@ global heading
 
    [ref]: /url
    | <- markup.list.numbered.markdown meta.link.reference.def.markdown punctuation.definition.reference.begin.markdown
-   |^^^^^^^^^^^ markup.list.numbered.markdown meta.link.reference.def.markdown
+   |^^^^^^^^^^ markup.list.numbered.markdown meta.link.reference.def.markdown
    |^^^ entity.name.reference.link.markdown
    |   ^ punctuation.definition.reference.end.markdown
    |    ^ punctuation.separator.key-value.markdown
    |      ^^^^ markup.underline.link.markdown
+   |          ^ markup.list.numbered.markdown - meta.link
 
 ## https://custom-tests/list-blocks/items-with-footnote-definitions
 
@@ -9576,3 +9639,12 @@ their paragraph
 |      ^ meta.block.conflict.end.diff - entity - punctuation
 |       ^^^^^^ meta.block.conflict.end.diff entity.name.section.diff
 |             ^ meta.block.conflict.end.diff - entity - punctuation
+
+[ref]: /url
+[ref]: /url "definition"
+[ref]: /url {#id}
+[ref]: /url (definition) {#id}
+[ref]: 
+  /url 
+  (definition) {#id}
+[ref]: /url

--- a/Markdown/tests/syntax_test_markdown.md
+++ b/Markdown/tests/syntax_test_markdown.md
@@ -9639,12 +9639,3 @@ their paragraph
 |      ^ meta.block.conflict.end.diff - entity - punctuation
 |       ^^^^^^ meta.block.conflict.end.diff entity.name.section.diff
 |             ^ meta.block.conflict.end.diff - entity - punctuation
-
-[ref]: /url
-[ref]: /url "definition"
-[ref]: /url {#id}
-[ref]: /url (definition) {#id}
-[ref]: 
-  /url 
-  (definition) {#id}
-[ref]: /url


### PR DESCRIPTION
This PR...

1. fixes an issue which causes multiple subsequent reference definitions to be listed as one item in Goto Symbol quick panel.

   Meta scopes of subsequent reference definitions are separated by excluding each definition's final linefeed from `meta.link.reference.def` scopes, so ST sees them as separate regions.

   Implementation requires branching to overcome ST's line blindness, first pushing a context to check next line's content. In case of required termination, context is rolled back to current line's eol before popping its context. That's quite some song and dance, but there's no other solution.

2. aligns reference definitions' implementations in block quotes and other paragraphs, so they exactly match with regards to features and structure.

3. removes possible block quote punctuation from symbols.

### Example

```markdown
## Heading 

This is [base][url] and a [^1].

[base]: #base
[url]: #version-url-date
[^1]: footnot 1
[^2]: footnot 2
```

##### Before

<img width="607" height="105" alt="grafik" src="https://github.com/user-attachments/assets/fcbd21e6-033e-4e81-a108-9031aad9fd18" />

Parsing syntax_test_markdown.markdown takes 35ms

#### After

<img width="664" height="201" alt="grafik" src="https://github.com/user-attachments/assets/676ef5e2-b652-4343-a511-5d2e1a4a08d9" />

Parsing syntax_test_markdown.markdown takes 38ms
