### PR TITLE
[C] Recognise types ending in _t

### DIFF
--- a/C++/C.sublime-syntax
+++ b/C++/C.sublime-syntax
@@ -303,6 +303,8 @@ contexts:
       scope: support.type.windows.c
     - match: \b(AbsoluteTime|Boolean|Byte|ByteCount|ByteOffset|BytePtr|CompTimeValue|ConstLogicalAddress|ConstStrFileNameParam|ConstStringPtr|Duration|Fixed|FixedPtr|Float32|Float32Point|Float64|Float80|Float96|FourCharCode|Fract|FractPtr|Handle|ItemCount|LogicalAddress|OptionBits|OSErr|OSStatus|OSType|OSTypePtr|PhysicalAddress|ProcessSerialNumber|ProcessSerialNumberPtr|ProcHandle|Ptr|ResType|ResTypePtr|ShortFixed|ShortFixedPtr|SignedByte|SInt16|SInt32|SInt64|SInt8|Size|StrFileName|StringHandle|StringPtr|TimeBase|TimeRecord|TimeScale|TimeValue|TimeValue64|UInt16|UInt32|UInt64|UInt8|UniChar|UniCharCount|UniCharCountPtr|UniCharPtr|UnicodeScalarValue|UniversalProcHandle|UniversalProcPtr|UnsignedFixed|UnsignedFixedPtr|UnsignedWide|UTF16Char|UTF32Char|UTF8Char)\b
       scope: support.type.mac-classic.c
+    - match: \b([A-Za-z0-9_]+_t)\b
+      scope: support.type.posix-reserved.c
     - include: types-parens
 
   types-parens:

--- a/C++/syntax_test_c.c
+++ b/C++/syntax_test_c.c
@@ -587,6 +587,9 @@ tss_dtor_t tss_dtor_t_var;
 once_flag once_flag_var;
 /* <- support.type.threads */
 
+some_arbitrary_type_t arbitrary_type_var;
+/* <- support.type.posix-reserved */
+
 void *null_pointer1 = NULL;
                     /* ^ constant.language.null */
 


### PR DESCRIPTION
This is one place where VS Code does better with the default syntax, because it recognises the majority of custom types as-is without any sort of structural type analysis. (This also works better than analysis, as that necessarily requires the LSP to be able to perform analysis, which isn't always the case).

https://github.com/microsoft/vscode/blob/3aef8be5e46aa7e97e8b0ed115f6147cd0b24634/extensions/cpp/syntaxes/c.tmLanguage.json#L195-L198