### PR TITLE
[PHP] Add pipe operator

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -2889,6 +2889,8 @@ contexts:
       scope: punctuation.section.embedded.begin.php
     - match: =>
       scope: punctuation.separator.key-value.php
+    - match: \|>
+      scope: keyword.operator.assignment.pipe.php
     - match: (?:\+|-|\*|/|%|&|\||\^|>>|<<|\.|\?\?)=
       scope: keyword.operator.assignment.augmented.php
     - match: (?:(=)(&))|(&(?=[[:alpha:]$_]))

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -3755,6 +3755,9 @@ $foo = (unset) $bar;
  * Operators Tests
  *****************************************************************************/
 
+   |>
+// ^^ keyword.operator.assignment.pipe.php
+
     += -= *= /= %= &= |= ^= >>= <<= .= ??=
 // ^ - keyword
 //  ^^ keyword.operator.assignment.augmented.php


### PR DESCRIPTION
This commit adds patterns for `|>` pipe operator supported by PHP 8.5+

see: https://thephp.foundation/blog/2025/07/11/php-85-adds-pipe-operator/