### PR TITLE
[C#] Allow any modifier order in nested methods

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -1099,7 +1099,7 @@ contexts:
       pop: true
     - include: keywords
     # C#7/9, nested method
-    - match: (?=(?:\b(?:async|ref)\s+)?(?:\bstatic\s+)?{{namespaced_name}}{{type_suffix}}\s+{{namespaced_name}}\s*\()
+    - match: (?=(?:\b(?:async|ref|static)\s+)*{{namespaced_name}}{{type_suffix}}\s+{{namespaced_name}}\s*\()
       push:
         - include: method_declaration
         - match: ''

--- a/C#/tests/syntax_test_GeneralStructure.cs
+++ b/C#/tests/syntax_test_GeneralStructure.cs
@@ -1460,7 +1460,7 @@ public class TestModifierOrder
 ///                   ^^^^^^^^^^^^^^^ entity.name.function
 ///                                  ^ punctuation.section.parameters.begin.cs
 ///                                                                               ^ punctuation.section.parameters.end.cs
-    static async Task OnExportCommand(FileInfo outputfile, CancellationToken token) => await Task.CompletedTask;
+    static async Task OnExportCommand(FileInfo outputfile, CancellationToken token) => await Task.CompletedTask {
 /// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - invalid
 /// ^^^^^^ storage.modifier
 ///        ^^^^^ storage.modifier
@@ -1468,4 +1468,18 @@ public class TestModifierOrder
 ///                   ^^^^^^^^^^^^^^^ entity.name.function
 ///                                  ^ punctuation.section.parameters.begin.cs
 ///                                                                               ^ punctuation.section.parameters.end.cs
+        async static Task NestedMethod();
+///     ^^^^^ storage.modifier.cs
+///           ^^^^^^ storage.modifier.cs
+///                  ^^^^ support.type.cs
+///                       ^^^^^^^^^^^^ meta.method.cs entity.name.function.cs
+///                                   ^^ meta.method.parameters.cs
+
+        static async Task NestedMethod();
+///     ^^^^^^ storage.modifier.cs
+///            ^^^^^ storage.modifier.cs
+///                  ^^^^ support.type.cs
+///                       ^^^^^^^^^^^^ meta.method.cs entity.name.function.cs
+///                                   ^^ meta.method.parameters.cs
+    }
 }


### PR DESCRIPTION
Fixes #4334

This PR allows any number of `async`, `ref` and `static` in any order in front of nested method definitions.