### PR TITLE
[HTML] Add support for "importmap" script type

### DIFF
--- a/HTML/HTML.sublime-syntax
+++ b/HTML/HTML.sublime-syntax
@@ -125,8 +125,9 @@ variables:
   # or whose essence is "application/json" or "text/json".
   # https://mimesniff.spec.whatwg.org/#understanding-mime-types
   # https://mimesniff.spec.whatwg.org/#json-mime-type
+  # https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap
   json_mime_type: |-
-     (?xi: (?: application/ | text/ | [[:ascii:]]+\+ ) json {{mime_type_parameters}}? )
+     (?xi: (?: (?: application/ | text/ | [[:ascii:]]+\+ ) json | importmap ) {{mime_type_parameters}}? )
 
   # A MIME type’s parameters is an ordered map whose keys are ASCII strings and values are strings
   # limited to HTTP quoted-string token code points. It is initially empty.

--- a/HTML/tests/syntax_test_scope.html
+++ b/HTML/tests/syntax_test_scope.html
@@ -207,6 +207,12 @@
 ##^^^^^^ - source.json.embedded
 ##      ^^^^^^^^^ meta.tag.script.end.html
 
+        <script type="importmap"> { "imports": {"circle": "https://example.com/shapes/circle.js" } }</script>
+        ## <- meta.tag.script.begin.html punctuation.definition.tag.begin.html
+        ##^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.script.begin.html
+        ##                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.json.embedded.html
+        ##                                                                                          ^^^^^^^^^ meta.tag.script.end.html
+
         <script type = "text/html"> <!--
         ##^^^^^^ meta.tag.script.begin.html - meta.tag meta.tag - meta.attribute-with-value
         ##      ^^^^^^^^^^^^^^^^^^ meta.tag.script.begin.html meta.attribute-with-value.type.html - meta.tag meta.tag - meta.attribute-with-value meta.attribute-with-value


### PR DESCRIPTION
This commit adds json highlighting in `<script type="importmap"> ... </script>`.

see: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap