### PR TITLE
[Makefile] avoid partial keyword matches; add `undefine`

### DIFF
--- a/Makefile/Makefile.sublime-syntax
+++ b/Makefile/Makefile.sublime-syntax
@@ -125,7 +125,7 @@ contexts:
     - include: variable-substitutions
     - include: control-flow
     - include: line-continuation
-    - match: ^\s*(endef)
+    - match: ^\s*(endef)\b
       captures:
         1: invalid.illegal.stray.endef.makefile
 
@@ -256,7 +256,7 @@ contexts:
   recipe-junction-between-spaces-or-tabs:
     - meta_content_scope: meta.function.body.makefile
     - include: comments
-    - match: ^\s*({{startdirective}})
+    - match: ^\s*({{startdirective}})\b
       captures:
         1: keyword.control.conditional.makefile
       push:
@@ -529,13 +529,16 @@ contexts:
         - include: shell-content
 
   variable-definitions:
-    - match: \s*(override)\b
+    - match: \s*\b(override)\b
       captures:
         1: keyword.control.makefile
-    - match: \s*(define)\b
+    - match: \s*\b(define)\b
       captures:
         1: keyword.control.makefile
       push: inside-define-directive-context
+    - match: \s*\b(undefine)\b
+      captures:
+        1: keyword.control.makefile
     - match: ^\s*(export)\b
       captures:
         1: keyword.control.makefile

--- a/Makefile/syntax_test_makefile.mak
+++ b/Makefile/syntax_test_makefile.mak
@@ -172,6 +172,14 @@ endef   # comment
 #^^^^ keyword.control.makefile
 #       ^^^ comment.line.number-sign.makefile
 
+# Avoid false positives such as partial matches.
+
+foodefine
+#^^^^^^^^^ - keyword
+
+definefoo
+#^^^^^^^^^ - keyword
+
 #########################
 # 6.5 setting variables #
 #########################
@@ -255,6 +263,26 @@ override \
 endef
 # <- keyword.control.makefile
 
+
+#############################
+# 6.11 undefining variables #
+#############################
+
+undefine foo
+#^^^^^^^ keyword.control.makefile
+#       ^^^^ -keyword
+
+  undefine foo
+# ^^^^^^^^ keyword.control.makefile
+#         ^^^^ -keyword
+
+# Avoid false positives such as partial matches.
+
+undefined
+#^^^^^^^^^ - keyword
+
+nundefine
+#^^^^^^^^^ - keyword
 
 ########################################
 # 6.11 target-specific variable values #


### PR DESCRIPTION
This fixes syntax highlighting for makefiles (such as [this one](https://github.com/jart/blink/blob/98f95e8383d1032eb4d2dc6aae937b23539e915e/Makefile)) which use `undefine`, which was broken due to partial matching of `define` (missing `\b`).