### PR TITLE
[Ruby] fix highlighting of __END__

### DIFF
--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -111,6 +111,7 @@ contexts:
       pop: 1
 
   expressions:
+    - include: data-section
     - include: constants
     - include: class
     - include: module
@@ -122,7 +123,6 @@ contexts:
     - include: method
     - include: strings
     - include: comments
-    - include: data-section
     - include: heredocs
     - include: punctuation
     - include: operators

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -1736,3 +1736,8 @@ _query = <<-SQL
 #             ^^^^^ meta.table-name.sql
   VALUES (1, 2, 3)
 SQL
+
+__END__
+#^^^^^^ meta.string.ruby
+  if end
+# ^^^^^^ text.plain


### PR DESCRIPTION
It was being highlighted as `variable.other.constant.ruby` previously. ~~The Ruby interpreter also allows whitespace after `__END__` (but not before).~~

*edit: I was actually totally wrong about that last part, I had just set up my editor to automatically remove trailing whitespace when testing...*