### PR TITLE
[CSS] Simplify indentation rules

### DIFF
--- a/CSS/Indentation Rules.tmPreferences
+++ b/CSS/Indentation Rules.tmPreferences
@@ -13,25 +13,10 @@
 			^.*
 			# followed by opening bracket
 			[(\[{]
-			# optionally followed by...
-			(?<balanced>
-			# balanced parentheses
-			  \( \g<balanced>* \)
-			# balanced brackets
-		  	| \[ \g<balanced>* \]
-			# balanced braces
-			| \{ \g<balanced>* \}
-			# double quoted string with ignored escaped quotation marks
-			| \" .*? (?<![^\\]\\)(?<![\\]{3})\"
-			# single quoted string with ignored escaped quotation marks
-			| \' .*? (?<![^\\]\\)\'
-			# block comment
-			| /\* .*? \*/
-			# anything but closing brackets
-			| [^])}]
-			)*
+			# optionally followed by block comment
+			(?: \s* /\* ((?!\*/).)* \*/ )*
 			# ... until end of line
-			$
+			\s* $
 		]]></string>
 		<key>preserveIndent</key>
 		<false/>

--- a/CSS/tests/syntax_test_indentation.css
+++ b/CSS/tests/syntax_test_indentation.css
@@ -5,7 +5,8 @@
 .class { color: red;
 }
 
-.class { color: red;
+.class {
+    color: red;
     background: beige;
 }
 
@@ -13,7 +14,8 @@
     background: beige;
 }
 
-.class { color: rgb(0, 0, 0);
+.class {
+    color: rgb(0, 0, 0);
     background: beige;
 }
 
@@ -338,12 +340,14 @@ abbr[                           /* ] }
     color: red;                 /* ; } */
 }                               /* ; } */
 
-.class { color: red;            /* ; } */
+.class {                        /* ; } */
+    color: red;                 /* ; } */
     background: beige;          /* ; } */
 }                               /* ; } */
 
 /* ignore closing brace in strings and comments */
-.class { font: "\"}";           /* ; } */
+.class {                        /* ; } */
+    font: "\"}";                /* ; } */
     background: beige;          /* ; } */
 }                               /* ; } */
 
@@ -351,12 +355,13 @@ abbr[                           /* ] }
     background: beige;          /* ; } */
 }                               /* ; } */
 
-.class { color: rgb(0, 0, 0);   /* ; } */
+.class {                        /* ; } */
+    color: rgb(0, 0, 0);        /* ; } */
     background: beige;          /* ; } */
 }                               /* ; } */
 
 abbr[title],                    /* ; } */
-abbr[                           /* ; } */
+abbr[                           /* ; ] */
     data-title                  /* ; } */
 ] {                             /* ; } */
     color: red;                 /* ; } */
@@ -439,4 +444,12 @@ abbr[                           /* ; */ /* ] /* comment
 .class {
 /**/ color: red;
 /**/ color /**/ : /**/ red /**/ ; /**/
+}
+
+/*
+ * issue: https://github.com/sublimehq/Packages/issues/4344
+ */
+a::after {
+    content: ' (' attr(href) ')';
+    color: red;
 }


### PR DESCRIPTION
Resolves #4344.

This commit removes attempts to be too smart with regards to finding unbalanced brackets, as it doesn't work reliable enough using single patterns.

Instead just accept trailing block comments after an opening bracket to indent line after.