### PR TITLE
[Python] Fix regexp quantifiers in raw f-strings

### DIFF
--- a/Python/Embeddings/RegExp (for Python raw-f-string).sublime-syntax
+++ b/Python/Embeddings/RegExp (for Python raw-f-string).sublime-syntax
@@ -1,0 +1,21 @@
+%YAML 1.2
+---
+scope: source.regexp.python.embedded.raw-f-string
+version: 2
+hidden: true
+
+extends: RegExp (for Python).sublime-syntax
+
+variables:
+  brace_start: \{\{
+  brace_end: \}\}
+
+contexts:
+  escaped-chars:
+    - meta_prepend: true
+    - match: \\({{brace_start}}|{{brace_end}})
+      scope: constant.character.escape.regexp
+      captures:
+        1: constant.character.escape.python
+    - match: (?:{{brace_start}}|{{brace_end}})
+      scope: constant.character.escape.python

--- a/Python/Embeddings/RegExp (for Python).sublime-syntax
+++ b/Python/Embeddings/RegExp (for Python).sublime-syntax
@@ -17,6 +17,11 @@ variables:
   capture_group_name: (?:[[:alpha:]_]\w*)
   capture_group: (?:[1-9][0-9]*|{{capture_group_name}})
 
+  # quantifiers
+  ranged_quantifier: '{{brace_start}}\d+(?:,\d*)?{{brace_end}}'
+  brace_start: \{
+  brace_end: \}
+
 contexts:
   base:
     - meta_prepend: true
@@ -64,3 +69,39 @@ contexts:
       scope: punctuation.definition.set.end.regexp
     - match: \)
       scope: punctuation.section.group.end.regexp
+
+  quantifiers:
+    - match: (?={{brace_start}}[\d{])
+      branch_point: ranged-quantifier
+      branch:
+        - ranged-quantifier
+        - ranged-quantifier-fallback
+    - match: '{{character_quantifier}}{{lazy_or_possessive}}'
+      scope: keyword.operator.quantifier.regexp
+      push: maybe-unexpected-quantifiers
+
+  ranged-quantifier:
+    - meta_include_prototype: false
+    - match: '{{brace_start}}'
+      scope: keyword.operator.quantifier.regexp
+      set: ranged-quantifier-min
+
+  ranged-quantifier-min:
+    - meta_content_scope: keyword.operator.quantifier.regexp
+    - match: ','
+      scope: keyword.operator.quantifier.regexp
+      set: ranged-quantifier-max
+    - include: ranged-quantifier-max
+
+  ranged-quantifier-max:
+    - meta_content_scope: keyword.operator.quantifier.regexp
+    - match: '{{brace_end}}'
+      scope: keyword.operator.quantifier.regexp
+      set: maybe-unexpected-quantifiers
+    - match: (?!\d)
+      fail: ranged-quantifier
+
+  ranged-quantifier-fallback:
+    - meta_include_prototype: false
+    - match: ''
+      pop: 1

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -2790,7 +2790,7 @@ contexts:
     - meta_content_scope: meta.string.python string.quoted.double.block.python source.regexp.python
     - include: triple-double-quoted-string-end
     - match: ''
-      push: scope:source.regexp.python#base-literal-extended
+      push: scope:source.regexp.python.embedded.raw-f-string#base-literal-extended
       with_prototype:
         - include: triple-double-quoted-string-pop
         - include: triple-double-quoted-raw-f-string-content
@@ -2998,7 +2998,8 @@ contexts:
       fail: triple-double-quoted-string-replacement
 
   triple-double-quoted-f-string-replacements:
-    - include: f-string-replacements
+    - include: escaped-f-string-braces
+    - include: invalid-f-string-replacements
     - match: \{
       scope: punctuation.section.interpolation.begin.python
       push:
@@ -3008,8 +3009,9 @@ contexts:
 
   triple-double-quoted-f-string-replacements-regexp:
     # Same as f-string-replacements, but will reset the entire scope stack.
-    - include: f-string-replacements-regexp
-    - match: \{
+    # Escaped f-string characters are handled by regexp syntax.
+    - include: invalid-f-string-replacements
+    - match: \{(?!{)
       scope: punctuation.section.interpolation.begin.python
       push:
         - f-string-replacement-regexp-meta
@@ -3140,7 +3142,7 @@ contexts:
     - meta_content_scope: meta.string.python string.quoted.double.python source.regexp.python
     - include: double-quoted-string-end
     - match: ''
-      push: scope:source.regexp.python#base-literal
+      push: scope:source.regexp.python.embedded.raw-f-string#base-literal
       with_prototype:
         - include: double-quoted-string-pop
         - include: double-quoted-raw-f-string-content
@@ -3343,7 +3345,8 @@ contexts:
       fail: double-quoted-string-replacement
 
   double-quoted-f-string-replacements:
-    - include: f-string-replacements
+    - include: escaped-f-string-braces
+    - include: invalid-f-string-replacements
     - match: \{
       scope: punctuation.section.interpolation.begin.python
       push:
@@ -3353,8 +3356,9 @@ contexts:
 
   double-quoted-f-string-replacements-regexp:
     # Same as f-string-replacements, but will reset the entire scope stack.
-    - include: f-string-replacements-regexp
-    - match: \{
+    # Escaped f-string characters are handled by regexp syntax.
+    - include: invalid-f-string-replacements
+    - match: \{(?!{)
       scope: punctuation.section.interpolation.begin.python
       push:
         - f-string-replacement-regexp-meta
@@ -3476,7 +3480,7 @@ contexts:
     - meta_content_scope: meta.string.python string.quoted.single.block.python source.regexp.python
     - include: triple-single-quoted-string-end
     - match: ''
-      push: scope:source.regexp.python#base-literal-extended
+      push: scope:source.regexp.python.embedded.raw-f-string#base-literal-extended
       with_prototype:
         - include: triple-single-quoted-string-pop
         - include: triple-single-quoted-raw-f-string-content
@@ -3683,7 +3687,8 @@ contexts:
       fail: triple-single-quoted-string-replacement
 
   triple-single-quoted-f-string-replacements:
-    - include: f-string-replacements
+    - include: escaped-f-string-braces
+    - include: invalid-f-string-replacements
     - match: \{
       scope: punctuation.section.interpolation.begin.python
       push:
@@ -3693,8 +3698,9 @@ contexts:
 
   triple-single-quoted-f-string-replacements-regexp:
     # Same as f-string-replacements, but will reset the entire scope stack.
-    - include: f-string-replacements-regexp
-    - match: \{
+    # Escaped f-string characters are handled by regexp syntax.
+    - include: invalid-f-string-replacements
+    - match: \{(?!{)
       scope: punctuation.section.interpolation.begin.python
       push:
         - f-string-replacement-regexp-meta
@@ -3893,7 +3899,7 @@ contexts:
     - meta_content_scope: meta.string.python string.quoted.single.python source.regexp.python
     - include: single-quoted-string-end
     - match: ''
-      push: scope:source.regexp.python#base-literal
+      push: scope:source.regexp.python.embedded.raw-f-string#base-literal
       with_prototype:
         - include: single-quoted-string-pop
         - include: single-quoted-raw-f-string-content
@@ -4028,7 +4034,8 @@ contexts:
       fail: single-quoted-string-replacement
 
   single-quoted-f-string-replacements:
-    - include: f-string-replacements
+    - include: escaped-f-string-braces
+    - include: invalid-f-string-replacements
     - match: \{
       scope: punctuation.section.interpolation.begin.python
       push:
@@ -4038,8 +4045,9 @@ contexts:
 
   single-quoted-f-string-replacements-regexp:
     # Same as f-string-replacements, but will reset the entire scope stack.
-    - include: f-string-replacements-regexp
-    - match: \{
+    # Escaped f-string characters are handled by regexp syntax.
+    - include: invalid-f-string-replacements
+    - match: \{(?!{)
       scope: punctuation.section.interpolation.begin.python
       push:
         - f-string-replacement-regexp-meta
@@ -4100,6 +4108,15 @@ contexts:
     # but don't scope them as escapes as they are treated literal
     - match: \\[\\'"]
 
+  escaped-f-string-braces:
+    # https://peps.python.org/pep-0498
+    # https://peps.python.org/pep-0701
+    # https://docs.python.org/3.6/reference/lexical_analysis.html#f-strings
+    - match: (\\)?(?:\{\{|\}\})
+      scope: constant.character.escape.python
+      captures:
+        1: invalid.deprecated.character.escape.python
+
   escaped-string-braces:
     - match: \{\{|\}\}
       scope: constant.character.escape.python
@@ -4152,30 +4169,11 @@ contexts:
     - match: \{
       pop: 1
 
-  f-string-replacements:
-    # https://peps.python.org/pep-0498
-    # https://peps.python.org/pep-0701
-    # https://docs.python.org/3.6/reference/lexical_analysis.html#f-strings
-    - match: (\\)?(?:\{\{|\}\})
-      scope: constant.character.escape.python
-      captures:
-        1: invalid.deprecated.character.escape.python
-    - include: invalid-f-string-replacements
-
   f-string-replacement-meta:
     - clear_scopes: 1
     - meta_include_prototype: false
     - meta_scope: meta.interpolation.python
     - include: immediately-pop
-
-  f-string-replacements-regexp:
-    # Same as f-string-replacements, but will reset the entire scope stack
-    # and has an additional match.
-    - match: \\?(\{\{|\}\})
-      scope: constant.character.escape.regexp
-      captures:
-        1: constant.character.escape.python
-    - include: invalid-f-string-replacements
 
   f-string-replacement-regexp-meta:
     # Same as f-string-replacement, but with clear_scopes: true
@@ -4202,7 +4200,8 @@ contexts:
   invalid-f-string-replacements:
     - match: \{\s*\}
       scope: invalid.illegal.empty-expression.python
-    - include: illegal-stray-braces
+    - match: \}(?!})
+      scope: invalid.illegal.stray.python
 
   # for use by inheriting syntaxes to easily inject string interpolation
   # in any kind of quoted or unquoted string

--- a/Python/tests/syntax_test_python_strings.py
+++ b/Python/tests/syntax_test_python_strings.py
@@ -1427,8 +1427,12 @@ fr"{var}? {var}* [{foo}-{bar},{{}}]+ {var}{2,3} {var}{{2,3}} {var}{{{beg},{end}}
 #              ^ keyword.operator.quantifier.regexp
 #                                  ^ keyword.operator.quantifier.regexp
 #                                         ^^^^^ - keyword.operator
-#                                                    ^^^^^^^ - keyword.operator
-#                                                                 ^^^^^^^^^^^^^^^ - keyword.operator
+#                                                    ^^^^^^^ keyword.operator.quantifier.regexp
+#                                                                 ^^ keyword.operator.quantifier.regexp
+#                                                                   ^^^^^ - keyword.operator
+#                                                                        ^ keyword.operator.quantifier.regexp
+#                                                                         ^^^^^ - keyword.operator
+#                                                                              ^^ keyword.operator.quantifier.regexp
 
 fr'{var}? {var}* [{foo}-{bar},{{}}]+ {var}{2,3} {var}{{2,3}} {var}{{{beg},{end}}}'
 # ^ meta.string.python string.quoted
@@ -1454,8 +1458,12 @@ fr'{var}? {var}* [{foo}-{bar},{{}}]+ {var}{2,3} {var}{{2,3}} {var}{{{beg},{end}}
 #              ^ keyword.operator.quantifier.regexp
 #                                  ^ keyword.operator.quantifier.regexp
 #                                         ^^^^^ - keyword.operator
-#                                                    ^^^^^^^ - keyword.operator
-#                                                                 ^^^^^^^^^^^^^^^ - keyword.operator
+#                                                    ^^^^^^^ keyword.operator.quantifier.regexp
+#                                                                 ^^ keyword.operator.quantifier.regexp
+#                                                                   ^^^^^ - keyword.operator
+#                                                                        ^ keyword.operator.quantifier.regexp
+#                                                                         ^^^^^ - keyword.operator
+#                                                                              ^^ keyword.operator.quantifier.regexp
 
 # Most of these were inspired by
 # https://github.com/python/cpython/commit/9a4135e939bc223f592045a38e0f927ba170da32
@@ -1797,8 +1805,12 @@ fr"""
 #        ^ keyword.operator.quantifier.regexp
 #               ^ keyword.operator.quantifier.regexp
 #                                     ^^^^^ - keyword.operator
-#                                                ^^^^^^^ - keyword.operator
-#                                                             ^^^^^^^^^^^^^^^ - keyword.operator
+#                                                ^^^^^^^ keyword.operator.quantifier.regexp
+#                                                             ^^ keyword.operator.quantifier.regexp
+#                                                               ^^^^^ - keyword.operator
+#                                                                    ^ keyword.operator.quantifier.regexp
+#                                                                     ^^^^^ - keyword.operator
+#                                                                          ^^ keyword.operator.quantifier.regexp
 """
 # <- meta.string.python string.quoted.double.block.python punctuation.definition.string.end.python
 #^^ meta.string.python string.quoted.double.block.python punctuation.definition.string.end.python
@@ -1835,8 +1847,12 @@ fr'''
 #        ^ keyword.operator.quantifier.regexp
 #               ^ keyword.operator.quantifier.regexp
 #                                     ^^^^^ - keyword.operator
-#                                                ^^^^^^^ - keyword.operator
-#                                                             ^^^^^^^^^^^^^^^ - keyword.operator
+#                                                ^^^^^^^ keyword.operator.quantifier.regexp
+#                                                             ^^ keyword.operator.quantifier.regexp
+#                                                               ^^^^^ - keyword.operator
+#                                                                    ^ keyword.operator.quantifier.regexp
+#                                                                     ^^^^^ - keyword.operator
+#                                                                          ^^ keyword.operator.quantifier.regexp
 '''
 # <- meta.string.python string.quoted.single.block.python punctuation.definition.string.end.python
 #^^ meta.string.python string.quoted.single.block.python punctuation.definition.string.end.python

--- a/Regular Expressions/RegExp (Basic).sublime-syntax
+++ b/Regular Expressions/RegExp (Basic).sublime-syntax
@@ -71,9 +71,10 @@ contexts:
     - include: anchors
     - include: backrefs
     - include: switches
-    - include: escaped-chars
     - include: charsets
     - include: operators
+    - include: quantifiers
+    - include: escaped-chars
 
   extended-patterns:
     - include: line-comments
@@ -301,7 +302,6 @@ contexts:
       push: maybe-unexpected-quantifiers
 
   literals:
-    - include: quantifiers
     - match: \.
       scope: keyword.other.any.regexp # https://github.com/sublimehq/Packages/issues/314
     - match: \)


### PR DESCRIPTION
This PR...

1. scopes `{1,2}` as ordinary interpolation in raw f-strings as literal braces and thus regexp ranged quantifiers must be denoted by `{{1,2}}`.
2. adds support for interpolation within ranged quantifiers (e.g.: `{{{a},{b}}}`).
3. refactors `f-string-replacements` and `f-string-replacements-regexp` contexts into `escaped-f-string-braces` as counter-part of `escaped-string-braces` and includes `invalid-f-string-interpolations` context separately.

Note: to be able to properly handle escaped f-string braces, context include order in _RegExp (Basic)_ is modified to give `quantifiers` precedence over `escaped-chars` context.