### PR TITLE
[Perl] Fix redundant section header

### DIFF
--- a/Perl/Perl.sublime-syntax
+++ b/Perl/Perl.sublime-syntax
@@ -361,7 +361,6 @@ contexts:
     - include: literal-angle-nested
 
 ###[ MERGE CONFLICT MARKERS ]##################################################
-###[ MERGE CONFLICT MARKERS ]##################################################
 
   merge-conflict-markers:
     # see also: Diff.sublime-syntax#conflict-markers


### PR DESCRIPTION
Removes duplicate comment from Perl.sublime-syntax