### PR TITLE
[C] Compile File with MSVC on Windows

### DIFF
--- a/C++/C Single File.sublime-build
+++ b/C++/C Single File.sublime-build
@@ -7,6 +7,19 @@
 	"variants":
 	[
 		{
+			"name": "MSVC",
+			"shell_cmd": "cl /nologo \"${file}\"",
+			"file_regex": "^(.*)\\(([0-9]*)\\):( )(.*)",
+			"windows": true,
+		},
+		{
+			"name": "MSVC Run",
+			"shell_cmd": "cl /nologo \"${file}\" && ${file_base_name}",
+			"file_regex": "^(.*)\\(([0-9]*)\\):( )(.*)",
+			"interactive": true,
+			"windows": true,
+		},
+		{
 			"name": "Run",
 			"shell_cmd": "gcc \"${file}\" -o \"${file_path}/${file_base_name}\" && \"${file_path}/${file_base_name}\"",
 			"interactive": true,


### PR DESCRIPTION
Hi,
I've noticed that the build file only works on machines that have `gcc` witch is not the case by default on Windows nor Mac. I think would be a good idea to use the default toolchains available on the system so maybe in a future commit we could add `clang` for mac.

Please tell me if I made a mistake on the syntax for defining os specific commands.