### PR TITLE
[Markdown] Fix typing ``` in the middle of a document

### DIFF
--- a/Markdown/Default.sublime-keymap
+++ b/Markdown/Default.sublime-keymap
@@ -10,18 +10,6 @@
             { "key": "selector", "operand": "text.html.markdown - markup.raw" }
         ]
     },
-    {
-        "keys": ["backspace"],
-        "command": "run_macro_file",
-        "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"},
-        "context": [
-            { "key": "setting.auto_match_enabled" },
-            { "key": "selection_empty", "match_all": true },
-            { "key": "selector", "operator": "equal", "operand": "text.html.markdown - markup.raw" },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\*$", "match_all": true },
-            { "key": "following_text", "operator": "regex_contains", "operand": "^\\*", "match_all": true }
-        ]
-    },
 
     // Auto-pair underscore
     {
@@ -32,18 +20,6 @@
             { "key": "setting.auto_match_enabled"},
             { "key": "selection_empty", "operand": false, "match_all": true },
             { "key": "selector", "operand": "text.html.markdown - markup.raw" }
-        ]
-    },
-    {
-        "keys": ["backspace"],
-        "command": "run_macro_file",
-        "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"},
-        "context": [
-            { "key": "setting.auto_match_enabled" },
-            { "key": "selection_empty", "match_all": true },
-            { "key": "selector", "operator": "equal", "operand": "text.html.markdown - markup.raw" },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "_$", "match_all": true },
-            { "key": "following_text", "operator": "regex_contains", "operand": "^_", "match_all": true }
         ]
     },
 
@@ -78,6 +54,18 @@
             { "key": "setting.auto_match_enabled" },
             { "key": "selection_empty", "operand": true, "match_all": true },
             { "key": "selector", "operand": "text.html.markdown markup.raw - markup.raw.code-fence - meta.code-fence" },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^`", "match_all": true }
+        ]
+    },
+    {
+        "keys": ["`"],
+        "command": "move",
+        "args": {"by": "characters", "forward": true},
+        "context": [
+            { "key": "setting.auto_match_enabled" },
+            { "key": "selection_empty", "operand": true, "match_all": true },
+            { "key": "selector", "operand": "text.html.markdown - markup.raw" },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "`$", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "^`", "match_all": true }
         ]
     },


### PR DESCRIPTION
Typing ``` was inserting ```` (except when typing at EOF), because the initial paired `` is not recognized by the syntax definition as a code block, and therefore the second backtick was inserting, rather than skipping over the paired character.

This change tweaks the key binding to work in this situation.

Additionally deleted the bindings that would delete ** and __ sequences with one keypress, because they're not auto-paired, so it doesn't make any sense to do this.