### PR TITLE
[Markdown] Remove auto-pairing of asterisk and underscore

### DIFF
--- a/Markdown/Default.sublime-keymap
+++ b/Markdown/Default.sublime-keymap
@@ -1,28 +1,4 @@
 [
-    // Auto-pair asterisks
-    {
-        "keys": ["*"],
-        "command": "insert_snippet",
-        "args": {"contents": "*${0:$SELECTION}*"},
-        "context": [
-            { "key": "setting.auto_match_enabled"},
-            { "key": "selection_empty", "operand": false, "match_all": true },
-            { "key": "selector", "operand": "text.html.markdown - markup.raw" }
-        ]
-    },
-
-    // Auto-pair underscore
-    {
-        "keys": ["_"],
-        "command": "insert_snippet",
-        "args": {"contents": "_${0:$SELECTION}_"},
-        "context": [
-            { "key": "setting.auto_match_enabled"},
-            { "key": "selection_empty", "operand": false, "match_all": true },
-            { "key": "selector", "operand": "text.html.markdown - markup.raw" }
-        ]
-    },
-
     // Auto-pair backticks
     {
         "keys": ["`"],


### PR DESCRIPTION
As a consequence of #4363, this commit also removes key bindings for auto-pairing `_` and `*`.