### PR TITLE
[D, Makefile, Rust] Standardize build output scopes

### DIFF
--- a/D/DMD Output.sublime-syntax
+++ b/D/DMD Output.sublime-syntax
@@ -18,3 +18,5 @@ contexts:
       captures:
         1: message.warning.build-output markup.warning.build-output
         2: punctuation.separator.build-output
+    - match: '^\[.+\]$'
+      scope: comment.line.result.build-output

--- a/Makefile/Make Output.sublime-syntax
+++ b/Makefile/Make Output.sublime-syntax
@@ -19,4 +19,4 @@ contexts:
         1: message.warning.build-output markup.warning.build-output
         2: punctuation.separator.build-output
     - match: '^\[.+\]$'
-      scope: comment.line.build-output
+      scope: comment.line.result.build-output

--- a/Rust/Cargo.sublime-syntax
+++ b/Rust/Cargo.sublime-syntax
@@ -16,4 +16,4 @@ contexts:
         1: message.error.build-output markup.error.build-output
         2: punctuation.separator.build-output
     - match: '^\[.+\]$'
-      scope: comment.line.build-output
+      scope: comment.line.result.build-output


### PR DESCRIPTION
I noticed that there are 3 packages (D, Makefile, Rust) which contain rudimentary syntaxes for the build results output panel. However, the scope names used therein don't follow a common style, which makes it difficult in color schemes to apply general rules for consistent styling in the build results panel, or to target individual scope names in a good way.

This pull request proposes the following changes to standardize some rules for the base scopes and the suffix of other scope names. The updated scope names are somewhat inspired by those used in `Syntax Test Result.sublime-syntax` from the Default package.

- change base scope from `source` to `text` (in accordance with `Syntax Test Result.sublime-syntax`)
- the base scope now follows the scheme `text.build-results.<compiler/tool name>`
- use `.build-results` scope suffix in the regular scope names
- distinguish between "error" and "warning" if applicable (the built-in color schemes now have special rules to highlight them)
- in addition to the relatively uncommon `message.error` / `message.warning` scopes, also use `markup.error` and `markup.warning` scopes on top, which are alternative scopes that are already used in the packages ecosystem and by some third-party color schemes
- add scopes for the capture groups of line and column numbers