### PR TITLE
[JavaScript] Add key binding for parentheses auto-indentation

### DIFF
--- a/JavaScript/Default.sublime-keymap
+++ b/JavaScript/Default.sublime-keymap
@@ -90,6 +90,26 @@
         ]
     },
 
+    // Add indented line in parentheses
+    { "keys": ["enter"], "command": "run_macro_file", "args": {"file": "res://Packages/Default/Add Line in Braces.sublime-macro"}, "context":
+        [
+            { "key": "setting.auto_indent" },
+            { "key": "selection_empty", "match_all": true },
+            { "key": "selector", "operand": "source.js, source.jsx, source.ts, source.tsx" },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\($", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^\\)", "match_all": true }
+        ]
+    },
+    { "keys": ["keypad_enter"], "command": "run_macro_file", "args": {"file": "res://Packages/Default/Add Line in Braces.sublime-macro"}, "context":
+        [
+            { "key": "setting.auto_indent" },
+            { "key": "selection_empty", "match_all": true },
+            { "key": "selector", "operand": "source.js, source.jsx, source.ts, source.tsx" },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\($", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^\\)", "match_all": true }
+        ]
+    },
+
     // JSX close tag
     { "keys": ["/"], "command": "close_tag", "args": { "insert_slash": true }, "context":
         [

--- a/JavaScript/Indentation Rules.tmPreferences
+++ b/JavaScript/Indentation Rules.tmPreferences
@@ -30,6 +30,8 @@
 			  \}
 			# dedent closing brackets
 			| \]
+			# dedent closing parentheses
+			| \)
 			# dedent closing tagged templates
 			| `
 			# detent `case ... :`
@@ -46,9 +48,9 @@
 			# line beginning with whitespace or block comments
 			^ (.*\*/)? \s*
 			(?:
-			# indent after opening braces (may be followed by whitespace or comments)
+			# indent after opening braces, brackets, and parentheses (may be followed by whitespace or comments)
 			# but exclude lines such as `extern "C" {`
-			  .* \{ (?: \s* /\*.*\*/ )* \s* (?: //.* )? $
+			  .* [\{\[\(] (?: \s* /\*.*\*/ )* \s* (?: //.* )? $
 			# indent after opening tagged template: e.g.: "css`"
 			# see: Indentation Rules - Template Strings.tmPreferences
 			# indent after `case ... :`

--- a/JavaScript/tests/syntax_test_js_indent_common.js
+++ b/JavaScript/tests/syntax_test_js_indent_common.js
@@ -953,11 +953,41 @@ function testWhileIndentationWithBraces(v)  {
     }
     while (
         v == foo( bar("") + "" )
-        )
+    )
     {
         v++;
         v++;
     }
+}
+
+function testParenthesisIndentation() {
+    myFunc(
+        
+    );
+
+    myFunc(
+        'arg1',
+        'arg2',
+        'arg3'
+    );
+
+    if (
+        (conditionA && conditionB) ||
+        (conditionC && conditionD)
+    ) {
+    }
+
+    outerFunc(
+        innerFunc(
+            'arg'
+        )
+    );
+
+    const myArrowFunc = (
+        param1,
+        param2
+    ) => {
+    };
 }
 
 function testWhileIndentationWithBracesAndComments(v)  {

--- a/JavaScript/tests/syntax_test_jsx_indent.jsx
+++ b/JavaScript/tests/syntax_test_jsx_indent.jsx
@@ -41,7 +41,7 @@ function Layout({ env }) {
             </p>
         </body>
         </html>
-        );
+    );
 }
 
 function Video({ video }) {
@@ -58,7 +58,7 @@ function Video({ video }) {
                 video={video}
             />
         </div>
-        );
+    );
 }
 
 function VideoList({ videos, emptyHeading }) {
@@ -87,8 +87,8 @@ function VideoList({ videos, emptyHeading }) {
                             }
                         </p>
                     </div>
-                    )
+                )
             }
         </section>
-        );
+    );
 }


### PR DESCRIPTION
with the cursor between parentheses:

```javascript
    function myFunc(|)
```

becomes:

```javascript
    function myFunc(
        |
    )
```

after hitting <kbd>Enter</kbd>.