### PR TITLE
[Go] Add keypad_enter binding for auto-pairing parentheses

### DIFF
--- a/Go/Default.sublime-keymap
+++ b/Go/Default.sublime-keymap
@@ -45,4 +45,13 @@
       { "key": "following_text", "operator": "regex_contains", "operand": "^\\)", "match_all": true },
     ]
   },
+  { "keys": ["keypad_enter"], "command": "run_macro_file", "args": {"file": "res://Packages/Default/Add Line in Braces.sublime-macro"}, "context":
+    [
+      { "key": "selector", "operator": "equal", "operand": "source.go", },
+      { "key": "setting.auto_indent", "operator": "equal", "operand": true },
+      { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+      { "key": "preceding_text", "operator": "regex_contains", "operand": "\\($", "match_all": true },
+      { "key": "following_text", "operator": "regex_contains", "operand": "^\\)", "match_all": true },
+    ]
+  },
 ]


### PR DESCRIPTION
related with #4370 

This commit adds `keypad_enter` binding additionally to already existing `enter`, to enable auto-indenting content between parentheses.