### PR TITLE
[ShellScript] Fix escaped chars in arithmetic expression identifiers

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -1903,8 +1903,9 @@ contexts:
       push: dec-number-body
 
   expression-variables:
-    # variables within arithmetic expressions must not contain quotes
-    - match: (?=[{{identifier_first_char}}$%`])
+    # variables within arithmetic expressions must not contain brace expansions
+    # or quotes, as expressions itself are partitioned by quotation marks
+    - match: (?=[{{identifier_first_char}}\\`%$])
       push:
         - subscript
         - expression-variable-chars
@@ -1913,6 +1914,7 @@ contexts:
     - meta_scope: variable.other.readwrite.shell
     - include: line-continuations
     - include: string-interpolations
+    - include: any-escapes
     - match: '{{identifier_break}}'
       pop: 1
 

--- a/ShellScript/Bash/tests/syntax_test_scope.bash
+++ b/ShellScript/Bash/tests/syntax_test_scope.bash
@@ -12535,10 +12535,11 @@ let-=
 let+=
 #^^^^ - storage - keyword.declaration
 
-let expr 'expr' "expr"
+let expr 'expr' "expr" \expr $expr `expr` {expr}
 # <- meta.function-call.identifier.shell support.function.shell
 #^^ meta.function-call.identifier.shell
-#  ^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell meta.arithmetic.shell
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell meta.arithmetic.shell
+#                                              ^ - meta.function-call.arguments - meta.arithmetic
 #^^ support.function.shell
 #   ^^^^ variable.other.readwrite.shell
 #        ^ punctuation.definition.quoted.begin.shell
@@ -12547,6 +12548,16 @@ let expr 'expr' "expr"
 #               ^ punctuation.definition.quoted.begin.shell
 #                ^^^^ variable.other.readwrite.shell
 #                    ^ punctuation.definition.quoted.end.shell
+#                      ^^^^^ variable.other.readwrite.shell
+#                      ^^ constant.character.escape.shell
+#                            ^^^^^ meta.interpolation.parameter.shell variable.other.readwrite.shell
+#                            ^ punctuation.definition.variable.shell
+#                                  ^^^^^^ meta.interpolation.command.shell
+#                                  ^ punctuation.section.interpolation.begin.shell
+#                                   ^^^^ meta.function-call.identifier.shell meta.command.shell variable.function.shell
+#                                       ^ punctuation.section.interpolation.end.shell
+#                                         ^ invalid.illegal.unexpected-token.shell
+#                                          ^^^^ variable.other.readwrite.shell
 
 let 5 \
     + 5


### PR DESCRIPTION
This PR enables identifiers to start with and scopes escaped characters.