### PR TITLE
[C#] Fix multi-line lambda class members

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -768,33 +768,55 @@ contexts:
     - match: (?={{name}})
       branch_point: method_or_member_variable_name
       branch:
-        - member_lambda_or_plain
+        - member_plain
+        - member_lambda
         - method_name
       pop: true
 
-  member_lambda_or_plain:
-    - match: ({{name}})\s*(=>)
-      scope: meta.method.cs
-      captures:
-        1: variable.other.member.cs
-        2: keyword.declaration.function.accessor.get.cs
-      set:
-        - meta_scope: meta.property.cs
-        - meta_content_scope: meta.method.cs
-        - include: line_of_code_in
-    - match: (?={{namespaced_name}}\s+{{name}}\s+=>)
-      pop: true
+  member_plain:
+    - meta_include_prototype: false
     - match: '{{name}}'
       scope: variable.other.member.cs
-    - match: (?==[^>])
+      set: member_plain_value
+    - match: (?=\S)
+      pop: true
+
+  member_plain_value:
+    - match: '[.<\{\[\(]|=>'
+      fail: method_or_member_variable_name
+    - match: (?==)
       set: member_variables_declaration
+    - match: ','
+      scope: punctuation.separator.variables.cs
+      set: member_plain
     - match: ';'
       scope: punctuation.terminator.statement.cs
       pop: true
     - match: (?=\})
       pop: true
     - match: (?=\S)
+      pop: true
+
+  member_lambda:
+    - meta_include_prototype: false
+    - match: '{{name}}'
+      scope: variable.other.member.cs
+      set:
+        - member_lambda_value
+        - member_lambda_operator
+    - match: (?=\S)
+      pop: true
+
+  member_lambda_operator:
+    - match: =>
+      scope: keyword.declaration.function.accessor.get.cs
+      pop: 1
+    - match: (?=\S)
       fail: method_or_member_variable_name
+
+  member_lambda_value:
+    - meta_scope: meta.property.cs meta.method.cs
+    - include: line_of_code_in
 
   method_name:
     - match: '({{name}})?\s*(\()'

--- a/C#/tests/syntax_test_C#7.cs
+++ b/C#/tests/syntax_test_C#7.cs
@@ -663,6 +663,16 @@ public readonly struct S
 ///                        ^ variable.other.member
 ///                         ^ punctuation.terminator.statement
 
+    public readonly int X = 0, Y = 1;    // All fields must be readonly
+///                     ^ variable.other.member
+///                       ^ keyword.operator.assignment.variable.cs
+///                         ^ meta.number.integer.decimal.cs constant.numeric.value.cs
+///                          ^ punctuation.separator.variables
+///                            ^ variable.other.member
+///                              ^ keyword.operator.assignment.variable.cs
+///                                ^ meta.number.integer.decimal.cs constant.numeric.value.cs
+///                                 ^ punctuation.terminator.statement
+
     public S(int age, string name)
     {
         this.Age = age;

--- a/C#/tests/syntax_test_C#8.cs
+++ b/C#/tests/syntax_test_C#8.cs
@@ -106,11 +106,30 @@ public struct Point3D
 ///               ^^^ storage.modifier
 ///                   ^^^^^^^^ storage.modifier
 ///                            ^^^^^^^ support.type
+///                                    ^^^^^^^^^^^^^^^^^^^^^ meta.property.cs meta.method.cs
 ///                                    ^^^^^^ variable.other.member
 ///                                           ^^ keyword.declaration.function.accessor.get
 ///                                              ^^^ keyword.other
 ///                                                  ^^^^^^ variable.other
 ///                                                        ^ punctuation.terminator.statement
+
+    public int P1
+        => M1 (M2 ());
+///^^^^^^^^^^^^^^^^^^^ meta.property.cs meta.method.cs
+///     ^^ keyword.declaration.function.accessor.get.cs
+///        ^^^ meta.function-call.cs
+///           ^ meta.function-call.cs meta.group.cs - meta.function-call meta.function-call
+///            ^^^ meta.function-call.cs meta.group.cs meta.function-call.cs - meta.group meta.group
+///               ^^ meta.function-call.cs meta.group.cs meta.function-call.cs meta.group.cs
+///                 ^ meta.function-call.cs meta.group.cs - meta.function-call meta.function-call
+///                  ^ - meta.function-call
+///        ^^ variable.function.cs
+///           ^ punctuation.section.group.begin.cs
+///            ^^ variable.function.cs
+///               ^ punctuation.section.group.begin.cs
+///                ^ punctuation.section.group.end.cs
+///                 ^ punctuation.section.group.end.cs
+///                  ^ punctuation.terminator.statement.cs
 
     // other members removed for space
 

--- a/C#/tests/syntax_test_GeneralStructure.cs
+++ b/C#/tests/syntax_test_GeneralStructure.cs
@@ -1446,6 +1446,17 @@ public class MyClass
     bool var // missing semi-colon
 /// ^^^^ storage.type
 ///      ^^^ variable.other.member
+
+    bool var
+        => return 0;
+///     ^^ keyword.declaration.function.accessor.get
+///        ^^^^^^ keyword.other
+///               ^ meta.number.integer.decimal constant.numeric.value
+///                ^ punctuation.terminator.statement
+
+    bool var // missing semi-colon
+/// ^^^^ storage.type
+///      ^^^ variable.other.member
 }
 /// <- meta.class.body meta.block punctuation.section.block.end
 /// ^ - meta


### PR DESCRIPTION
Fixes #4210

This commit fixes lambda methods, the body of which starts on a separate line.

The `member_lambda_or_plain` branch is separated into two, starting with trying to match plain members, followed by lambda-style getters and methods.