### PR TITLE
[C#] Add support for C#9 function pointers

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -1712,7 +1712,7 @@ contexts:
   inside_funcptr_type_calling_convention:
     - meta_content_scope: meta.brackets.cs
     - match: \]
-      scope: meta.brackets.cs punctuation.section.brackets.begin.cs
+      scope: meta.brackets.cs punctuation.section.brackets.end.cs
       pop: true
     - match: ','
       scope: punctuation.separator.type.cs

--- a/C#/tests/syntax_test_C#9.cs
+++ b/C#/tests/syntax_test_C#9.cs
@@ -517,7 +517,7 @@ delegate* unmanaged[Cdecl] <int, int>;
 ///                ^^^^^^^ meta.brackets.cs
 ///                ^ punctuation.section.brackets.begin.cs
 ///                 ^^^^^ storage.modifier.funcptr.cs
-///                      ^ punctuation.section.brackets.begin.cs
+///                      ^ punctuation.section.brackets.end.cs
 ///                        ^^^^^^^^^^ meta.generic.cs
 ///                        ^ punctuation.definition.generic.begin.cs
 ///                         ^^^ storage.type.cs
@@ -540,7 +540,7 @@ delegate* unmanaged[Stdcall, SuppressGCTransition] <in int, out int, readonly re
 ///                 ^^^^^^^ storage.modifier.funcptr.cs
 ///                        ^ punctuation.separator.type.cs
 ///                          ^^^^^^^^^^^^^^^^^^^^ support.type.cs
-///                                              ^ punctuation.section.brackets.begin.cs
+///                                              ^ punctuation.section.brackets.end.cs
 ///                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.generic.cs
 ///                                                ^ punctuation.definition.generic.begin.cs
 ///                                                 ^^ storage.modifier.cs
@@ -575,7 +575,7 @@ delegate*
 ///     ^^^^^^^^^^^^^^^^^^^^ support.type.cs
     ]
 ///^^ meta.type.funcptr.cs meta.brackets.cs
-/// ^ punctuation.section.brackets.begin.cs
+/// ^ punctuation.section.brackets.end.cs
 ///  ^ meta.type.funcptr.cs - meta.brackets
     <
 /// <- meta.type.funcptr.cs - meta.brackets - meta.generic


### PR DESCRIPTION
Fixes #3131

This PR adds `funcptr_...` contexts, implementing C#9 function pointers.

see: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-9.0/function-pointers
