### PR TITLE
[Matlab] Fix merge conflict markers in comments

### DIFF
--- a/Matlab/Matlab.sublime-syntax
+++ b/Matlab/Matlab.sublime-syntax
@@ -475,6 +475,7 @@ contexts:
       captures:
         1: punctuation.definition.comment.matlab
       pop: 1
+    - include: merge-conflict-markers
     - include: block-comments
 
   line-comments:

--- a/Matlab/syntax_test_matlab.matlab
+++ b/Matlab/syntax_test_matlab.matlab
@@ -3,6 +3,32 @@
 %---------------------------------------------
 % Merge Conflict Markers
 
+%{
+
+  Merge conflicts in comments
+
+<<<<<<< HEAD
+%  <- meta.block.conflict.begin.diff punctuation.section.block.begin.diff
+% ^^^^^ meta.block.conflict.begin.diff punctuation.section.block.begin.diff
+%      ^ meta.block.conflict.begin.diff - entity - punctuation
+%       ^^^^ meta.block.conflict.begin.diff entity.name.section.diff
+%           ^ meta.block.conflict.begin.diff - entity - punctuation
+
+=======
+%  <- meta.block.conflict.separator.diff punctuation.section.block.diff
+% ^^^^^ meta.block.conflict.separator.diff punctuation.section.block.diff
+%      ^ meta.block.conflict.separator.diff - punctuation
+
+>>>>>>> master
+%  <- meta.block.conflict.end.diff punctuation.section.block.end.diff
+% ^^^^^ meta.block.conflict.end.diff punctuation.section.block.end.diff
+%      ^ meta.block.conflict.end.diff - entity - punctuation
+%       ^^^^^^ meta.block.conflict.end.diff entity.name.section.diff
+%             ^ meta.block.conflict.end.diff - entity - punctuation
+%}
+
+% Top-level merge conflicts
+
 <<<<<<< HEAD
 %  <- meta.block.conflict.begin.diff punctuation.section.block.begin.diff
 % ^^^^^ meta.block.conflict.begin.diff punctuation.section.block.begin.diff


### PR DESCRIPTION
This PR adds patterns to scope merge conflict markers in block comments.