### PR TITLE
[Ruby] Fix merge conflict markers in comments

### DIFF
--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -137,6 +137,7 @@ contexts:
         - match: ^=end
           scope: punctuation.definition.comment.end.ruby
           pop: true
+        - include: merge-conflict-markers
     - match: \#+
       scope: punctuation.definition.comment.ruby
       push:

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -31,6 +31,27 @@
 # Merge Conflicts
 ##################
 
+=begin
+<<<<<<< HEAD
+#  <- meta.block.conflict.begin.diff punctuation.section.block.begin.diff
+# ^^^^^ meta.block.conflict.begin.diff punctuation.section.block.begin.diff
+#      ^ meta.block.conflict.begin.diff - entity - punctuation
+#       ^^^^ meta.block.conflict.begin.diff entity.name.section.diff
+#           ^ meta.block.conflict.begin.diff - entity - punctuation
+
+=======
+#  <- meta.block.conflict.separator.diff punctuation.section.block.diff
+# ^^^^^ meta.block.conflict.separator.diff punctuation.section.block.diff
+#      ^ meta.block.conflict.separator.diff - punctuation
+
+>>>>>>> master
+#  <- meta.block.conflict.end.diff punctuation.section.block.end.diff
+# ^^^^^ meta.block.conflict.end.diff punctuation.section.block.end.diff
+#      ^ meta.block.conflict.end.diff - entity - punctuation
+#       ^^^^^^ meta.block.conflict.end.diff entity.name.section.diff
+#             ^ meta.block.conflict.end.diff - entity - punctuation
+=end
+
 <<<<<<< HEAD
 #  <- meta.block.conflict.begin.diff punctuation.section.block.begin.diff
 # ^^^^^ meta.block.conflict.begin.diff punctuation.section.block.begin.diff


### PR DESCRIPTION
This PR adds patterns to scope merge conflict markers in block comments.