### PR TITLE
[Ruby] Fix regexp patterns at the beginning of blocks

### DIFF
--- a/Ruby/Ruby.sublime-syntax
+++ b/Ruby/Ruby.sublime-syntax
@@ -484,7 +484,7 @@ contexts:
       scope: meta.block.parameters.ruby punctuation.definition.parameters.begin.ruby
       set: block-parameters
     - match: (?=\s*[^\s\|])
-      pop: true
+      set: try-regex
 
   block-parameters:
     - meta_content_scope: meta.block.parameters.ruby

--- a/Ruby/syntax_test_ruby.rb
+++ b/Ruby/syntax_test_ruby.rb
@@ -1618,6 +1618,22 @@ end
 
 ['a()', 'b()'].select { |var| /^a\(/ =~ var }
 #                             ^^^^^^ string.regexp
+#                                    ^^ keyword.operator.comparison.ruby
+#                                           ^ punctuation.section.scope
+
+['a()', 'b()'].select { /^a\(/ =~ var }
+#                       ^^^^^^ string.regexp
+#                              ^^ keyword.operator.comparison.ruby
+#                                     ^ punctuation.section.scope
+
+# issue 3817
+let(:error_msg) { /can't be blank/ }
+#                 ^^^^^^^^^^^^^^^^ string.regexp
+#                                  ^ punctuation.section.scope
+
+let(:error_msg) { |var| /can't be blank/ }
+#                       ^^^^^^^^^^^^^^^^ string.regexp
+#                                        ^ punctuation.section.scope
 
 {foo: /bar/}
 #     ^^^^^ string.regexp


### PR DESCRIPTION
fixes #3817

This commit fixes `/.../` patterns appearing directly after `{` in blocks.