### PR TITLE
[LaTeX] Refine macro definitions

### DIFF
--- a/LaTeX/LaTeX.sublime-syntax
+++ b/LaTeX/LaTeX.sublime-syntax
@@ -83,7 +83,7 @@ contexts:
 
   latex-newcommand-macros:
     - match: (\\)(?:new|renew|provide)command(?:\*|(?![A-Za-z@]))
-      scope: keyword.declaration.function.latex storage.modifier.newcommand.latex
+      scope: meta.function.latex keyword.declaration.function.latex
       captures:
         1: punctuation.definition.backslash.latex
       push:
@@ -92,7 +92,7 @@ contexts:
         - latex-newcommand-argspec
         - latex-newcommand-commandname
     - match: (\\)DeclareMathOperator(?:\*|(?![A-Za-z@]))
-      scope: support.function.declare-math-operator.latex storage.modifier.newcommand.latex
+      scope: meta.function.latex support.function.declare-math-operator.latex
       captures:
         1: punctuation.definition.backslash.latex
       push:
@@ -170,13 +170,10 @@ contexts:
   # we need a separate context for command definitions, because they can contain
   # un-balanced elements.
   latex-newcommand-definition:
-    - meta_scope: meta.function.latex
-    - match: (?=\{)
-      set:
-        - def-function-body-meta
-        - macro-braces-begin
+    - meta_content_scope: meta.function.latex
     - match: (?=\\)
       set: latex-newcommand-expression
+    - include: def-function-block
     - include: paragraph-pop
     - include: else-pop
 
@@ -204,7 +201,7 @@ contexts:
   xparse-newcommand-macros:
     # https://www.ctan.org/pkg/xparse
     - match: (\\)(?:(?:New|Renew|Provide|Declare)(:?Expandable)?DocumentCommand){{endcs}}
-      scope: keyword.declaration.function.latex storage.modifier.newcommand.latex
+      scope: meta.function.latex keyword.declaration.function.latex
       captures:
         1: punctuation.definition.backslash.latex
       push:

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -470,27 +470,19 @@ contexts:
 
   macros:
     - match: (\\)[gex]?def{{endcs}}
-      scope: keyword.declaration.function.tex storage.modifier.definition.tex
+      scope: meta.function.tex keyword.declaration.function.tex
       captures:
         1: punctuation.definition.backslash.tex
-      push: def-function-expect-identifier
-
+      push: def-function-identifier
     - match: (\\)(?:outer|long|global){{endcs}}
       scope: storage.modifier.definition.tex
       captures:
         1: punctuation.definition.backslash.tex
 
-  def-function-expect-identifier:
-    - meta_scope: meta.function.tex
-    - match: (?=\\)
-      set: def-function-identifier
-    - include: paragraph-pop
-    - include: else-pop
-
   def-function-identifier:
-    - meta_scope: meta.function.identifier.tex
+    - meta_content_scope: meta.function.tex
     - match: (\\){{cmdname}}
-      scope: entity.name.definition.tex
+      scope: meta.function.identifier.tex entity.name.definition.tex
       captures:
         1: punctuation.definition.backslash.tex
       set: def-function-parameters
@@ -499,31 +491,40 @@ contexts:
 
   def-function-parameters:
     - meta_content_scope: meta.function.parameters.tex
-    - match: (?=\{)
-      set:
-        - def-function-body-meta
-        - macro-braces-begin
-    - match: (\#)[0-9]
-      scope: variable.parameter.tex
-      captures:
-        1: punctuation.definition.variable.tex
+    - include: def-function-block
+    - include: def-function-parameter-brackets
+    - include: macro-parameters
     - include: escaped-character
     - include: paragraph-pop
 
-  def-function-body-meta:
-    - meta_include_prototype: false
-    - meta_scope: meta.function.body.tex
-    - include: immediately-pop
+  def-function-parameter-brackets:
+    - match: \[
+      scope: punctuation.definition.group.bracket.begin.tex
+      push: def-function-parameter-bracket-body
+
+  def-function-parameter-bracket-body:
+    - meta_scope: meta.group.bracket.tex
+    - match: \]
+      scope: punctuation.definition.group.bracket.end.tex
+      pop: 1
+    - include: macro-parameters
+    - include: general-constants
+    - include: general-commands
+
+  def-function-block:
+    - match: \{
+      scope: punctuation.definition.group.brace.begin.tex
+      set: def-function-block-body
+
+  def-function-block-body:
+    - meta_scope: meta.function.body.tex meta.group.brace.tex
+    - include: macro-braces-end
+    - include: macro-braces-content
 
   macro-braces:
     - match: \{
       scope: punctuation.definition.group.brace.begin.tex
       push: macro-braces-body
-
-  macro-braces-begin:
-    - match: \{
-      scope: punctuation.definition.group.brace.begin.tex
-      set: macro-braces-body
 
   macro-braces-end:
      - match: \}
@@ -540,7 +541,7 @@ contexts:
   # only partially matched.
   macro-braces-content:
     - include: macro-braces
-    - include: macro-placeholders
+    - include: macro-variables
     - include: controls
     - include: registers
     - include: math-builtin
@@ -548,12 +549,19 @@ contexts:
     - include: general-constants
     - include: general-commands
 
-  macro-placeholders:
-    - match: '(#+)(\d)'
+  macro-parameters:
+    # parameter declarations in macro signatures
+    - match: (\#+)[0-9]
       scope: variable.parameter.tex
       captures:
-        1: punctuation.definition.placeholder.tex
-        2: meta.number.integer.decimal.tex constant.numeric.value.tex
+        1: punctuation.definition.variable.tex
+
+  macro-variables:
+    # parameter references in macro code
+    - match: (\#+)[0-9]
+      scope: variable.other.readwrite.tex
+      captures:
+        1: punctuation.definition.variable.tex
 
 ###[ MATH ]####################################################################
 

--- a/LaTeX/tests/syntax_test_latex.tex
+++ b/LaTeX/tests/syntax_test_latex.tex
@@ -88,9 +88,8 @@
 %           ^^^^ entity.name.newcommand.latex
 %                 ^ constant.numeric.value.latex
 %                    ^^^^ support.function.general.latex
-%                         ^ punctuation.definition.placeholder.tex
-%                         ^^ variable.parameter.tex
-%                          ^ meta.number.integer.decimal constant.numeric.value.tex
+%                         ^^ variable.other.readwrite.tex
+%                         ^ punctuation.definition.variable.tex
 
 \newcommand{\foo}[2][default]{\baz #1 #2}
 %^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.function meta.function
@@ -103,6 +102,8 @@
 %           ^^^^ entity.name.newcommand.latex
 %                 ^ constant.numeric.value.latex
 %                             ^^^^ support.function.general.latex
+%                                  ^^ variable.other.readwrite.tex
+%                                     ^^ variable.other.readwrite.tex
 
 \renewcommand{\foo}[1]{\baz #1}
 %^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.function meta.function
@@ -113,6 +114,7 @@
 %^^^^^^^^^^^^ keyword.declaration.function.latex
 %             ^^^^ entity.name.newcommand.latex
 %                      ^^^^ support.function.general.latex
+%                           ^^ variable.other.readwrite.tex
 
   \providecommand{\f@o}[2][default]{\baz #1 #2}
 % ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.function meta.function
@@ -126,6 +128,8 @@
 %                 ^^^^ entity.name.newcommand.latex
 %                       ^ constant.numeric.value.latex
 %                                   ^^^^ support.function.general.latex
+%                                        ^^ variable.other.readwrite.tex
+%                                           ^^ variable.other.readwrite.tex
 
 \newcommand\foo{\baz}
 %^^^^^^^^^^^^^^^^^^^^ - meta.function meta.function
@@ -183,7 +187,7 @@
 
 \newcommand \baz [1] [def] {\textbf{#1}}
 %^^^^^^^^^^^ meta.function.latex
-%^^^^^^^^^^ keyword.declaration.function.latex storage.modifier.newcommand.latex
+%^^^^^^^^^^ keyword.declaration.function.latex
 %           ^^^^ meta.function.identifier.latex entity.name.newcommand.latex
 %           ^ punctuation.definition.backslash.latex
 %               ^ meta.function.latex
@@ -202,9 +206,8 @@
 %                           ^ punctuation.definition.backslash.latex
 %                                  ^^^^ meta.group.brace.tex
 %                                  ^ punctuation.definition.group.brace.begin.tex
-%                                   ^^ variable.parameter.tex
-%                                   ^ punctuation.definition.placeholder.tex
-%                                    ^ meta.number.integer.decimal.tex constant.numeric.value.tex
+%                                   ^^ variable.other.readwrite.tex
+%                                   ^ punctuation.definition.variable.tex
 %                                     ^ punctuation.definition.group.brace.end.tex
 %                                      ^ punctuation.definition.group.brace.end.tex
 
@@ -220,7 +223,11 @@
 %      ^^^^^^^^ meta.function.parameters.default-value.latex comment.line.percentage.tex
   cu{]}t] {\textbf{#1}}
 % ^^^^^^^ meta.function.parameters.default-value.latex
-%         ^^^^^^^^^^^^^ meta.function.body
+%         ^^^^^^^^^^^^^ meta.function.body.tex meta.group.brace.tex
+%         ^ punctuation.definition.group.brace.begin.tex
+%                 ^ punctuation.definition.group.brace.begin.tex
+%                  ^^ variable.other.readwrite.tex
+%                    ^^ punctuation.definition.group.brace.end.tex
 
 % The argument count can also be based on another macro. Check that we accept this
 \def\one{1}
@@ -242,7 +249,7 @@
 
 \DeclareMathOperator{\op } {op}
 %^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.function meta.function
-%^^^^^^^^^^^^^^^^^^^ meta.function.latex support.function.declare-math-operator.latex storage.modifier.newcommand.latex
+%^^^^^^^^^^^^^^^^^^^ meta.function.latex support.function.declare-math-operator.latex
 %^^^^^^^^^^^^^^^^^^^ meta.function.latex
 %                   ^^^^^^ meta.function.identifier.latex
 %                         ^ meta.function.latex
@@ -262,7 +269,7 @@
 % ^^^^^^ support.function.general.latex
 
 \newcommand\"{quote}
-%^^^^^^^^^^ meta.function.latex keyword.declaration.function.latex storage.modifier.newcommand.latex
+%^^^^^^^^^^ meta.function.latex keyword.declaration.function.latex
 %          ^^ meta.function.identifier.latex entity.name.newcommand.latex
 %            ^^^^^^^ meta.function.body.tex meta.group.brace.tex
 %          ^ punctuation.definition.backslash.latex

--- a/LaTeX/tests/syntax_test_latex.xparse.tex
+++ b/LaTeX/tests/syntax_test_latex.xparse.tex
@@ -9,7 +9,7 @@
 %                             ^^ meta.function.parameters.latex
 %                               ^^^^^^^^^ meta.function.body.tex meta.group.brace.tex
 %                                        ^ - meta.function
-%^^^^^^^^^^^^^^^^^^ keyword.declaration.function.latex storage.modifier.newcommand.latex
+%^^^^^^^^^^^^^^^^^^ keyword.declaration.function.latex
 %                  ^ punctuation.definition.group.brace.begin.tex
 %                   ^^^^^^^^^ entity.name.newcommand.latex
 %                   ^ punctuation.definition.backslash.latex
@@ -26,7 +26,7 @@
 %                              ^^^ meta.function.parameters.latex
 %                                 ^^^^^^^^^^^^ meta.function.body meta.group.brace
 %                                             ^ - meta.function
-%^^^^^^^^^^^^^^^^^^ keyword.declaration.function.latex storage.modifier.newcommand.latex
+%^^^^^^^^^^^^^^^^^^ keyword.declaration.function.latex
 %                  ^ punctuation.definition.group.brace.begin.tex
 %                   ^^^^^^^^^^ entity.name.newcommand.latex
 %                   ^ punctuation.definition.backslash.latex
@@ -35,7 +35,8 @@
 %                               ^ storage.type.latex
 %                                ^ punctuation.definition.group.brace.end.tex
 %                                 ^ punctuation.definition.group.brace.begin.tex
-%                                          ^^ variable.parameter.tex
+%                                          ^^ variable.other.readwrite.tex
+%                                          ^ punctuation.definition.variable.tex
 %                                            ^ punctuation.definition.group.brace.end.tex
 
 \NewDocumentCommand\nobrace{o}{content}
@@ -45,7 +46,7 @@
 %                          ^^^ meta.function.parameters.latex
 %                             ^^^^^^^^^ meta.function.body
 %                                      ^ - meta.function
-%^^^^^^^^^^^^^^^^^^ keyword.declaration.function.latex storage.modifier.newcommand.latex
+%^^^^^^^^^^^^^^^^^^ keyword.declaration.function.latex
 %                   ^^^^^^^ entity.name.newcommand.latex
 %                           ^ storage.type.latex
 
@@ -56,7 +57,7 @@
 %                              ^^^^^^^^^^ meta.function.parameters.latex
 %                                         ^^^^^^^^^ meta.function.body
 %                                                  ^ - meta.function
-%^^^^^^^^^^^^^^^^^^ keyword.declaration.function.latex storage.modifier.newcommand.latex
+%^^^^^^^^^^^^^^^^^^ keyword.declaration.function.latex
 %                   ^^^^^^^^^^ entity.name.newcommand.latex
 %                               ^ storage.type.latex
 %                                 ^ storage.modifier.latex
@@ -72,7 +73,7 @@
 %                             ^^^^^^^^^ meta.function.parameters.latex - meta.function.latex
 %                                      ^^^^^^^^ meta.function.body - meta.function.parameters.latex
 %                                              ^ - meta.function
-%^^^^^^^^^^^^^^^^^^ keyword.declaration.function.latex storage.modifier.newcommand.latex
+%^^^^^^^^^^^^^^^^^^ keyword.declaration.function.latex
 %                   ^^^^^^^^^ entity.name.newcommand.latex
 %                              ^ storage.type.latex
 %                                ^ constant.character.latex constant.other.token.latex
@@ -86,7 +87,7 @@
 %                                               ^ meta.function.latex
 %                                                ^^^^^^^^ meta.function.body - meta.function.parameters.latex
 %                                                        ^ - meta.function
-%^^^^^^^^^^^^^^^^^^^^^^ keyword.declaration.function.latex storage.modifier.newcommand.latex
+%^^^^^^^^^^^^^^^^^^^^^^ keyword.declaration.function.latex
 %                       ^^^^^^^^^ entity.name.newcommand.latex
 %                                  ^ storage.type.latex
 %                                   ^^^^^^ constant.other.token.latex
@@ -122,7 +123,7 @@
 %                              ^^^^^^^^^ meta.function.parameters.latex - meta.function.latex
 %                                       ^^^^^^^^ meta.function.body -meta.function.latex
 %                                               ^ - meta.function
-%^^^^^^^^^^^^^^^^^^ keyword.declaration.function.latex storage.modifier.newcommand.latex
+%^^^^^^^^^^^^^^^^^^ keyword.declaration.function.latex
 %                   ^^^^^^^^^^ entity.name.newcommand.latex
 %                               ^ storage.type.latex
 %                                 ^ constant.character.latex constant.other.token.latex
@@ -136,7 +137,7 @@
 %                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.parameters.default-value.latex - meta.function.parameters.latex
 %                                                                      ^ meta.function.parameters.latex
 %                                                                       ^^^^^^^^ meta.function.body meta.group.brace
-%^^^^^^^^^^^^^^^^^^ keyword.declaration.function.latex storage.modifier.newcommand.latex
+%^^^^^^^^^^^^^^^^^^ keyword.declaration.function.latex
 %                   ^^^^^^^^^ entity.name.newcommand.latex
 %                              ^ storage.type.latex
 %                               ^^ constant.character.latex constant.other.token.latex
@@ -152,7 +153,7 @@
 %                                        ^ meta.function.parameters.latex punctuation.definition.group.brace.end.tex
 %                                         ^^^^^^^^^^^^^^^ meta.function.body
 %                                                        ^ - meta.function
-%^^^^^^^^^^^^^^^^^^ keyword.declaration.function.latex storage.modifier.newcommand.latex
+%^^^^^^^^^^^^^^^^^^ keyword.declaration.function.latex
 %                   ^^^^^^^^^ entity.name.newcommand.latex
 %                              ^ storage.type.latex
 
@@ -175,7 +176,7 @@ with paragraph}}{function body}
 %                                ^ meta.function.parameters.latex
 %                                 ^^^^^^^^^^^^^^^ meta.function.body
 %                                                ^ - meta.function
-%^^^^^^^^^^^^^^^^^^ keyword.declaration.function.latex storage.modifier.newcommand.latex
+%^^^^^^^^^^^^^^^^^^ keyword.declaration.function.latex
 %                   ^^^^^^^^^ entity.name.newcommand.latex
 %                              ^ storage.type.latex
 
@@ -188,7 +189,7 @@ with paragraph}}{function body}
 %                                 ^ meta.function.parameters.latex
 %                                  ^^^^^^^^^^^^^^^ meta.function.body
 %                                                 ^ - meta.function
-%^^^^^^^^^^^^^^^^^^ storage.modifier.newcommand.latex
+%^^^^^^^^^^^^^^^^^^
 %                  ^ punctuation.definition.group.brace.begin.tex
 %                   ^^^^^^^^^ entity.name.newcommand.latex
 %                            ^ punctuation.definition.group.brace.end.tex
@@ -213,9 +214,8 @@ with paragraph}}{function body}
 %                              ^ storage.type.latex
 %                               ^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.parameters.default-value.latex meta.group.brace.tex
 %                               ^ punctuation.definition.group.brace.begin.tex
-%                                ^^ variable.parameter.tex
-%                                ^ punctuation.definition.placeholder.tex
-%                                 ^ meta.number.integer.decimal.tex constant.numeric.value.tex
+%                                ^^ variable.other.readwrite.tex
+%                                ^ punctuation.definition.variable.tex
 %                                    ^^^^^ support.function.tex
 %                                          ^^^^^^^^ support.function.tex
 %                                    ^ punctuation.definition.backslash.tex
@@ -232,7 +232,7 @@ with paragraph}}{function body}
 %                            ^^^^^^^^^^^^ meta.function.identifier.latex
 %                                        ^^^^^^^^ meta.function.parameters.latex
 %                                                ^^^^^^^^^^^^^^^ meta.function.body
-%^^^^^^^^^^^^^^^^^^^^^^^^^^^^ storage.modifier.newcommand.latex
+%^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 %                             ^^^^^^^^^^ entity.name.newcommand.latex
 %                                         ^ storage.type.latex
 %                                          ^^^^^ constant.other.token.latex
@@ -245,7 +245,7 @@ with paragraph}}{function body}
 %                  ^^^^^^^^^^^^ meta.function.identifier.latex
 %                              ^^^^^^^^ meta.function.parameters.latex
 %                                      ^^^^^^ meta.function.body
-%^^^^^^^^^^^^^^^^^^ keyword.declaration.function.latex storage.modifier.newcommand.latex
+%^^^^^^^^^^^^^^^^^^ keyword.declaration.function.latex
 %                   ^^^^^^^^^^ entity.name.newcommand.latex
 %                               ^ storage.type.latex
 %                                ^^^^^ constant.other.token.latex
@@ -256,7 +256,7 @@ with paragraph}}{function body}
 %                  ^^^^^^^^^^^^ meta.function.identifier.latex
 %                              ^^^^^^^^^^ meta.function.parameters.latex
 %                                        ^^^^^^ meta.function.body
-%^^^^^^^^^^^^^^^^^^ keyword.declaration.function.latex storage.modifier.newcommand.latex
+%^^^^^^^^^^^^^^^^^^ keyword.declaration.function.latex
 %                   ^^^^^^^^^^ entity.name.newcommand.latex
 %                               ^ storage.type.latex
 %                                 ^^^^^ constant.other.token.latex
@@ -268,7 +268,7 @@ with paragraph}}{function body}
 %                  ^^^^^^^^^^^^ meta.function.identifier.latex
 %                              ^^^^^^^ meta.function.parameters.latex
 %                                     ^^^^^^ meta.function.body
-%^^^^^^^^^^^^^^^^^^ keyword.declaration.function.latex storage.modifier.newcommand.latex
+%^^^^^^^^^^^^^^^^^^ keyword.declaration.function.latex
 %                   ^^^^^^^^^^ entity.name.newcommand.latex
 %                               ^ storage.type.latex
 %                                 ^^ constant.character.latex constant.other.token.latex
@@ -314,14 +314,12 @@ with paragraph}}{function body}
 %                                 ^ punctuation.definition.backslash.latex
 %                                           ^^^^ meta.group.brace.tex
 %                                           ^ punctuation.definition.group.brace.begin.tex
-%                                            ^^ variable.parameter.tex
-%                                            ^ punctuation.definition.placeholder.tex
-%                                             ^ meta.number.integer.decimal.tex constant.numeric.value.tex
+%                                            ^^ variable.other.readwrite.tex
+%                                            ^ punctuation.definition.variable.tex
 %                                              ^ punctuation.definition.group.brace.end.tex
 %                                               ^ punctuation.definition.group.brace.end.tex
 %                                                 ^ storage.type.latex
 %                                                   ^ punctuation.definition.group.brace.end.tex
-
 
 
 % Now for some broken and incomplete examples
@@ -392,9 +390,8 @@ other stuff
 %                                     ^ punctuation.definition.backslash.latex
 %                                             ^ punctuation.definition.group.brace.end.tex
 %                                              ^ punctuation.definition.group.brace.begin.tex
-%                                                        ^^ variable.parameter.tex
-%                                                        ^ punctuation.definition.placeholder.tex
-%                                                         ^ meta.number.integer.decimal.tex constant.numeric.value.tex
+%                                                        ^^ variable.other.readwrite.tex
+%                                                        ^ punctuation.definition.variable.tex
 %                                                           ^ punctuation.definition.group.brace.end.tex
 
 

--- a/LaTeX/tests/syntax_test_tex.tex
+++ b/LaTeX/tests/syntax_test_tex.tex
@@ -29,7 +29,7 @@
 
 % Check the main scopes
   \def\macro{replacement}
-% ^^^^ meta.function.tex keyword.declaration.function.tex storage.modifier.definition.tex
+% ^^^^ meta.function.tex keyword.declaration.function.tex
 %     ^^^^^^ meta.function.identifier.tex entity.name.definition.tex
 %            ^^^^^^^^^^^^ meta.function.body.tex
 
@@ -45,17 +45,23 @@
 
 % With spaces and parameter specification
  \def \foo [#1]#2{The first argument is ``#1'', the second one is ``#2''}
-%^^^^ keyword.declaration.function.tex storage.modifier.definition.tex
 %^^^^^ meta.function.tex
-%     ^^^^ meta.function.identifier.tex entity.name.definition.tex
-%         ^^^^^^^ meta.function.parameters.tex -meta.function.tex
-%           ^^ variable.parameter.tex
-%              ^^ variable.parameter.tex
+%     ^^^^ meta.function.identifier.tex
+%         ^^^^^^^ meta.function.parameters.tex - meta.function.tex
 %                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.body.tex
+%^^^^ keyword.declaration.function.tex
+%^ punctuation.definition.backslash.tex
+%     ^^^^ entity.name.definition.tex
+%     ^ punctuation.definition.backslash.tex
+%          ^^^^ meta.group.bracket.tex
+%          ^ punctuation.definition.group.bracket.begin.tex
+%           ^^ variable.parameter.tex
+%             ^ punctuation.definition.group.bracket.end.tex
+%              ^^ variable.parameter.tex
 
 % With line continuation
  \def \foo [#1]#2%
-%^^^^ keyword.declaration.function.tex storage.modifier.definition.tex
+%^^^^ keyword.declaration.function.tex
 %^^^^^meta.function.tex
 %     ^^^^ meta.function.identifier.tex entity.name.definition.tex
 %         ^^^^^^^ meta.function.parameters.tex
@@ -67,7 +73,7 @@
 
 % With nested braces
  \def \author {William {\sc Smith}}
-%^^^^ keyword.declaration.function.tex storage.modifier.definition.tex
+%^^^^ keyword.declaration.function.tex
 %^^^^^ meta.function.tex
 %     ^^^^^^^ meta.function.identifier.tex entity.name.definition.tex
 %            ^ meta.function.parameters.tex
@@ -76,18 +82,26 @@
 
 % gdef as a global variation of def
  \gdef\macro{replacement}
-%^^^^^ meta.function.tex keyword.declaration.function.tex storage.modifier.definition.tex
+%^^^^^ meta.function.tex keyword.declaration.function.tex
 %     ^^^^^^ meta.function.identifier.tex entity.name.definition.tex
 %            ^^^^^^^^^^^^ meta.function.body.tex
 
 % edef as an immediately expanded version of def. Note that here,
 % argument specifications would not be allowed by TeX.
  \edef\macro{replacement}
-%^^^^^ meta.function.tex keyword.declaration.function.tex storage.modifier.definition.tex
+%^^^^^ meta.function.tex keyword.declaration.function.tex
 %     ^^^^^^ meta.function.identifier.tex entity.name.definition.tex
 %            ^^^^^^^^^^^^ meta.function.body.tex
 
-
+% parameter definition and references
+\def\macro##1##2{\>\textbf{##1}\>##2\\}
+%         ^^^^^^ meta.function.parameters.tex variable.parameter.tex
+%         ^^ punctuation.definition.variable.tex
+%            ^^ punctuation.definition.variable.tex
+%                          ^^^ variable.other.readwrite.tex
+%                          ^^ punctuation.definition.variable.tex
+%                                ^^^ variable.other.readwrite.tex
+%                                ^^ punctuation.definition.variable.tex
 
 % And now, the really weird cases
 %  escaped characters in the argument specification
@@ -115,7 +129,7 @@
 
 %  defining special character macros
  \def\_{underscore}
-%^^^^ meta.function.tex keyword.declaration.function.tex storage.modifier.definition.tex
+%^^^^ meta.function.tex keyword.declaration.function.tex
 %    ^^ meta.function.identifier.tex entity.name.definition.tex
 %      ^^^^^^^^^^^^ meta.function.body.tex
 
@@ -143,17 +157,17 @@ some other text
  \long\def\test#1{#1}
 %^^^^^ storage.modifier.definition.tex
 %^ punctuation.definition.backslash.tex
-%     ^^^^ meta.function.tex keyword.declaration.function.tex storage.modifier.definition.tex
+%     ^^^^ meta.function.tex keyword.declaration.function.tex
 
  \outer\def\test#1{#1}
 %^^^^^^ storage.modifier.definition.tex
 %^ punctuation.definition.backslash.tex
-%      ^^^^ meta.function.tex keyword.declaration.function.tex storage.modifier.definition.tex
+%      ^^^^ meta.function.tex keyword.declaration.function.tex
 
  \global\def\test#1{#1}
 %^^^^^^^ storage.modifier.definition.tex
 %^ punctuation.definition.backslash.tex
-%       ^^^^ meta.function.tex keyword.declaration.function.tex storage.modifier.definition.tex
+%       ^^^^ meta.function.tex keyword.declaration.function.tex
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -166,14 +180,13 @@ some other text
 %^^^ meta.function.tex
 %   ^^^^^ meta.function.identifier.tex
 %        ^^^^^^^^^^^^^^^^^ meta.function.body.tex meta.group.brace.tex
-%^^^ keyword.declaration.function.tex storage.modifier.definition.tex
+%^^^ keyword.declaration.function.tex
 %   ^^^^^ entity.name.definition.tex
 %        ^ punctuation.definition.group.brace.begin.tex
 %         ^^^^^^^^ keyword.control.conditional.if.tex
 %         ^ punctuation.definition.backslash.tex
-%                  ^^ variable.parameter.tex
-%                  ^ punctuation.definition.placeholder.tex
-%                   ^ meta.number.integer.decimal.tex constant.numeric.value.tex
+%                  ^^ variable.other.readwrite.tex
+%                  ^ punctuation.definition.variable.tex
 %                     ^^ constant.character.escape.tex
 %                     ^ punctuation.definition.backslash.tex
 %                        ^ punctuation.definition.group.brace.end.tex
@@ -187,11 +200,11 @@ some other text
 %        ^^^^^^^^^^^^^^^^^^^^^ meta.function.body.tex meta.group.brace.tex
 %         ^^^^^^^ meta.register.tex
 %                 ^^^^ meta.group.brace.tex meta.group.brace.tex
-%^^^ keyword.declaration.function.tex storage.modifier.definition.tex
+%^^^ keyword.declaration.function.tex
 %   ^^^^^ entity.name.definition.tex
 %        ^ punctuation.definition.group.brace.begin.tex
 %               ^ meta.number.integer.decimal.tex constant.numeric.value.tex
-%                  ^^ variable.parameter.tex
+%                  ^^ variable.other.readwrite.tex
 %                      ^^^^^^ keyword.other.math.greek.tex
 
 
@@ -876,7 +889,7 @@ some other text
 % No assignment, the = is outside of the macro
 \def\macro{\abovedisplayskip}=5pt
 %                            ^ - keyword.operator.assignment.tex
-%^^^ meta.function.tex keyword.declaration.function.tex storage.modifier.definition.tex
+%^^^ meta.function.tex keyword.declaration.function.tex
 %   ^^^^^^ meta.function.identifier.tex entity.name.definition.tex
 %   ^ punctuation.definition.backslash.tex
 %         ^^^^^^^^^^^^^^^^^^^ meta.function.body.tex meta.group.brace.tex


### PR DESCRIPTION
This commit...
1. reduces required context switches in macro definitions
2. scopes brackets in macro signatures
3. scopes macro variables `#1` as `variable.parameter` in signatures and as `variable.other` in macro code.
4. drops stacked `storage.modifier` scopes from `\def` `\newcommand` etc. declaration keywords.