### PR TITLE
[LaTeX] Refine comment scopes

### DIFF
--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -143,9 +143,15 @@ contexts:
 ###[ COMMENTS ]################################################################
 
   comments:
-    - match: '%.*$\n?'
-      scope: comment.line.percentage.tex
+    - match: \%
+      scope: punctuation.definition.comment.tex
+      push: comment-body
     - include: merge-conflict-markers
+
+  comment-body:
+    - meta_scope: comment.line.percentage.tex
+    - match: $\n?
+      pop: 1
 
 ###[ MERGE CONFLICT MARKERS ]##################################################
 

--- a/LaTeX/tests/syntax_test_tex.tex
+++ b/LaTeX/tests/syntax_test_tex.tex
@@ -1,6 +1,14 @@
 % SYNTAX TEST "Packages/LaTeX/TeX.sublime-syntax"
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                 Comments
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+% This is a comment
+% <- comment.line.percentage.tex punctuation.definition.comment.tex
+%^^^^^^^^^^^^^^^^^^^ comment.line.percentage.tex - punctuation
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %                 Merge Conflict Marker Tests
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 


### PR DESCRIPTION
This commit...

1. scopes comment sign `%` `punctuation.definition`
2. pushes into a comment-body context to enable interpolation