### PR TITLE
[LaTeX] Merge math command contexts

### DIFF
--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -673,9 +673,9 @@ contexts:
   math-braces:
     - match: \{
       scope: punctuation.definition.group.brace.begin.tex
-      push: math-brace-group-body
+      push: math-braces-body
 
-  math-brace-group-body:
+  math-braces-body:
     - meta_scope: meta.group.brace.tex
     - include: brace-group-end
     - include: math-content


### PR DESCRIPTION
This PR ...

1. merges uniquely used math built-in command related contexts to slightly reduce compiled syntax cache size.
2. aligns math braces related context name with the other ones, which also don't combine group and brace.