### PR TITLE
[LaTeX] Fix internal macro names

### DIFF
--- a/LaTeX/LaTeX.sublime-syntax
+++ b/LaTeX/LaTeX.sublime-syntax
@@ -181,6 +181,11 @@ contexts:
     - meta_scope: meta.function.body.latex
     # but in principle, a single token is also valid,
     # thus either a command sequence ...
+    - match: (\\){{macroname}}
+      scope: support.function.internal.latex
+      captures:
+        1: punctuation.definition.backslash.latex
+      pop: 1
     - match: (\\){{cmdname}}
       scope: support.function.general.latex
       captures:
@@ -347,7 +352,11 @@ contexts:
 
   general-commands:
     - include: begin-end-commands
-    - match: (\\)[A-Za-z@]+
+    - match: (\\){{macroname}}
+      scope: support.function.internal.latex
+      captures:
+        1: punctuation.definition.backslash.latex
+    - match: (\\){{letter}}+
       scope: support.function.general.latex
       captures:
         1: punctuation.definition.backslash.latex

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -113,9 +113,12 @@ variables:
   letter: '[A-Za-z@]'
   nonletter: '[^A-Za-z@]'
   # look-ahead for end of command sequence
-  endcs: '(?!{{letter}})'
+  endcs: '(?!{{macrosep}}?{{letter}})'
   # a command name: either a sequence of letters, or a single non-letter
   cmdname: '(?x: {{letter}}+ | {{nonletter}})'
+  # internal macro name: a sequence of letters containing `_` and `:` for structure
+  macroname: '_*{{letter}}+(?:{{macrosep}}+{{letter}}+)+'
+  macrosep: '[_:]'
   # hexadecimal digits in different casing
   lchexdigit: (?:[0-9a-f])
   uchexdigit: (?:[0-9A-F])
@@ -291,6 +294,10 @@ contexts:
 ###[ COMMANDS ]################################################################
 
   general-commands:
+    - match: (\\){{macroname}}
+      scope: support.function.internal.tex
+      captures:
+        1: punctuation.definition.backslash.tex
     - match: (\\){{letter}}+
       scope: support.function.general.tex
       captures:
@@ -308,7 +315,7 @@ contexts:
     - include: escaped-character
 
   escaped-character:
-    - match: (\\){{nonletter}}
+    - match: (\\)(?!{{macroname}}){{nonletter}}
       scope: constant.character.escape.tex
       captures:
         1: punctuation.definition.backslash.tex
@@ -487,8 +494,13 @@ contexts:
 
   def-function-identifier:
     - meta_content_scope: meta.function.tex
+    - match: (\\){{macroname}}
+      scope: meta.function.identifier.tex entity.name.function.internal.tex
+      captures:
+        1: punctuation.definition.backslash.tex
+      set: def-function-parameters
     - match: (\\){{cmdname}}
-      scope: meta.function.identifier.tex entity.name.definition.tex
+      scope: meta.function.identifier.tex entity.name.function.tex
       captures:
         1: punctuation.definition.backslash.tex
       set: def-function-parameters

--- a/LaTeX/tests/syntax_test_tex.tex
+++ b/LaTeX/tests/syntax_test_tex.tex
@@ -38,7 +38,7 @@
 % Check the main scopes
   \def\macro{replacement}
 % ^^^^ meta.function.tex keyword.declaration.function.tex
-%     ^^^^^^ meta.function.identifier.tex entity.name.definition.tex
+%     ^^^^^^ meta.function.identifier.tex entity.name.function.tex
 %            ^^^^^^^^^^^^ meta.function.body.tex
 
 % Check punctuation scopes
@@ -59,7 +59,7 @@
 %                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.body.tex
 %^^^^ keyword.declaration.function.tex
 %^ punctuation.definition.backslash.tex
-%     ^^^^ entity.name.definition.tex
+%     ^^^^ entity.name.function.tex
 %     ^ punctuation.definition.backslash.tex
 %          ^^^^ meta.group.bracket.tex
 %          ^ punctuation.definition.group.bracket.begin.tex
@@ -71,7 +71,7 @@
  \def \foo [#1]#2%
 %^^^^ keyword.declaration.function.tex
 %^^^^^meta.function.tex
-%     ^^^^ meta.function.identifier.tex entity.name.definition.tex
+%     ^^^^ meta.function.identifier.tex entity.name.function.tex
 %         ^^^^^^^ meta.function.parameters.tex
 %                ^^ comment.line.percentage.tex
   {The first argument is ``#1''.
@@ -83,7 +83,7 @@
  \def \author {William {\sc Smith}}
 %^^^^ keyword.declaration.function.tex
 %^^^^^ meta.function.tex
-%     ^^^^^^^ meta.function.identifier.tex entity.name.definition.tex
+%     ^^^^^^^ meta.function.identifier.tex entity.name.function.tex
 %            ^ meta.function.parameters.tex
 %             ^^^^^^^^^^^^^^^^^^^^^ meta.function.body.tex
 
@@ -91,14 +91,14 @@
 % gdef as a global variation of def
  \gdef\macro{replacement}
 %^^^^^ meta.function.tex keyword.declaration.function.tex
-%     ^^^^^^ meta.function.identifier.tex entity.name.definition.tex
+%     ^^^^^^ meta.function.identifier.tex entity.name.function.tex
 %            ^^^^^^^^^^^^ meta.function.body.tex
 
 % edef as an immediately expanded version of def. Note that here,
 % argument specifications would not be allowed by TeX.
  \edef\macro{replacement}
 %^^^^^ meta.function.tex keyword.declaration.function.tex
-%     ^^^^^^ meta.function.identifier.tex entity.name.definition.tex
+%     ^^^^^^ meta.function.identifier.tex entity.name.function.tex
 %            ^^^^^^^^^^^^ meta.function.body.tex
 
 % parameter definition and references
@@ -138,7 +138,7 @@
 %  defining special character macros
  \def\_{underscore}
 %^^^^ meta.function.tex keyword.declaration.function.tex
-%    ^^ meta.function.identifier.tex entity.name.definition.tex
+%    ^^ meta.function.identifier.tex entity.name.function.tex
 %      ^^^^^^^^^^^^ meta.function.body.tex
 
 %  stop scope for incomplete defs
@@ -156,6 +156,38 @@ some other text
 %  command just prefixed with def. Needs to be picked up as a custom command
 \deftext
 %^^^^^^^ support.function.general.tex
+
+% internal macro definition
+\def\internal_macro{}
+%^^^ meta.function.tex keyword.declaration.function.tex
+%   ^^^^^^^^^^^^^^^ meta.function.identifier.tex entity.name.function.internal.tex
+%   ^ punctuation.definition.backslash.tex
+%                  ^^ meta.function.body.tex meta.group.brace.tex
+%                  ^ punctuation.definition.group.brace.begin.tex
+%                   ^ punctuation.definition.group.brace.end.tex
+
+% internal macro definition with argspec
+\def\internal_macro:N #1 {#1}
+%^^^ meta.function.tex keyword.declaration.function.tex
+%   ^^^^^^^^^^^^^^^^^ meta.function.identifier.tex entity.name.function.internal.tex
+%   ^ punctuation.definition.backslash.tex
+%                    ^^^^ meta.function.parameters.tex
+%                     ^^ variable.parameter.tex
+%                     ^ punctuation.definition.variable.tex
+%                        ^^^^ meta.function.body.tex meta.group.brace.tex
+%                        ^ punctuation.definition.group.brace.begin.tex
+%                         ^^ variable.other.readwrite.tex
+%                         ^ punctuation.definition.variable.tex
+%                           ^ punctuation.definition.group.brace.end.tex
+
+% private internal macro definition per naming convention
+\def\__priv_internal_macro{}
+%^^^ meta.function.tex keyword.declaration.function.tex
+%   ^^^^^^^^^^^^^^^^^^^^^^ meta.function.identifier.tex entity.name.function.internal.tex
+%   ^ punctuation.definition.backslash.tex
+%                         ^^ meta.function.body.tex meta.group.brace.tex
+%                         ^ punctuation.definition.group.brace.begin.tex
+%                          ^ punctuation.definition.group.brace.end.tex
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -189,7 +221,7 @@ some other text
 %   ^^^^^ meta.function.identifier.tex
 %        ^^^^^^^^^^^^^^^^^ meta.function.body.tex meta.group.brace.tex
 %^^^ keyword.declaration.function.tex
-%   ^^^^^ entity.name.definition.tex
+%   ^^^^^ entity.name.function.tex
 %        ^ punctuation.definition.group.brace.begin.tex
 %         ^^^^^^^^ keyword.control.conditional.if.tex
 %         ^ punctuation.definition.backslash.tex
@@ -209,7 +241,7 @@ some other text
 %         ^^^^^^^ meta.register.tex
 %                 ^^^^ meta.group.brace.tex meta.group.brace.tex
 %^^^ keyword.declaration.function.tex
-%   ^^^^^ entity.name.definition.tex
+%   ^^^^^ entity.name.function.tex
 %        ^ punctuation.definition.group.brace.begin.tex
 %               ^ meta.number.integer.decimal.tex constant.numeric.value.tex
 %                  ^^ variable.other.readwrite.tex
@@ -224,6 +256,37 @@ some other text
 %        ^^^^^^^^ meta.function.body.tex meta.group.brace.tex
 %         ^^^^^^ meta.register.tex
 %                ^^^^^^^^^^^ - meta.function.body
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                 Internal Macro Names
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\internal_macro
+% <- support.function.internal.tex punctuation.definition.backslash.tex
+%^^^^^^^^^^^^^^ support.function.internal.tex
+
+\internal_macro:N
+% <- support.function.internal.tex punctuation.definition.backslash.tex
+%^^^^^^^^^^^^^^^^ support.function.internal.tex
+
+\__internal_macro
+% <- support.function.internal.tex punctuation.definition.backslash.tex
+%^^^^^^^^^^^^^^^^ support.function.internal.tex
+
+\__plaintext
+% <- constant.character.escape.tex punctuation.definition.backslash.tex
+%^ constant.character.escape.tex
+% ^^^^^^^^^^ - support
+
+\loop_macro
+% <- support.function.internal.tex punctuation.definition.backslash.tex
+%^^^^^^^^^^ support.function.internal.tex
+
+\new_macro
+% <- support.function.internal.tex punctuation.definition.backslash.tex
+%^^^^^^^^^ support.function.internal.tex
+
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %                 Control flow / Conditionals
@@ -898,7 +961,7 @@ some other text
 \def\macro{\abovedisplayskip}=5pt
 %                            ^ - keyword.operator.assignment.tex
 %^^^ meta.function.tex keyword.declaration.function.tex
-%   ^^^^^^ meta.function.identifier.tex entity.name.definition.tex
+%   ^^^^^^ meta.function.identifier.tex entity.name.function.tex
 %   ^ punctuation.definition.backslash.tex
 %         ^^^^^^^^^^^^^^^^^^^ meta.function.body.tex meta.group.brace.tex
 %         ^ punctuation.definition.group.brace.begin.tex


### PR DESCRIPTION
This commit...

1. adds support for internal macro names, which in addition to normal commands, may contain `_` and `:` for structuring purposes.

   Typesetting commands and internal macro names are assigned distinct scopes.

2. changes scope of command definitions to `entity.name.function`.