### PR TITLE
[LaTeX] Fix math equation termination

### DIFF
--- a/LaTeX/LaTeX.sublime-syntax
+++ b/LaTeX/LaTeX.sublime-syntax
@@ -275,7 +275,7 @@ contexts:
 
   xparse-newcommand-args-token:
     - meta_include_prototype: false
-    - include: unmatched-brace-pop
+    - include: stray-brace-pop
     - match: (?=\{)
       set:
         - xparse-newcommand-args-wrapped-token
@@ -311,7 +311,7 @@ contexts:
 
   xparse-newcommand-optarg-value:
     - meta_include_prototype: false
-    - include: unmatched-brace-pop
+    - include: stray-brace-pop
     - match: (?=\{)
       set:
         - xparse-newcommand-optarg-wrapped-value
@@ -689,8 +689,6 @@ contexts:
 
   math-content:
     - meta_prepend: true
-    - match: (?=\})
-      pop: 1
     - include: verb
     - include: text-decorators
     - include: references

--- a/LaTeX/TeX.sublime-syntax
+++ b/LaTeX/TeX.sublime-syntax
@@ -606,6 +606,7 @@ contexts:
     - include: math-variables
     - include: math-numbers
     - include: general-constants
+    - include: stray-brace-pop
 
   math-builtins:
     - match: (\\){{greeks}}{{endcs}}
@@ -719,6 +720,6 @@ contexts:
     - match: ^(?=\s*$)
       pop: 1
 
-  unmatched-brace-pop:
+  stray-brace-pop:
     - match: (?=})
       pop: 1

--- a/LaTeX/tests/syntax_test_latex.tex
+++ b/LaTeX/tests/syntax_test_latex.tex
@@ -832,7 +832,6 @@ The \emph{verbatim} environment sets everything in verbatim.
 %^^ string.other.math.latex punctuation.definition.string.begin.latex
 %            ^^ string.other.math.latex punctuation.definition.string.end.latex - markup.math.inline
 
-
  \[
 %^^ string.other.math.latex punctuation.definition.string.begin.latex
   f(x) = x^2 \text{ $f$ is a function}
@@ -841,6 +840,74 @@ The \emph{verbatim} environment sets everything in verbatim.
  \]
 %^^ meta.environment.math.block.bracket.latex punctuation.definition.string.end.latex - markup.math.inline
 %  ^ - meta.environment.math
+
+% Check math termination on closing braces
+
+\macro{ $$f(x) = x^2 }
+%     ^^ meta.group.brace.tex - meta.environment
+%       ^^^^^^^^^^^^^ meta.group.brace.tex meta.environment.math.block.dollar.tex
+%                    ^ meta.group.brace.tex - meta.environment
+%       ^^ string.other.math.tex punctuation.definition.string.begin.tex
+%                    ^ punctuation.definition.group.brace.end.tex
+
+\macro{ $$f(x) = { ( x^2 + a - 2 } }
+%     ^^ meta.group.brace.tex - meta.environment
+%       ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group.brace.tex meta.environment.math.block.dollar.tex
+%                                  ^ meta.group.brace.tex - meta.environment
+%       ^^ string.other.math.tex punctuation.definition.string.begin.tex
+%                                  ^ punctuation.definition.group.brace.end.tex
+
+\macro{ \(f(x) = x^2 }
+%     ^^ meta.group.brace.tex - meta.environment
+%       ^^^^^^^^^^^^^ meta.group.brace.tex meta.environment.math.inline.paren.latex
+%                    ^ meta.group.brace.tex - meta.environment
+%       ^^ string.other.math.latex punctuation.definition.string.begin.latex
+%                    ^ punctuation.definition.group.brace.end.tex
+
+\macro{ \(f(x) = { ( x^2 + a - 2 } }
+%     ^^ meta.group.brace.tex - meta.environment
+%       ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group.brace.tex meta.environment.math.inline.paren.latex
+%                                  ^ meta.group.brace.tex - meta.environment
+%       ^^ string.other.math.latex punctuation.definition.string.begin.latex
+%                                  ^ punctuation.definition.group.brace.end.tex
+
+\macro{ \[f(x) = x^2 }
+%     ^^ meta.group.brace.tex - meta.environment
+%       ^^^^^^^^^^^^^ meta.group.brace.tex meta.environment.math.block.bracket.latex
+%                    ^ meta.group.brace.tex - meta.environment
+%       ^^ string.other.math.latex punctuation.definition.string.begin.latex
+%                    ^ punctuation.definition.group.brace.end.tex
+
+\macro{ \[f(x) = { ( x^2 + a - 2 } }
+%     ^^ meta.group.brace.tex - meta.environment
+%       ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group.brace.tex meta.environment.math.block.bracket.latex
+%                                  ^ meta.group.brace.tex - meta.environment
+%       ^^ string.other.math.latex punctuation.definition.string.begin.latex
+%                                  ^ punctuation.definition.group.brace.end.tex
+
+\macro{\begin{equation}}
+%^^^^^ support.function.general.latex
+%     ^^^^^^^^^^^^^^^^^^ meta.group.brace.tex
+%     ^ punctuation.definition.group.brace.begin.tex
+%      ^^^^^^ support.function.begin.latex keyword.control.flow.begin.latex
+%      ^ punctuation.definition.backslash.latex
+%            ^ punctuation.definition.group.brace.begin.tex
+%             ^^^^^^^^ variable.parameter.function.latex
+%                     ^^ punctuation.definition.group.brace.end.tex
+
+\macro{\begin{equation}f(x) = x^2}
+%^^^^^ support.function.general.latex
+%     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group.brace.tex
+%     ^ punctuation.definition.group.brace.begin.tex
+%      ^^^^^^ support.function.begin.latex keyword.control.flow.begin.latex
+%      ^ punctuation.definition.backslash.latex
+%            ^ punctuation.definition.group.brace.begin.tex
+%             ^^^^^^^^ variable.parameter.function.latex
+%                     ^ punctuation.definition.group.brace.end.tex
+%                      ^^^^^^^^^^ meta.environment.math.block.latex markup.math.block
+%                                ^ punctuation.definition.group.brace.end.tex
+
+% Ensuremath
 
 \ensuremath{f(x) = x^2}
 % <- meta.function.ensuremath.latex support.function.ensuremath.latex punctuation.definition.backslash.latex
@@ -866,6 +933,8 @@ The \emph{verbatim} environment sets everything in verbatim.
 
 \ensuremaths{5}
 %            ^ - meta.function.ensuremath.latex
+
+% Math Environments
 
 \begin{equation}
 % <- support.function.begin.latex keyword.control.flow.begin.latex punctuation.definition.backslash.latex
@@ -929,6 +998,7 @@ f(x) = x^2
 %   ^ punctuation.definition.group.brace.begin.tex
 %    ^^^^^^^^^^^^ variable.parameter.function.latex
 %                ^ punctuation.definition.group.brace.end.tex
+
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %                 Boxes

--- a/LaTeX/tests/syntax_test_tex.math.tex
+++ b/LaTeX/tests/syntax_test_tex.math.tex
@@ -75,6 +75,37 @@ $\lim_{x \rightarrow 0} \sin x$
 %     ^ string.other.math.tex punctuation.definition.string.end.tex
 %      ^ - meta.environment.math
 
+% verify closing brace terminates inline math equation
+\macro{$}{$f=}{$f(x)={2\cdot x}}
+%     ^^^^^^^^^^^^^^^ meta.group.brace.tex - meta.group meta.group
+%                    ^^^^^^^^^^ meta.group.brace.tex meta.group.brace.tex
+%                              ^ meta.group.brace.tex
+%                               ^ - meta.group
+%     ^ punctuation.definition.group.brace.begin.tex
+%      ^ meta.environment.math.inline.dollar.tex string.other.math.tex punctuation.definition.string.begin.tex
+%       ^ punctuation.definition.group.brace.end.tex
+%        ^ punctuation.definition.group.brace.begin.tex
+%         ^^^ meta.environment.math.inline.dollar.tex
+%         ^ string.other.math.tex punctuation.definition.string.begin.tex
+%          ^^ markup.math.inline
+%          ^ variable.other.math.tex
+%           ^ keyword.operator.comparison.tex
+%            ^ punctuation.definition.group.brace.end.tex
+%             ^ punctuation.definition.group.brace.begin.tex
+%              ^^^^^^^^^^^^^^^^ meta.environment.math.inline.dollar.tex
+%              ^ string.other.math.tex punctuation.definition.string.begin.tex
+%               ^^^^^^^^^^^^^^^ markup.math.inline
+%               ^ variable.other.math.tex
+%                ^ punctuation.section.parens.begin.tex
+%                 ^ variable.other.math.tex
+%                  ^ punctuation.section.parens.end.tex
+%                   ^ keyword.operator.comparison.tex
+%                    ^ punctuation.definition.group.brace.begin.tex
+%                     ^ meta.number.integer.decimal.tex constant.numeric.value.tex
+%                      ^^^^^ keyword.other.math.binary-operator.tex
+%                      ^ punctuation.definition.backslash.tex
+%                             ^^ punctuation.definition.group.brace.end.tex
+
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %                                Display Math
@@ -85,6 +116,37 @@ $\lim_{x \rightarrow 0} \sin x$
 %^^^^^^^^^^^^^^ meta.environment.math.block.dollar.tex
 %  ^^^^^^^^^^ markup.math.block - string
 %            ^^ string.other.math.tex punctuation.definition.string.end.tex - markup.math.block
+
+% verify closing brace terminates block math equation
+\macro{$$}{$$f=}{$$f(x)={2\cdot x}}
+%     ^^^^^^^^^^^^^^^^^^ meta.group.brace.tex - meta.group meta.group
+%                       ^^^^^^^^^^ meta.group.brace.tex meta.group.brace.tex
+%                                 ^ meta.group.brace.tex
+%                                  ^ - meta.group
+%     ^ punctuation.definition.group.brace.begin.tex
+%      ^^ meta.environment.math.block.dollar.tex string.other.math.tex punctuation.definition.string.begin.tex
+%        ^ punctuation.definition.group.brace.end.tex
+%         ^ punctuation.definition.group.brace.begin.tex
+%          ^^^^ meta.environment.math.block.dollar.tex
+%          ^^ string.other.math.tex punctuation.definition.string.begin.tex
+%            ^^ markup.math.block
+%            ^ variable.other.math.tex
+%             ^ keyword.operator.comparison.tex
+%              ^ punctuation.definition.group.brace.end.tex
+%               ^ punctuation.definition.group.brace.begin.tex
+%                ^^^^^^^^^^^^^^^^^ meta.environment.math.block.dollar.tex
+%                ^^ string.other.math.tex punctuation.definition.string.begin.tex
+%                  ^^^^^^^^^^^^^^^ markup.math.block
+%                  ^ variable.other.math.tex
+%                   ^ punctuation.section.parens.begin.tex
+%                    ^ variable.other.math.tex
+%                     ^ punctuation.section.parens.end.tex
+%                      ^ keyword.operator.comparison.tex
+%                       ^ punctuation.definition.group.brace.begin.tex
+%                        ^ meta.number.integer.decimal.tex constant.numeric.value.tex
+%                         ^^^^^ keyword.other.math.binary-operator.tex
+%                         ^ punctuation.definition.backslash.tex
+%                                ^^ punctuation.definition.group.brace.end.tex
 
 $$
 % <- meta.environment.math.block.dollar.tex punctuation.definition.string.begin.tex


### PR DESCRIPTION
This commit ensures to pop off math equation contexts on possibly stray closing braces, to ensure wrapping braces to stay intact.

LaTeX already implemented it for all sorts of equations, even `\begin...\end` environments. This commit just extends it to TeX's dollar math.

_This brings syntax highlighting behavior inline with latex compilers, which raise errors on stray braces within math equations._