### PR TITLE
[ShellScript] Add support for arithmethic expansions in square brackets

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -2816,6 +2816,11 @@ contexts:
       branch:
         - arithmetic-expansion
         - command-expansion
+    - match: (\$)(\[)
+      captures:
+        1: punctuation.definition.variable.shell.shell
+        2: punctuation.section.interpolation.begin.shell.shell
+      push: arithmetic-expansion-bracket-body
 
   arithmetic-expansion:
     - match: (\$)(\(\()
@@ -2831,6 +2836,14 @@ contexts:
       pop: 1
     - match: (?=\))
       fail: arithmetic-expansion
+    - include: expression-content
+    - include: expression-illegals
+
+  arithmetic-expansion-bracket-body:
+    - meta_scope: meta.interpolation.arithmetic.shell.shell
+    - match: \]
+      scope: punctuation.section.interpolation.end.shell.shell
+      pop: 1
     - include: expression-content
     - include: expression-illegals
 
@@ -3405,7 +3418,7 @@ variables:
   case_clause_end: ;;&?|;&
 
   # Parameter expansions
-  is_interpolation: (?=\$[({{{identifier_char}}{{special_variables}}]|`)
+  is_interpolation: (?=\$[({\[{{identifier_char}}{{special_variables}}]|`)
   parameter_switch: '[AEKLPQUaku]'
 
   # Filename expansions

--- a/ShellScript/Bash/tests/syntax_test_scope.bash
+++ b/ShellScript/Bash/tests/syntax_test_scope.bash
@@ -117,6 +117,9 @@ $((
 # ^^^^^^^^^^ - comment
 ))
 
+$[ # comment ]
+#^^^^^^^^^^^^^ - comment
+
 cmd \
 # comment after line continuation
 # <- comment.line.number-sign.shell punctuation.definition.comment.shell
@@ -4152,6 +4155,13 @@ x="$(( foo++ ))"
 #   ^^ punctuation.section.interpolation.begin.shell
 #         ^^ keyword
 #            ^^ punctuation.section.interpolation.end.shell
+
+x="$[ foo++ ]"
+#^ keyword.operator.assignment.shell
+#  ^ punctuation.definition.variable.shell
+#   ^ punctuation.section.interpolation.begin.shell
+#        ^^ keyword
+#           ^ punctuation.section.interpolation.end.shell
 
 # These are all legal identifiers for variables.
 alias=hello
@@ -9164,11 +9174,31 @@ stash) || true)
 # https://www.gnu.org/software/bash/manual/bash.html#Arithmetic-Expansion     #
 ###############################################################################
 
+$(())
+# <- meta.function-call.identifier.shell meta.command.shell meta.interpolation.arithmetic.shell punctuation.definition.variable.shell
+#^^^^ meta.function-call.identifier.shell meta.command.shell meta.interpolation.arithmetic.shell
+#^^ punctuation.section.interpolation.begin.shell
+#  ^^ punctuation.section.interpolation.end.shell
+
+$(( var + 1 ))
+# <- meta.function-call.identifier.shell meta.command.shell meta.interpolation.arithmetic.shell punctuation.definition.variable.shell
+#^^^^^^^^^^^^^ meta.function-call.identifier.shell meta.command.shell meta.interpolation.arithmetic.shell
+#^^ punctuation.section.interpolation.begin.shell
+#   ^^^ variable.other.readwrite.shell
+#       ^ keyword.operator.arithmetic.shell
+#         ^ meta.number.integer.decimal.shell constant.numeric.value.shell
+#           ^^ punctuation.section.interpolation.end.shell
+
 : $(())
+#^^^^^^ meta.function-call.arguments.shell
 # ^^^^^ meta.string.glob.shell meta.interpolation.arithmetic.shell
+# ^ punctuation.definition.variable.shell
+#  ^^ punctuation.section.interpolation.begin.shell
+#    ^^ punctuation.section.interpolation.end.shell
 
 : $((  ))
-# ^^^^^^^ meta.interpolation.arithmetic.shell
+#^^^^^^^^ meta.function-call.arguments.shell
+# ^^^^^^^ meta.string.glob.shell meta.interpolation.arithmetic.shell
 # ^ punctuation.definition.variable.shell
 #  ^^ punctuation.section.interpolation.begin.shell
 #      ^^ punctuation.section.interpolation.end.shell
@@ -9204,6 +9234,66 @@ stash) || true)
 #       ^^^ variable.other.readwrite.shell
 #          ^ punctuation.section.interpolation.end.shell
 #            ^^ punctuation.section.interpolation.end.shell
+
+$[]
+# <- meta.function-call.identifier.shell meta.command.shell meta.interpolation.arithmetic.shell.shell punctuation.definition.variable.shell.shell
+#^^ meta.function-call.identifier.shell meta.command.shell meta.interpolation.arithmetic.shell.shell
+#^ punctuation.section.interpolation.begin.shell.shell
+# ^ punctuation.section.interpolation.end.shell.shell
+
+$[var + 1]
+# <- meta.function-call.identifier.shell meta.command.shell meta.interpolation.arithmetic.shell.shell punctuation.definition.variable.shell.shell
+#^^^^^^^^^ meta.function-call.identifier.shell meta.command.shell meta.interpolation.arithmetic.shell.shell
+#^ punctuation.section.interpolation.begin.shell.shell
+# ^^^ variable.other.readwrite.shell
+#     ^ keyword.operator.arithmetic.shell
+#       ^ meta.number.integer.decimal.shell constant.numeric.value.shell
+#        ^ punctuation.section.interpolation.end.shell.shell
+
+: $[]
+#^^^^ meta.function-call.arguments.shell
+# ^^^ meta.string.glob.shell meta.interpolation.arithmetic.shell.shell
+# ^ punctuation.definition.variable.shell.shell
+#  ^ punctuation.section.interpolation.begin.shell.shell
+#   ^ punctuation.section.interpolation.end.shell.shell
+
+: $[  ]
+# ^^^^^ meta.string.glob.shell meta.interpolation.arithmetic.shell.shell
+# ^ punctuation.definition.variable.shell.shell
+#  ^ punctuation.section.interpolation.begin.shell.shell
+#     ^ punctuation.section.interpolation.end.shell.shell
+
+: $[ `date +%Y`[2] ]
+# ^^^^^^^^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.arithmetic.shell
+# ^ punctuation.definition.variable.shell
+#  ^ punctuation.section.interpolation.begin.shell
+#    ^^^^^^^^^^ meta.interpolation.command.shell
+#    ^ punctuation.section.interpolation.begin.shell
+#             ^ punctuation.section.interpolation.end.shell
+#              ^^^ meta.item-access.shell
+#                  ^ punctuation.section.interpolation.end.shell
+
+: $[ ${var} + 5 * ($var-1) ]
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.arithmetic.shell.shell
+# ^ punctuation.definition.variable.shell.shell
+#  ^ punctuation.section.interpolation.begin.shell.shell
+#    ^^^^^^ meta.interpolation.parameter.shell
+#    ^ punctuation.definition.variable.shell
+#     ^ punctuation.section.interpolation.begin.shell
+#      ^^^ variable.other.readwrite.shell
+#         ^ punctuation.section.interpolation.end.shell
+#           ^ keyword.operator.arithmetic.shell
+#             ^ meta.number.integer.decimal.shell constant.numeric.value.shell
+#               ^ keyword.operator.arithmetic.shell
+#                 ^^^^^^^^ meta.group.shell
+#                 ^ punctuation.section.group.begin.shell
+#                  ^^^^ meta.interpolation.parameter.shell variable.other.readwrite.shell
+#                  ^ punctuation.definition.variable.shell
+#                      ^ keyword.operator.arithmetic.shell
+#                       ^ meta.number.integer.decimal.shell constant.numeric.value.shell
+#                        ^ punctuation.section.group.end.shell
+#                          ^ punctuation.section.interpolation.end.shell.shell
+
 
 ###############################################################################
 # 3.5.8.1 Pattern Matching                                                    #

--- a/ShellScript/Zsh.sublime-syntax
+++ b/ShellScript/Zsh.sublime-syntax
@@ -670,24 +670,6 @@ contexts:
     - include: eregexp-group-content
     - include: word-end
 
-###[ ARITHMETIC EXPANSIONS ]###################################################
-
-  arithmetic-expansions:
-    - meta_prepend: true
-    - match: (\$)(\[)
-      captures:
-        1: punctuation.definition.variable.shell.zsh
-        2: punctuation.section.interpolation.begin.shell.zsh
-      push: zsh-arithmetic-expansion-body
-
-  zsh-arithmetic-expansion-body:
-    - meta_scope: meta.interpolation.arithmetic.shell.zsh
-    - match: \]
-      scope: punctuation.section.interpolation.end.shell.zsh
-      pop: 1
-    - include: expression-content
-    - include: expression-illegals
-
 ###[ BRACE EXPANSIONS ]########################################################
 
   brace-interpolations:
@@ -1755,9 +1737,6 @@ variables:
   oct_digit: '[0-7_]'
 
   case_clause_end: ;[;&|]
-
-  # Parameter expansions
-  is_interpolation: (?=\$[({\[{{identifier_char}}{{special_variables}}]|`)
 
   # A character that, when unquoted, separates words.
   # Bash ones + `{` and `}`


### PR DESCRIPTION
This commit moves implementation for arithmetic expansions in square brackets from Zsh to Bash as depsite not being document, it is supported by current versions of Bash and actively used in Linux kernel repository.

e.g.: https://github.com/torvalds/linux/blob/cc3ee4ba57b76deefb52aee5f57a46dc07bda9f7/samples/bpf/do_hbm_test.sh#L300