### PR TITLE
[Python] Fix tuple detection and unpack operators

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1986,7 +1986,14 @@ contexts:
   maybe-group:
     - match: \(
       scope: punctuation.section.group.begin.python
-      set: group-body
+      set:
+        - group-body
+        - maybe-group-begin
+
+  maybe-group-begin:
+    - match: (?=\*)
+      fail: generators-groups-and-tuples
+    - include: else-pop
 
   group-body:
     - meta_scope: meta.group.python
@@ -2000,7 +2007,9 @@ contexts:
   maybe-generator:
     - match: \(
       scope: punctuation.section.sequence.begin.python
-      set: generator-body
+      set:
+        - generator-body
+        - allow-unpack-operators
 
   generator-body:
     - meta_scope: meta.sequence.generator.python
@@ -2012,7 +2021,9 @@ contexts:
   maybe-tuple:
     - match: \(
       scope: punctuation.section.sequence.begin.python
-      set: tuple-body
+      set:
+        - tuple-body
+        - allow-unpack-operators
 
   tuple-body:
     - meta_scope: meta.sequence.tuple.python

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -2763,6 +2763,14 @@ generator = (i for i in range(100))
 #              ^^^^^^^^ meta.expression.generator
 #              ^^^ keyword.control.loop.for.generator
 #                    ^^ keyword.control.loop.in
+
+generator = (*i for i in k)
+#           ^^^^^^^^^^^^^^^ meta.sequence.generator.python
+#            ^ keyword.operator.unpacking.sequence.python
+#               ^^^^^^^^ meta.expression.generator.python
+#               ^^^ keyword.control.loop.for.generator
+#                     ^^ keyword.control.loop.in
+
 list_ = [i for i in range(100)]
 #       ^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence
 #          ^^^^^^^^ meta.expression.generator
@@ -2997,9 +3005,13 @@ foo, bar = get_vars()
 #  ^ punctuation.separator.sequence.python
 #        ^ keyword.operator.assignment.python
 
+t = (*tuple())
+#   ^^^^^^^^^^ meta.sequence.tuple.python
+#    ^ keyword.operator.unpacking.sequence.python
+
 t = (*tuple(), *[1, 2], 3*1)
 #   ^^^^^^^^^^^^^^^^^^^^^^ meta.sequence.tuple.python
-#    ^ keyword.operator.arithmetic.python
+#    ^ keyword.operator.unpacking.sequence.python
 #     ^^^^^ support.type.python
 #              ^ keyword.operator.unpacking.sequence.python
 #                        ^ keyword.operator.arithmetic.python


### PR DESCRIPTION
This PR ensures...

1. unpack operators after opening parenthesis of tuples being scoped correctly
2. correct scope of tuples, if content begins with unpacked sequence