### PR TITLE
[SQL] Fix MySQL default column values

### DIFF
--- a/SQL/MySQL.sublime-syntax
+++ b/SQL/MySQL.sublime-syntax
@@ -78,7 +78,7 @@ variables:
     | second(?: _microsecond )? | quarter | month | week )
 
   builtin_constants: |-
-    (?xi: all | default | maxvalue
+    (?xi: all | maxvalue
     # index algorithm/lock values
     | inplace | copy | nocopy | instant | exclusive | shared
     | system\s+versioning )

--- a/SQL/SQL (basic).sublime-syntax
+++ b/SQL/SQL (basic).sublime-syntax
@@ -816,6 +816,8 @@ contexts:
     - match: \b(?i:unique)\b
       scope: storage.modifier.sql
       push: maybe-column-name-list
+    - include: logical-operators
+    - include: constants
     - include: column-reference-definitions
 
   column-reference-definitions:

--- a/SQL/tests/syntax/syntax_test_mysql.sql
+++ b/SQL/tests/syntax/syntax_test_mysql.sql
@@ -87,14 +87,12 @@
 --                 ^^^^^ constant.language.boolean.false.sql
 --                      ^ - constant
 
-    all default maxvalue
+    all maxvalue
 -- ^ - constant
 --  ^^^ constant.language.sql
 --     ^ - constant
---      ^^^^^^^ constant.language.sql
---             ^ - constant
---              ^^^^^^^^ constant.language.sql
---                      ^ - constant
+--      ^^^^^^^^ constant.language.sql
+--              ^ - constant
 
     inplace copy nocopy instant exclusive shared
 -- ^ - constant
@@ -1381,6 +1379,64 @@ create table fancy_table (
 --                                          ^^ keyword.operator.comparison
 --                                             ^^^^^^^^^^ meta.column-name
 );
+
+
+ALTER TABLE abc
+    ADD COLUMN column1 VARCHAR(10) NOT NULL DEFAULT 'Foo' AFTER bar,
+-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.alter.sql
+--  ^^^ keyword.other.ddl.sql
+--      ^^^^^^ keyword.other.ddl.sql
+--             ^^^^^^^ meta.column-name.sql variable.other.member.declaration.sql
+--                     ^^^^^^^^^^^ storage.type.sql
+--                            ^^^^ meta.parens.sql
+--                            ^ punctuation.definition.parens.begin.sql
+--                             ^^ meta.number.integer.decimal.sql constant.numeric.value.sql
+--                               ^ punctuation.definition.parens.end.sql
+--                                 ^^^ keyword.operator.logical.sql
+--                                     ^^^^ constant.language.null.sql
+--                                          ^^^^^^^ storage.modifier.sql
+--                                                  ^^^^^ meta.string.sql string.quoted.single.sql
+--                                                  ^ punctuation.definition.string.begin.sql
+--                                                      ^ punctuation.definition.string.end.sql
+--                                                        ^^^^^ keyword.other.position.sql
+--                                                              ^^^ meta.column-name.sql
+--                                                                 ^ punctuation.separator.sequence.sql
+    ADD COLUMN column2 DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) AFTER column1,
+-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.alter.sql
+--  ^^^ keyword.other.ddl.sql
+--      ^^^^^^ keyword.other.ddl.sql
+--             ^^^^^^^ meta.column-name.sql variable.other.member.declaration.sql
+--                     ^^^^^^^^^^^ storage.type.sql
+--                             ^^^ meta.parens.sql
+--                             ^ punctuation.definition.parens.begin.sql
+--                              ^ meta.number.integer.decimal.sql constant.numeric.value.sql
+--                               ^ punctuation.definition.parens.end.sql
+--                                 ^^^ keyword.operator.logical.sql
+--                                     ^^^^ constant.language.null.sql
+--                                          ^^^^^^^ storage.modifier.sql
+--                                                  ^^^^^^^^^^^^^^^^^^^^ meta.function-call.sql
+--                                                  ^^^^^^^^^^^^^^^^^ support.function.scalar.sql
+--                                                                   ^^^ meta.group.sql
+--                                                                   ^ punctuation.section.arguments.begin.sql
+--                                                                    ^ meta.number.integer.decimal.sql constant.numeric.value.sql
+--                                                                     ^ punctuation.section.arguments.end.sql
+--                                                                       ^^^^^ keyword.other.position.sql
+--                                                                             ^^^^^^^ meta.column-name.sql
+--                                                                                    ^ punctuation.separator.sequence.sql
+    ADD COLUMN column3 DATETIME(6) NULL AFTER column2,
+    ADD INDEX idx_abc_foo (column1, column2);
+-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.alter.sql
+--  ^^^ keyword.other.ddl.sql
+--      ^^^^^ keyword.other.ddl.sql
+--            ^^^^^^^^^^^ meta.index-name.sql
+--                        ^^^^^^^^^^^^^^^^^^ meta.group.table-columns.sql
+--                        ^ punctuation.section.group.begin.sql
+--                         ^^^^^^^ meta.column-name.sql
+--                                ^ punctuation.separator.sequence.sql
+--                                  ^^^^^^^ meta.column-name.sql
+--                                         ^ punctuation.section.group.end.sql
+--                                          ^ punctuation.terminator.statement.sql
+
 
 CREATE TABLE foo LIKE bar;
 -- <- meta.statement.create.sql keyword.other.ddl.sql


### PR DESCRIPTION
This commit...

fixes MySQL default column values which weren't being scoped correctly when preceded by `NULL` in a column definition.