### PR TITLE
[JavaScript] Use more specific scope for logical in keyword

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1567,7 +1567,7 @@ contexts:
       scope: keyword.operator.js
       push: expression-begin
     - match: in{{identifier_break}}
-      scope: keyword.operator.js
+      scope: keyword.operator.logical.js
       push: expression-begin
     - match: '=(?![=>])'
       scope: keyword.operator.assignment.js

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -1338,7 +1338,7 @@ a = /\//u + 0;
 
     x
     in y;
-//  ^^ keyword.operator
+//  ^^ keyword.operator.logical
 
     x
     instanceof y;

--- a/JavaScript/tests/syntax_test_js_bindings.js
+++ b/JavaScript/tests/syntax_test_js_bindings.js
@@ -280,6 +280,6 @@ using [ x ] = 0;
 await using in x;
 //^^^ keyword.control.flow.await
 //    ^^^^^ variable.other.readwrite
-//          ^^ keyword.operator
+//          ^^ keyword.operator.logical
 //             ^ variable.other.readwrite
 //              ^ punctuation.terminator.statement

--- a/JavaScript/tests/syntax_test_js_control.js
+++ b/JavaScript/tests/syntax_test_js_control.js
@@ -179,7 +179,7 @@
 //  ^^^ keyword.control.loop.for
 //      ^^^^^^^^^^^^^^ meta.group
 //       ^ punctuation.separator.expression
-//           ^^ keyword.operator
+//           ^^ keyword.operator.logical
 //                  ^ punctuation.separator.expression
 
     for (a[x in list];;;) {}
@@ -187,7 +187,7 @@
 //  ^^^ keyword.control.loop.for
 //      ^^^^^^^^^^^^^^^^ meta.group
 //        ^^^^^^^^^^^ meta.brackets
-//           ^^ keyword.operator
+//           ^^ keyword.operator.logical
 //                   ^ punctuation.separator.expression
 //                    ^ punctuation.separator.expression
 //                     ^ invalid.illegal.unexpected-token
@@ -363,9 +363,10 @@
 //                                   ^ punctuation.section.group.end
 //                                     ^^ meta.block
 
-    for (var in list) (i = 0 ; i < 10; i++)
-//  ^^^^^^^^^^^^^^^^^^ meta.for.js
-//                    ^^^^^^^^^^^^^^^^^^^^^ meta.group.js - meta.for
+    for (i in list) (i = 0 ; i < 10; i++)
+//  ^^^^^^^^^^^^^^^ meta.for.js
+//         ^^ keyword.control.loop.in.js
+//                  ^^^^^^^^^^^^^^^^^^^^^ meta.group.js - meta.for
 
 for
     42;


### PR DESCRIPTION
This commit scopes logical `in` keyword `keyword.operator.logical`, following the scheme of PR #4227 and #4271 as a follow-up of #4420.

It fixes a syntax test, using invalid syntax `for (var in list)`, in which `in` was scoped logical keyword due to `var` not being a valid iterator variable.