### PR TITLE
[JavaScript] Fix keywords in front of template strings

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1308,11 +1308,11 @@ contexts:
     - include: string-content
 
   literal-string-templates:
-    - match: (?=(?:(?:/\*\s*{{identifier_name}}\s*\*/|{{identifier_name}})\s*)?{{tagged_template_quote_begin}})
+    - match: (?=(?:(?:/\*\s*{{identifier_name}}\s*\*/|{{non_reserved_identifier}})\s*)?{{tagged_template_quote_begin}})
       push: literal-string-template-begin
 
   literal-string-template:
-    - match: (?=(?:(?:/\*\s*{{identifier_name}}\s*\*/|{{identifier_name}})\s*)?{{tagged_template_quote_begin}})
+    - match: (?=(?:(?:/\*\s*{{identifier_name}}\s*\*/|{{non_reserved_identifier}})\s*)?{{tagged_template_quote_begin}})
       set: literal-string-template-begin
 
   literal-string-template-begin:

--- a/JavaScript/tests/syntax_test_js_template.js
+++ b/JavaScript/tests/syntax_test_js_template.js
@@ -491,3 +491,15 @@ var js = js`
 /*^^^ meta.string.template.js string.quoted.other.js */
 /*  ^ punctuation.definition.string.end.js */
 /*   ^ punctuation.terminator.statement.js */
+
+return`template`
+/*^^^^ keyword.control.flow.return.js */
+/*    ^^^^^^^^^^ meta.string.template.js string.quoted.other.js */
+/*    ^ punctuation.definition.string.begin.js */
+/*             ^ punctuation.definition.string.end.js */
+
+yield`template`
+/*^^^ keyword.control.flow.yield.js */
+/*   ^^^^^^^^^^ meta.string.template.js string.quoted.other.js */
+/*   ^ punctuation.definition.string.begin.js */
+/*            ^ punctuation.definition.string.end.js */


### PR DESCRIPTION
This commit ensures reserved words being scoped correctly in front of template strings.