### PR TITLE
[XML] Recognize slnx file extension

### DIFF
--- a/XML/XML.sublime-syntax
+++ b/XML/XML.sublime-syntax
@@ -58,6 +58,7 @@ file_extensions:
   - rng
   - rss
   - opml
+  - slnx
   - svg
   - xaml
 


### PR DESCRIPTION
The .slnx is the new XML based MSBuild Solution file format by Microsoft designed to replace the old proprietary incomprehensible .sln format.

Read more: https://devblogs.microsoft.com/dotnet/introducing-slnx-support-dotnet-cli/