### PR TITLE
[Rust] fix annotations

### DIFF
--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -393,7 +393,7 @@ contexts:
       pop: true
 
   attribute-call:
-    - meta_content_scope: meta.group.rust
+    - meta_content_scope: meta.function-call.rust meta.group.rust
     - match: \)
       scope: meta.function-call.rust meta.group.rust punctuation.section.group.end.rust
       pop: true

--- a/Rust/tests/syntax_test_attributes.rs
+++ b/Rust/tests/syntax_test_attributes.rs
@@ -6,13 +6,13 @@
 // ^^^ variable.annotation
 //     ^ keyword.operator.assignment
 //       ^^^^^^^^^^^^ support.macro
-//                   ^^^^^^^^^^^^^^^^^ meta.group
+//                   ^^^^^^^^^^^^^^^^^ meta.function-call meta.group
 //                   ^ punctuation.section.group.begin
 //                    ^^^^^^^^^^^^^^^ string.quoted.double
 //                    ^ punctuation.definition.string.begin
 //                                  ^ punctuation.definition.string.end
 //                                   ^ punctuation.section.group.end
-//                                    ^ punctuation.section.group.end
+//                                    ^ punctuation.section.group.end - meta.function-call
 //                                     ^ - meta.annotation
 
 #![warn(unused)]


### PR DESCRIPTION
- annotations on the first line of a file were mistakenly being scoped as a shebang.
- annotations using macro functions were not scoping the macro call.