### PR TITLE
[Python] Remove obsolete/unused type parameter context

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1119,13 +1119,6 @@ contexts:
 
 ###[ TYPE PARAMETERS ]########################################################
 
-  type-parameter-lists:
-    - match: \[
-      scope: meta.generic.python punctuation.definition.generic.begin.python
-      push:
-        - type-parameter-list-body
-        - allow-unpack-operators
-
   type-parameter-list:
     - match: \[
       scope: meta.generic.python punctuation.definition.generic.begin.python


### PR DESCRIPTION
This PR just removes an unused context.