### PR TITLE
[Python] Fix first case statement termination

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1230,6 +1230,7 @@ contexts:
         - structural-pattern-fallback
 
   case-statement:
+    - meta_include_prototype: false
     - match: case
       scope:
         meta.statement.conditional.case.python
@@ -1239,16 +1240,20 @@ contexts:
         - case-statement-begin
 
   case-statement-begin:
+    - meta_include_prototype: false
     # fail if match is directly followed by `:` or end of statement
     - match: (?=$|#|;|:)
       fail: case-statements
     - include: allow-unpack-operators
 
   case-statement-end:
-    - match: '{{colon}}'
-      scope:
-        meta.statement.conditional.case.python
-        punctuation.section.block.begin.python
+    # Note: Consume any whitespace up to eol, including newline, to apply
+    # `meta.disable-dedentation` to full line, which is requied to actually
+    # disable default dedentation rules.
+    - match: ({{colon}})(?:\s*\n)?
+      captures:
+        1: meta.statement.conditional.case.python
+           punctuation.section.block.begin.python
       pop: 1
 
   case-statement-fail:
@@ -1606,31 +1611,20 @@ contexts:
   maybe-first-case-statement:
     # Disable dedentation of first case statement by special indentation rule.
     # see: https://github.com/sublimehq/Packages/issues/3456
-    - match: case\b
-      scope:
-        meta.statement.conditional.case.python
-        keyword.control.conditional.case.python
-      set:
-        - after-first-case-statement
-        - meta-disable-dedentation
-        - case-statement-pattern
-        - allow-unpack-operators
+    - match: (?=case\b)
+      set: first-case-statement
+    - include: line-continuations
     - include: comments
     - include: else-pop
 
-  after-first-case-statement:
-    - meta_include_prototype: false
-    - match: \@
-      scope: meta.annotation.python punctuation.definition.annotation.python
-      set: decorator-body
-    - include: immediately-pop
-
-  meta-disable-dedentation:
+  first-case-statement:
     - meta_include_prototype: false
     - meta_scope: meta.disable-dedentation.python
-    - include: else-pop
+    - include: case-statements
+    - include: immediately-pop
 
   structural-pattern-fallback:
+    - meta_include_prototype: false
     # Fallback context, which is used if `match` or `case` don't seem to
     # start a structural match pattern statement.
     - match: (?={{path}}\s*\()

--- a/Python/tests/syntax_test_indentation_case.py
+++ b/Python/tests/syntax_test_indentation_case.py
@@ -15,3 +15,9 @@ match var:
         case = 6
     case {"key": "value"}:
         case = 7
+
+# first case with comments
+
+match var:
+    case 10:        # comment
+        case = 1

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -1700,6 +1700,85 @@ def _():
 #         ^ keyword.operator.assignment.python
 #           ^ meta.number.integer.decimal.python constant.numeric.value.python
 
+match incomlete_first_case_expression_01:
+    case
+#   ^^^^ meta.generic-name.python
+    case foo:
+#   ^^^^^^^^^ meta.statement.conditional.case
+#   ^^^^ keyword.control.conditional.case.python
+
+match incomlete_first_case_expression_02:
+    case "foo"
+#   ^^^^ meta.generic-name.python
+#        ^^^^^ meta.string.python string.quoted.double.python
+    case foo:
+#   ^^^^^^^^^ meta.statement.conditional.case
+#   ^^^^ keyword.control.conditional.case.python
+
+match incomlete_first_case_expression_03:
+    case "foo" as bar
+#   ^^^^ meta.generic-name.python
+#        ^^^^^ meta.string.python string.quoted.double.python
+#              ^^ invalid.illegal.name.python
+#                 ^^^ meta.generic-name.python
+    case foo:
+#   ^^^^^^^^^ meta.statement.conditional.case
+#   ^^^^ keyword.control.conditional.case.python
+
+match incomlete_first_case_expression_04:
+    case "foo" if bar
+#   ^^^^ meta.generic-name.python
+#        ^^^^^ meta.string.python string.quoted.double.python
+#              ^^ keyword.control.conditional.if.python
+#                 ^^^ meta.generic-name.python
+    case foo:
+#   ^^^^^^^^^ meta.statement.conditional.case
+#   ^^^^ keyword.control.conditional.case.python
+
+match incomlete_first_case_expression_05:
+    case "foo" if bar  # comment
+#   ^^^^ meta.generic-name.python
+#        ^^^^^ meta.string.python string.quoted.double.python
+#              ^^ keyword.control.conditional.if.python
+#                 ^^^ meta.generic-name.python
+#                      ^^^^^^^^^^ comment.line.number-sign.python
+    case foo:
+#   ^^^^^^^^^ meta.statement.conditional.case
+#   ^^^^ keyword.control.conditional.case.python
+
+match not_a_first_case_expression_01:
+    case = 10
+#   ^^^^ meta.generic-name.python
+#        ^ keyword.operator.assignment.python
+#          ^^ meta.number.integer.decimal.python constant.numeric.value.python
+    case foo:
+#   ^^^^^^^^^ meta.statement.conditional.case
+#   ^^^^ keyword.control.conditional.case.python
+
+match not_a_first_case_expression_02:
+    case: dict[str] = 10
+#   ^^^^ meta.generic-name.python
+#       ^ punctuation.separator.annotation.python
+#         ^^^^^^^^^ meta.type.python
+#         ^^^^ support.type.python
+#             ^^^^^ meta.brackets.python
+#                   ^ keyword.operator.assignment.python
+#                     ^^ meta.number.integer.decimal.python constant.numeric.value.python
+    case foo:
+#   ^^^^^^^^^ meta.statement.conditional.case
+#   ^^^^ keyword.control.conditional.case.python
+
+match not_a_first_case_expression_03:
+    case(10)
+#   ^^^^ meta.function-call.identifier.python variable.function.python
+#       ^^^^ meta.function-call.arguments.python
+#       ^ punctuation.section.arguments.begin.python
+#        ^^ meta.number.integer.decimal.python constant.numeric.value.python
+#          ^ punctuation.section.arguments.end.python
+    case foo:
+#   ^^^^^^^^^ meta.statement.conditional.case
+#   ^^^^ keyword.control.conditional.case.python
+
 ##################
 # Function definitions
 ##################
@@ -2149,8 +2228,8 @@ def f[
 match test:
     case "func":
         def func(arg): pass
-# <- meta.disable-dedentation.python - meta.function
-#^^^^^^^ meta.disable-dedentation.python - meta.function
+# <- - meta.disable-dedentation - meta.function
+#^^^^^^^ - meta.disable-dedentation - meta.function
 #       ^^^^^^^^ meta.function.python
 #       ^^^ keyword.declaration.function.python
 #           ^^^^ entity.name.function.python
@@ -2327,8 +2406,22 @@ class GenericClass[T: X, **U]:
 match test:
     case "class":
         class name(): pass
-# <- meta.disable-dedentation.python - meta.class
-#^^^^^^^ meta.disable-dedentation.python - meta.class
+# <- - meta.disable-dedentation - meta.class
+#^^^^^^^ - meta.disable-dedentation - meta.class
+#       ^^^^^^^^^^ meta.class.python
+#       ^^^^^ keyword.declaration.class.python
+#             ^^^^ entity.name.class.python
+#                 ^^ meta.class.inheritance.python
+#                 ^ punctuation.section.inheritance.begin.python
+#                  ^ punctuation.section.inheritance.end.python
+#                   ^ meta.class.python punctuation.section.block.begin.python
+#                     ^^^^ keyword.control.flow.pass.python
+
+match test:
+    case "class":  # comment
+        class name(): pass
+# <- - meta.disable-dedentation - meta.class
+#^^^^^^^ - meta.disable-dedentation - meta.class
 #       ^^^^^^^^^^ meta.class.python
 #       ^^^^^ keyword.declaration.class.python
 #             ^^^^ entity.name.class.python
@@ -2469,7 +2562,17 @@ class Foo:
 match test:
     case "type":
         type foo
-#^^^^^^^ meta.disable-dedentation.python - meta.type
+# <- - meta.disable-dedentation - meta.type
+#^^^^^^^ - meta.disable-dedentation - meta.type
+#       ^^^^^^^^ meta.type-alias.python
+#       ^^^^ keyword.declaration.class.python
+#            ^^^ entity.name.type.alias.python
+
+match test:
+    case "type":  # comment
+        type foo
+# <- - meta.disable-dedentation - meta.type
+#^^^^^^^ - meta.disable-dedentation - meta.type
 #       ^^^^^^^^ meta.type-alias.python
 #       ^^^^ keyword.declaration.class.python
 #            ^^^ entity.name.type.alias.python
@@ -2631,7 +2734,17 @@ class Class():
 match test:
     case "func":
         @guarded
-#^^^^^^^ meta.disable-dedentation.python - meta.annotation
+# <- - meta.disable-dedentation - meta.annotation
+#^^^^^^^ - meta.disable-dedentation - meta.annotation
+#       ^^^^^^^^ meta.annotation.python
+#       ^ punctuation.definition.annotation.python
+#        ^^^^^^^ variable.annotation.python
+
+match test:
+    case "func":  # comment
+        @guarded
+# <- - meta.disable-dedentation - meta.annotation
+#^^^^^^^ - meta.disable-dedentation - meta.annotation
 #       ^^^^^^^^ meta.annotation.python
 #       ^ punctuation.definition.annotation.python
 #        ^^^^^^^ variable.annotation.python


### PR DESCRIPTION
This PR ...

1. fixes first incomplete case statement failing valid 2nd case statement due to calling `fail` outside of a branch point. That's caused by first case statement re-using contexts of common case statements.

2. fixes first statement after `match ...:` being scoped wrong, when starting with `case` soft keyword, by implementing first case statement with same branching strategy as all other ones.

Notes:

1. As a side effect all case statements are highlighted the same way.
2. Previously introduced special context `after-first-case-statement` becomes obsolete and is removed.