### PR TITLE
[Python] Reorganize variables

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -36,243 +36,6 @@ first_line_match: |-
   | ^ \s* \# .*? -\*- .*? \bpython(?:\d(?:\.\d+)?)?\b .*? -\*-  # editorconfig
   )
 
-variables:
-  shebang_language: \b(?:python(?:\d(?:\.\d+)?)?|uv)\b
-
-  # We support unicode here because Python 3 is the future
-  identifier_continue: '[[:alnum:]_]'
-  identifier: '[[:alpha:]_]{{identifier_continue}}*\b'
-  identifier_constant: '(?:[\p{Lu}_][\p{Lu}_\d]*)?[\p{Lu}]{2,}[\p{Lu}_\d]*\b'  # require 2 consecutive upper-case letters
-  digits: (?:\d+(?:_\d+)*)
-  exponent: (?:[eE][-+]?{{digits}})
-  path: '({{identifier}}[ ]*\.[ ]*)*{{identifier}}'
-  illegal_names: (?:and|as|assert|break|class|continue|def|del|elif|else|except|finally|for|from|global|if|import|in|is|lambda|not|or|pass|raise|return|try|while|with|yield)
-
-  strftime_spec: (?:%(?:[aAwdbBGmyYHIpMSfzZjuUVWcxX%]|-[dmHIMSj]))
-
-  augmented_assignment_operators: |-
-    (?x: >>= | <<= | \*\*= | //= | \+= | -= | \*= | /= | %= | @= | &= | \|= | \^= )
-
-  assignment_operator: '=(?!=)'
-
-  colon: ':(?!=)'
-
-  string_prefix: '[bBfFrRtTuU]{,2}'
-
-  sql_indicator: |-
-    (?x: \s* (?:
-    # dml statements
-      SELECT | INSERT | REPLACE | DELETE | TRUNCATE | UPDATE | MERGE\s+INTO
-    # ddl statements
-    | ADD | ALTER | CREATE | DROP
-    # conditional
-    | IF \s+ (?: NOT \s+ )? EXISTS
-    # declaration
-    | DECLARE | WITH | BEGIN
-    ) \s )
-
-  builtin_exceptions: |-
-    (?x:
-      ArithmeticError
-    | AssertionError
-    | AttributeError
-    | BaseException
-    | BlockingIOError
-    | BrokenPipeError
-    | BufferError
-    | BytesWarning
-    | ChildProcessError
-    | ConnectionAbortedError
-    | ConnectionRefusedError
-    | ConnectionResetError
-    | DeprecationWarning
-    | EnvironmentError
-    | EOFError
-    | Exception
-    | FileExistsError
-    | FileNotFoundError
-    | FloatingPointError
-    | FutureWarning
-    | GeneratorExit
-    | ImportError
-    | ImportWarning
-    | IndentationError
-    | IndexError
-    | InterruptedError
-    | IOError
-    | IsADirectoryError
-    | KeyboardInterrupt
-    | KeyError
-    | LookupError
-    | MemoryError
-    | ModuleNotFoundError
-    | NameError
-    | NotADirectoryError
-    | NotImplemented
-    | NotImplementedError
-    | OSError
-    | OverflowError
-    | PendingDeprecationWarning
-    | PermissionError
-    | ProcessLookupError
-    | RecursionError
-    | ReferenceError
-    | ResourceWarning
-    | RuntimeError
-    | RuntimeWarning
-    | StandardError
-    | StopAsyncIteration
-    | StopIteration
-    | SyntaxError
-    | SyntaxWarning
-    | SystemError
-    | SystemExit
-    | TabError
-    | TimeoutError
-    | TypeError
-    | UnboundLocalError
-    | UnicodeDecodeError
-    | UnicodeEncodeError
-    | UnicodeTranslateError
-    | UnicodeWarning
-    | UserWarning
-    | ValueError
-    | VMSError
-    | Warning
-    | WindowsError
-    | ZeroDivisionError
-    )\b
-
-  builtin_functions: |-
-    (?x:
-      __import__ | all | abs | any | ascii | bin | callable | chr | classmethod
-    | compile | delattr | dir | divmod | enumerate | eval | filter | format
-    | getattr | globals | hasattr | hash | help | hex | id | input | isinstance
-    | issubclass | iter | len | locals | map | max | min | next | oct | open
-    | ord | pow | property | range | repr | reversed | round | setattr | sorted
-    | staticmethod | sum | super | type(?=\s*\() | vars | zip
-    # Python 2 functions
-    | apply | cmp | coerce | execfile | intern | raw_input | reduce | reload
-    | unichr | xrange
-    # Python 3 functions
-    | aiter| anext| breakpoint | exec | print
-    )\b
-
-  builtin_types: |-
-    (?x:
-      bool | bytearray | bytes | complex | dict | float | frozenset | int
-    | list | memoryview | object | set | slice | str | tuple
-    # Python 2 types
-    | basestring | long | unicode
-    # Python 2 types prone to conflicts
-    # | buffer | file
-    )\b
-
-  typing_functions: |-
-    (?x:
-      assert_type | assert_never | clear_overloads | dataclass_transform | final
-    | get_args | get_origin | get_overloads | get_type_hints | is_typeddict
-    | no_type_check | no_type_check_decorator | overload | override | reveal_type
-    | runtime_checkable
-    )\b
-
-  typing_types: |-
-    (?x:
-    # Super-special typing primitives.
-      Annotated | Any | Callable | ClassVar | Concatenate | Final | ForwardRef
-    | Generic | Literal | Optional | ParamSpec | Protocol | Tuple | Type
-    | TypeVar | TypeVarTuple | Union
-    # ABCs (from collections.abc).
-    | AbstractSet | ByteString | Container | ContextManager | Hashable | ItemsView
-    | Iterable | Iterator | KeysView | Mapping | MappingView | MutableMapping
-    | MutableSequence | MutableSet | Sequence | Sized | ValuesView | Awaitable
-    | AsyncIterator | AsyncIterable | Coroutine | Collection | AsyncGenerator
-    | AsyncContextManager
-    # Structural checks, a.k.a. protocols.
-    | Reversible | SupportsAbs | SupportsBytes | SupportsComplex | SupportsFloat
-    | SupportsIndex | SupportsInt | SupportsRound
-    # Concrete collection types.
-    | ChainMap | Counter | Deque | Dict | DefaultDict | List | OrderedDict
-    | Set | FrozenSet | NamedTuple | TypedDict | Generator
-    # Other concrete types.
-    | BinaryIO | IO | Match | Pattern | TextIO
-    # One-off things.
-    | AnyStr | LiteralString | Never | NewType | NoReturn | NotRequired
-    | ParamSpecArgs | ParamSpecKwargs | Required | Self | Text | TypeAlias
-    | TypeGuard | Unpack
-    )\b
-
-  magic_functions: |-
-    (?x: __(?:
-    # unary operators
-    invert | neg | pos | abs
-    # binary operators
-    | add | and | contains | div | divmod | floordiv | lshift | mod | mul | or
-    | pow | rshift | sub | truediv | xor
-    # right-hand binary operators
-    | radd | rand | rdiv | rdivmod | rfloordiv | rlshift | rmod | rmul | ror
-    | rpow | rrshift | rsub | rtruediv | rxor
-    # in-place operator assignments
-    | iadd | iand | idiv | ifloordiv | ilshift | imod | imul | ior | ipow
-    | irshift | isub | itruediv | ixor
-    # comparisons
-    | eq | ge | gt | le | lt | ne
-    | cmp | rcmp  # py2
-    # primary coercion
-    | bool | str
-    | nonzero | unicode  # py2
-    # number coercion (converts something to a number)
-    | bytes | complex | float | index | int | round
-    | long  # py2
-    # other "coercion"
-    | format | len | length_hint | hash | repr | reversed
-    | coerce | hex | oct  # py2
-    | fspath
-    # iterator (and 'await')
-    | iter | next
-    | aiter | anext
-    | await
-    # attribute and item access
-    | delattr | delitem | delslice
-    | getattr | getattribute | getitem | getslice
-    | setattr | setitem | setslice
-    | dir | missing
-    # context manager
-    | enter | exit
-    | aenter | aexit
-    # other class magic
-    | call | del | init | new | init_subclass
-    | instancecheck | sizeof | subclasscheck | subclasshook
-    # pickling
-    | getnewargs | getnewargs_ex | getstate | setstate | reduce | reduce_ex
-    # descriptors
-    | delete | get | set | set_name
-    # class-specific
-    | subclasses
-    # dataclasses (PEP 557)
-    | post_init
-    # for typing core support (PEP 560)
-    | class_getitem | mro_entries
-    )__\b )
-
-  magic_variables: |-
-    (?x: __(?:
-    # generic object
-    class | dict | doc | module | name
-    # module-specific / global
-    | all | builtins | cached | file | loader | package | path | spec
-    # functions & methods
-    | annotations | closure | code | defaults | func | globals | kwdefaults | self | qualname
-    # classes (attributes)
-    | bases | prepare | slots | metaclass | mro | weakref
-    # Python 2
-    | members | methods
-    # Python 3.12 (PEP 698)
-    | override
-    )__\b )
-
-##############################################################################
-
 contexts:
   main:
     - meta_include_prototype: false
@@ -4247,3 +4010,240 @@ contexts:
     - include: triple-single-quoted-string
     - match: ^(?!\s*{{string_prefix}}['"]{3})
       pop: 1
+
+##############################################################################
+
+variables:
+  shebang_language: \b(?:python(?:\d(?:\.\d+)?)?|uv)\b
+
+  # We support unicode here because Python 3 is the future
+  identifier_continue: '[[:alnum:]_]'
+  identifier: '[[:alpha:]_]{{identifier_continue}}*\b'
+  identifier_constant: '(?:[\p{Lu}_][\p{Lu}_\d]*)?[\p{Lu}]{2,}[\p{Lu}_\d]*\b'  # require 2 consecutive upper-case letters
+  digits: (?:\d+(?:_\d+)*)
+  exponent: (?:[eE][-+]?{{digits}})
+  path: '({{identifier}}[ ]*\.[ ]*)*{{identifier}}'
+  illegal_names: (?:and|as|assert|break|class|continue|def|del|elif|else|except|finally|for|from|global|if|import|in|is|lambda|not|or|pass|raise|return|try|while|with|yield)
+
+  strftime_spec: (?:%(?:[aAwdbBGmyYHIpMSfzZjuUVWcxX%]|-[dmHIMSj]))
+
+  augmented_assignment_operators: |-
+    (?x: >>= | <<= | \*\*= | //= | \+= | -= | \*= | /= | %= | @= | &= | \|= | \^= )
+
+  assignment_operator: '=(?!=)'
+
+  colon: ':(?!=)'
+
+  string_prefix: '[bBfFrRtTuU]{,2}'
+
+  sql_indicator: |-
+    (?x: \s* (?:
+    # dml statements
+      SELECT | INSERT | REPLACE | DELETE | TRUNCATE | UPDATE | MERGE\s+INTO
+    # ddl statements
+    | ADD | ALTER | CREATE | DROP
+    # conditional
+    | IF \s+ (?: NOT \s+ )? EXISTS
+    # declaration
+    | DECLARE | WITH | BEGIN
+    ) \s )
+
+  builtin_exceptions: |-
+    (?x:
+      ArithmeticError
+    | AssertionError
+    | AttributeError
+    | BaseException
+    | BlockingIOError
+    | BrokenPipeError
+    | BufferError
+    | BytesWarning
+    | ChildProcessError
+    | ConnectionAbortedError
+    | ConnectionRefusedError
+    | ConnectionResetError
+    | DeprecationWarning
+    | EnvironmentError
+    | EOFError
+    | Exception
+    | FileExistsError
+    | FileNotFoundError
+    | FloatingPointError
+    | FutureWarning
+    | GeneratorExit
+    | ImportError
+    | ImportWarning
+    | IndentationError
+    | IndexError
+    | InterruptedError
+    | IOError
+    | IsADirectoryError
+    | KeyboardInterrupt
+    | KeyError
+    | LookupError
+    | MemoryError
+    | ModuleNotFoundError
+    | NameError
+    | NotADirectoryError
+    | NotImplemented
+    | NotImplementedError
+    | OSError
+    | OverflowError
+    | PendingDeprecationWarning
+    | PermissionError
+    | ProcessLookupError
+    | RecursionError
+    | ReferenceError
+    | ResourceWarning
+    | RuntimeError
+    | RuntimeWarning
+    | StandardError
+    | StopAsyncIteration
+    | StopIteration
+    | SyntaxError
+    | SyntaxWarning
+    | SystemError
+    | SystemExit
+    | TabError
+    | TimeoutError
+    | TypeError
+    | UnboundLocalError
+    | UnicodeDecodeError
+    | UnicodeEncodeError
+    | UnicodeTranslateError
+    | UnicodeWarning
+    | UserWarning
+    | ValueError
+    | VMSError
+    | Warning
+    | WindowsError
+    | ZeroDivisionError
+    )\b
+
+  builtin_functions: |-
+    (?x:
+      __import__ | all | abs | any | ascii | bin | callable | chr | classmethod
+    | compile | delattr | dir | divmod | enumerate | eval | filter | format
+    | getattr | globals | hasattr | hash | help | hex | id | input | isinstance
+    | issubclass | iter | len | locals | map | max | min | next | oct | open
+    | ord | pow | property | range | repr | reversed | round | setattr | sorted
+    | staticmethod | sum | super | type(?=\s*\() | vars | zip
+    # Python 2 functions
+    | apply | cmp | coerce | execfile | intern | raw_input | reduce | reload
+    | unichr | xrange
+    # Python 3 functions
+    | aiter| anext| breakpoint | exec | print
+    )\b
+
+  builtin_types: |-
+    (?x:
+      bool | bytearray | bytes | complex | dict | float | frozenset | int
+    | list | memoryview | object | set | slice | str | tuple
+    # Python 2 types
+    | basestring | long | unicode
+    # Python 2 types prone to conflicts
+    # | buffer | file
+    )\b
+
+  typing_functions: |-
+    (?x:
+      assert_type | assert_never | clear_overloads | dataclass_transform | final
+    | get_args | get_origin | get_overloads | get_type_hints | is_typeddict
+    | no_type_check | no_type_check_decorator | overload | override | reveal_type
+    | runtime_checkable
+    )\b
+
+  typing_types: |-
+    (?x:
+    # Super-special typing primitives.
+      Annotated | Any | Callable | ClassVar | Concatenate | Final | ForwardRef
+    | Generic | Literal | Optional | ParamSpec | Protocol | Tuple | Type
+    | TypeVar | TypeVarTuple | Union
+    # ABCs (from collections.abc).
+    | AbstractSet | ByteString | Container | ContextManager | Hashable | ItemsView
+    | Iterable | Iterator | KeysView | Mapping | MappingView | MutableMapping
+    | MutableSequence | MutableSet | Sequence | Sized | ValuesView | Awaitable
+    | AsyncIterator | AsyncIterable | Coroutine | Collection | AsyncGenerator
+    | AsyncContextManager
+    # Structural checks, a.k.a. protocols.
+    | Reversible | SupportsAbs | SupportsBytes | SupportsComplex | SupportsFloat
+    | SupportsIndex | SupportsInt | SupportsRound
+    # Concrete collection types.
+    | ChainMap | Counter | Deque | Dict | DefaultDict | List | OrderedDict
+    | Set | FrozenSet | NamedTuple | TypedDict | Generator
+    # Other concrete types.
+    | BinaryIO | IO | Match | Pattern | TextIO
+    # One-off things.
+    | AnyStr | LiteralString | Never | NewType | NoReturn | NotRequired
+    | ParamSpecArgs | ParamSpecKwargs | Required | Self | Text | TypeAlias
+    | TypeGuard | Unpack
+    )\b
+
+  magic_functions: |-
+    (?x: __(?:
+    # unary operators
+    invert | neg | pos | abs
+    # binary operators
+    | add | and | contains | div | divmod | floordiv | lshift | mod | mul | or
+    | pow | rshift | sub | truediv | xor
+    # right-hand binary operators
+    | radd | rand | rdiv | rdivmod | rfloordiv | rlshift | rmod | rmul | ror
+    | rpow | rrshift | rsub | rtruediv | rxor
+    # in-place operator assignments
+    | iadd | iand | idiv | ifloordiv | ilshift | imod | imul | ior | ipow
+    | irshift | isub | itruediv | ixor
+    # comparisons
+    | eq | ge | gt | le | lt | ne
+    | cmp | rcmp  # py2
+    # primary coercion
+    | bool | str
+    | nonzero | unicode  # py2
+    # number coercion (converts something to a number)
+    | bytes | complex | float | index | int | round
+    | long  # py2
+    # other "coercion"
+    | format | len | length_hint | hash | repr | reversed
+    | coerce | hex | oct  # py2
+    | fspath
+    # iterator (and 'await')
+    | iter | next
+    | aiter | anext
+    | await
+    # attribute and item access
+    | delattr | delitem | delslice
+    | getattr | getattribute | getitem | getslice
+    | setattr | setitem | setslice
+    | dir | missing
+    # context manager
+    | enter | exit
+    | aenter | aexit
+    # other class magic
+    | call | del | init | new | init_subclass
+    | instancecheck | sizeof | subclasscheck | subclasshook
+    # pickling
+    | getnewargs | getnewargs_ex | getstate | setstate | reduce | reduce_ex
+    # descriptors
+    | delete | get | set | set_name
+    # class-specific
+    | subclasses
+    # dataclasses (PEP 557)
+    | post_init
+    # for typing core support (PEP 560)
+    | class_getitem | mro_entries
+    )__\b )
+
+  magic_variables: |-
+    (?x: __(?:
+    # generic object
+    class | dict | doc | module | name
+    # module-specific / global
+    | all | builtins | cached | file | loader | package | path | spec
+    # functions & methods
+    | annotations | closure | code | defaults | func | globals | kwdefaults | self | qualname
+    # classes (attributes)
+    | bases | prepare | slots | metaclass | mro | weakref
+    # Python 2
+    | members | methods
+    # Python 3.12 (PEP 698)
+    | override
+    )__\b )


### PR DESCRIPTION
This is a pure maintanance PR to...

1. move global `variables:` context to the bottom 
2. merge some uniquely used contexts into `statements`

It does not change any pattern or modify behavior.

Primary intent is to move the huge variables list to the bottom, as it is less important compared to normal contexts.