### PR TITLE
[C#] Improve fold rules

### DIFF
--- a/C#/Fold.tmPreferences
+++ b/C#/Fold.tmPreferences
@@ -20,48 +20,64 @@
                 <string>punctuation.section.parameters.begin</string>
                 <key>end</key>
                 <string>punctuation.section.parameters.end</string>
+                <key>excludeTrailingNewlines</key>
+                <false/>
             </dict>
             <dict>
                 <key>begin</key>
                 <string>punctuation.section.brackets.begin</string>
                 <key>end</key>
                 <string>punctuation.section.brackets.end</string>
+                <key>excludeTrailingNewlines</key>
+                <false/>
             </dict>
             <dict>
                 <key>begin</key>
                 <string>punctuation.section.braces.begin</string>
                 <key>end</key>
                 <string>punctuation.section.braces.end</string>
+                <key>excludeTrailingNewlines</key>
+                <false/>
             </dict>
             <dict>
                 <key>begin</key>
                 <string>punctuation.section.sequence.begin</string>
                 <key>end</key>
                 <string>punctuation.section.sequence.end</string>
+                <key>excludeTrailingNewlines</key>
+                <false/>
             </dict>
             <dict>
                 <key>begin</key>
                 <string>punctuation.section.group.begin</string>
                 <key>end</key>
                 <string>punctuation.section.group.end</string>
+                <key>excludeTrailingNewlines</key>
+                <false/>
             </dict>
             <dict>
                 <key>begin</key>
                 <string>punctuation.definition.annotation.begin</string>
                 <key>end</key>
                 <string>punctuation.definition.annotation.end</string>
+                <key>excludeTrailingNewlines</key>
+                <false/>
             </dict>
             <dict>
                 <key>begin</key>
                 <string>punctuation.definition.generic.begin</string>
                 <key>end</key>
                 <string>punctuation.definition.generic.end</string>
+                <key>excludeTrailingNewlines</key>
+                <false/>
             </dict>
             <dict>
                 <key>begin</key>
                 <string>meta.preprocessor.region meta.fold.begin</string>
                 <key>end</key>
                 <string>meta.preprocessor.region meta.fold.end</string>
+                <key>excludeTrailingNewlines</key>
+                <false/>
             </dict>
         </array>
     </dict>


### PR DESCRIPTION
This commit includes trailing newlines into all fold-able regions, but blocks.

Blocks may appear between if-else statements, which behaves better when keeping closing punctuation on separate lines.