### PR TITLE
[Python] Revise lambda expressions and unpack operators

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -571,7 +571,9 @@ contexts:
     - meta_content_scope: meta.class.python
     - match: \(
       scope: punctuation.section.inheritance.begin.python
-      set: class-definition-base-list-body
+      set:
+        - class-definition-base-list-body
+        - maybe-unpack-operator-in-brackets
     - include: class-definition-end
 
   class-definition-base-list-body:
@@ -584,6 +586,7 @@ contexts:
       pop: 1
     - match: ','
       scope: punctuation.separator.inheritance.python
+      push: maybe-unpack-operator-in-brackets
     # expression-in-a-group (without qualified-names)
     - include: line-continuations
     - include: illegal-assignment-expressions

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -2581,6 +2581,19 @@ class MyClass(Inherited, \
 #   ^^^ comment.block.documentation.python
     pass
 
+class MyClass(*bases, *more_bases):
+#^^^^^^^^^^^^ meta.class.python
+#^^^^ keyword.declaration.class.python
+#     ^^^^^^^ entity.name.class.python
+#            ^^^^^^^^^^^^^^^^^^^^^ meta.class.inheritance.python
+#            ^ punctuation.section.inheritance.begin.python
+#             ^ keyword.operator.unpacking.sequence.python
+#              ^^^^^ entity.other.inherited-class.python
+#                   ^ punctuation.separator.inheritance.python
+#                     ^ keyword.operator.unpacking.sequence.python
+#                      ^^^^^^^^^^ entity.other.inherited-class.python
+#                                ^ punctuation.section.inheritance.end.python
+#                                 ^ meta.class.python punctuation.section.block.begin.python
 
 class DataClass(TypedDict, None, total=False, True=False):
 #     ^^^^^^^^^ entity.name.class.python


### PR DESCRIPTION
This PR primarily ensures proper lambda expression termination, depending on being located inside or outside of brackets. 

This also requires rethinking when unpack operator contexts have to be popped off stack, to ensure all expressions are terminated properly.

_All expressions are terminated by semicolons or line breaks not preceded by line-continuation characters. When enclosed by bracktes, they may however span multiple lines without line continuation being required._

Following existing naming schema, a new `maybe-unpack-operator-in-brackets` is introduced for use in all expressions within brackets, which allow both sequence and dictionary unpack operators.

As this change affected many code lines, the chance is taken to replace `allow-` context name prefix by `maybe-` and use "singular" naming to express popping behavior.