### PR TITLE
[Python] Fix upper-case qualified function calls

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1624,7 +1624,6 @@ contexts:
     - include: magic-variable
     - include: wildcard-variable
     - include: illegal-name
-    - include: constant-name
     - include: function-name
     - include: immediately-pop
 

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -637,6 +637,16 @@ dotted . identifier(12, True)
 #      ^ punctuation.accessor.dot
 #        ^^^^^^^^^^ variable.function
 
+dotted . IDENTIFIER(12, True)
+# <- meta.path.python - meta.function-call
+#^^^^^^^^ - meta.function-call
+#        ^^^^^^^^^^ meta.function-call.identifier.python - meta.function-call meta.function-call
+#                  ^^^^^^^^^^ meta.function-call.arguments.python - meta.function-call meta.function-call
+#^^^^^^^^^^^^^^^^^^ meta.path
+#^^^^^^^^ - variable.function
+#      ^ punctuation.accessor.dot
+#        ^^^^^^^^^^ variable.function
+
 open.__new__(12, \
 # <- meta.path.python meta.generic-name.python - meta.function-call
 #^^^^ - meta.function-call


### PR DESCRIPTION
This PR removes `constant-name` context include from qualified function names, to prefer highlighting upper-case identifiers `variable.function` instead of `variable.other.constant` in qualified function calls.

Note: That's already the case for unqualified function calls.