### PR TITLE
[Python] Scope PascalCased identifiers as classes

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -614,8 +614,22 @@ contexts:
       push:
         - function-call-argument-list
         - unqualified-function-call-name
-    - match: '{{identifier}}'
+    - match: (?={{identifier_start}})
+      push: unqualified-base-class-name-content
+
+  unqualified-base-class-name-content:
+    - include: builtin-exception
+    - include: builtin-type
+    - include: class-variable
+    - include: magic-function
+    - include: magic-variable
+    - include: wildcard-variable
+    - include: constant-name
+    - match: '{{identifier_class}}'
       scope: entity.other.inherited-class.python
+      pop: 1
+    - include: generic-name
+    - include: immediately-pop
 
   qualified-base-class-separator:
     - meta_include_prototype: false
@@ -640,9 +654,13 @@ contexts:
       set:
         - function-call-argument-list
         - qualified-function-call-name
-    - match: \s*({{identifier}})
+    - match: \s*({{identifier_class}})
       captures:
         1: entity.other.inherited-class.python
+      pop: 1
+    - match: \s*({{identifier}})
+      captures:
+        1: variable.other.python
       pop: 1
     - include: line-continuation-immediately-pop
 

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -2676,17 +2676,23 @@ class MyClass(Inherited, \
 #   ^^^ comment.block.documentation.python
     pass
 
-class MyClass(*bases, *more_bases):
+bases = [Foo, Bar]
+# <- variable.other.python
+#^^^^ variable.other.python
+#        ^^^ support.class.python
+#             ^^^ support.class.python
+
+class MyClass(*bases, *MORE_BASES):
 #^^^^^^^^^^^^ meta.class.python
 #^^^^ keyword.declaration.class.python
 #     ^^^^^^^ entity.name.class.python
 #            ^^^^^^^^^^^^^^^^^^^^^ meta.class.inheritance.python
 #            ^ punctuation.section.inheritance.begin.python
 #             ^ keyword.operator.unpacking.sequence.python
-#              ^^^^^ entity.other.inherited-class.python
+#              ^^^^^ variable.other.python
 #                   ^ punctuation.separator.inheritance.python
 #                     ^ keyword.operator.unpacking.sequence.python
-#                      ^^^^^^^^^^ entity.other.inherited-class.python
+#                      ^^^^^^^^^^ variable.other.constant.python
 #                                ^ punctuation.section.inheritance.end.python
 #                                 ^ meta.class.python punctuation.section.block.begin.python
 


### PR DESCRIPTION
This is a rather opinionated PR to align highlighting of modern python3 code with languages like C# or Java and Github's way of treating pascal case identifiers as classes.

The suggestion relies on modern code style conventions to distinguish ordinary variables or functions from class references or instantiations.

Python itself doesn't technically require classes to be pascal case or variables to be snake_case. Thus a syntax focused purly on technical constraints might choose a common scope for all identifiers.

This PR however increases consistency of highlighting class names accross all locations, assuming proper code styling being applied.

