### PR TITLE
[SQL] Fix MySQL/PostgreSQL generated always as

### DIFF
--- a/SQL/MySQL.sublime-syntax
+++ b/SQL/MySQL.sublime-syntax
@@ -1091,10 +1091,13 @@ contexts:
   column-modifiers:
     - meta_prepend: true
     - match: \b(?i:generated\s+always\s+as)\b
-      scope: storage.modifier.mysql
-      push: group
+      scope: storage.modifier.sql
+      push: generated-always-as-expression
     - match: \b(?i:stored|virtual)\b
-      scope: storage.modifier.mysql
+      scope: storage.modifier.sql
+
+  generated-always-as-expression:
+    - include: maybe-group
 
 ###[ EVENT EXPRESSIONS ]#######################################################
 

--- a/SQL/PostgreSQL.sublime-syntax
+++ b/SQL/PostgreSQL.sublime-syntax
@@ -222,6 +222,13 @@ contexts:
     - match: \]
       scope: punctuation.section.brackets.end.psql
 
+###[ COLUMN EXPRESSIONS ]######################################################
+
+  generated-always-as-expression:
+    - match: \b(?i:identity)\b
+      scope: storage.modifier.sql
+    - include: else-pop
+
 ###[ EXTENSION EXPRESSIONS ]###################################################
 
   extension-attributes:

--- a/SQL/tests/syntax/syntax_test_mysql.sql
+++ b/SQL/tests/syntax/syntax_test_mysql.sql
@@ -1343,7 +1343,7 @@ create table fancy_table (
 --                  ^ punctuation.definition.parens.begin.sql
 --                   ^^^ meta.number.integer.decimal.sql constant.numeric.value.sql
 --                      ^ punctuation.definition.parens.end.sql
---                        ^^^^^^^^^^^^^^^^^^^ storage.modifier.mysql
+--                        ^^^^^^^^^^^^^^^^^^^ storage.modifier.sql
 --                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group.sql
 --                                            ^ punctuation.section.group.begin.sql
 --                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.sql
@@ -2388,14 +2388,14 @@ ALTER ONLINE IGNORE TABLE IF EXISTS tbl_name WAIT 100
 --                              ^ punctuation.separator.sequence.sql
 --                               ^ meta.number.integer.decimal.sql constant.numeric.value.sql
 --                                ^ punctuation.definition.parens.end.sql
---                                  ^^^^^^^^^^^^^^^^^^^ storage.modifier.mysql
+--                                  ^^^^^^^^^^^^^^^^^^^ storage.modifier.sql
 --                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group.sql
 --                                                      ^ punctuation.section.group.begin.sql
 --                                                       ^^^^^^^^ meta.column-name.sql
 --                                                               ^ keyword.operator.arithmetic.sql
 --                                                                ^^^^^^^^^^^^^^^ meta.column-name.sql
 --                                                                               ^ punctuation.section.group.end.sql
---                                                                                 ^^^^^^ storage.modifier.mysql
+--                                                                                 ^^^^^^ storage.modifier.sql
 --                                                                                       ^ punctuation.terminator.statement.sql
 
 -- ----------------------------------------------------------------------------

--- a/SQL/tests/syntax/syntax_test_postgres.psql
+++ b/SQL/tests/syntax/syntax_test_postgres.psql
@@ -495,9 +495,50 @@ ALTER TABLE mytable ADD flag VARCHAR(1) CHECK (code IN ('A', 'B', 'C')) DEFAULT 
 --                                                                                 ^ punctuation.terminator.statement.sql
 
 CREATE TABLE test1 (
-    name                     varchar(500)  NOT NULL PRIMARY KEY,
-    description              varchar       NOT NULL DEFAULT '',
-    authors                  varchar[],
+    id            BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.create.sql meta.table.sql meta.group.table-columns.sql
+--  ^^ meta.column-name.sql variable.other.member.declaration.sql
+--                ^^^^^^ storage.type.sql
+--                       ^^^^^^^^^^^^^^^^^^^ storage.modifier.sql
+--                                           ^^^^^^^^ storage.modifier.sql
+--                                                    ^^^^^^^^^^^ storage.modifier.sql
+--                                                               ^ punctuation.separator.sequence.sql
+    name          varchar(500)  NOT NULL PRIMARY KEY,
+--  ^^^^ meta.column-name.sql variable.other.member.declaration.sql
+--                ^^^^^^^^^^^^ storage.type.sql
+--                       ^^^^^ meta.parens.sql
+--                       ^ punctuation.definition.parens.begin.sql
+--                        ^^^ meta.number.integer.decimal.sql constant.numeric.value.sql
+--                           ^ punctuation.definition.parens.end.sql
+--                              ^^^ keyword.operator.logical.sql
+--                                  ^^^^ constant.language.null.sql
+--                                       ^^^^^^^^^^^ storage.modifier.sql
+--                                                  ^ punctuation.separator.sequence.sql
+    description   varchar       NOT NULL DEFAULT '',
+--  ^^^^^^^^^^^ meta.column-name.sql variable.other.member.declaration.sql
+--                ^^^^^^^ storage.type.sql
+--                              ^^^ keyword.operator.logical.sql
+--                                  ^^^^ constant.language.null.sql
+--                                       ^^^^^^^ storage.modifier.sql
+--                                               ^^ meta.string.sql string.quoted.single.sql
+--                                               ^ punctuation.definition.string.begin.sql
+--                                                ^ punctuation.definition.string.end.sql
+--                                                 ^ punctuation.separator.sequence.sql
+--  ^^^^^^^^^^^ meta.column-name.sql variable.other.member.declaration.sql
+--                ^^^^^^^ storage.type.sql
+--                              ^^^ keyword.operator.logical.sql
+--                                  ^^^^ constant.language.null.sql
+--                                       ^^^^^^^ storage.modifier.sql
+--                                               ^^ meta.string.sql string.quoted.single.sql
+--                                               ^ punctuation.definition.string.begin.sql
+--                                                ^ punctuation.definition.string.end.sql
+--                                                 ^ punctuation.separator.sequence.sql
+    authors       varchar[],
+--  ^^^^^^^ meta.column-name.sql variable.other.member.declaration.sql
+--                ^^^^^^^^^ storage.type.sql
+--                       ^ punctuation.section.brackets.begin.psql
+--                        ^ punctuation.section.brackets.end.psql
+--                         ^ punctuation.separator.sequence.sql
 );
 
 CREATE TABLE test2 (


### PR DESCRIPTION
1. add bailout to MySQL in case `generated always as` is not followed by expression group.
2. add `generated always as identity` to Postgre.
3. normalize related scopes to `.sql` as it looks odd to see combination of .mysql and .psql in Postgre