### PR TITLE
[YAML] Change scope of document boundary punctuation

### DIFF
--- a/YAML/YAML.sublime-syntax
+++ b/YAML/YAML.sublime-syntax
@@ -222,9 +222,9 @@ contexts:
 
   main:
     - match: ^---
-      scope: entity.other.document.begin.yaml
+      scope: punctuation.section.document.begin.yaml
     - match: ^\.{3}
-      scope: entity.other.document.end.yaml
+      scope: punctuation.section.document.end.yaml
     - include: directive
     - include: node
 

--- a/YAML/tests/syntax_test_general.yaml
+++ b/YAML/tests/syntax_test_general.yaml
@@ -18,12 +18,12 @@
 ## Document markers
 
 ---
-#^^ entity.other.document.begin
-# <- entity.other.document.begin
+#^^ punctuation.section.document.begin
+# <- punctuation.section.document.begin
 
 ...
-#^^ entity.other.document.end
-# <- entity.other.document.end
+#^^ punctuation.section.document.end
+# <- punctuation.section.document.end
 
 
 ##############################################################################


### PR DESCRIPTION
This PR proposes to change scope of `---` and `...` document boundary markers to `punctuation.section.document.[begin|end]`.