### PR TITLE
[SQL] Provide identifier and string prototype contexts

### DIFF
--- a/Go/Embeddings/SQL (for Go Embedded Backtick Strings).sublime-syntax
+++ b/Go/Embeddings/SQL (for Go Embedded Backtick Strings).sublime-syntax
@@ -8,14 +8,19 @@ hidden: true
 extends: Packages/SQL/SQL.sublime-syntax
 
 contexts:
-  prototype_without_comments:
+
+  prototype:
     - meta_prepend: true
     - include: scope:source.go#match-raw-text-content
 
-  string-escape:
+  comment-prototype:
     - meta_prepend: true
-    - include: scope:source.go#match-raw-string-content
+    - include: scope:source.go#match-raw-text-content
 
-  string-interpolation:
+  identifier-prototype:
+    - meta_prepend: true
+    - include: scope:source.go#match-raw-text-content
+
+  string-prototype:
     - meta_prepend: true
     - include: scope:source.go#match-raw-string-content

--- a/JavaScript/Embeddings/SQL (for JS template).sublime-syntax
+++ b/JavaScript/Embeddings/SQL (for JS template).sublime-syntax
@@ -9,6 +9,19 @@ hidden: true
 extends: Packages/SQL/SQL.sublime-syntax
 
 contexts:
+
   prototype:
     - meta_prepend: true
     - include: scope:source.js#text-interpolations
+
+  comment-prototype:
+    - meta_prepend: true
+    - include: scope:source.js#text-interpolations
+
+  identifier-prototype:
+    - meta_prepend: true
+    - include: scope:source.js#text-interpolations
+
+  string-prototype:
+    - meta_prepend: true
+    - include: scope:source.js#string-interpolations

--- a/JavaScript/Embeddings/SQL (for TS template).sublime-syntax
+++ b/JavaScript/Embeddings/SQL (for TS template).sublime-syntax
@@ -9,6 +9,19 @@ hidden: true
 extends: Packages/SQL/SQL.sublime-syntax
 
 contexts:
+
   prototype:
     - meta_prepend: true
     - include: scope:source.ts#text-interpolations
+
+  comment-prototype:
+    - meta_prepend: true
+    - include: scope:source.ts#text-interpolations
+
+  identifier-prototype:
+    - meta_prepend: true
+    - include: scope:source.ts#text-interpolations
+
+  string-prototype:
+    - meta_prepend: true
+    - include: scope:source.ts#string-interpolations

--- a/JavaScript/tests/syntax_test_js_template.js
+++ b/JavaScript/tests/syntax_test_js_template.js
@@ -349,6 +349,37 @@ var sql = sql`SELECT * FROM ${users};`
 /*                                  ^ punctuation.terminator.statement.sql - meta.interpolation.js */
 /*                                   ^ string.quoted.other.js punctuation.definition.string.end.js */
 
+var sql = SQL`"${this.tableName}"."createdAt" <= '${values.length}'`
+/*           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.template.js */
+/*           ^ string.quoted.other.js punctuation.definition.string.begin.js */
+/*            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sql.embedded.js */
+/*            ^^^^^^^^^^^^^^^^^^^ meta.string.sql */
+/*            ^ string.quoted.double.sql punctuation.definition.string.begin.sql */
+/*             ^^^^^^^^^^^^^^^^^ meta.interpolation.js */
+/*             ^^ punctuation.section.interpolation.begin.js */
+/*               ^^^^^^^^^^^^^^ source.js.embedded */
+/*               ^^^^ variable.language.this.js */
+/*                   ^ punctuation.accessor.js */
+/*                    ^^^^^^^^^ meta.property.object.js */
+/*                             ^ punctuation.section.interpolation.end.js */
+/*                              ^ string.quoted.double.sql punctuation.definition.string.end.sql */
+/*                               ^^^^^^^^^^^^ meta.column-name.sql */
+/*                               ^ punctuation.accessor.dot.sql */
+/*                                ^ punctuation.definition.identifier.begin.sql */
+/*                                          ^ punctuation.definition.identifier.end.sql */
+/*                                            ^^ keyword.operator.comparison.sql */
+/*                                               ^^^^^^^^^^^^^^^^^^ meta.string.sql */
+/*                                               ^ string.quoted.single.sql punctuation.definition.string.begin.sql */
+/*                                                ^^^^^^^^^^^^^^^^ meta.interpolation.js */
+/*                                                ^^ punctuation.section.interpolation.begin.js */
+/*                                                  ^^^^^^^^^^^^^ source.js.embedded */
+/*                                                  ^^^^^^ variable.other.readwrite.js */
+/*                                                        ^ punctuation.accessor.js */
+/*                                                         ^^^^^^ meta.property.object.js */
+/*                                                               ^ punctuation.section.interpolation.end.js */
+/*                                                                ^ string.quoted.single.sql punctuation.definition.string.end.sql */
+/*                                                                 ^ string.quoted.other.js punctuation.definition.string.end.js */
+
 /*
  * Unknown Template
  */

--- a/JavaScript/tests/syntax_test_typescript_template.ts
+++ b/JavaScript/tests/syntax_test_typescript_template.ts
@@ -350,6 +350,37 @@ var sql = sql`SELECT * FROM ${users};`
 /*                                  ^ punctuation.terminator.statement.sql - meta.interpolation.js */
 /*                                   ^ string.quoted.other.js punctuation.definition.string.end.js */
 
+var sql = SQL`"${this.tableName}"."createdAt" <= '${values.length}'`
+/*           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.template.js */
+/*           ^ string.quoted.other.js punctuation.definition.string.begin.js */
+/*            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sql.embedded.js */
+/*            ^^^^^^^^^^^^^^^^^^^ meta.string.sql */
+/*            ^ string.quoted.double.sql punctuation.definition.string.begin.sql */
+/*             ^^^^^^^^^^^^^^^^^ meta.interpolation.js */
+/*             ^^ punctuation.section.interpolation.begin.js */
+/*               ^^^^^^^^^^^^^^ source.js.embedded */
+/*               ^^^^ variable.language.this.js */
+/*                   ^ punctuation.accessor.js */
+/*                    ^^^^^^^^^ meta.property.object.js */
+/*                             ^ punctuation.section.interpolation.end.js */
+/*                              ^ string.quoted.double.sql punctuation.definition.string.end.sql */
+/*                               ^^^^^^^^^^^^ meta.column-name.sql */
+/*                               ^ punctuation.accessor.dot.sql */
+/*                                ^ punctuation.definition.identifier.begin.sql */
+/*                                          ^ punctuation.definition.identifier.end.sql */
+/*                                            ^^ keyword.operator.comparison.sql */
+/*                                               ^^^^^^^^^^^^^^^^^^ meta.string.sql */
+/*                                               ^ string.quoted.single.sql punctuation.definition.string.begin.sql */
+/*                                                ^^^^^^^^^^^^^^^^ meta.interpolation.js */
+/*                                                ^^ punctuation.section.interpolation.begin.js */
+/*                                                  ^^^^^^^^^^^^^ source.js.embedded */
+/*                                                  ^^^^^^ variable.other.readwrite.js */
+/*                                                        ^ punctuation.accessor.js */
+/*                                                         ^^^^^^ meta.property.object.js */
+/*                                                               ^ punctuation.section.interpolation.end.js */
+/*                                                                ^ string.quoted.single.sql punctuation.definition.string.end.sql */
+/*                                                                 ^ string.quoted.other.js punctuation.definition.string.end.js */
+
 /*
  * Unknown Template
  */

--- a/PHP/Embeddings/SQL (for PHP Interpolated).sublime-syntax
+++ b/PHP/Embeddings/SQL (for PHP Interpolated).sublime-syntax
@@ -7,9 +7,6 @@ hidden: true
 extends: Packages/SQL/SQL.sublime-syntax
 
 contexts:
-  prototype_without_comments:
-    - meta_prepend: true
-    - include: Packages/PHP/PHP Source.sublime-syntax#interpolations
 
   main:
     - meta_prepend: true
@@ -17,35 +14,18 @@ contexts:
     - match: \)
       scope: punctuation.section.group.end.sql
 
-###[ COMMENTS ]################################################################
-
-  inside-number-sign-comment:
+  prototype:
     - meta_append: true
     - include: Packages/PHP/PHP Source.sublime-syntax#interpolations
 
-  inside-double-dash-comment:
+  comment-prototype:
     - meta_append: true
     - include: Packages/PHP/PHP Source.sublime-syntax#interpolations
 
-  inside-comment-docblock:
-    - meta_append: true
-    - include: Packages/PHP/PHP Source.sublime-syntax#interpolations
-
-  inside-comment-block:
-    - meta_append: true
-    - include: Packages/PHP/PHP Source.sublime-syntax#interpolations
-
-###[ LITERALS ]################################################################
-
-  inside-like-single-quoted-string:
+  identifier-prototype:
     - meta_prepend: true
-    - include: Packages/PHP/PHP Source.sublime-syntax#string-interpolations
+    - include: Packages/PHP/PHP Source.sublime-syntax#interpolations
 
-  inside-single-quoted-string:
-    - meta_prepend: true
-    - include: Packages/PHP/PHP Source.sublime-syntax#string-interpolations
-
-  string-interpolations:
-    # this context is included in anonymous string contexts
+  string-prototype:
     - meta_prepend: true
     - include: Packages/PHP/PHP Source.sublime-syntax#string-interpolations

--- a/PHP/Embeddings/SQL (for PHP).sublime-syntax
+++ b/PHP/Embeddings/SQL (for PHP).sublime-syntax
@@ -7,16 +7,32 @@ hidden: true
 extends: Packages/SQL/SQL.sublime-syntax
 
 contexts:
-  prototype_without_comments:
-    - meta_prepend: true
-    - include: php-single-quoted-strings
-    - include: php-string-single-quoted-escapes
 
   main:
     - meta_prepend: true
     # prevent stray bracket highlighting
     - match: \)
       scope: punctuation.section.group.end.sql
+
+  prototype:
+    - meta_prepend: true
+    - include: php-single-quoted-strings
+    - include: php-string-single-quoted-escapes
+
+  comment-prototype:
+    - meta_prepend: true
+    - include: php-single-quoted-strings
+    - include: php-string-single-quoted-escapes
+
+  identifier-prototype:
+    - meta_prepend: true
+    - include: php-single-quoted-strings
+    - include: php-string-single-quoted-escapes
+
+  string-prototype:
+    - meta_prepend: true
+    - include: php-single-quoted-strings
+    - include: php-string-single-quoted-escapes
 
   php-string-single-quoted-escapes:
     - match: \\[\\']

--- a/Rails/SQL (Rails).sublime-syntax
+++ b/Rails/SQL (Rails).sublime-syntax
@@ -16,35 +16,14 @@ contexts:
     - meta_prepend: true
     - include: HTML (Rails).sublime-syntax#rails-embedded
 
-###[ COMMENTS ]################################################################
-
-  inside-number-sign-comment:
-    - meta_append: true
+  comment-prototype:
+    - meta_prepend: true
     - include: HTML (Rails).sublime-syntax#rails-embedded
 
-  inside-double-dash-comment:
-    - meta_append: true
+  identifier-prototype:
+    - meta_prepend: true
     - include: HTML (Rails).sublime-syntax#rails-embedded
 
-  inside-comment-docblock:
-    - meta_append: true
-    - include: HTML (Rails).sublime-syntax#rails-embedded
-
-  inside-comment-block:
-    - meta_append: true
-    - include: HTML (Rails).sublime-syntax#rails-embedded
-
-###[ LITERALS ]################################################################
-
-  inside-like-single-quoted-string:
-    - meta_append: true
-    - include: HTML (Rails).sublime-syntax#rails-interpolations
-
-  inside-single-quoted-string:
-    - meta_append: true
-    - include: HTML (Rails).sublime-syntax#rails-interpolations
-
-  string-interpolations:
-    # this context is included in anonymous string contexts
-    - meta_append: true
+  string-prototype:
+    - meta_prepend: true
     - include: HTML (Rails).sublime-syntax#rails-interpolations

--- a/Ruby/Embeddings/SQL (for Ruby).sublime-syntax
+++ b/Ruby/Embeddings/SQL (for Ruby).sublime-syntax
@@ -8,53 +8,26 @@ extends: Packages/SQL/SQL.sublime-syntax
 
 contexts:
 
-###[ COMMENTS ]################################################################
-
   comments:
     # Notes:
     # 1. comments are included in `prototype` thus apply everywhere
     # 2. prepend patterns here to ensure Ruby interpolation `#{...}` takes
     #    precedence over any kind of comment (e.g. number-sighn comments).
     - meta_prepend: true
-    - include: embedded-ruby
-
-  inside-number-sign-comment:
-    # Explicitly prepend embedded-ruby as `prototype` is not included
-    # in comments due to comments being included in `prototype`.
-    - meta_append: true
-    - include: embedded-ruby
-
-  inside-double-dash-comment:
-    - meta_append: true
-    - include: embedded-ruby
-
-  inside-comment-docblock:
-    - meta_append: true
-    - include: embedded-ruby
-
-  inside-comment-block:
-    - meta_append: true
-    - include: embedded-ruby
-
-  embedded-ruby:
     - include: Ruby.sublime-syntax#escaped-char
     - include: Ruby.sublime-syntax#embedded-ruby
 
-###[ LITERALS ]################################################################
+  comment-prototype:
+    - meta_prepend: true
+    - include: Ruby.sublime-syntax#escaped-char
+    - include: Ruby.sublime-syntax#embedded-ruby
 
-  inside-like-single-quoted-string:
-    - meta_append: true
-    - include: interpolated-ruby
+  identifier-prototype:
+    - meta_prepend: true
+    - include: Ruby.sublime-syntax#escaped-char
+    - include: Ruby.sublime-syntax#embedded-ruby
 
-  inside-single-quoted-string:
-    - meta_append: true
-    - include: interpolated-ruby
-
-  string-interpolations:
-    # this context is included in anonymous string contexts
-    - meta_append: true
-    - include: interpolated-ruby
-
-  interpolated-ruby:
+  string-prototype:
+    - meta_prepend: true
     - include: Ruby.sublime-syntax#escaped-char
     - include: Ruby.sublime-syntax#interpolated-ruby

--- a/SQL/MySQL.sublime-syntax
+++ b/SQL/MySQL.sublime-syntax
@@ -120,6 +120,7 @@ contexts:
     - meta_scope: comment.line.number-sign.sql
     - match: \n
       pop: 1
+    - include: comment-prototype
 
 ###[ DECLARE STATEMENTS ]######################################################
 
@@ -1902,6 +1903,7 @@ contexts:
     - match: /
       scope: punctuation.definition.string.end.sql
       pop: 1
+    - include: string-prototype
     - include: string-interpolations
     - match: \\/
       scope: constant.character.escape.slash.sql
@@ -1924,6 +1926,7 @@ contexts:
     - match: \"
       scope: punctuation.definition.string.end.sql
       pop: 1
+    - include: string-prototype
     - include: string-interpolations
 
   interpolations:
@@ -1937,6 +1940,7 @@ contexts:
     - match: \}
       scope: punctuation.definition.string.end.sql
       pop: 1
+    - include: string-prototype
     - include: string-interpolations
 
   string-interpolations:
@@ -1954,6 +1958,7 @@ contexts:
     - match: \'
       scope: meta.string.mysql punctuation.definition.string.end.mysql
       pop: 1
+    - include: string-prototype
     - match: '[$.\[\]]'
       scope: punctuation.accessor.mysql
     - match: \w+

--- a/SQL/PostgreSQL.sublime-syntax
+++ b/SQL/PostgreSQL.sublime-syntax
@@ -363,6 +363,7 @@ contexts:
     - match: \'
       scope: punctuation.definition.string.end.sql
       pop: 1
+    - include: string-prototype
     - match: \\[0-7]{1,3}
       scope: constant.character.escape.sql
     - match: \\x\h{1,2}
@@ -381,6 +382,7 @@ contexts:
     - match: \'
       scope: punctuation.definition.string.end.sql
       pop: 1
+    - include: string-prototype
     - match: \\[0-7]{1,3}
       scope: constant.character.escape.sql
     - match: \\x\h{8}

--- a/SQL/SQL (basic).sublime-syntax
+++ b/SQL/SQL (basic).sublime-syntax
@@ -63,9 +63,6 @@ variables:
 contexts:
   prototype:
     - include: comments
-    - include: prototype_without_comments
-
-  prototype_without_comments: []
 
   main:
     - include: sql
@@ -108,6 +105,7 @@ contexts:
     - meta_scope: comment.line.double-dash.sql
     - match: \n
       pop: 1
+    - include: comment-prototype
 
   inside-comment-docblock:
     - meta_scope: comment.block.documentation.sql
@@ -117,6 +115,7 @@ contexts:
     - match: ^\s*(\*)(?!\**/)
       captures:
         1: punctuation.definition.comment.sql
+    - include: comment-prototype
     - include: merge-conflict-markers
 
   inside-comment-block:
@@ -124,7 +123,10 @@ contexts:
     - match: \*+/
       scope: punctuation.definition.comment.end.sql
       pop: 1
+    - include: comment-prototype
     - include: merge-conflict-markers
+
+  comment-prototype: []
 
 ###[ MERGE CONFLICT MARKERS ]##################################################
 
@@ -1063,6 +1065,7 @@ contexts:
   inside-user-type:
     # note: may contain foreign variable interpolation
     - meta_scope: support.type.sql
+    - include: identifier-prototype
     - match: '{{simple_identifier_break}}'
       pop: 1
 
@@ -1423,6 +1426,7 @@ contexts:
     - match: \`
       scope: punctuation.definition.identifier.end.sql
       pop: 1
+    - include: identifier-prototype
 
   double-quoted-identifier-part:
     - match: \"
@@ -1432,10 +1436,10 @@ contexts:
   inside-double-quoted-identifier-part:
     # note: may contain foreign variable interpolation
     - meta_include_prototype: false
-    - include: prototype_without_comments
     - match: \"
       scope: punctuation.definition.identifier.end.sql
       pop: 1
+    - include: identifier-prototype
 
   single-quoted-identifier-part:
     - match: \'
@@ -1445,10 +1449,10 @@ contexts:
   inside-single-quoted-identifier-part:
     # note: may contain foreign variable interpolation
     - meta_include_prototype: false
-    - include: prototype_without_comments
     - match: \'
       scope: punctuation.definition.identifier.end.sql
       pop: 1
+    - include: identifier-prototype
 
   simple-identifier-part:
     - match: (?=\S)
@@ -1456,8 +1460,12 @@ contexts:
 
   inside-simple-identifier-part:
     # note: may contain foreign variable interpolation
+    - meta_include_prototype: false
+    - include: identifier-prototype
     - match: '{{simple_identifier_break}}'
       pop: 1
+
+  identifier-prototype: []
 
   wildcard-identifiers:
     - match: \*
@@ -1502,11 +1510,14 @@ contexts:
     - match: \'
       scope: punctuation.definition.string.end.sql
       pop: 1
+    - include: string-prototype
     - include: string-escapes
 
   string-escapes:
     - match: '{{string_escape}}'
       scope: constant.character.escape.sql
+
+  string-prototype: []
 
 ###[ LIKE EXPRESSIONS ]########################################################
 
@@ -1597,6 +1608,7 @@ contexts:
     - match: \'
       scope: punctuation.definition.string.end.sql
       pop: 1
+    - include: string-prototype
     - match: '%'
       scope: constant.other.wildcard.percent.sql
     - match: '_'


### PR DESCRIPTION
This PR...

1. provides dedicated contexts 3rd-party syntaxes can prepend rules to, in order to add interpolation support to identifiers and literal strings.
2. applies new context structure to existing template syntaxes (ERB, Go, PHP, Ruby).
3. extends SQL for template strings in JavaScript/TypeScript (addresses #4463).
