### PR TITLE
[D] Fix struct literals

### DIFF
--- a/D/D.sublime-syntax
+++ b/D/D.sublime-syntax
@@ -1335,8 +1335,9 @@ contexts:
           set: [value-group-after-parens, function-argument, function-argument-or-type]
         - match: '(?=\S)'
           set: [value-group-after, value]
-    - match: '(?={)'
-      set: [value-after, block-statement]
+    - match: '\{'
+      scope: punctuation.section.block.begin.d
+      set: [value-block-after, value-array-list]
     - match: '\['
       scope: punctuation.section.brackets.begin.d
       set: [value-bracket-after, value-array-list]
@@ -1605,6 +1606,12 @@ contexts:
     - match: ':'
       scope: keyword.operator.ternary.d
       set: value
+    - include: not-whitespace-illegal-pop
+  value-block-after:
+    - meta_scope: meta.block.d
+    - match: \}
+      scope: punctuation.section.block.end.d
+      set: value-after
     - include: not-whitespace-illegal-pop
   value-parens-after:
     - match: '\)'

--- a/D/tests/syntax_test_d.d
+++ b/D/tests/syntax_test_d.d
@@ -2063,15 +2063,21 @@ extern(1)
 //                 ^ punctuation.section.group.end.d
 //                   ^ punctuation.section.block.begin.d
     template a(size_t f) {
-  //^^^^^^^^ keyword.declaration.template.d
-  //         ^ entity.name.template.d
-  //          ^ punctuation.section.group.begin.d
-  //           ^^^^^^ support.type.builtin-alias.d
-  //                  ^ variable.parameter.d
-  //                   ^ punctuation.section.group.end.d
-  //                     ^ punctuation.section.block.begin.d
+//  ^^^^^^^^ keyword.declaration.template.d
+//           ^ entity.name.template.d
+//            ^ punctuation.section.group.begin.d
+//             ^^^^^^ support.type.builtin-alias.d
+//                    ^ variable.parameter.d
+//                     ^ punctuation.section.group.end.d
+//                       ^ punctuation.section.block.begin.d
+      T a;
+//    ^ storage.type.d
+//      ^ variable.other.d
+//       ^ punctuation.terminator.d
     }
-  //^ punctuation.section.block.end.d
+// <- meta.block.d meta.block.d
+//^^^ meta.block.d meta.block.d
+//  ^ punctuation.section.block.end.d
   }
 //^ punctuation.section.block.end.d
   template foo(T) if (is(T : class)) {}
@@ -2091,20 +2097,25 @@ extern(1)
 //                                 ^ punctuation.section.parens.end.d
 //                                   ^ punctuation.section.block.begin.d
 //                                    ^ punctuation.section.block.end.d
-  @property foo(T) = {
+
+// https://dlang.org/spec/function.html#property-functions
+  @property foo(T) {
 //^^^^^^^^^ storage.modifier.d
+//          ^^^ meta.function.d
+//             ^^^ meta.function.parameters.d
+//                 ^^ meta.function.d meta.block.d
 //          ^^^ entity.name.function.d
 //             ^ punctuation.section.group.begin.d
 //              ^ variable.parameter.d
 //               ^ punctuation.section.group.end.d
-//                 ^ keyword.operator.assignment.d
-//                   ^ punctuation.section.block.begin.d
+//                 ^ punctuation.section.block.begin.d
     T a;
-  //^ storage.type.d
-  //  ^ variable.other.d
-  //   ^ punctuation.terminator.d
+//  ^ storage.type.d
+//    ^ variable.other.d
+//     ^ punctuation.terminator.d
   }();
-//^ punctuation.section.block.end.d
+// <- meta.function.d meta.block.d
+//^ meta.function.d meta.block.d punctuation.section.block.end.d
 // ^ punctuation.section.parens.begin.d
 //  ^ punctuation.section.parens.end.d
 //   ^ punctuation.terminator.d
@@ -2118,6 +2129,10 @@ extern(1)
 //                     ^ variable.parameter.d
 //                      ^ punctuation.section.group.end.d
 //                        ^ punctuation.section.block.begin.d
+    T a;
+//  ^ storage.type.d
+//    ^ variable.other.d
+//     ^ punctuation.terminator.d
   }
 //^ punctuation.section.block.end.d
   mixin Foo!("foo");
@@ -2207,6 +2222,10 @@ extern(1)
 //    ^ meta.number.integer.decimal.d
 //     ^ punctuation.section.parens.end.d
 //       ^ punctuation.section.block.begin.d
+    T s;
+//  ^ storage.type.d
+//    ^ variable.other.d
+//     ^ punctuation.terminator.d
   }
 //^ punctuation.section.block.end.d
   if (1) {} else {}
@@ -2288,6 +2307,10 @@ extern(1)
   //^^ keyword.control.loop.d
     {
   //^ punctuation.section.block.begin.d
+      T s;
+  //  ^ storage.type.d
+  //    ^ variable.other.d
+  //     ^ punctuation.terminator.d
     } while (1);
   //^ punctuation.section.block.end.d
   //  ^^^^^ keyword.control.loop.d
@@ -2316,6 +2339,10 @@ extern(1)
 //           ^ meta.number.integer.decimal.d
 //            ^ punctuation.section.parens.end.d
 //              ^ punctuation.section.block.begin.d
+    T s;
+//  ^ storage.type.d
+//    ^ variable.other.d
+//     ^ punctuation.terminator.d
   }
 //^ punctuation.section.block.end.d
   for(int a;;12) {
@@ -3020,6 +3047,22 @@ extern(1)
 //                      ^ meta.number.integer.decimal.d
 //                       ^ punctuation.section.parens.end.d
 //                        ^ punctuation.terminator.d
+  (int foo) => { id: "value", name: foo };
+//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.d
+//          ^^ meta.function.d keyword.declaration.function.anonymous.d
+//             ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.d
+//             ^ punctuation.section.block.begin.d
+//               ^^ variable.other.d
+//                 ^ punctuation.separator.key-value.d
+//                   ^^^^^^^ meta.string.d string.quoted.double.d
+//                   ^ punctuation.definition.string.begin.d
+//                         ^ punctuation.definition.string.end.d
+//                          ^ punctuation.separator.sequence.d
+//                            ^^^^ variable.other.d
+//                                ^ punctuation.separator.key-value.d
+//                                  ^^^ variable.other.d
+//                                      ^ punctuation.section.block.end.d
+//                                       ^ punctuation.terminator.d
   (foo..., bar) @safe {};
 //^ punctuation.section.group.begin.d
 // ^^^ variable.other.d
@@ -3542,8 +3585,8 @@ extern(1)
 //    ^ keyword.operator.assignment.d
 //      ^^^^^^^^^^^^^^^^^ meta.block.d
 //      ^ punctuation.section.block.begin.d
-//        ^ entity.name.label.d
-//         ^ punctuation.separator.d
+//        ^ variable.other.d
+//         ^ punctuation.separator.key-value.d
 //           ^ meta.number.integer.decimal.d
 //            ^ punctuation.separator.sequence.d
 //              ^ variable.other.d
@@ -3596,3 +3639,4 @@ extern(1)
 //               ^ keyword.operator.assignment.d
 //                 ^^ constant.numeric.value.d
 //                   ^ punctuation.section.parens.end.d
+


### PR DESCRIPTION
Fixes #4465 

This PR adds support for struct literals, following specification of https://dlang.org/spec/struct.html#static_struct_init.

All braces within expressions are treated literal structs, while braces after statements remain statement blocks.

Note: Fixes a test of potentially invalid `@property function() ...` syntax, according to https://dlang.org/spec/function.html#property-functions
