### PR TITLE
[C#] Fix null checks

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -1324,7 +1324,7 @@ contexts:
     - match: \b(as|is(?:\s+not)?)\s+
       captures:
         1: keyword.operator.reflection.cs
-      push: [maybe_pattern_matching_object, type_no_space_pop_if_anonymous]
+      push: [maybe_pattern_matching_object, maybe_type_or_null]
     - match: \b(checked|unchecked)\b
       scope: keyword.other.cs
       push:
@@ -1429,7 +1429,10 @@ contexts:
           set: [constructor_arguments, arguments]
         - include: type
 
-  type_no_space_pop_if_anonymous:
+  maybe_type_or_null:
+    - match: null\b
+      scope: constant.language.null.cs
+      pop: 2
     - match: (?=\{)
       pop: true
     - include: type_no_space

--- a/C#/tests/syntax_test_C#9.cs
+++ b/C#/tests/syntax_test_C#9.cs
@@ -296,6 +296,17 @@ Point p = new (3, 5);
 ///                ^ punctuation.section.group.end
 ///                 ^ punctuation.terminator.statement
 
+if (input is null) { }
+/// ^^^^^ variable.other
+///       ^^ keyword.operator.reflection
+///          ^^^^ constant.language.null.cs
+
+if (input is not null) { }
+/// ^^^^^ variable.other
+///       ^^ keyword.operator.reflection
+///          ^^^ keyword.operator.reflection.cs
+///              ^^^^ constant.language.null.cs
+
 if (e is not Customer) { }
 ///   ^^^^^^ keyword.operator.reflection
 ///          ^^^^^^^^ support.type


### PR DESCRIPTION
This PR adds support for `var is [not] null` checks, introduced by C#9.

see: https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-version-history#c-version-9