### PR TITLE
[C#] Align scope of generic type parameters

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -1853,17 +1853,20 @@ contexts:
       pop: true
     - match: ','
       scope: punctuation.separator.type.cs
-    - include: type
 
   type_argument:
     - meta_content_scope: meta.generic.cs
     - include: type_arg_param_common
+    - include: type
 
   type_parameter:
     - meta_content_scope: meta.generic.cs
+    - include: type_arg_param_common
+    - include: type_common_except_bare_custom_type
     - match: (?:in|out)\b
       scope: storage.modifier.cs
-    - include: type_arg_param_common
+    - match: '{{name}}'
+      scope: variable.parameter.type.cs
 
   type_no_space:
     - include: type

--- a/C#/tests/syntax_test_C#14.cs
+++ b/C#/tests/syntax_test_C#14.cs
@@ -120,7 +120,7 @@ delegate bool TryParse<T>(string text, out T result);
 //            ^^^^^^^^ variable.other.member.delegate.cs
 //                    ^^^ meta.generic.cs
 //                    ^ punctuation.definition.generic.begin.cs
-//                     ^ support.type.cs
+//                     ^ variable.parameter.type.cs
 //                      ^ meta.delegate.cs meta.generic.cs punctuation.definition.generic.end.cs
 //                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.delegate.parameters.cs
 //                       ^ punctuation.section.parameters.begin.cs

--- a/C#/tests/syntax_test_C#7.cs
+++ b/C#/tests/syntax_test_C#7.cs
@@ -105,9 +105,9 @@ class Foo {
 ///                      ^^^ entity.name.function
 ///                         ^^^^^^ meta.generic
 ///                         ^ punctuation.definition.generic.begin
-///                          ^ support.type
+///                          ^ variable.parameter.type
 ///                           ^ punctuation.separator
-///                             ^ support.type
+///                             ^ variable.parameter.type
 ///                              ^ punctuation.definition.generic.end
 ///                               ^^^^^^^ meta.method.parameters
 ///                               ^ punctuation.section.parameters.begin
@@ -760,10 +760,10 @@ public delegate void SpanAction<T, in TArg>(Span<T> span, TArg arg) ;
 ///             ^^^^ storage.type
 ///                  ^^^^^^^^^^ variable.other.member.delegate
 ///                            ^^^^^^^^^^^^ meta.generic
-///                             ^ support.type
+///                             ^ variable.parameter.type
 ///                              ^ punctuation.separator.type
 ///                                ^^ storage.modifier
-///                                   ^^^^ support.type
+///                                   ^^^^ variable.parameter.type
 ///                                                                 ^ punctuation.terminator.statement.cs
 
 void Test ()

--- a/C#/tests/syntax_test_C#9.cs
+++ b/C#/tests/syntax_test_C#9.cs
@@ -331,7 +331,7 @@ public record B<T>(T Num)<NoGeneric>;
 ///           ^ entity.name.class
 ///            ^^^ meta.generic
 ///            ^ punctuation.definition.generic.begin
-///             ^ support.type
+///             ^ variable.parameter.type
 ///              ^ punctuation.definition.generic.end
 ///               ^ punctuation.section.parameters.begin
 ///                     ^ punctuation.section.parameters.end
@@ -344,7 +344,7 @@ public record C<TNum> (TNum Num) where TNum : class;
 ///    ^^^^^^ keyword.declaration.class.record
 ///           ^ entity.name.class
 ///            ^ punctuation.definition.generic.begin
-///             ^^^^ support.type
+///             ^^^^ variable.parameter.type
 ///                 ^ punctuation.definition.generic.end
 ///                   ^ punctuation.section.parameters.begin
 ///                    ^^^^ support.type
@@ -363,7 +363,7 @@ public record D<TNum> (TNum Num) where TNum : class { public const int TEST = 4;
 ///    ^^^^^^ keyword.declaration.class.record
 ///           ^ entity.name.class
 ///            ^ punctuation.definition.generic.begin
-///             ^^^^ support.type
+///             ^^^^ variable.parameter.type
 ///                 ^ punctuation.definition.generic.end
 ///                   ^ punctuation.section.parameters.begin
 ///                    ^^^^ support.type
@@ -420,7 +420,7 @@ public class MyClass { public record MyRecord <T> (int nums) { public const int 
 ///                           ^^^^^^ keyword.declaration.class.record
 ///                                  ^^^^^^^^ entity.name.class
 ///                                           ^ punctuation.definition.generic.begin
-///                                            ^ support.type
+///                                            ^ variable.parameter.type
 ///                                             ^ punctuation.definition.generic.end
 ///                                               ^ meta.class.constructor.parameters punctuation.section.parameters.begin
 ///                                                ^^^ storage.type

--- a/C#/tests/syntax_test_GeneralStructure.cs
+++ b/C#/tests/syntax_test_GeneralStructure.cs
@@ -668,7 +668,7 @@ namespace TestNamespace . Test
 ///                      ^^^ entity.name.function
 ///                                     ^^^ meta.generic
 ///                                     ^ punctuation.definition.generic.begin
-///                                      ^ support.type
+///                                      ^ variable.parameter.type
 ///                                         ^ support.type
 ///                                           ^ variable.parameter
 ///                                               ^ variable.function
@@ -840,9 +840,9 @@ namespace TestNamespace . Test
 ///                             ^ variable.other.member.delegate
 ///                                      ^^^^^^^^^^^^^^^^^ meta.generic
 ///                                      ^ punctuation.definition.generic.begin
-///                                       ^^^^^^ support.type
+///                                       ^^^^^^ variable.parameter.type
 ///                                             ^ punctuation.separator
-///                                               ^^^^^^^ support.type
+///                                               ^^^^^^^ variable.parameter.type
 ///                                                      ^ punctuation.definition.generic.end
 ///                                                        ^^^^^^^^^^^^^ meta.delegate.parameters
 ///                                                        ^ - meta.delegate meta.delegate


### PR DESCRIPTION
Resolves #4473

This PR changes scope of type parameters to `variable.parameter.type` to align with Go, Java, JavaScript and Python.

Separate scopes for type parameter declaration and type parameter references intend to help with visually distinct generic definitions from references and maybe also enable Goto Definition vs. Goto Reference.