### PR TITLE
[Erlang] Change variadic operator scopes

### DIFF
--- a/Erlang/Erlang.sublime-syntax
+++ b/Erlang/Erlang.sublime-syntax
@@ -1070,7 +1070,7 @@ contexts:
       scope: punctuation.section.parameters.begin.erlang
       set:
         - meta_scope: meta.fun.parameters.erlang
-        - include: variable-any
+        - include: variadic-operators
         - include: parameters-common
         - include: type-parameter
     - include: else-pop
@@ -1164,7 +1164,7 @@ contexts:
       scope: punctuation.section.sequence.begin.erlang
       push:
         - meta_scope: meta.sequence.list.erlang
-        - include: variable-any
+        - include: variadic-operators
         - include: list-common
         - include: type-expressions
 
@@ -1174,7 +1174,7 @@ contexts:
       scope: punctuation.section.sequence.begin.erlang
       push:
         - meta_scope: meta.sequence.list.erlang
-        - include: variable-any
+        - include: variadic-operators
         - include: list-common
         - include: type-parameter
 
@@ -1383,7 +1383,7 @@ contexts:
       scope: punctuation.section.sequence.begin.erlang
       push:
         - meta_scope: meta.sequence.tuple.erlang
-        - include: variable-any
+        - include: variadic-operators
         - include: tuple-common
         - include: type-expressions
 
@@ -1393,7 +1393,7 @@ contexts:
       scope: punctuation.section.sequence.begin.erlang
       push:
         - meta_scope: meta.sequence.tuple.erlang
-        - include: variable-any
+        - include: variadic-operators
         - include: tuple-common
         - include: type-parameter
 
@@ -1547,10 +1547,6 @@ contexts:
     - match: _{{ident_break}}
       scope: variable.language.anonymous.erlang
       pop: 1
-
-  variable-any:
-    - match: \.{3}
-      scope: variable.language.any.erlang
 
   variable-other:
     - match: '{{variable}}'
@@ -2049,6 +2045,10 @@ contexts:
     - include: else-pop
 
 ###[ OPERATORS ]##############################################################
+
+  variadic-operators:
+    - match: \.{3}
+      scope: keyword.operator.variadic.erlang
 
   operator-comprehension:
     - match: \|\|

--- a/Erlang/syntax_test_erlang.erl
+++ b/Erlang/syntax_test_erlang.erl
@@ -2680,7 +2680,7 @@ preprocessor_spec_tests() -> .
 %                                                    ^ punctuation.section.sequence.begin.erlang
 %                                                     ^^^^ support.type.erlang
 %                                                           ^ punctuation.separator.sequence.erlang
-%                                                             ^^^ variable.language.any.erlang
+%                                                             ^^^ keyword.operator.variadic.erlang
 %                                                                ^ punctuation.terminator.clause.erlang
 
 -spec Foo.
@@ -3317,7 +3317,7 @@ preprocessor_fun_type_tests() -> .
 %              ^^^ support.type.erlang
 %                 ^ punctuation.section.arguments.begin.erlang
 %                  ^ punctuation.section.parameters.begin.erlang
-%                   ^^^ variable.language.any.erlang
+%                   ^^^ keyword.operator.variadic.erlang
 %                      ^ punctuation.section.parameters.end.erlang
 %                        ^^ punctuation.separator.parameters-return-type.erlang
 %                           ^^^ storage.type.erlang


### PR DESCRIPTION
This PR changes scope of `...` to `keyword.operator.variadic` to align with all other syntaxes in this repo.