### PR TITLE
[Scala] Tweak varargs scopes

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -712,7 +712,7 @@ contexts:
           set:
             - match: '(\*)\s*(?=[\),=])'
               captures:
-                1: keyword.operator.varargs.scala
+                1: keyword.operator.quantifier.scala
             - match: '(?=\))'
               pop: 1
             - match: ','
@@ -840,7 +840,7 @@ contexts:
               set:
                 - match: '(\*)\s*(?=[\),=])'
                   captures:
-                    1: keyword.operator.varargs.scala
+                    1: keyword.operator.quantifier.scala
                 - match: '(?=\))'
                   pop: 1
                 - match: ','
@@ -890,7 +890,7 @@ contexts:
               set:
                 - match: '(\*)\s*(?=[\),=])'
                   captures:
-                    1: keyword.operator.varargs.scala
+                    1: keyword.operator.quantifier.scala
                 - match: '(?=\))'
                   pop: 1
                 - match: ','
@@ -1732,10 +1732,10 @@ contexts:
     - match: '{{op}}'     # let it fall through
     - match: '@'
       scope: keyword.operator.at.scala
-    - match: '_\s*\*'
-      scope: keyword.operator.varargs.scala
-    - match: '_'
-      scope: variable.language.anonymous.scala
+    - match: '(_)(?:\s*(\*))?'
+      captures:
+        1: variable.language.anonymous.scala
+        2: keyword.operator.quantifier.scala
     - match: ','
       scope: punctuation.separator.scala
     - include: ascription
@@ -1872,10 +1872,10 @@ contexts:
         - include: delimited-type-expression
     - match: '@'
       scope: keyword.operator.at.scala
-    - match: '_\s*\*'
-      scope: keyword.operator.varargs.scala
-    - match: '_'
-      scope: variable.language.anonymous.scala
+    - match: '(_)(?:\s*(\*))?'
+      captures:
+        1: variable.language.anonymous.scala
+        2: keyword.operator.quantifier.scala
     - match: ','
       scope: punctuation.separator.scala
     - match: (?=\})
@@ -1938,8 +1938,10 @@ contexts:
           scope: punctuation.definition.block.end.scala
           pop: 1
         - include: declarations
-    - match: '_\s*\*'
-      scope: keyword.operator.varargs.scala
+    - match: '(_)(?:\s*(\*))?'
+      captures:
+        1: variable.language.anonymous.scala
+        2: keyword.operator.quantifier.scala
     # the whitespace covering is required to deal with the very aggressive scope popping for single type exprs
     - match: '\s*(=>>)\s*'
       captures:

--- a/Scala/tests/syntax_test_scala.scala
+++ b/Scala/tests/syntax_test_scala.scala
@@ -1195,15 +1195,18 @@ foo({ _: Unit => () })
 //            ^^ keyword.declaration.function.arrow
 
   stuff: _*
-//       ^^ keyword.operator.varargs.scala
+//       ^ variable.language.anonymous.scala
+//        ^ keyword.operator.quantifier.scala
 
 {
   case _ @ _* =>
-//         ^^ keyword.operator.varargs.scala
+//         ^ variable.language.anonymous.scala
+//          ^ keyword.operator.quantifier.scala
 }
 
   val _ @ _* = things
-//        ^^ keyword.operator.varargs.scala
+//        ^ variable.language.anonymous.scala
+//         ^ keyword.operator.quantifier.scala
 
 s"testing ${things} and more!"
 //          ^^^^^^ - string
@@ -1486,9 +1489,9 @@ new {
 }
 
 def foo(a: String*, b: (Int => String)*, c: Int*): Negative*
-//               ^ keyword.operator.varargs.scala
-//                                    ^ keyword.operator.varargs.scala
-//                                             ^ keyword.operator.varargs.scala
+//               ^ keyword.operator.quantifier.scala
+//                                    ^ keyword.operator.quantifier.scala
+//                                             ^ keyword.operator.quantifier.scala
 //                                                         ^ - support
 
 def foo[A[_] <: B](a: Int + String): Unit
@@ -1502,7 +1505,7 @@ def foo[A[_] <: B](a: Int + String): Unit
 //                                ^ punctuation.section.group.end.scala
 
 class Foo(a: String*)
-//                 ^ keyword.operator.varargs.scala
+//                 ^ keyword.operator.quantifier.scala
 
 class Foo(a: String* )
 //                  ^ - keyword
@@ -1981,7 +1984,8 @@ Data.Boolean()
         prop { k: Int Refined RPositive => }
 
 tail: _ *
-//    ^^^ keyword.operator.varargs.scala
+//    ^ variable.language.anonymous.scala
+//      ^ keyword.operator.quantifier.scala
 
     val Message(
       Address(from),


### PR DESCRIPTION
This commit scopes anonymous and named varargs expressions using existing scopes of other languages.

see also: https://www.scala-lang.org/api/current/scala/quoted/Varargs$.html

Basically current Scala syntax definition supports two forms of varargs

  1. expr*
  2. _*

Considerations:

  1. Both look like regexp patterns followed by `*` quantifier.
  2. The underscore is used whenever a variable name is not needed.
  3. Python supports a comparable unpacking expression `*_`.

Combining those two points, results in ...

  1. scoping `*` as `keyword.operator.quantifier` which RegExp uses for it.
  2. scoping `_` in front of `*` as `variable.language.anonymous`.