### PR TITLE
[Scala] Change block and group punctuation scopes

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -1918,10 +1918,10 @@ contexts:
       scope: punctuation.terminator.scala
       pop: 1
     - match: \(
-      scope: punctuation.definition.group.begin.scala
+      scope: punctuation.section.group.begin.scala
       push:
         - match: \)
-          scope: punctuation.definition.group.end.scala
+          scope: punctuation.section.group.end.scala
           pop: 1
         - include: delimited-type-group-expression
     - match: \[
@@ -1932,10 +1932,10 @@ contexts:
           pop: 1
         - include: delimited-type-expression
     - match: \{
-      scope: punctuation.definition.block.begin.scala
+      scope: punctuation.section.block.begin.scala
       push:
         - match: \}
-          scope: punctuation.definition.block.end.scala
+          scope: punctuation.section.block.end.scala
           pop: 1
         - include: declarations
     - match: '_\s*\*'
@@ -2110,10 +2110,10 @@ contexts:
           set: single-type-expression-tail
         - include: delimited-type-expression
     - match: '\('
-      scope: punctuation.definition.group.begin.scala
+      scope: punctuation.section.group.begin.scala
       set:
         - match: '\)'
-          scope: punctuation.definition.group.end.scala
+          scope: punctuation.section.group.end.scala
           set: single-type-expression-tail
         - include: delimited-type-group-expression
     - include: base-type-expression
@@ -2185,10 +2185,10 @@ contexts:
       scope: support.type.scala
       set: single-type-expression-tail-no-function-type-expectation
     - match: '\{'
-      scope: punctuation.definition.block.begin.scala
+      scope: punctuation.section.block.begin.scala
       set:
         - match: \}
-          scope: punctuation.definition.block.end.scala
+          scope: punctuation.section.block.end.scala
           set: single-type-expression-tail-no-function
         - include: main
     - match: '(?=\()'
@@ -2245,11 +2245,11 @@ contexts:
       scope: support.type.scala
       set: single-type-expression-tail-no-function-no-or-type-expectation
     - match: '\{'
-      scope: punctuation.definition.block.begin.scala
+      scope: punctuation.section.block.begin.scala
       set:
         - meta_scope: meta.block.scala
         - match: \}
-          scope: punctuation.definition.block.end.scala
+          scope: punctuation.section.block.end.scala
           set: single-type-expression-tail-no-function-no-or
         - include: main
     - match: '(?=\()'
@@ -2315,10 +2315,10 @@ contexts:
       scope: support.type.scala
       set: single-type-expression-tail-type-expectation
     - match: '\{'
-      scope: punctuation.definition.block.begin.scala
+      scope: punctuation.section.block.begin.scala
       set:
         - match: \}
-          scope: punctuation.definition.block.end.scala
+          scope: punctuation.section.block.end.scala
           set: single-type-expression-tail
         - include: main
     - match: '(?=\()'
@@ -2334,7 +2334,7 @@ contexts:
 
   type-match-body:
     - match: '\{'
-      scope: punctuation.definition.block.begin.scala
+      scope: punctuation.section.block.begin.scala
       set: delimited-type-match-body
     - match: '\n'
       set: type-match-body-newline
@@ -2355,7 +2355,7 @@ contexts:
 
   delimited-type-match-body:
     - match: '\}'
-      scope: punctuation.definition.block.end.scala
+      scope: punctuation.section.block.end.scala
       pop: 1
     - match: '\bcase\b'
       scope: keyword.declaration.other.scala
@@ -2381,7 +2381,7 @@ contexts:
 
   delimited-type-case-rightarrow:
     - match: '\}'
-      scope: punctuation.definition.block.end.scala
+      scope: punctuation.section.block.end.scala
       pop: 1
     - match: '(?=\bcase\b)'
       set: delimited-type-match-body

--- a/Scala/tests/syntax_test_scala.scala
+++ b/Scala/tests/syntax_test_scala.scala
@@ -1933,14 +1933,14 @@ import scalaz._
 // ^^^^^^ - support.type
 
   type Foo = Thing { val a: Int }
-  //               ^ punctuation.definition.block.begin.scala
-  //                            ^ punctuation.definition.block.end.scala
+  //               ^ punctuation.section.block.begin.scala
+  //                            ^ punctuation.section.block.end.scala
 
   type Foo = (Bar op (Baz))
-  //         ^ punctuation.definition.group.begin.scala
-  //                 ^ punctuation.definition.group.begin.scala
-  //                     ^ punctuation.definition.group.end.scala
-  //                      ^ punctuation.definition.group.end.scala
+  //         ^ punctuation.section.group.begin.scala
+  //                 ^ punctuation.section.group.begin.scala
+  //                     ^ punctuation.section.group.end.scala
+  //                      ^ punctuation.section.group.end.scala
 
    def identity: CFId
    override final def equals(other: Any): Boolean

--- a/Scala/tests/syntax_test_scala3.scala
+++ b/Scala/tests/syntax_test_scala3.scala
@@ -53,11 +53,11 @@ againmore: (x, y) => 42
 //             ^ variable.parameter.scala
 
 againmore: (x, y)
-//         ^ punctuation.definition.group.begin.scala
+//         ^ punctuation.section.group.begin.scala
 //          ^ support.type.scala
 //           ^ punctuation.separator.scala
 //             ^ support.type.scala
-//              ^ punctuation.definition.group.end.scala
+//              ^ punctuation.section.group.end.scala
 
 confusion: (x: Int) => 12
 //          ^ variable.parameter.scala
@@ -381,7 +381,7 @@ case Foo => ()
 type Elem[X] = X match {
 //             ^ support.class.scala
 //               ^^^^^ keyword.control.flow.scala
-//                     ^ punctuation.definition.block.begin.scala
+//                     ^ punctuation.section.block.begin.scala
 
 
    case String => Foo
@@ -402,7 +402,7 @@ type Elem[X] = X match {
 
 
 }
-// <- punctuation.definition.block.end.scala
+// <- punctuation.section.block.end.scala
 
 trait Greeting(val name: String)
 //                 ^^^^ variable.parameter.scala
@@ -502,7 +502,7 @@ val i: 0x01 = 0x01
 
 type Foo = (true)
 //          ^^^^ constant.language.boolean.true.scala
-//              ^ punctuation.definition.group.end.scala
+//              ^ punctuation.section.group.end.scala
 
 enum Color {
 // <- keyword.declaration.enum.scala


### PR DESCRIPTION
This commit scopes parentheses and braces `punctuation.section`.