### PR TITLE
[Git Fromats] recognise short hashes git rebase

### DIFF
--- a/Git Formats/Git Rebase.sublime-syntax
+++ b/Git Formats/Git Rebase.sublime-syntax
@@ -13,7 +13,7 @@ first_line_match: '^(?:drop|edit|fixup|pick|reword|squash|[defprsx]) \h{7,} '
 
 variables:
   comment_char: '[#;]'
-  hash: \b\h{7,}\b
+  hash: \b\h{4,}\b
   option: (-)[[:alnum:]]+\b
 
 contexts:

--- a/Git Formats/tests/syntax_test_git_rebase
+++ b/Git Formats/tests/syntax_test_git_rebase
@@ -22,6 +22,15 @@ pick d284bb2 Initial commit
 #    ^^^^^^^ constant.other.hash
 #           ^ - constant - comment
 #            ^^^^^^^^^^^^^^^ comment.line.git.rebase
+pick d284 Initial commit
+# <- meta.commit
+#^^^^^^^^^^^^^^^^^^^^^^^ meta.commit
+# <- keyword.operator.commit.pick
+#^^^ keyword.operator.commit.pick
+#   ^ - storage.type.commit
+#    ^^^^ constant.other.hash
+#        ^ - constant - comment
+#         ^^^^^^^^^^^^^^^ comment.line.git.rebase
 pick d284bb2 # Initial commit
 # <- meta.commit
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.commit


### PR DESCRIPTION
Per the [git documentation](https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection#:~:text=as%20long%20as%20that%20partial%20hash%20is%20at%20least%20four%20characters%20long%20and%20unambiguous), a commit hash has a minimum of 4 characters. This can be triggered by setting the core.abbrev config to 4.

This PR applies the change to the Git Rebase syntax.

~~It does bave a downside, which is that hashes inside the commit message are also highlighted. This is already a problem, but words made from hex characters that are at least 7 chars long are fairly rare (defaced, effaced...) By lowering it to 4 the list grows a bit (cafe, face, fade...)~~ only true for Git Commit, not Rebase

I do think it's worth adding here, at least. I probably wouldn't add it in the Git Commit one. My reasoning is:
- the failure mode is that short git hashes in a rebase file are marked as invalid, which is pretty bad UX. In a git rebase with this setting, that's every single line.
- in Git Message it probably pays to he more conservative with hash recognition, even people that have short hashes configured still refer to them with longer lengths inside commits