### PR TITLE
[C#] Fix explicit declarations in tuples

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -1645,7 +1645,7 @@ contexts:
       scope: keyword.operator.assignment.cs
     - match: _\b
       scope: variable.language.anonymous.cs
-    - match: (?!{{reserved}})(?={{namespaced_name}}{{type_suffix}}\s+{{name}}\s*[:,])
+    - match: (?!{{reserved}})(?={{namespaced_name}}{{type_suffix}}\s+{{name}})
       push: var_declaration_explicit
     - match: '({{name}})(<)'
       captures:

--- a/C#/tests/syntax_test_C#7.cs
+++ b/C#/tests/syntax_test_C#7.cs
@@ -341,21 +341,21 @@ class Foo {
 ///                     ^^^^^^^^^ meta.sequence.tuple
 ///                      ^ meta.number.integer.decimal constant.numeric.value
 ///                       ^ punctuation.separator.sequence
-        (string Alpha, string Beta) namedLetters = ("a", "b");
+        (string Alpha, MyString Beta) namedLetters = ("a", "b");
 ///     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence.tuple
 ///     ^ punctuation.section.sequence.begin
 ///      ^^^^^^ storage.type
 ///             ^^^^^ variable.other
 ///                  ^ punctuation.separator.sequence
-///                    ^^^^^^ storage.type
-///                           ^^^^ variable.other
-///                               ^ punctuation.section.sequence.end
-///                                 ^^^^^^^^^^^^ variable.other
-///                                              ^ keyword.operator.assignment
-///                                                ^ punctuation.section.sequence.begin
-///                                                    ^ punctuation.separator.sequence
-///                                                         ^ punctuation.section.sequence.end
-///                                                          ^ punctuation.terminator.statement
+///                    ^^^^^^^^ support.type.cs
+///                             ^^^^ variable.other
+///                                 ^ punctuation.section.sequence.end
+///                                   ^^^^^^^^^^^^ variable.other
+///                                                ^ keyword.operator.assignment
+///                                                  ^ punctuation.section.sequence.begin
+///                                                      ^ punctuation.separator.sequence
+///                                                           ^ punctuation.section.sequence.end
+///                                                            ^ punctuation.terminator.statement
 
         (
 ///     ^ meta.sequence.tuple punctuation.section.sequence.begin
@@ -363,7 +363,9 @@ class Foo {
 ///         ^^^^^^ storage.type
 ///                ^^^^^ variable.other
 ///                     ^ punctuation.separator.sequence
-            string Beta
+            MyString Beta
+///         ^^^^^^^^ support.type.cs
+///                  ^^^^ variable.other
         ) namedLetters = ("a", "b");
 ///     ^ punctuation.section.sequence.end
 ///       ^^^^^^^^^^^^ variable.other


### PR DESCRIPTION
Addresses #4468

This PR resolves highlighting explicitly typed tuple members.

<img width="615" height="84" alt="grafik" src="https://github.com/user-attachments/assets/d10317fe-72de-4a15-a96d-da3587071b7b" />
