### PR TITLE
[C#] Fix type highlighting after multiple spaces

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -946,12 +946,10 @@ contexts:
       pop: true
 
   method_param_type_modifier:
-    - match: '\s*({{method_param_type_modifier}})\s'
+    - match: ({{method_param_type_modifier}})\s*
       captures:
         1: storage.modifier.parameter.cs
-    - match: \s
-      pop: true
-    - include: type
+    - include: type_no_space
 
   constructor_prebody:
     - meta_scope: meta.method.constructor.cs
@@ -1454,8 +1452,6 @@ contexts:
     - match: null\b
       scope: constant.language.null.cs
       pop: 2
-    - match: (?=\{)
-      pop: true
     - include: type_no_space
 
   line_of_code_in:
@@ -1916,7 +1912,7 @@ contexts:
 
   type_no_space:
     - include: type
-    - match: \s
+    - match: ''
       pop: true
 
   # bools, numbers, chars, simple strings

--- a/C#/tests/syntax_test_GeneralStructure.cs
+++ b/C#/tests/syntax_test_GeneralStructure.cs
@@ -93,6 +93,27 @@ namespace YourNamespace
 ///                                                                                      ^^^^^ variable.language
 ///                                                                                           ^ punctuation.section.group.end
 ///                                                                                            ^ punctuation.terminator
+        // see: https://github.com/sublimehq/Packages/issues/4491
+        internal static void SetFrom(this   s8[]   A,   int   I,  params);
+///     ^^^^^^^^ storage.modifier.access.cs
+///              ^^^^^^ storage.modifier.cs
+///                     ^^^^ storage.type.cs
+///                          ^^^^^^^ meta.method.cs entity.name.function.cs
+///                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.method.parameters.cs
+///                                 ^ punctuation.section.parameters.begin.cs
+///                                  ^^^^ storage.modifier.parameter.cs
+///                                         ^^ support.type.cs
+///                                           ^^ meta.brackets.cs
+///                                           ^ punctuation.section.brackets.begin.cs
+///                                            ^ punctuation.section.brackets.end.cs
+///                                                ^ variable.parameter.cs
+///                                                 ^ punctuation.separator.parameter.function.cs
+///                                                     ^^^ storage.type.cs
+///                                                           ^ variable.parameter.cs
+///                                                            ^ punctuation.separator.parameter.function.cs
+///                                                               ^^^^^^ storage.modifier.parameter.cs
+///                                                                     ^ punctuation.section.parameters.end.cs
+///                                                                      ^ meta.method.cs punctuation.terminator.statement.cs
 
         public bool IsZero => IsConst(Numeric<Type>.Zero);
 ///                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property


### PR DESCRIPTION
Fixes #4491

This PR fixes multiple whitespaces after modifiers causing parameter type not being highlighted.