### PR TITLE
[C#] Replace pop: true

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -40,7 +40,7 @@ contexts:
       push:
         - meta_scope: comment.line.double-slash.cs
         - match: $\n?
-          pop: true
+          pop: 1
         - include: comments_in
     - match: '/\*'
       scope: punctuation.definition.comment.begin.cs
@@ -48,7 +48,7 @@ contexts:
         - meta_scope: comment.block.cs
         - match: '\*/'
           scope: punctuation.definition.comment.end.cs
-          pop: true
+          pop: 1
         - match: ^\s*(\*)(?!/)
           captures:
             1: punctuation.definition.comment.cs
@@ -79,11 +79,11 @@ contexts:
             2: punctuation.separator.argument.value.cs
         - match: '/?>'
           scope: punctuation.definition.tag.end.cs
-          pop: true
+          pop: 1
         - match: '"[^"]*"'
           scope: string.quoted.double.cs
         - match: $
-          pop: true
+          pop: 1
     - match: '(</)({{name}})(>)'
       captures:
         1: punctuation.definition.tag.begin.cs
@@ -93,7 +93,7 @@ contexts:
       captures:
         1: punctuation.definition.comment.documentation.cs
     - match: '^\s*(?!///)'
-      pop: true
+      pop: 1
     - include: comments_in
     - match: '[\w\s]+|.'
       scope: text.documentation.cs
@@ -166,7 +166,7 @@ contexts:
       scope: punctuation.separator.annotation.cs
     - match: \]
       scope: punctuation.definition.annotation.end.cs
-      pop: true
+      pop: 1
 
   attribute_name:
     - meta_content_scope: variable.annotation.cs
@@ -262,10 +262,10 @@ contexts:
               scope: meta.number.integer.hexadecimal.cs constant.numeric.value.cs
             - match: '}"'
               scope: punctuation.definition.string.end.cs
-              pop: true
+              pop: 1
             - match: \.
               scope: invalid.illegal.cs
-              pop: true
+              pop: 1
         - match: '"'
           scope: punctuation.definition.string.begin.cs
           push: inside_string
@@ -282,7 +282,7 @@ contexts:
             2: string.unquoted.warning.cs
         - include: comments
         - match: $
-          pop: true
+          pop: 1
     - match: '\b(nullable)\s+(enable|disable|restore)(?:\s+(annotations|warnings))?\b'
       captures:
         1: keyword.other.preprocessor.cs
@@ -294,14 +294,14 @@ contexts:
         1: punctuation.definition.preprocessor.cs
         2: variable.language.cs
     - match: $
-      pop: true
+      pop: 1
 
   # Pops out at the end of the line and handles comments.
   # Marks the rest of the line as invalid.
   option_done:
     - include: comments
     - match: $
-      pop: true
+      pop: 1
     - match: \S
       scope: invalid.illegal.cs
 
@@ -315,7 +315,7 @@ contexts:
         - meta_scope: meta.block.cs
         - match: '\}'
           scope: punctuation.section.block.end.cs
-          pop: true
+          pop: 1
         - include: statements
     - include: attribute
     - include: using
@@ -330,7 +330,7 @@ contexts:
     - match: (?=\S)
       push:
         - match: (?={{visibility}}|\b(?:class|delegate|interface|namespace|readonly|record|required|static)\b)
-          pop: true
+          pop: 1
         - include: line_of_code
 
   stray_close_bracket:
@@ -382,11 +382,11 @@ contexts:
       scope: meta.path.cs punctuation.accessor.dot.cs
     - match: ';'
       scope: punctuation.terminator.statement.cs
-      pop: true
+      pop: 1
     - match: '[^\s;]+'
       scope: invalid.illegal.expected-namespace.cs
     - match: '$'
-      pop: true
+      pop: 1
 
 ###[ NAMESPACE DECLARATIONS ]##################################################
 
@@ -423,7 +423,7 @@ contexts:
   unqualified_namespace_declaration_name:
     - match: '{{name}}'
       scope: entity.name.namespace.cs
-      pop: true
+      pop: 1
     - include: else_pop
 
   namespace_declaration_block:
@@ -436,7 +436,7 @@ contexts:
     - meta_scope: meta.block.cs
     - match: \}
       scope: punctuation.section.block.end.cs
-      pop: true
+      pop: 1
     - include: statements
 
 ###[ CLASS DECLARATIONS ]######################################################
@@ -489,9 +489,9 @@ contexts:
                 set:
                   - match: ';'
                     scope: punctuation.terminator.statement.cs
-                    pop: true
+                    pop: 1
                   - match: '(?=\S)'
-                    pop: true
+                    pop: 1
               - include: attribute
               - match: '{{name}}'
                 scope: entity.name.constant.cs
@@ -547,7 +547,7 @@ contexts:
     - meta_content_scope: meta.class.record.body.cs
     - match: ';'
       scope: punctuation.terminator.statement.cs
-      pop: true
+      pop: 1
     - include: data_type_expect_block
 
 ###[ STRUCT DECLARATIONS ]#####################################################
@@ -597,7 +597,7 @@ contexts:
     - match: (?=where\b)
       set: type_constraint
     - match: (?=[{;(])
-      pop: true
+      pop: 1
 
   type_constraint:
     - include: type_constraint_common
@@ -615,7 +615,7 @@ contexts:
     - meta_include_prototype: false
     - match: \(
       scope: punctuation.section.group.begin.cs
-      pop: true
+      pop: 1
 
   inside_inherited_class_arguments:
     - clear_scopes: 1
@@ -623,12 +623,12 @@ contexts:
     - meta_scope: meta.class.constructor.arguments.cs meta.group.cs
     - match: \)
       scope: punctuation.section.group.end.cs
-      pop: true
+      pop: 1
     - include: immediately_pop
 
   type_constraint_common:
     - match: (?=\{)
-      pop: true
+      pop: 1
     - include: namespace_variables
     - match: '\b(where)\s+(?:({{base_type}})|({{name}}))\s*(:)'
       captures:
@@ -656,7 +656,7 @@ contexts:
     - include: terminator
     - match: \S*
       scope: invalid.illegal.cs
-      pop: true
+      pop: 1
 
   data_type_inside_block:
     - meta_scope: meta.block.cs
@@ -696,7 +696,7 @@ contexts:
   event_declaration_after_name:
     - match: ';'
       scope: punctuation.terminator.statement.cs
-      pop: true
+      pop: 1
     - match: \{
       scope: punctuation.section.block.begin.cs
       set: event_handler_declaration_body
@@ -709,7 +709,7 @@ contexts:
     - include: attribute
     - match: \}
       scope: punctuation.section.block.end.cs
-      pop: true
+      pop: 1
     - match: \b(add)\b
       scope: keyword.declaration.function.accessor.add.cs
       push: method_body
@@ -757,7 +757,7 @@ contexts:
   delegate_name:
     - match: '{{name}}'
       scope: variable.other.member.delegate.cs
-      pop: true
+      pop: 1
     - include: else_pop
 
   delegate_parameters:
@@ -861,7 +861,7 @@ contexts:
     - match: '(?=\{)'
       set: method_body
     - match: '(?=\S)'
-      pop: true
+      pop: 1
 
   method_name_or_member_variable:
     - match: '\.'
@@ -880,7 +880,7 @@ contexts:
         - member_variable
         - member_lambda
         - method_name
-      pop: true
+      pop: 1
 
   expect_type_member:
     - match: (?=\S)
@@ -888,7 +888,7 @@ contexts:
 
   type_member:
     - match: (?=this\b)
-      pop: true
+      pop: 1
     - include: type_no_space
 
   member_variable:
@@ -908,7 +908,7 @@ contexts:
       set: member_variable
     - match: ';'
       scope: punctuation.terminator.statement.cs
-      pop: true
+      pop: 1
     - include: else_pop
 
   member_variable_declarations:
@@ -925,13 +925,13 @@ contexts:
       scope: punctuation.separator.variables.cs
     - match: ';'
       scope: punctuation.terminator.statement.cs
-      pop: true
+      pop: 1
     - match: (?=[]})>;])
-      pop: true
+      pop: 1
 
   member_variable_declaration_value:
     - match: (?=;|,)
-      pop: true
+      pop: 1
     - include: line_of_code_in
 
   member_lambda:
@@ -974,7 +974,7 @@ contexts:
           captures:
             1: punctuation.definition.generic.end.cs
             2: punctuation.accessor.dot.cs
-          pop: true
+          pop: 1
         - match: ','
           scope: punctuation.separator.parameter.type.cs
         - include: type
@@ -1002,14 +1002,14 @@ contexts:
         - match: \s*(,)
           captures:
             1: punctuation.separator.variables.cs
-          pop: true
+          pop: 1
         - match: ''
-          pop: true
+          pop: 1
     - match: '(?=\s*\{)'
       set: method_accessor
     - match: ';'
       scope: punctuation.terminator.statement.cs
-      pop: true
+      pop: 1
 
   method_body_transition:
     - match: ''
@@ -1019,7 +1019,7 @@ contexts:
     - meta_content_scope: meta.method.parameters.cs
     - match: \)
       scope: meta.method.parameters.cs punctuation.section.parameters.end.cs
-      pop: true
+      pop: 1
     - match: (?=\S)
       push: [method_param, method_param_type]
 
@@ -1027,7 +1027,7 @@ contexts:
     - meta_content_scope: meta.brackets.cs
     - match: \]
       scope: meta.brackets.cs punctuation.section.brackets.end.cs
-      pop: true
+      pop: 1
     - match: (?=\S)
       push: [method_param, method_param_type]
 
@@ -1041,9 +1041,9 @@ contexts:
         - maybe_pointer
     - match: ','
       scope: punctuation.separator.parameter.function.cs
-      pop: true
+      pop: 1
     - match: (?=\}|\)|>|\]|;)
-      pop: true
+      pop: 1
 
   method_param_type:
     - include: attribute
@@ -1052,7 +1052,7 @@ contexts:
     - match: (?=[^\s\[;])
       set: method_param_type_modifier
     - match: (?=\}|\)|>|\]|;)
-      pop: true
+      pop: 1
 
   method_param_type_modifier:
     - match: ({{method_param_type_modifier}})\s*
@@ -1074,10 +1074,10 @@ contexts:
       set: method_body_brace_begin
     - match: ;
       scope: punctuation.terminator.statement.cs
-      pop: true
+      pop: 1
     - match: \S+
       scope: invalid.illegal.cs
-      pop: true
+      pop: 1
 
   method_body_brace_begin:
     - match: \{
@@ -1088,7 +1088,7 @@ contexts:
     - meta_scope: meta.method.body.cs meta.block.cs
     - match: \}
       scope: punctuation.section.block.end.cs
-      pop: true
+      pop: 1
     - include: stray_close_bracket
     - include: code_block_in
 
@@ -1126,7 +1126,7 @@ contexts:
         - include: line_of_code_in
     - match: \S
       scope: invalid.illegal.cs
-      pop: true
+      pop: 1
 
 ###[ VAR DECLARATIONS ]########################################################
 
@@ -1143,7 +1143,7 @@ contexts:
         - meta_content_scope: meta.sequence.tuple.cs
         - match: \)
           scope: meta.sequence.tuple.cs punctuation.section.sequence.end.cs
-          pop: true
+          pop: 1
         - match: _\b
           scope: variable.language.anonymous.cs
         - match: '{{name}}'
@@ -1154,7 +1154,7 @@ contexts:
       captures:
         1: storage.type.variable.cs
         2: variable.other.cs
-      pop: true
+      pop: 1
     - include: var_declaration_explicit
 
   var_declaration_explicit:
@@ -1174,9 +1174,9 @@ contexts:
             - match: '({{name}})\s*'
               captures:
                 1: variable.other.cs
-              pop: true
+              pop: 1
             - match: (?=[,);}])
-              pop: true
+              pop: 1
         - include: inside_type_argument
     - match: '({{base_type}}){{type_suffix_capture}}'
       captures:
@@ -1191,9 +1191,9 @@ contexts:
         - match: '({{name}})\s*'
           captures:
             1: variable.other.cs
-          pop: true
+          pop: 1
         - match: (?=[,);}])
-          pop: true
+          pop: 1
     - match: '(?:({{name}}){{type_suffix_capture}})(?:\s+({{name}}))?\s*'
       captures:
         1: support.type.cs
@@ -1204,9 +1204,9 @@ contexts:
         6: punctuation.section.brackets.end.cs
         7: keyword.operator.pointer.cs
         8: variable.other.cs
-      pop: true
+      pop: 1
     - match: (?=\))
-      pop: true
+      pop: 1
 
   variables_declaration:
     - match: '='
@@ -1220,17 +1220,17 @@ contexts:
       scope: punctuation.separator.variables.cs
     - match: ';'
       scope: punctuation.terminator.statement.cs
-      pop: true
+      pop: 1
     - match: (?=\{|\}|\)|>|\])
-      pop: true
+      pop: 1
 
   variables_declaration_value:
     - match: (?=;|,)
-      pop: true
+      pop: 1
     - match: (?=\{)
       push:
         - match: (?=[^,\s{}])
-          pop: true
+          pop: 1
         - include: initializer_constructor
     - include: line_of_code_in
 
@@ -1301,7 +1301,7 @@ contexts:
       captures:
         1: keyword.control.flow.break.cs
         2: punctuation.terminator.statement.cs
-      pop: true
+      pop: 1
     - match: \b(throw)\b
       scope: keyword.control.flow.throw.cs
       set: line_of_code_in
@@ -1315,14 +1315,14 @@ contexts:
         1: keyword.control.flow.goto.cs
         2: constant.other.label.cs
         3: punctuation.terminator.statement.cs
-      pop: true
+      pop: 1
     - include: keywords
     # C#7/9, nested method
     - match: (?=(?:\b(?:async|ref|static)\s+)*{{namespaced_name}}{{type_suffix}}\s+{{namespaced_name}}\s*\()
       push:
         - include: member_declaration
         - match: ''
-          pop: true
+          pop: 1
     - match: \bconst\b
       scope: storage.modifier.cs
     - match: '(var|dynamic)\s+({{reserved}}|{{base_type}})\s*(=)'
@@ -1350,7 +1350,7 @@ contexts:
       captures:
         1: entity.name.label.cs
         2: punctuation.separator.cs
-      pop: true
+      pop: 1
     - include: namespace_variables
     - match: '({{name}})\s+({{name}})'
       captures:
@@ -1371,7 +1371,7 @@ contexts:
             - meta_content_scope: meta.block.cs
             - match: \}
               scope: meta.block.cs punctuation.section.block.end.cs
-              pop: true
+              pop: 1
             - include: code_block_in
         - match: (?=\S)
           set: line_of_code
@@ -1383,7 +1383,7 @@ contexts:
         - line_of_code_in
         - maybe_pointer
     - match: (?=;|\)|\})
-      pop: true
+      pop: 1
     - match: ','
       scope: punctuation.separator.expression.cs
       push: line_of_code_in
@@ -1399,7 +1399,7 @@ contexts:
           - meta_scope: meta.block.cs
           - match: \}
             scope: punctuation.section.block.end.cs
-            pop: true
+            pop: 1
           - include: code_block_in
       - include: else_pop
     - include: else_pop
@@ -1415,10 +1415,10 @@ contexts:
         - match: '\s*(\))'
           captures:
             1: meta.group.cs punctuation.section.group.end.cs
-          pop: true
+          pop: 1
         - include: line_of_code_in
     - match: (?=[^(])
-      pop: true
+      pop: 1
 
   if_block:
     - match: \{
@@ -1427,12 +1427,12 @@ contexts:
         - meta_content_scope: meta.block.cs
         - match: \}
           scope: meta.block.cs punctuation.section.block.end.cs
-          pop: true
+          pop: 1
         - include: code_block_in
     - match: (?=\S)
       set:
         - match: (?=else\b)
-          pop: true
+          pop: 1
         - include: line_of_code
 
   else_block:
@@ -1450,7 +1450,7 @@ contexts:
             - meta_content_scope: meta.block.cs
             - match: \}
               scope: meta.block.cs punctuation.section.block.end.cs
-              pop: true
+              pop: 1
             - include: code_block_in
         - match: (?=\S)
           set: line_of_code
@@ -1463,7 +1463,7 @@ contexts:
         - meta_scope: meta.group.cs
         - match: '\)'
           scope: punctuation.section.group.end.cs
-          pop: true
+          pop: 1
         - include: line_of_code_in
     - include: else_pop
 
@@ -1474,7 +1474,7 @@ contexts:
         - meta_scope: meta.block.cs
         - match: \}
           scope: punctuation.section.block.end.cs
-          pop: true
+          pop: 1
         - match: '\b(default)\s*(:)'
           captures:
             1: keyword.control.switch.case.cs
@@ -1490,13 +1490,13 @@ contexts:
               push: var_declaration_explicit
             - match: ':'
               scope: punctuation.separator.case-statement.cs
-              pop: true
+              pop: 1
             - include: line_of_code_in
             - match: $
-              pop: true
+              pop: 1
         - include: code_block_in
     - match: '(?=\S)'
-      pop: true
+      pop: 1
 
 ###[ EXCEPTION STATEMENTS ]####################################################
 
@@ -1507,7 +1507,7 @@ contexts:
         - meta_scope: meta.block.cs
         - match: \}
           scope: punctuation.section.block.end.cs
-          pop: true
+          pop: 1
         - include: code_block_in
     - include: else_pop
 
@@ -1559,7 +1559,7 @@ contexts:
         - meta_scope: meta.block.cs
         - match: \}
           scope: punctuation.section.block.end.cs
-          pop: true
+          pop: 1
         - include: code_block_in
     - include: else_pop
 
@@ -1572,14 +1572,14 @@ contexts:
         - line_of_code_in
         - maybe_pointer
     - match: (?=;|\)|\})
-      pop: true
+      pop: 1
 
   foreach_var_assignment:
     - match: \bin\b
       scope: keyword.control.loop.in.cs
       set: line_of_code_in
     - match: (?=\)|\})
-      pop: true
+      pop: 1
 
   for_block:
     - meta_content_scope: meta.group.cs
@@ -1592,7 +1592,7 @@ contexts:
           - meta_scope: meta.block.cs
           - match: \}
             scope: punctuation.section.block.end.cs
-            pop: true
+            pop: 1
           - include: code_block_in
       - match: (?=\S)
         set:
@@ -1611,7 +1611,7 @@ contexts:
         - meta_scope: meta.group.cs
         - match: '\)'
           scope: punctuation.section.group.end.cs
-          pop: true
+          pop: 1
         - include: line_of_code_in
     - include: else_pop
 
@@ -1622,7 +1622,7 @@ contexts:
         - meta_scope: meta.block.cs
         - match: '\}'
           scope: punctuation.section.block.end.cs
-          pop: true
+          pop: 1
         - include: code_block_in
     - match: (?=\S)
       set:
@@ -1632,14 +1632,14 @@ contexts:
 
   line_of_code_in:
     - match: (?=\bvar\b)
-      pop: true
+      pop: 1
     - include: lambdas
     - include: line_of_code_in_no_semicolon
     - match: ';'
       scope: punctuation.terminator.statement.cs
-      pop: true
+      pop: 1
     - match: (?=\))
-      pop: true
+      pop: 1
 
   line_of_code_in_no_semicolon:
     - match: \b(value)\b
@@ -1708,7 +1708,7 @@ contexts:
           scope: punctuation.separator.type.cs
         - match: '>'
           scope: meta.generic.cs punctuation.definition.generic.end.cs
-          pop: true
+          pop: 1
         - include: type
     - match: '((?!{{reserved}}\b){{name}})\s*(\()'
       scope: meta.function-call.cs
@@ -1727,7 +1727,7 @@ contexts:
       scope: storage.modifier.cs
       push:
         - match: (?=\[)
-          pop: true
+          pop: 1
         - include: type
     - match: \bswitch\b
       scope: keyword.control.flow.cs
@@ -1744,7 +1744,7 @@ contexts:
       push:
         - match: ':'
           scope: keyword.operator.ternary.cs
-          pop: true
+          pop: 1
         - include: line_of_code_in
     - match: '(\()\s*(\*)\s*({{name}})\s*(\))'
       captures:
@@ -1759,7 +1759,7 @@ contexts:
         - meta_scope: meta.cast.cs
         - match: \)
           scope: punctuation.section.group.end.cs
-          pop: true
+          pop: 1
         - match: '{{base_type}}'
           scope: storage.type.cs
         - match: '{{name}}'
@@ -1782,10 +1782,10 @@ contexts:
       set:
         - match: \}
           scope: punctuation.section.block.end.cs
-          pop: true
+          pop: 1
         - include: code_block_in
     - match: (?=[]}>,]|{{reserved}})
-      pop: true
+      pop: 1
 
   keywords:
     - include: funcptr_types
@@ -1809,7 +1809,7 @@ contexts:
         - meta_content_scope: meta.group.cs
         - match: \)
           scope: meta.group.cs punctuation.section.group.end.cs
-          pop: true
+          pop: 1
         - match: '({{base_type}})\b'
           scope: storage.type.cs
         # We don't if these are types of variables, so we guess that
@@ -1825,7 +1825,7 @@ contexts:
         - meta_content_scope: meta.group.cs
         - match: \)
           scope: meta.group.cs punctuation.section.group.end.cs
-          pop: true
+          pop: 1
         - include: type
     - match: \b(as|is(?:\s+not)?)\s+
       captures:
@@ -1840,7 +1840,7 @@ contexts:
             - meta_scope: meta.group.cs
             - match: \)
               scope: punctuation.section.group.end.cs
-              pop: true
+              pop: 1
             - include: line_of_code_in
         - match: \{
           scope: punctuation.section.block.begin.cs
@@ -1848,7 +1848,7 @@ contexts:
             - meta_scope: meta.block.cs
             - match: \}
               scope: punctuation.section.block.end.cs
-              pop: true
+              pop: 1
             - include: code_block_in
         - match: \S
           scope: invalid.illegal.expected.block.cs
@@ -1861,7 +1861,7 @@ contexts:
             - meta_scope: meta.block.cs
             - match: \}
               scope: punctuation.section.block.end.cs
-              pop: true
+              pop: 1
             - include: code_block_in
         - match: \S
           scope: invalid.illegal.expected.block.cs
@@ -1904,7 +1904,7 @@ contexts:
               push: line_of_code_in
             - match: \]
               scope: punctuation.section.brackets.end.cs
-              pop: true
+              pop: 1
             - match: '(?=\S)'
               push: line_of_code_in
         - match: (?:\s*((\()\s*(\)))\s*)?(\{)
@@ -1924,7 +1924,7 @@ contexts:
     - meta_scope: meta.instance.cs meta.class.body.anonymous.cs meta.block.cs
     - match: \}
       scope: punctuation.section.block.end.cs
-      pop: true
+      pop: 1
     - match: ','
       scope: punctuation.separator.class.cs
     - match: '({{name}})\s*(=)'
@@ -1940,7 +1940,7 @@ contexts:
   maybe_pointer:
     - match: '[*&]'
       scope: keyword.operator.pointer.cs
-      pop: true
+      pop: 1
     - include: else_pop
 
 ###[ GROUP AND TUPLE EXPRESSIONS ]#############################################
@@ -1955,7 +1955,7 @@ contexts:
     - meta_scope: meta.group.cs
     - match: \)
       scope: punctuation.section.group.end.cs
-      pop: true
+      pop: 1
     - match: ','
       fail: tuple_or_group
     - include: lambdas
@@ -1971,7 +1971,7 @@ contexts:
     - meta_scope: meta.sequence.tuple.cs
     - match: \)
       scope: punctuation.section.sequence.end.cs
-      pop: true
+      pop: 1
     - match: ','
       scope: punctuation.separator.sequence.cs
     - match: ':'
@@ -2007,7 +2007,7 @@ contexts:
       scope: punctuation.separator.accessor.cs
     - match: \]
       scope: meta.brackets.cs punctuation.section.brackets.end.cs
-      pop: true
+      pop: 1
     - include: line_of_code_in
 
 ###[ CONSTRUCTOR EXPRESSIONS ]#################################################
@@ -2022,7 +2022,7 @@ contexts:
   maybe_constructor_initializer:
     - meta_content_scope: meta.instance.cs meta.group.cs
     - match: (?=[^\s{])
-      pop: true
+      pop: 1
     - match: \{
       scope: punctuation.section.braces.begin.cs
       set: initializer_constructor
@@ -2031,7 +2031,7 @@ contexts:
     - meta_content_scope: meta.instance.cs meta.braces.cs
     - match: \}
       scope: meta.instance.cs meta.braces.cs punctuation.section.braces.end.cs
-      pop: true
+      pop: 1
     - match: \{
       scope: punctuation.section.braces.begin.cs
       push: initializer_constructor
@@ -2053,7 +2053,7 @@ contexts:
     - meta_content_scope: meta.function-call.cs meta.group.cs
     - match: \)
       scope: meta.function-call.cs meta.group.cs punctuation.section.group.end.cs
-      pop: true
+      pop: 1
     - include: immediately_pop
 
   arguments:
@@ -2065,7 +2065,7 @@ contexts:
           captures:
             1: storage.modifier.argument.cs
         - match: (?!{{namespaced_name}}{{type_suffix}}\s+{{name}})
-          pop: true
+          pop: 1
         - include: var_declaration
     - match: (ref)\s
       captures:
@@ -2085,17 +2085,17 @@ contexts:
     - match: ','
       scope: punctuation.separator.argument.cs
     - match: (?=\))
-      pop: true
+      pop: 1
     - match: ;
       scope: invalid.illegal.expected-close-paren.cs
-      pop: true
+      pop: 1
     - include: stray_close_bracket
     - match: (?=\S)
       push:
         - include: lambdas
         - include: line_of_code_in_no_semicolon
         - match: (?=[;)])
-          pop: true
+          pop: 1
 
 ###[ LAMBDA EXPRESSIONS ]######################################################
 
@@ -2131,7 +2131,7 @@ contexts:
   lambda_expect_body:
     - meta_scope: meta.function.anonymous.cs
     - match: '(?=;)'
-      pop: true
+      pop: 1
     - include: line_of_code_in
 
 ###[ SWITCH EXPRESSIONS ]######################################################
@@ -2143,13 +2143,13 @@ contexts:
         - meta_scope: meta.block.cs
         - match: \}
           scope: punctuation.section.block.end.cs
-          pop: true
+          pop: 1
         - match: '=>'
           scope: punctuation.separator.case-expression.cs
           push:
             - match: ','
               scope: punctuation.terminator.case-expression.cs
-              pop: true
+              pop: 1
             - include: line_of_code_in
         - match: \b_\b
           scope: variable.language.anonymous.cs
@@ -2161,7 +2161,7 @@ contexts:
             - meta_scope: meta.sequence.tuple.cs
             - match: \)
               scope: punctuation.section.sequence.end.cs
-              pop: true
+              pop: 1
             - match: ','
               scope: punctuation.separator.sequence.cs
             - match: _\b
@@ -2185,7 +2185,7 @@ contexts:
     - meta_content_scope: meta.instance.property-subpattern.cs meta.class.body.anonymous.cs meta.block.cs
     - match: \}
       scope: meta.instance.property-subpattern.cs meta.class.body.anonymous.cs meta.block.cs punctuation.section.block.end.cs
-      pop: true
+      pop: 1
     - match: ','
       scope: punctuation.separator.property.cs
     - match: ({{name}})\s*(\.)
@@ -2232,7 +2232,7 @@ contexts:
     - meta_scope: meta.sequence.tuple.cs
     - match: \)
       scope: punctuation.section.sequence.end.cs
-      pop: true
+      pop: 1
     - match: ','
       scope: punctuation.separator.sequence.cs
     - match: (?=\S)
@@ -2266,7 +2266,7 @@ contexts:
         1: meta.generic.cs punctuation.definition.generic.begin.cs
       push: inside_type_argument
     - match: (?=[]})>,;>:]|=>)
-      pop: true
+      pop: 1
 
   type_common:
     - include: type_common_except_bare_custom_type
@@ -2283,7 +2283,7 @@ contexts:
         5: punctuation.separator.cs
         6: punctuation.section.brackets.end.cs
         7: keyword.operator.pointer.cs
-      pop: true
+      pop: 1
     - match: ','
       scope: punctuation.separator.type.cs
 
@@ -2352,7 +2352,7 @@ contexts:
     - meta_content_scope: meta.brackets.cs
     - match: \]
       scope: meta.brackets.cs punctuation.section.brackets.end.cs
-      pop: true
+      pop: 1
     - match: ','
       scope: punctuation.separator.type.cs
     - match: (?:Cdecl|Stdcall|Thiscall|Fastcall)\b
@@ -2370,7 +2370,7 @@ contexts:
     - meta_content_scope: meta.generic.cs
     - match: '>'
       scope: meta.generic.cs punctuation.definition.generic.end.cs
-      pop: true
+      pop: 1
     - match: ','
       scope: punctuation.separator.type.cs
     - match: (?:in|out|ref|readonly)\b
@@ -2511,7 +2511,7 @@ contexts:
     - meta_scope: meta.string.cs string.quoted.double.cs
     - match: '"'
       scope: punctuation.definition.string.end.cs
-      pop: true
+      pop: 1
     - include: string_prototype
     - include: string_escapes
     - include: string_placeholder_escapes
@@ -2523,7 +2523,7 @@ contexts:
       push: inside_extended_string_placeholder
     - match: $\n?
       scope: invalid.illegal.unclosed-string.cs
-      pop: true
+      pop: 1
 
   inside_extended_string_placeholder:
     - meta_scope: constant.other.placeholder.cs
@@ -2538,7 +2538,7 @@ contexts:
     - meta_scope: meta.string.interpolated.cs string.quoted.double.cs
     - match: '"'
       scope: punctuation.definition.string.end.cs
-      pop: true
+      pop: 1
     - include: string_prototype
     - include: string_escapes
     - include: string_placeholder_escapes
@@ -2549,7 +2549,7 @@ contexts:
       scope: invalid.illegal.unescaped-placeholder.cs
     - match: $\n?
       scope: invalid.illegal.unclosed-string.cs
-      pop: true
+      pop: 1
 
   inside_format_string_interpolation:
     - clear_scopes: 1
@@ -2557,7 +2557,7 @@ contexts:
     - meta_content_scope: source.cs
     - match: \}
       scope: punctuation.section.interpolation.end.cs
-      pop: true
+      pop: 1
     - include: string_interpolation_width
     - include: string_placeholder_format
     - include: line_of_code_in
@@ -2565,7 +2565,7 @@ contexts:
   string_placeholder_format:
     - match: ':(?=")'
       scope: invalid.illegal.unclosed-string-placeholder.cs
-      pop: true
+      pop: 1
     - match: ':'
       scope: punctuation.separator.cs
       push: inside_string_placeholder_format
@@ -2576,7 +2576,7 @@ contexts:
     - include: string_escapes
     - include: string_placeholder_escapes
     - match: (?=\})
-      pop: true
+      pop: 1
     - match: (?:[^}"\\](?:\\.)*)*(?=")
       scope: invalid.illegal.unclosed-string-placeholder.cs
       pop: 2
@@ -2591,7 +2591,7 @@ contexts:
     - include: verbatim_string_escapes
     - match: '"'
       scope: punctuation.definition.string.end.cs
-      pop: true
+      pop: 1
     - include: string_prototype
     - include: string_placeholder_escapes
     - include: string_placeholders
@@ -2604,7 +2604,7 @@ contexts:
       with_prototype:
         - include: verbatim_string_escapes
         - match: (?=")
-          pop: true
+          pop: 1
         - include: string_prototype
         - include: string_placeholder_escapes
         - include: string_placeholders
@@ -2632,7 +2632,7 @@ contexts:
     - include: verbatim_string_escapes
     - match: '"'
       scope: punctuation.definition.string.end.cs
-      pop: true
+      pop: 1
     - include: string_prototype
     - include: string_placeholder_escapes
     - include: verbatim_format_string_interpolations
@@ -2644,7 +2644,7 @@ contexts:
       with_prototype:
         - include: verbatim_string_escapes
         - match: (?=")
-          pop: true
+          pop: 1
         - include: string_prototype
         - include: string_placeholder_escapes
         - include: verbatim_format_string_interpolations
@@ -2663,7 +2663,7 @@ contexts:
     - meta_content_scope: source.cs
     - match: \}
       scope: punctuation.section.interpolation.end.cs
-      pop: true
+      pop: 1
     - include: string_interpolation_width
     - include: verbatim_string_placeholder_format
     - include: line_of_code_in
@@ -2671,7 +2671,7 @@ contexts:
   verbatim_string_placeholder_format:
     - match: ':(?="(?!"))'
       scope: invalid.illegal.unclosed-string-placeholder.cs
-      pop: true
+      pop: 1
     - match: ':'
       scope: punctuation.separator.cs
       push: inside_verbatim_string_placeholder_format
@@ -2682,7 +2682,7 @@ contexts:
     - include: verbatim_string_escapes
     - include: string_placeholder_escapes
     - match: (?=\})
-      pop: true
+      pop: 1
     - match: \\(?:""|[^"])
       scope: constant.character.escape.cs
     - match: (?:[^}"]|"")*(?="(?!"))
@@ -2702,7 +2702,7 @@ contexts:
     - meta_scope: meta.string.cs string.quoted.double.block.cs
     - match: '"""'
       scope: punctuation.definition.string.end.cs
-      pop: true
+      pop: 1
     - include: string_prototype
     - include: string_placeholder_escapes
     - include: string_placeholders
@@ -2714,7 +2714,7 @@ contexts:
       set: scope:source.sql
       with_prototype:
         - match: (?=""")
-          pop: true
+          pop: 1
         - include: string_prototype
     - include: else_pop
 
@@ -2723,7 +2723,7 @@ contexts:
     - meta_scope: meta.string.cs string.quoted.double.block.cs
     - match: \1
       scope: punctuation.definition.string.end.cs
-      pop: true
+      pop: 1
     - include: string_prototype
     - include: string_placeholder_escapes
     - include: string_placeholders
@@ -2749,7 +2749,7 @@ contexts:
     - meta_scope: meta.string.interpolated.cs string.quoted.double.block.cs
     - match: \1
       scope: punctuation.definition.string.end.cs
-      pop: true
+      pop: 1
     - include: string_prototype
     - match: \{{2,}|\}{1,}
       scope: invalid.illegal.unexpected-token.cs
@@ -2763,7 +2763,7 @@ contexts:
     - meta_content_scope: source.cs
     - match: \}
       scope: punctuation.section.interpolation.end.cs
-      pop: true
+      pop: 1
     - include: string_interpolation_width
     - include: raw_string_placeholder_format
     - include: line_of_code_in
@@ -2773,7 +2773,7 @@ contexts:
     - meta_scope: meta.string.interpolated.cs string.quoted.double.block.cs
     - match: \1
       scope: punctuation.definition.string.end.cs
-      pop: true
+      pop: 1
     - include: string_prototype
     - match: \{{2}(?!\{)
       scope: punctuation.section.interpolation.begin.cs
@@ -2787,7 +2787,7 @@ contexts:
     - meta_content_scope: source.cs
     - match: \}{2}
       scope: punctuation.section.interpolation.end.cs
-      pop: true
+      pop: 1
     - include: string_interpolation_width
     - include: raw_string_placeholder_format
     - include: line_of_code_in
@@ -2797,7 +2797,7 @@ contexts:
     - meta_scope: meta.string.interpolated.cs string.quoted.double.block.cs
     - match: \1
       scope: punctuation.definition.string.end.cs
-      pop: true
+      pop: 1
     - include: string_prototype
     - match: \{{3}(?!\{)
       scope: punctuation.section.interpolation.begin.cs
@@ -2811,7 +2811,7 @@ contexts:
     - meta_content_scope: source.cs
     - match: \}{3}
       scope: punctuation.section.interpolation.end.cs
-      pop: true
+      pop: 1
     - include: string_interpolation_width
     - include: raw_string_placeholder_format
     - include: line_of_code_in
@@ -2821,7 +2821,7 @@ contexts:
     - meta_scope: meta.string.interpolated.cs string.quoted.double.block.cs
     - match: \1
       scope: punctuation.definition.string.end.cs
-      pop: true
+      pop: 1
     - include: string_prototype
     - match: \{{4}(?!\{)
       scope: punctuation.section.interpolation.begin.cs
@@ -2835,7 +2835,7 @@ contexts:
     - meta_content_scope: source.cs
     - match: \}{4}
       scope: punctuation.section.interpolation.end.cs
-      pop: true
+      pop: 1
     - include: string_interpolation_width
     - include: raw_string_placeholder_format
     - include: line_of_code_in
@@ -2849,7 +2849,7 @@ contexts:
     - meta_scope: meta.format-spec.cs
     - meta_content_scope: constant.other.format-spec.cs
     - match: (?=\})
-      pop: true
+      pop: 1
     - match: (?=")
       pop: 2
     - match: \\
@@ -2883,9 +2883,9 @@ contexts:
       captures:
         1: punctuation.definition.placeholder.end.cs
         2: invalid.illegal.unescaped-placeholder.cs
-      pop: true
+      pop: 1
     - match: (?=")
-      pop: true
+      pop: 1
 
   string_placeholder_width:
     - match: \s*(?:(,)\s*((-?)\d+)\s*)?
@@ -2911,12 +2911,12 @@ contexts:
 
   else_pop:
     - match: (?=\S)
-      pop: true
+      pop: 1
 
   immediately_pop:
     # immediately pop, but not before newlines
     - match: (?=[^\n])
-      pop: true
+      pop: 1
 
 ###[ VARIABLES ]###############################################################
 


### PR DESCRIPTION
As `pop: 2` is already used/needed, replace remaining `pop: true` instances.