### PR TITLE
[C#] Migrate to sublime syntax version 2

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -7,6 +7,7 @@
 
 name: C#
 scope: source.cs
+version: 2
 
 file_extensions:
   - cs
@@ -478,30 +479,27 @@ contexts:
         4: storage.type.cs
       push:
         - meta_content_scope: meta.enum.cs
-        - match: (?=\{)
+        - match: \{
+          scope: punctuation.section.block.begin.cs
           set:
-          - match: \{
-            scope: punctuation.section.block.begin.cs
-            set:
-              - meta_scope: meta.enum.body.cs meta.block.cs
-              - match: \}
-                scope: punctuation.section.block.end.cs
-                set:
-                  - match: ';'
-                    scope: punctuation.terminator.statement.cs
-                    pop: 1
-                  - match: '(?=\S)'
-                    pop: 1
-              - include: attribute
-              - match: '{{name}}'
-                scope: entity.name.constant.cs
-              - match: '='
-                scope: keyword.operator.assignment.cs
-                push:
-                  - line_of_code_in
-                  - maybe_pointer
-              - match: ','
-                scope: punctuation.separator.enum.cs
+            - meta_scope: meta.enum.body.cs meta.block.cs
+            - match: \}
+              scope: punctuation.section.block.end.cs
+              set:
+                - match: ';'
+                  scope: punctuation.terminator.statement.cs
+                  pop: 1
+                - include: else_pop
+            - include: attribute
+            - match: '{{name}}'
+              scope: entity.name.constant.cs
+            - match: '='
+              scope: keyword.operator.assignment.cs
+              push:
+                - line_of_code_in
+                - maybe_pointer
+            - match: ','
+              scope: punctuation.separator.enum.cs
 
 ###[ INTERFACE DECLARATIONS ]##################################################
 
@@ -1099,13 +1097,13 @@ contexts:
       set:
         - meta_content_scope: meta.property.cs meta.block.cs
         - match: \}
-          scope: punctuation.section.block.end.cs
+          scope: meta.property.cs meta.block.cs punctuation.section.block.end.cs
           set:
             - meta_content_scope: meta.property.cs
             - match: =
               scope: keyword.operator.assignment.cs
               set:
-                - meta_content_scope: meta.property.cs
+                - meta_scope: meta.property.cs
                 - include: line_of_code_in
             - include: else_pop
         - match: (?:\b(readonly)\b\s+)?\b(get)\b
@@ -1122,7 +1120,7 @@ contexts:
     - match: '=>'
       scope: keyword.declaration.function.arrow.cs
       set:
-        - meta_content_scope: meta.method.cs
+        - meta_content_scope: meta.property.cs
         - include: line_of_code_in
     - match: \S
       scope: invalid.illegal.cs
@@ -1366,11 +1364,11 @@ contexts:
       scope: meta.group.cs punctuation.section.group.end.cs
       set:
         - match: \{
-          scope: meta.block.cs punctuation.section.block.begin.cs
+          scope: punctuation.section.block.begin.cs
           set:
-            - meta_content_scope: meta.block.cs
+            - meta_scope: meta.block.cs
             - match: \}
-              scope: meta.block.cs punctuation.section.block.end.cs
+              scope: punctuation.section.block.end.cs
               pop: 1
             - include: code_block_in
         - match: (?=\S)
@@ -1393,40 +1391,37 @@ contexts:
     - match: \)
       scope: meta.group.cs punctuation.section.group.end.cs
       set:
-      - match: \{
-        scope: punctuation.section.block.begin.cs
-        set:
-          - meta_scope: meta.block.cs
-          - match: \}
-            scope: punctuation.section.block.end.cs
-            pop: 1
-          - include: code_block_in
-      - include: else_pop
+        - match: \{
+          scope: punctuation.section.block.begin.cs
+          set:
+            - meta_scope: meta.block.cs
+            - match: \}
+              scope: punctuation.section.block.end.cs
+              pop: 1
+            - include: code_block_in
+        - include: else_pop
     - include: else_pop
 
 ###[ CONDITIONAL STATEMENTS ]##################################################
 
   if_condition:
-    - match: '\s*(\()'
-      captures:
-        1: meta.group.cs punctuation.section.group.begin.cs
+    - match: \(
+      scope: punctuation.section.group.begin.cs
       set:
-        - meta_content_scope: meta.group.cs
-        - match: '\s*(\))'
-          captures:
-            1: meta.group.cs punctuation.section.group.end.cs
+        - meta_scope: meta.group.cs
+        - match: \)
+          scope: punctuation.section.group.end.cs
           pop: 1
         - include: line_of_code_in
-    - match: (?=[^(])
-      pop: 1
+    - include: else_pop
 
   if_block:
     - match: \{
-      scope: meta.block.cs punctuation.section.block.begin.cs
+      scope: punctuation.section.block.begin.cs
       set:
-        - meta_content_scope: meta.block.cs
+        - meta_scope: meta.block.cs
         - match: \}
-          scope: meta.block.cs punctuation.section.block.end.cs
+          scope: punctuation.section.block.end.cs
           pop: 1
         - include: code_block_in
     - match: (?=\S)
@@ -1436,20 +1431,18 @@ contexts:
         - include: line_of_code
 
   else_block:
-    - match: (else\s+if)\b\s*
-      captures:
-        1: keyword.control.conditional.elseif.cs
+    - match: else\s+if\b
+      scope: keyword.control.conditional.elseif.cs
       push: [if_block, if_condition]
-    - match: (else)\s*
+    - match: else\b
       scope: keyword.control.conditional.else.cs
       set:
-        - match: \s*(\{)
-          captures:
-            1: meta.block.cs punctuation.section.block.begin.cs
+        - match: \{
+          scope: punctuation.section.block.begin.cs
           set:
-            - meta_content_scope: meta.block.cs
+            - meta_scope: meta.block.cs
             - match: \}
-              scope: meta.block.cs punctuation.section.block.end.cs
+              scope: punctuation.section.block.end.cs
               pop: 1
             - include: code_block_in
         - match: (?=\S)
@@ -1457,11 +1450,11 @@ contexts:
     - include: else_pop
 
   switch_condition:
-    - match: '\('
+    - match: \(
       scope: punctuation.section.group.begin.cs
       set:
         - meta_scope: meta.group.cs
-        - match: '\)'
+        - match: \)
           scope: punctuation.section.group.end.cs
           pop: 1
         - include: line_of_code_in
@@ -1584,7 +1577,7 @@ contexts:
   for_block:
     - meta_content_scope: meta.group.cs
     - match: \)
-      scope: punctuation.section.group.end.cs
+      scope: meta.group.cs punctuation.section.group.end.cs
       set:
       - match: \{
         scope: punctuation.section.block.begin.cs
@@ -1595,8 +1588,7 @@ contexts:
             pop: 1
           - include: code_block_in
       - match: (?=\S)
-        set:
-          - include: line_of_code
+        set: line_of_code
 
   do_condition:
     - match: \b(while)\b
@@ -1620,13 +1612,12 @@ contexts:
       scope: punctuation.section.block.begin.cs
       set:
         - meta_scope: meta.block.cs
-        - match: '\}'
+        - match: \}
           scope: punctuation.section.block.end.cs
           pop: 1
         - include: code_block_in
     - match: (?=\S)
-      set:
-        - include: line_of_code
+      set: line_of_code
 
 ###[ EXPRESSIONS ]#############################################################
 
@@ -1695,7 +1686,7 @@ contexts:
         - match: ','
           scope: punctuation.separator.type.cs
         - match: '>'
-          scope: punctuation.definition.generic.end.cs
+          scope: meta.generic.cs punctuation.definition.generic.end.cs
           set: function_call_begin_paren
         - include: type
     - match: ({{name}})(<)(?={{namespaced_name}}>\s*\.)
@@ -1888,7 +1879,7 @@ contexts:
     - match: (?=[^{\s])
       # This is not an anonymous class
       set:
-        - meta_content_scope: meta.instance.cs
+        - meta_scope: meta.instance.cs
         - match: '{{brackets_capture}}'
           captures:
             1: meta.brackets.cs
@@ -1908,7 +1899,6 @@ contexts:
             - match: '(?=\S)'
               push: line_of_code_in
         - match: (?:\s*((\()\s*(\)))\s*)?(\{)
-          scope: meta.instance.cs
           captures:
             1: meta.group.cs
             2: punctuation.section.group.begin.cs
@@ -2015,7 +2005,7 @@ contexts:
   constructor_arguments:
     - meta_content_scope: meta.instance.cs meta.group.cs
     - match: \)
-      scope: punctuation.section.group.end.cs
+      scope: meta.instance.cs meta.group.cs punctuation.section.group.end.cs
       set: maybe_constructor_initializer
     - include: maybe_constructor_initializer
 
@@ -2024,7 +2014,7 @@ contexts:
     - match: (?=[^\s{])
       pop: 1
     - match: \{
-      scope: punctuation.section.braces.begin.cs
+      scope: meta.instance.cs meta.braces.cs punctuation.section.braces.begin.cs
       set: initializer_constructor
 
   initializer_constructor:
@@ -2033,7 +2023,7 @@ contexts:
       scope: meta.instance.cs meta.braces.cs punctuation.section.braces.end.cs
       pop: 1
     - match: \{
-      scope: punctuation.section.braces.begin.cs
+      scope: meta.instance.cs meta.braces.cs punctuation.section.braces.begin.cs
       push: initializer_constructor
     - match: ','
       scope: punctuation.separator.array-element.cs
@@ -2045,7 +2035,7 @@ contexts:
   function_call_begin_paren:
     - meta_content_scope: meta.function-call.cs
     - match: \(
-      scope: meta.group.cs punctuation.section.group.begin.cs
+      scope: meta.function-call.cs meta.group.cs punctuation.section.group.begin.cs
       set: [function_call_arguments, arguments]
     - include: else_pop
 
@@ -2177,14 +2167,14 @@ contexts:
 
   maybe_pattern_matching_object:
     - match: \{
-      scope: meta.instance.property-subpattern.cs meta.class.body.anonymous.cs meta.block.cs punctuation.section.block.begin.cs
+      scope: punctuation.section.block.begin.cs
       set: pattern_matching_object
     - include: else_pop
 
   pattern_matching_object:
-    - meta_content_scope: meta.instance.property-subpattern.cs meta.class.body.anonymous.cs meta.block.cs
+    - meta_scope: meta.instance.property-subpattern.cs meta.class.body.anonymous.cs meta.block.cs
     - match: \}
-      scope: meta.instance.property-subpattern.cs meta.class.body.anonymous.cs meta.block.cs punctuation.section.block.end.cs
+      scope: punctuation.section.block.end.cs
       pop: 1
     - match: ','
       scope: punctuation.separator.property.cs
@@ -2441,20 +2431,20 @@ contexts:
 
   regex_string:
     - match: '"'
-      scope: punctuation.definition.string.begin.cs
+      scope: meta.string.cs string.quoted.double.cs punctuation.definition.string.begin.cs
       embed: scope:source.regexp
-      embed_scope: meta.string.cs meta.regexp.cs
+      embed_scope: meta.string.cs string.quoted.double.cs source.regexp
       escape: '"'
       escape_captures:
-        0: punctuation.definition.string.end.cs
+        0: meta.string.cs string.quoted.double.cs punctuation.definition.string.end.cs
       pop: 1
     - match: '@"'
-      scope: punctuation.definition.string.begin.cs
+      scope: meta.string.cs string.quoted.double.verbatim.cs punctuation.definition.string.begin.cs
       embed: scope:source.regexp
-      embed_scope: meta.string.cs meta.regexp.cs
+      embed_scope: meta.string.cs string.quoted.double.verbatim.cs source.regexp
       escape: '"'
       escape_captures:
-        0: punctuation.definition.string.end.cs
+        0: meta.string.cs string.quoted.double.verbatim.cs punctuation.definition.string.end.cs
       pop: 1
     - include: else_pop
 

--- a/C#/tests/syntax_test_C#11.cs
+++ b/C#/tests/syntax_test_C#11.cs
@@ -691,7 +691,7 @@ class SomeClass
 ///                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group.cs
 ///                ^ punctuation.section.group.begin.cs
 ///                 ^ punctuation.definition.string.begin.cs
-///                  ^^^^^^^ meta.string.cs meta.regexp.cs source.regexp meta.mode.basic.regexp
+///                  ^^^^^^^ meta.string.cs string.quoted.double.cs source.regexp meta.mode.basic.regexp
 ///                     ^ keyword.operator.alternation.regexp
 ///                         ^ punctuation.definition.string.end.cs
 ///                          ^ punctuation.separator.argument.cs
@@ -723,8 +723,8 @@ class SomeClass
 ///  ^^^^^^^^^^^^^^ variable.annotation.cs
 ///                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group.cs
 ///                ^ punctuation.section.group.begin.cs
-///                 ^^ punctuation.definition.string.begin.cs
-///                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.cs meta.regexp.cs source.regexp
+///                 ^^ meta.string.cs string.quoted.double.verbatim.cs punctuation.definition.string.begin.cs
+///                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.cs string.quoted.double.cs source.regexp meta.mode.basic.regexp
 ///                   ^^^^^ meta.mode.basic.regexp
 ///                   ^ keyword.control.anchor.regexp
 ///                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group.regexp meta.mode.basic.regexp
@@ -740,7 +740,7 @@ class SomeClass
 ///                                             ^^^^^^^ keyword.operator.quantifier.regexp
 ///                                                    ^ punctuation.section.group.end.regexp
 ///                                                     ^ meta.mode.basic.regexp keyword.control.anchor.regexp
-///                                                      ^ punctuation.definition.string.end.cs
+///                                                      ^ meta.string.cs string.quoted.double.verbatim.cs punctuation.definition.string.end.cs
 ///                                                       ^ punctuation.section.group.end.cs
 ///                                                        ^ punctuation.definition.annotation.end.cs
     private static partial Regex SomeRegex();

--- a/C#/tests/syntax_test_C#14.cs
+++ b/C#/tests/syntax_test_C#14.cs
@@ -141,8 +141,7 @@ TryParse<int> parse2 = (string text, out int result) => Int32.TryParse(text, out
 //          ^ punctuation.definition.generic.end.cs
 //            ^^^^^^ variable.other.cs
 //                   ^ keyword.operator.assignment.cs
-//                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.anonymous.cs
-//                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group.cs
+//                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.anonymous.cs meta.group.cs - meta.function meta.function
 //                     ^ punctuation.section.group.begin.cs
 //                      ^^^^^^ storage.type.cs
 //                             ^^^^ variable.parameter.cs
@@ -150,13 +149,14 @@ TryParse<int> parse2 = (string text, out int result) => Int32.TryParse(text, out
 //                                   ^^^ storage.modifier.parameter.cs
 //                                       ^^^ storage.type.cs
 //                                           ^^^^^^ variable.parameter.cs
-//                                                 ^ meta.group.cs punctuation.section.group.end.cs
+//                                                 ^ punctuation.section.group.end.cs
+//                                                  ^^^^^^^^^^^^^^^^^^ meta.function.anonymous.cs - meta.function meta.function - meta.group
 //                                                   ^^ keyword.declaration.function.arrow.cs
 //                                                      ^^^^^ variable.other.cs
 //                                                           ^ punctuation.accessor.dot.cs
 //                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.cs
 //                                                            ^^^^^^^^ variable.function.cs
-//                                                                    ^^^^^^^^^^^^^^^^^^ meta.group.cs
+//                                                                    ^^^^^^^^^^^^^^^^^^ meta.function.anonymous.cs meta.group.cs - meta.function meta.function
 //                                                                    ^ punctuation.section.group.begin.cs
 //                                                                     ^^^^ variable.other.cs
 //                                                                         ^ punctuation.separator.argument.cs
@@ -173,21 +173,21 @@ TryParse<int> parse1 = (text, out result) => Int32.TryParse(text, out result);
 //          ^ punctuation.definition.generic.end.cs
 //            ^^^^^^ variable.other.cs
 //                   ^ keyword.operator.assignment.cs
-//                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.anonymous.cs
-//                     ^^^^^^^^^^^^^^^^^^^^^ meta.group.cs
+//                     ^^^^^^^^^^^^^^^^^^ meta.function.anonymous.cs meta.group.cs - meta.function meta.function
 //                     ^ punctuation.section.group.begin.cs
 //                      ^^^^ variable.parameter.cs
 //                          ^ punctuation.separator.parameter.function.cs
 //                            ^^^ storage.modifier.parameter.cs
 //                               ^^^^^^^^^^^ - storage
 //                                ^^^^^^ variable.parameter.cs
-//                                      ^ meta.group.cs punctuation.section.group.end.cs
+//                                      ^ punctuation.section.group.end.cs
+//                                       ^^^^^^^^^^^^^^^^^^ meta.function.anonymous.cs - meta.function meta.function - meta.group
 //                                        ^^ keyword.declaration.function.arrow.cs
 //                                           ^^^^^ variable.other.cs
 //                                                ^ punctuation.accessor.dot.cs
 //                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.cs
 //                                                 ^^^^^^^^ variable.function.cs
-//                                                         ^^^^^^^^^^^^^^^^^^ meta.group.cs
+//                                                         ^^^^^^^^^^^^^^^^^^ meta.function.anonymous.cs meta.group.cs - meta.function meta.function
 //                                                         ^ punctuation.section.group.begin.cs
 //                                                          ^^^^ variable.other.cs
 //                                                              ^ punctuation.separator.argument.cs
@@ -205,7 +205,7 @@ TryParse<int> parse1 = (text, out Int32 result) => Int32.TryParse(text, out resu
 //            ^^^^^^ variable.other.cs
 //                   ^ keyword.operator.assignment.cs
 //                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.anonymous.cs
-//                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group.cs
+//                     ^^^^^^^^^^^^^^^^^^^^^^^^ meta.group.cs
 //                     ^ punctuation.section.group.begin.cs
 //                      ^^^^ variable.parameter.cs
 //                          ^ punctuation.separator.parameter.function.cs

--- a/C#/tests/syntax_test_C#8.cs
+++ b/C#/tests/syntax_test_C#8.cs
@@ -343,7 +343,8 @@ namespace CommonTests.Attributes;
 public class CustomAutoDataAttribute() : AutoDataAttribute(
     () =>
 ///^^^^^^^ meta.class.constructor.arguments.cs meta.group.cs
-/// ^^^^^ meta.function.anonymous.cs meta.group.cs
+/// ^^ meta.function.anonymous.cs meta.group.cs
+///   ^^^^ meta.function.anonymous.cs - meta.function meta.group
 /// ^ punctuation.section.group.begin.cs
 ///  ^ punctuation.section.group.end.cs
 ///    ^^ keyword.declaration.function.arrow.cs

--- a/C#/tests/syntax_test_c#.cs
+++ b/C#/tests/syntax_test_c#.cs
@@ -401,7 +401,7 @@ public class Program {
 //^^^^^^^^^^^^^^ meta.class.body.cs meta.block.cs meta.method.body.cs meta.block.cs
 //^^^^^^^ meta.block.cs
 //      ^ punctuation.section.block.end.cs
-//        ^^^^^ keyword.control.conditional.else.cs
+//        ^^^^ keyword.control.conditional.else.cs
 //             ^ meta.block.cs punctuation.section.block.begin.cs
             Console.WriteLine ("false");
         }


### PR DESCRIPTION
This PR implements required changes to migrate to syntax version 2

Notes:

1. it fixes an indentation error
2. it changes a lambda property's body from `meta.method` to `meta.property`
3. it scopes regular expressions `string`
4. it fixes space after `else` being scoped `keyword`

Beyond that this PC includes only changes which are required to maintain meta scopes (without gaps or overlaps).

Any further changes (named contexts for groups and blocks, ...) are planned for future changes.