### PR TITLE
[C#] Add missing bailout from member declaration

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -881,6 +881,8 @@ contexts:
         - member_lambda
         - method_name
       pop: 1
+    - include: terminator
+    - include: else_pop
 
   expect_type_member:
     - match: (?=\S)

--- a/C#/tests/syntax_test_GeneralStructure.cs
+++ b/C#/tests/syntax_test_GeneralStructure.cs
@@ -14,6 +14,10 @@ namespace YourNamespace
 /// ^ keyword.declaration.class
 ///        ^ entity.name.class
     {
+        Int;
+///     ^^^ support.type.cs
+///        ^ punctuation.terminator.statement.cs
+
         Int x;
 ///     ^^^ support.type
 ///         ^ variable.other.member


### PR DESCRIPTION
This PR fixes highlighting failing after incomplete member declarations caused by missing bailout.