### PR TITLE
[C#] Fix switch case keyword scopes

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -1741,7 +1741,7 @@ contexts:
           pop: 1
         - include: type
     - match: \bswitch\b
-      scope: keyword.control.flow.cs
+      scope: keyword.control.conditional.switch.cs
       push: switch_expression
     - match: '({{reserved}})\b'
       scope: keyword.other.cs

--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -1488,7 +1488,7 @@ contexts:
           pop: 1
         - match: \b(default)\s*(:)
           captures:
-            1: keyword.control.conditional.case.cs
+            1: keyword.control.conditional.default.cs
             2: punctuation.separator.case-statement.cs
         - match: \bcase\b
           scope: keyword.control.conditional.case.cs

--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -1258,10 +1258,9 @@ contexts:
       captures:
         1: keyword.control.conditional.if.cs
       set: [else_block, if_block, if_condition]
-    - match: \b(switch)\b
-      captures:
-        1: keyword.control.flow.switch.cs
-      set: [switch_block, if_condition]
+    - match: \bswitch\b
+      scope: keyword.control.conditional.switch.cs
+      set: [switch_block, switch_condition]
     - match: \b(for)\s*(\()(?=(?:{{name}}|var)\s(?!=))
       captures:
         1: keyword.control.loop.for.cs
@@ -1320,7 +1319,7 @@ contexts:
     - match: \b(goto)\s+(case)\b
       captures:
         1: keyword.control.flow.goto.cs
-        2: keyword.control.switch.case.cs
+        2: keyword.control.conditional.case.cs
       set: line_of_code_in
     - match: '\b(goto)\s+({{name}})\s*(;)'
       captures:
@@ -1487,18 +1486,18 @@ contexts:
         - match: \}
           scope: punctuation.section.block.end.cs
           pop: 1
-        - match: '\b(default)\s*(:)'
+        - match: \b(default)\s*(:)
           captures:
-            1: keyword.control.switch.case.cs
+            1: keyword.control.conditional.case.cs
             2: punctuation.separator.case-statement.cs
-        - match: '\b(case)\b'
-          scope: keyword.control.switch.case.cs
+        - match: \bcase\b
+          scope: keyword.control.conditional.case.cs
           push:
             - match: '{{name}}(?=\s*:)'
               scope: constant.other.cs
-            - match: '\bwhen\b'
-              scope: keyword.control.switch.case.when.cs
-            - match: '(?={{namespaced_name}}{{type_suffix}}\s+{{name}}\s+when\b)'
+            - match: \bwhen\b
+              scope: keyword.control.conditional.when.cs
+            - match: (?={{namespaced_name}}{{type_suffix}}\s+{{name}}\s+when\b)
               push: var_declaration_explicit
             - match: ':'
               scope: punctuation.separator.case-statement.cs
@@ -2166,7 +2165,7 @@ contexts:
         - match: \b_\b
           scope: variable.language.anonymous.cs
         - match: '\bwhen\b'
-          scope: keyword.control.switch.case.when.cs
+          scope: keyword.control.conditional.when.cs
         - match: \(
           scope: punctuation.section.sequence.begin.cs
           push:

--- a/C#/tests/syntax_test_C#11.cs
+++ b/C#/tests/syntax_test_C#11.cs
@@ -565,7 +565,7 @@ public static void M(string myString)
 */
 string message = $"The usage policy for {safetyScore} is {
     safetyScore switch
-///             ^^^^^^ meta.string.interpolated source keyword.control.flow
+///             ^^^^^^ meta.string.interpolated source keyword.control.conditional.switch
     {
         > 90 => "Unlimited usage",
         > 80 => "General usage, with daily safety check",

--- a/C#/tests/syntax_test_C#7.cs
+++ b/C#/tests/syntax_test_C#7.cs
@@ -198,10 +198,10 @@ class Foo {
 
         switch (sh) {
             case Shape shape when sh.Area == 0:
-///         ^^^^ keyword.control.switch.case
+///         ^^^^ keyword.control.conditional.case
 ///              ^^^^^ support.type
 ///                    ^^^^^ variable.other
-///                          ^^^^ keyword.control.switch.case.when
+///                          ^^^^ keyword.control.conditional.when
 ///                               ^^ variable.other
 ///                                 ^ punctuation.accessor.dot
 ///                                  ^^^^ variable.other
@@ -211,23 +211,23 @@ class Foo {
                 Console.WriteLine($"The shape: {sh.GetType().Name} with no dimensions");
                 break;
             case int? example when example == 5:
-///         ^^^^ keyword.control.switch.case
+///         ^^^^ keyword.control.conditional.case
 ///              ^^^ storage.type
 ///                 ^ storage.type.nullable
 ///                   ^^^^^^^ variable.other
-///                           ^^^^ keyword.control.switch.case.when
+///                           ^^^^ keyword.control.conditional.when
 ///                                ^^^^^^^ variable.other
 ///                                        ^^ keyword.operator.comparison
 ///                                           ^ meta.number.integer.decimal constant.numeric.value
 ///                                            ^ punctuation.separator.case-statement
             case Shape<Shape> shape when shape.Area > 0:
-///         ^^^^ keyword.control.switch.case
+///         ^^^^ keyword.control.conditional.case
 ///              ^^^^^ support.type
 ///                   ^ punctuation.definition.generic.begin
 ///                    ^^^^^ support.type
 ///                         ^ punctuation.definition.generic.end
 ///                           ^^^^^ variable.other
-///                                 ^^^^ keyword.control.switch.case.when
+///                                 ^^^^ keyword.control.conditional.when
 ///                                      ^^^^^ variable.other
 ///                                           ^ punctuation.accessor.dot
 ///                                            ^^^^ variable.other

--- a/C#/tests/syntax_test_C#8.cs
+++ b/C#/tests/syntax_test_C#8.cs
@@ -53,7 +53,7 @@ public static decimal CalculateToll(object vehicle) =>
         DeliveryTruck t when t.GrossWeightClass > 5000 => 10.00m + 5.00m,
 ///     ^^^^^^^^^^^^^ support.type
 ///                   ^ variable.other
-///                     ^^^^ keyword.control.switch.case.when
+///                     ^^^^ keyword.control.conditional.when
 ///                          ^ variable.other
 ///                           ^ punctuation.accessor.dot
 ///                            ^^^^^^^^^^^^^^^^ variable.other
@@ -259,7 +259,7 @@ static Quadrant GetQuadrant(Point point) => point switch
     var (x, y) when x > 0 && y > 0 => Quadrant.One,
 /// ^^^ storage.type.variable
 ///     ^^^^^^ meta.sequence.tuple
-///            ^^^^ keyword.control.switch.case.when
+///            ^^^^ keyword.control.conditional.when
 ///                 ^ variable.other
 ///                   ^ keyword.operator.comparison
 ///                     ^ constant.numeric.value

--- a/C#/tests/syntax_test_C#8.cs
+++ b/C#/tests/syntax_test_C#8.cs
@@ -48,7 +48,7 @@ interface ILogger
 public static decimal CalculateToll(object vehicle) =>
     vehicle switch
 /// ^^^^^^^ variable.other
-///         ^^^^^^ keyword.control.flow
+///         ^^^^^^ keyword.control.conditional.switch
     {
         DeliveryTruck t when t.GrossWeightClass > 5000 => 10.00m + 5.00m,
 ///     ^^^^^^^^^^^^^ support.type

--- a/C#/tests/syntax_test_C#9.cs
+++ b/C#/tests/syntax_test_C#9.cs
@@ -76,7 +76,7 @@ var myValue = (args.Length > 0) switch { true => int.Parse(args[0]), _ => 4 };
 Console.WriteLine(myValue);
 
 var message = myValue switch
-///                   ^^^^^^ keyword.control.flow
+///                   ^^^^^^ keyword.control.conditional.switch
 {
     <= 0 => "Less than or equal to 0",
 /// ^^ keyword.operator.comparison
@@ -129,7 +129,7 @@ static bool CheckIfCanWalkIntoBank(Bank bank, bool isVip)
     return (bank.Status, isVip) switch
 /// ^^^^^^ keyword.control.flow.return
 ///        ^^^^^^^^^^^^^^^^^^^^ meta.sequence.tuple
-///                             ^^^^^^ keyword.control.flow
+///                             ^^^^^^ keyword.control.conditional.switch
     {
         (BankBranchStatus.Open, _) => true,
 ///     ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence.tuple
@@ -260,7 +260,7 @@ public class TollCalculator
 ///                             ^ punctuation.accessor.dot
 ///                              ^^^^^ variable.other
 ///                                   ^ punctuation.section.group.end
-///                                     ^^^^^^ keyword.control.flow
+///                                     ^^^^^^ keyword.control.conditional.switch
             {
 ///         ^ punctuation.section.block.begin
                 0 => 1.00m,

--- a/C#/tests/syntax_test_C#9.cs
+++ b/C#/tests/syntax_test_C#9.cs
@@ -51,14 +51,14 @@ if (myValue is > 0 and <= 10)
 switch (myValue)
 {
     case <= 0:
-/// ^^^^ keyword.control.switch.case
+/// ^^^^ keyword.control.conditional.case
 ///      ^^ keyword.operator.comparison
 ///         ^ constant.numeric.value
 ///          ^ punctuation.separator.case-statement
         Console.WriteLine("Less than or equal to 0");
         break;
     case > 0 and <= 10:
-/// ^^^^ keyword.control.switch.case
+/// ^^^^ keyword.control.conditional.case
 ///      ^ keyword.operator.comparison
 ///        ^ constant.numeric.value
 ///          ^^^ keyword.operator.logical
@@ -116,7 +116,7 @@ static bool CheckIfCanWalkIntoBank(Bank bank, bool isVip)
 ///     ^^^^^^^^^^^^^^^^ variable.other
 ///                     ^ punctuation.accessor.dot
 ///                      ^^^^^^^^^^^^^^^^ variable.other
-///                                       ^^^^ keyword.control.switch.case.when
+///                                       ^^^^ keyword.control.conditional.when
 ///                                            ^ keyword.operator.logical
 ///                                             ^^^^^ variable.other
 ///                                                   ^^ punctuation.separator.case-expression
@@ -224,7 +224,7 @@ public class TollCalculator
             Bus b when ((double)b.Riders / (double)b.Capacity) < 0.50 => 5.00m + 2.00m,
 ///         ^^^ support.type
 ///             ^ variable.other
-///               ^^^^ keyword.control.switch.case.when
+///               ^^^^ keyword.control.conditional.when
 ///                      ^^^^^^ meta.cast storage.type
             Bus b when ((double)b.Riders / (double)b.Capacity) > 0.90 => 5.00m - 1.00m,
             Bus b => 5.00m,

--- a/C#/tests/syntax_test_GeneralStructure.cs
+++ b/C#/tests/syntax_test_GeneralStructure.cs
@@ -370,7 +370,7 @@ namespace TestNamespace . Test
 ///         ^ meta.method meta.block meta.block punctuation.section.block.end
 
             switch (foo) {
-///         ^^^^^^ keyword.control.flow.switch
+///         ^^^^^^ keyword.control.conditional.switch
 ///                ^^^^^ meta.group
 ///                ^ punctuation.section.group.begin
 ///                 ^^^ variable.other
@@ -385,7 +385,7 @@ namespace TestNamespace . Test
                     break;
 ///                 ^ keyword.control
                 case BLBodyBattleLibrary.ContextType.TapUp:
-///             ^^^^ keyword.control.switch.case
+///             ^^^^ keyword.control.conditional.case
 ///                  ^^^^^^^^^^^^^^^^^^^ variable.other
 ///                                     ^ punctuation.accessor.dot
 ///                                      ^^^^^^^^^^^ variable.other
@@ -393,27 +393,27 @@ namespace TestNamespace . Test
 ///                                                  ^^^^^ constant.other
 ///                                                       ^ punctuation.separator.case-statement
                 case BindingFlags.Static:
-///             ^^^^ keyword.control.switch.case
+///             ^^^^ keyword.control.conditional.case
 ///                  ^^^^^^^^^^^^ variable.other
 ///                              ^ punctuation.accessor.dot
 ///                               ^^^^^^ constant.other
 ///                                     ^ punctuation.separator.case-statement
                 case test:
-///             ^^^^ keyword.control.switch.case
+///             ^^^^ keyword.control.conditional.case
 ///                  ^^^^ constant.other
 ///                      ^ punctuation.separator.case-statement
                 case this.test;
-///             ^^^^ keyword.control.switch.case
+///             ^^^^ keyword.control.conditional.case
 ///                  ^^^^ variable.language.this
 ///                      ^ punctuation.accessor.dot
                 case 1*2:
-///             ^^^^ keyword.control.switch.case
+///             ^^^^ keyword.control.conditional.case
 ///                  ^ constant.numeric
 ///                   ^ keyword.operator
 ///                    ^ constant.numeric
 ///                     ^ punctuation.separator.case-statement
                 case bar("hello"):
-///             ^^^^ keyword.control.switch.case
+///             ^^^^ keyword.control.conditional.case
 ///                  ^^^ variable.function
 ///                     ^ punctuation.section.group.begin
 ///                      ^^^^^^^ string.quoted.double
@@ -421,7 +421,7 @@ namespace TestNamespace . Test
 ///                              ^ punctuation.separator.case-statement
                     break;
                 case abc.def:
-///             ^^^^ keyword.control.switch.case
+///             ^^^^ keyword.control.conditional.case
 ///                  ^^^ variable.other
 ///                     ^ punctuation.accessor.dot
 ///                      ^^^ constant.other
@@ -1157,14 +1157,14 @@ namespace TestNamespace . Test
                 result += 4;
                 goto case 'b';
 ///             ^^^^ keyword.control.flow.goto
-///                  ^^^^ keyword.control.switch.case
+///                  ^^^^ keyword.control.conditional.case
 ///                       ^^^ meta.string string.quoted.single
 ///                       ^ punctuation.definition.string.begin
 ///                        ^ constant.character.literal
 ///                         ^ punctuation.definition.string.end
 ///                          ^ punctuation.terminator.statement
             case 'b':
-///         ^^^^ keyword.control.switch.case - invalid
+///         ^^^^ keyword.control.conditional.case - invalid
 ///              ^^^ meta.string string.quoted.single
 ///              ^ punctuation.definition.string.begin
 ///               ^ constant.character.literal

--- a/C#/tests/syntax_test_GeneralStructure.cs
+++ b/C#/tests/syntax_test_GeneralStructure.cs
@@ -1174,6 +1174,13 @@ namespace TestNamespace . Test
             case 'c':
                 result += 8;
                 break;
+
+            default:
+///         ^^^^^^^ keyword.control.conditional.default
+///                ^ punctuation.separator.case-statement
+                break;
+///             ^^^^^ keyword.control.flow.break
+///                  ^ punctuation.terminator.statement
         }
 
     int foo;


### PR DESCRIPTION
This PR applies scope naming guidelines to switch..case related keywords.