### PR TITLE
[JavaScript] Fix import keyword scope

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -2798,7 +2798,7 @@ contexts:
 
   import-meta-expression:
     - match: import{{identifier_break}}
-      scope: keyword.import.js
+      scope: keyword.control.import.js
       set: import-expression-end
 
   import-expression-end:

--- a/JavaScript/tests/syntax_test_js_import_export.js
+++ b/JavaScript/tests/syntax_test_js_import_export.js
@@ -258,13 +258,13 @@ export default$
 
 let x = import.meta;
 //      ^^^^^^^^^^^ - meta.import
-//      ^^^^^^ keyword.import
+//      ^^^^^^ keyword.control.import
 //            ^ punctuation.accessor
 //             ^^^^ variable.language.import
 
     import.meta;
 //  ^^^^^^^^^^^ - meta.import
-//  ^^^^^^ keyword.import
+//  ^^^^^^ keyword.control.import
 //        ^ punctuation.accessor
 //         ^^^^ variable.language.import
 
@@ -276,7 +276,7 @@ let x = import.meta;
 //   ^^^^ variable.language.import
 
     import('foo');
-//  ^^^^^^ keyword.import
+//  ^^^^^^ keyword.control.import
 //        ^^^^^^^ meta.group
 
     import


### PR DESCRIPTION
This commit applies a commonly used `keyword.control.import` scope.

This is the only usage of `keyword.import`, which is otherwise not known to be agreed part of scope naming guideline.