### PR TITLE
[JavaScript] Fix scope of generator operator

### DIFF
--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1662,7 +1662,7 @@ contexts:
         - match: $
           pop: 1
         - match: \*
-          scope: keyword.operator.generator.asterisk.js
+          scope: storage.modifier.generator.js
           set: expression-begin
         - match: (?=\S)
           set: expression-begin
@@ -1867,7 +1867,7 @@ contexts:
 
   function-declaration-expect-generator-star:
     - match: \*
-      scope: keyword.declaration.generator.js
+      scope: storage.modifier.generator.js
       pop: 1
     - include: else-pop
 

--- a/JavaScript/JavaScript.sublime-syntax
+++ b/JavaScript/JavaScript.sublime-syntax
@@ -1662,7 +1662,7 @@ contexts:
         - match: $
           pop: 1
         - match: \*
-          scope: keyword.generator.asterisk.js
+          scope: keyword.operator.generator.asterisk.js
           set: expression-begin
         - match: (?=\S)
           set: expression-begin

--- a/JavaScript/tests/syntax_test_js.js
+++ b/JavaScript/tests/syntax_test_js.js
@@ -160,7 +160,7 @@ someFunction({
 //  ^^^ entity.name.function variable.other.readwrite
 //        ^^^^^^^^^^^ meta.function - meta.function meta.function
 //        ^^^^^^^^ keyword.declaration.function
-//                ^ keyword.declaration.generator
+//                ^ storage.modifier.generator.js
     {
 
     }

--- a/JavaScript/tests/syntax_test_js_control.js
+++ b/JavaScript/tests/syntax_test_js_control.js
@@ -387,7 +387,7 @@ while (true)
 
     x = yield * 42;
 //      ^^^^^ keyword.control.flow.yield
-//            ^ keyword.generator.asterisk
+//            ^ keyword.operator.generator.asterisk
 
     x = yield
     function f() {}

--- a/JavaScript/tests/syntax_test_js_control.js
+++ b/JavaScript/tests/syntax_test_js_control.js
@@ -385,9 +385,13 @@ while (true)
     x = yield;
 //      ^^^^^ keyword.control.flow.yield
 
+    x = yield* 42;
+//      ^^^^^ keyword.control.flow.yield
+//           ^ storage.modifier.generator.js
+
     x = yield * 42;
 //      ^^^^^ keyword.control.flow.yield
-//            ^ keyword.operator.generator.asterisk
+//            ^ storage.modifier.generator.js
 
     x = yield
     function f() {}


### PR DESCRIPTION
This commit scopes `*` after `yield` and `function` `storage.modifier.generator` as current scope is unique and scope naming guideline doesn't contain an aggreed `generator` 2nd level scope.

The asterisk turns a function into a generator when following the `function` keyword.

The `yield*` expression delegates value generation to another generator like `yield from` in Python.