### PR TITLE
[C#] Don't stack keyword and illegal scope

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -1305,7 +1305,7 @@ contexts:
       scope: keyword.control.loop.while.cs
       set: [while_block, while_condition]
     - match: \b(else|case|catch|finally)\b
-      scope: keyword.control.cs invalid.illegal.unexpected.keyword.cs
+      scope: invalid.illegal.unexpected.keyword.cs
     - match: \b(return|yield\s+return)\b
       scope: keyword.control.flow.return.cs
       set: line_of_code_in


### PR DESCRIPTION
This commit removes `keyword.control.cs` from illegal usage locations of some keywords. Despite it not being very useful for highlighting it would alternatively require to create separate patterns to apply full `keyword.control.[conditional|exception]` scopes for consistency with legal usage positions.