### PR TITLE
[Markdown] Fix code span termination in table cells

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -330,7 +330,7 @@ variables:
   table_codespan_content: |-
     (?x:
       [^`|]             # first or only char must not be a backtick or pipe.
-      (?:[^|]*?[^`|])?  # none must be a pipe, the last additionally must not be a backtick
+      (?:[^|]*?[^`|])?? # none must be a pipe, the last additionally must not be a backtick
     )
 
   table_end: |-

--- a/Markdown/tests/syntax_test_markdown.md
+++ b/Markdown/tests/syntax_test_markdown.md
@@ -3467,6 +3467,57 @@ test
 > bar
 | <- markup.quote punctuation.definition.blockquote - meta.table
 
+c1        | c2
+--------- | ---------
+`Row 1`   | `a`, `b`, `c`
+|^^^^^^^^^^^^^^^^^^^^^^^^^ meta.table.markdown-gfm
+|^^^^^^ markup.raw.inline.markdown
+|     ^ punctuation.definition.raw.end.markdown
+|         ^ punctuation.separator.table-cell.markdown
+|           ^^^ markup.raw.inline.markdown
+|           ^ punctuation.definition.raw.begin.markdown
+|             ^ punctuation.definition.raw.end.markdown
+|                ^^^ markup.raw.inline.markdown
+|                ^ punctuation.definition.raw.begin.markdown
+|                  ^ punctuation.definition.raw.end.markdown
+|                     ^^^ markup.raw.inline.markdown
+|                     ^ punctuation.definition.raw.begin.markdown
+|                       ^ punctuation.definition.raw.end.markdown
+
+c1        | c2
+--------- | ---------
+`Row 2`   | ``a``, ``b``, ``c``
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.table.markdown-gfm
+|^^^^^^ markup.raw.inline.markdown
+|     ^ punctuation.definition.raw.end.markdown
+|         ^ punctuation.separator.table-cell.markdown
+|           ^^^^^ markup.raw.inline.markdown
+|           ^^ punctuation.definition.raw.begin.markdown
+|              ^^ punctuation.definition.raw.end.markdown
+|                  ^^^^^ markup.raw.inline.markdown
+|                  ^^ punctuation.definition.raw.begin.markdown
+|                     ^^ punctuation.definition.raw.end.markdown
+|                         ^^^^^ markup.raw.inline.markdown
+|                         ^^ punctuation.definition.raw.begin.markdown
+|                            ^^ punctuation.definition.raw.end.markdown
+
+c1        | c2
+--------- | ---------
+`Row 3`   | ```a```, ```b```, ```c```
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.table.markdown-gfm
+|^^^^^^ markup.raw.inline.markdown
+|     ^ punctuation.definition.raw.end.markdown
+|         ^ punctuation.separator.table-cell.markdown
+|           ^^^^^^^ markup.raw.inline.markdown
+|           ^^^ punctuation.definition.raw.begin.markdown
+|               ^^^ punctuation.definition.raw.end.markdown
+|                    ^^^^^^^ markup.raw.inline.markdown
+|                    ^^^ punctuation.definition.raw.begin.markdown
+|                        ^^^ punctuation.definition.raw.end.markdown
+|                             ^^^^^^^ markup.raw.inline.markdown
+|                             ^^^ punctuation.definition.raw.begin.markdown
+|                                 ^^^ punctuation.definition.raw.end.markdown
+
 | c1  |  c2    | c3      | c4     | c5          | c6       | c7
 | --- | ---    | ---     | ---    | ---         | ---      | ---
 | ` ` | ` me ` | `` ` `` | ` `` ` | ``foo`bar`` | ```foo`` | ``foo```


### PR DESCRIPTION
Fixes #4513

This PR adjusts `table_codespan_content` to give closing backticks precedence over code span content. This is required to properly terminate them at first matching backtick.