### PR TITLE
[C#] Refactor preprocessor

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -195,125 +195,196 @@ contexts:
 ###[ PREPROCESSOR DIRECTIVES ]#################################################
 
   preprocessor_directives:
-    - match: '^\s*(#)\s*(region)\b\s*(\S.*)'
-      scope: meta.preprocessor.region.cs
-      captures:
-        1: keyword.other.preprocessor.cs
-        2: keyword.other.preprocessor.cs
-        3: entity.name.section.cs meta.fold.begin.cs
-    - match: '^\s*(#)\s*(region)\b\s*'
-      scope: meta.preprocessor.region.cs
-      captures:
-        1: keyword.other.preprocessor.cs
-        2: keyword.other.preprocessor.cs meta.fold.begin.cs
-    - match: '^\s*(#)\s*(endregion)\b[^\S\n]*(.*)($\n?)'
-      scope: meta.preprocessor.region.cs
-      captures:
-        1: keyword.other.preprocessor.cs
-        2: keyword.other.preprocessor.cs
-        3: variable.other.section.cs
-        4: meta.fold.end.cs
-    - match: '^\s*((#)\s*)'
-      captures:
-        1: keyword.other.preprocessor.cs
-        2: punctuation.definition.preprocessor.cs
-      push: preprocessor_option
+    - match: ^(?=\s*#)
+      push: preprocessor_directive
 
-  preprocessor_option:
+  preprocessor_directive:
+    - meta_include_prototype: false
     - meta_scope: meta.preprocessor.cs
-    - match: '\b(define|undef)\s+({{name}})\b'
-      captures:
-        1: keyword.control.preprocessor.cs
-        2: entity.name.constant.cs
-    - match: '\b(el)?if\b'
-      scope: keyword.control.preprocessor.cs
-      push:
-        - match: '\(|\)'
-          scope: punctuation.section.parens.cs
-        - match: '&&|\|\||!'
-          scope: keyword.operator.logical.cs
-        - match: '\b(true|false)\b'
-          scope: constant.language.cs
-        - match: '{{name}}'
-          scope: constant.other.flag.cs
-        - include: option_done
-    - match: '\b(else|endif)\b'
-      scope: keyword.control.preprocessor.cs
-      push: option_done
-    # error, warning, region and endregion may be followed by any text.
-    # Comments doesn't apply in this case, see ECMA C# specification.
-    - match: '\b(error|warning)\b\s*(.*)'
-      captures:
-        1: keyword.other.preprocessor.cs
-        2: string.unquoted.cs
-
-    - match: '\b(line)\s+(default|hidden)\b'
-      captures:
-        1: keyword.other.preprocessor.cs
-        2: keyword.other.preprocessor.cs
-      push: option_done
-    - match: '\b(line)\s+(\d*)\s+((").*("))?'
-      captures:
-        1: keyword.other.preprocessor.cs
-        2: meta.number.integer.decimal.cs constant.numeric.value.cs
-        3: string.quoted.double.cs
-        4: punctuation.definition.string.begin.cs
-        5: punctuation.definition.string.end.cs
-      push: option_done
-    - match: '\b(pragma)\s+(checksum)\s+'
-      captures:
-        1: keyword.other.preprocessor.cs
-        2: keyword.other.preprocessor.cs
-      push:
-        - match: '"{'
-          scope: punctuation.definition.string.begin.cs
-          push:
-            - meta_scope: string.quoted.double.hash.cs
-            - match: '[-\h]+'
-              scope: meta.number.integer.hexadecimal.cs constant.numeric.value.cs
-            - match: '}"'
-              scope: punctuation.definition.string.end.cs
-              pop: 1
-            - match: \.
-              scope: invalid.illegal.cs
-              pop: 1
-        - match: '"'
-          scope: punctuation.definition.string.begin.cs
-          push: inside_string
-        - include: option_done
-
-    - match: '(pragma)\s+(warning)\b'
-      captures:
-        1: keyword.other.preprocessor.cs
-        2: keyword.other.preprocessor.cs
-      push:
-        - match: \b(disable|restore)\b(?:\s+([\p{L}_-]+))?
-          captures:
-            1: keyword.other.preprocessor.cs
-            2: string.unquoted.warning.cs
-        - include: comments
-        - match: $
-          pop: 1
-    - match: '\b(nullable)\s+(enable|disable|restore)(?:\s+(annotations|warnings))?\b'
-      captures:
-        1: keyword.other.preprocessor.cs
-        2: keyword.other.preprocessor.cs
-        3: keyword.other.preprocessor.cs
-
-    - match: (:)(\w+)
+    # Note: Repeated `\s*(#)` is required as some of them are to be scoped
+    #       fold markers to support syntax based folding of blocks.
+    - match: \s*(#:)(\w+)\b(?:\s*(\S.*?))?{{wspace_eol}}
       captures:
         1: punctuation.definition.preprocessor.cs
         2: variable.language.cs
-    - match: $
+        3: meta.string.cs string.unquoted.cs
+      pop: 1
+    - match: \s*(#)\s*(region)\b(?:\s*(\S.*?))?({{wspace_eol}})
+      captures:
+        1: punctuation.definition.preprocessor.cs
+        2: keyword.control.directive.region.cs
+        3: entity.name.section.cs
+        4: meta.fold.block.begin.cs
+      pop: 1
+    - match: \s*(#)\s*(endregion)\b(?:\s*(\S.*?))?{{wspace_eol}}
+      captures:
+        1: meta.fold.block.end.cs punctuation.definition.preprocessor.cs
+        2: keyword.control.directive.endregion.cs
+        3: variable.other.section.cs
+      pop: 1
+    - match: \s*(#)\s*(?:(error)|(warning))\b(?:\s*(\S.*?))?{{wspace_eol}}
+      captures:
+        1: punctuation.definition.preprocessor.cs
+        2: keyword.control.directive.error.cs
+        3: keyword.control.directive.warning.cs
+        4: meta.string.cs string.unquoted.cs
+      pop: 1
+    - match: \s*(#)\s*(line)\b
+      captures:
+        1: punctuation.definition.preprocessor.cs
+        2: keyword.control.directive.line.cs
+      set: preprocessor_line
+    - match: \s*(#)\s*(if)\b
+      captures:
+        1: punctuation.definition.preprocessor.cs
+        2: keyword.control.directive.conditional.if.cs
+      set: preprocessor_if_condition
+    - match: \s*(#)\s*(elif)\b
+      captures:
+        1: meta.fold.block.end.cs punctuation.definition.preprocessor.cs
+        2: keyword.control.directive.conditional.elseif.cs
+      set: preprocessor_if_condition
+    - match: \s*(#)\s*(else)\b
+      captures:
+        1: meta.fold.block.end.cs punctuation.definition.preprocessor.cs
+        2: keyword.control.directive.conditional.else.cs
+      set: expect_preprocessor_fold_begin
+    - match: \s*(#)\s*(endif)\b
+      captures:
+        1: meta.fold.block.end.cs punctuation.definition.preprocessor.cs
+        2: keyword.control.directive.conditional.end.cs
+      set: expect_preprocessor_end
+    - match: \s*(#)\s*(?:(define)|(undef))\b(?:\s*({{name}}))?
+      captures:
+        1: punctuation.definition.preprocessor.cs
+        2: keyword.control.directive.define.cs
+        3: keyword.control.directive.undefine.cs
+        4: entity.name.constant.preprocessor.cs
+      set: expect_preprocessor_end
+    - match: \s*(#)\s*(nullable)(?:\s+(enable|disable|restore)(?:\s+(annotations|warnings))?)?\b
+      captures:
+        1: punctuation.definition.preprocessor.cs
+        2: keyword.control.directive.nullable.cs
+        3: keyword.control.directive.other.cs
+        4: constant.language.messages.cs
+      set: expect_preprocessor_end
+    - match: \s*(#)\s*(pragma)\b
+      captures:
+        1: punctuation.definition.preprocessor.cs
+        2: keyword.control.directive.pragma.cs
+      set: preprocessor_pragma_name
+    - match: \s*(#)\s*({{name}})
+      captures:
+        1: punctuation.definition.preprocessor.cs
+    - match: $\n?|(?=\s*/[/*])
       pop: 1
 
-  # Pops out at the end of the line and handles comments.
-  # Marks the rest of the line as invalid.
-  option_done:
-    - include: comments
-    - match: $
+  preprocessor_if_condition:
+    - meta_content_scope: meta.preprocessor.cs
+    - match: \(
+      scope: punctuation.section.group.begin.cs
+      push: inside_preprocessor_if_condition_group
+    - match: (?:&&|\|\||!)
+      scope: keyword.operator.logical.cs
+    - include: language_constants
+    - match: '{{name}}'
+      scope: constant.other.preprocessor.cs
+    - include: expect_preprocessor_fold_begin
+
+  inside_preprocessor_if_condition_group:
+    - meta_scope: meta.group.cs
+    - match: \)
+      scope: punctuation.section.group.end.cs
       pop: 1
-    - match: \S
+    - include: preprocessor_if_condition
+
+  preprocessor_line:
+    - meta_content_scope: meta.preprocessor.cs
+    - match: \"
+      scope: punctuation.definition.string.begin.cs
+      push: inside_string
+    - match: (?:default|hidden)\b
+      scope: constant.language.preprocessor.cs
+    - match: \d+
+      scope: meta.number.integer.decimal.cs constant.numeric.value.cs
+    - include: expect_preprocessor_end
+
+  preprocessor_pragma_name:
+    - meta_content_scope: meta.preprocessor.cs
+    - match: checksum\b
+      scope: meta.preprocessor.cs entity.name.pragma.checksum.cs
+      set: preprocessor_pragma_checksum_args
+    - match: warning\b
+      scope: meta.preprocessor.cs entity.name.pragma.warning.cs
+      set: preprocessor_pragma_warning_args
+    - match: '{{name}}'
+      scope: meta.preprocessor.cs entity.name.pragma.other.cs
+      set: preprocessor_pragma_other_args
+    - include: expect_preprocessor_end
+
+  preprocessor_pragma_checksum_args:
+    - meta_content_scope: meta.preprocessor.cs
+    - match: \"\{
+      scope: punctuation.definition.string.begin.cs
+      push: inside_preprocessor_pragma_checksum_hash
+    - match: \"
+      scope: punctuation.definition.string.begin.cs
+      push: inside_string
+    - include: expect_preprocessor_end
+
+  inside_preprocessor_pragma_checksum_hash:
+    - meta_include_prototype: false
+    - meta_scope: meta.string.hash.cs string.quoted.double.cs
+    - meta_content_scope: meta.number.integer.hexadecimal.cs constant.numeric.value.cs
+    - match: \}\"
+      scope: punctuation.definition.string.end.cs
+      pop: 1
+    - match: $\n?
+      scope: invalid.illegal.unclosed-string.cs
+      pop: 1
+    - match: '[^-\h]+'
+      scope: invalid.illegal.cs
+
+  preprocessor_pragma_other_args:
+    - meta_content_scope: meta.preprocessor.cs
+    - match: \"
+      scope: punctuation.definition.string.begin.cs
+      push: inside_string
+    - match: \d+
+      scope: meta.number.integer.decimal.cs constant.numeric.value.cs
+    - match: '[\p{L}_-]+'
+      scope: meta.string.cs string.unquoted.cs
+    - include: expect_preprocessor_end
+
+  preprocessor_pragma_warning_args:
+    - meta_content_scope: meta.preprocessor.cs
+    - match: (disable|restore)(?:\s+([\p{L}_-]+))?
+      scope: meta.preprocessor.cs
+      captures:
+        1: keyword.control.directive.other.cs
+        2: meta.string.cs string.unquoted.cs
+      set: expect_preprocessor_end
+    - include: expect_preprocessor_end
+
+  expect_preprocessor_end:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.preprocessor.cs
+    - match: $\n?|(?=\s*/[/*])
+      scope: meta.preprocessor.cs
+      pop: 1
+    - match: \S+
+      scope: invalid.illegal.cs
+
+  expect_preprocessor_fold_begin:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.preprocessor.cs
+    - match: '{{wspace_eol}}'
+      scope: meta.preprocessor.cs meta.fold.block.begin.cs
+      pop: 1
+    - match: \s*(?=/[/*])
+      scope: meta.fold.block.begin.cs
+      pop: 1
+    - match: \S+
       scope: invalid.illegal.cs
 
 ###[ GLOBAL STATEMENTS ]#######################################################
@@ -2383,13 +2454,7 @@ contexts:
 
   # bools, numbers, chars, simple strings
   literals:
-    # language constants
-    - match: \bfalse\b
-      scope: constant.language.boolean.false.cs
-    - match: \btrue\b
-      scope: constant.language.boolean.true.cs
-    - match: \bnull\b
-      scope: constant.language.null.cs
+    - include: language_constants
     # characters
     - match: '''\'''
       scope: invalid.illegal.lone-escape.cs
@@ -2438,6 +2503,14 @@ contexts:
         1: constant.numeric.value.cs
         2: constant.numeric.suffix.cs
     - include: strings
+
+  language_constants:
+    - match: \bfalse\b
+      scope: constant.language.boolean.false.cs
+    - match: \btrue\b
+      scope: constant.language.boolean.true.cs
+    - match: \bnull\b
+      scope: constant.language.null.cs
 
 ###[ REGULAR EXPRESSIONS ]#####################################################
 
@@ -2954,6 +3027,8 @@ variables:
   other_char: '(?:{{unicode_char}}|[_0-9\p{L}])'
   name_normal: '{{start_char}}{{other_char}}*\b'
   cap_name: '(\p{Lu}{{other_char}})'
+
+  wspace_eol: '\s*(?:\n|$)'
 
   method_param_type_modifier: \b(?:out|ref|this|params|in)\b
 

--- a/C#/Fold.tmPreferences
+++ b/C#/Fold.tmPreferences
@@ -73,11 +73,11 @@
             </dict>
             <dict>
                 <key>begin</key>
-                <string>meta.preprocessor.region meta.fold.begin</string>
+                <string>meta.fold.block.begin</string>
                 <key>end</key>
-                <string>meta.preprocessor.region meta.fold.end</string>
+                <string>meta.fold.block.end</string>
                 <key>excludeTrailingNewlines</key>
-                <false/>
+                <true/>
             </dict>
         </array>
     </dict>

--- a/C#/tests/syntax_test_GeneralStructure.cs
+++ b/C#/tests/syntax_test_GeneralStructure.cs
@@ -1055,12 +1055,15 @@ namespace TestNamespace . Test
 
         #region Empty region 01 // not a comment !
 ///     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.preprocessor
-///     ^^^^^^^  keyword.other.preprocessor
+///     ^ punctuation.definition.preprocessor - keyword
+///      ^^^^^^ keyword.control.directive.region
 ///             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ entity.name.section
 ///                             ^^^^^^^ - comment
 
         #endregion Empty region 01
-///     ^^^^^^^^^^  keyword.other.preprocessor
+///     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.preprocessor.cs
+///     ^ punctuation.definition.preprocessor - keyword
+///      ^^^^^^^^^ keyword.control.directive.endregion
 ///                ^^^^^^^^^^^^^^^ variable.other.section
     }
 /// ^ punctuation.section.block.end

--- a/C#/tests/syntax_test_PreprocessorDirectives.cs
+++ b/C#/tests/syntax_test_PreprocessorDirectives.cs
@@ -1,94 +1,185 @@
 /// SYNTAX TEST "Packages/C#/C#.sublime-syntax"
 
+#def
+/// <- meta.preprocessor.cs punctuation.definition.preprocessor.cs
+ /// <- meta.preprocessor.cs - keyword - punctuation
+///^^ meta.preprocessor.cs - meta.preprocessor meta.preprocessor - keyword - punctuation
+
 #define DEBUG
-///     ^^ entity.name.constant
+///^^^^^^^^^^^ meta.preprocessor.cs - meta.preprocessor meta.preprocessor - meta.fold
+///^^^^ keyword.control.directive.define.cs
+///     ^^^^^ entity.name.constant.preprocessor.cs
 #define MYTEST
-#undef DEBUG
+///^^^^^^^^^^^^ meta.preprocessor.cs - meta.preprocessor meta.preprocessor  - meta.fold
+///^^^^ keyword.control.directive.define.cs
+///     ^^^^^^ entity.name.constant.preprocessor.cs
+#undef DEBUG    // comment
+///^^^^^^^^^ meta.preprocessor.cs - meta.preprocessor meta.preprocessor
+///^^^ keyword.control.directive.undefine.cs
+///    ^^^^^ entity.name.constant.preprocessor.cs
+///         ^^^^ - comment - meta.preprocessor
+///             ^^^^^^^^^^^ comment.line.double-slash.cs
+///             ^^ punctuation.definition.comment.cs
 
 using System;
 #pragma warning disable warning-list
-/// ^ keyword.other.preprocessor
-///       ^ keyword.other.preprocessor
+///^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.preprocessor.cs - meta.preprocessor meta.preprocessor  - meta.fold
+///^^^^ keyword.control.directive.pragma.cs
+///     ^^^^^^^ entity.name.pragma.warning.cs
+///             ^^^^^^^ keyword.control.directive.other.cs
+///                     ^^^^^^^^^^^^ meta.string.cs string.unquoted.cs
 #pragma warning restore warning-list
 #pragma checksum "file.cs" "{3673e4ca-6098-4ec1-890f-8fceb2a794a2}" "{012345678AB}" // New checksum
-///       ^ keyword.other.preprocessor
-///                 ^ string.quoted.double
-///                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.number.integer.hexadecimal constant.numeric.value
+///^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.preprocessor.cs - meta.preprocessor meta.preprocessor  - meta.fold
+///^^^^ keyword.control.directive.pragma.cs
+///     ^^^^^^^^ entity.name.pragma.checksum.cs
+///              ^^^^^^^^^ meta.string.cs string.quoted.double.cs
+///              ^ punctuation.definition.string.begin.cs
+///                      ^ punctuation.definition.string.end.cs
+///                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.hash.cs string.quoted.double.cs
+///                        ^^ punctuation.definition.string.begin.cs
+///                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.number.integer.hexadecimal.cs constant.numeric.value.cs
+///                                                              ^^ punctuation.definition.string.end.cs
+///                                                                 ^^^^^^^^^^^^^^^ meta.string.hash.cs string.quoted.double.cs
+///                                                                 ^^ punctuation.definition.string.begin.cs
+///                                                                   ^^^^^^^^^^^ meta.number.integer.hexadecimal.cs constant.numeric.value.cs
+///                                                                              ^^ punctuation.definition.string.end.cs
+///                                                                                ^ - comment - meta.preprocessor
+///                                                                                 ^^^^^^^^^^^^^^^^ comment.line.double-slash.cs
+///                                                                                 ^^ punctuation.definition.comment.cs
+
+#pragma unknown value
+/// <- meta.preprocessor.cs punctuation.definition.preprocessor.cs
+///^^^^^^^^^^^^^^^^^^^ meta.preprocessor.cs
+///^^^^ keyword.control.directive.pragma.cs
+///     ^^^^^^^ entity.name.pragma.other.cs
+///             ^^^^^ meta.string.cs string.unquoted.cs
 
 #region
-/// ^^ meta.preprocessor.region keyword.other.preprocessor meta.fold.begin
+/// <- meta.preprocessor.cs punctuation.definition.preprocessor.cs - meta.fold - keyword
+///^^^^ meta.preprocessor.cs keyword.control.directive.region.cs - meta.fold
+///    ^ meta.preprocessor.cs meta.fold.block.begin.cs - keyword
 #region MyClass definition
-/// ^^ meta.preprocessor.region keyword.other.preprocessor - meta.fold
-///     ^^ meta.preprocessor.region entity.name.section meta.fold.begin
+/// <- meta.preprocessor.cs punctuation.definition.preprocessor.cs - meta.fold - keyword
+///^^^^^^^^^^^^^^^^^^^^^^^ meta.preprocessor.cs - meta.preprocessor meta.preprocessor  - meta.fold
+///^^^^ keyword.control.directive.region.cs
+///     ^^^^^^^^^^^^^^^^^^ entity.name.section.cs
+///                       ^ meta.preprocessor.cs meta.fold.block.begin.cs - entity
 public class MyClass
 {
     static void Main()
     {
 #if (DEBUG && !MYTEST)
+/// <- meta.preprocessor.cs punctuation.definition.preprocessor.cs - meta.fold - keyword
         Console.WriteLine("DEBUG is defined");
 #elif (!DEBUG && MYTEST)
+/// <- meta.preprocessor.cs meta.fold.block.end.cs punctuation.definition.preprocessor.cs - keyword
         Console.WriteLine("MYTEST is defined");
 #elif (DEBUG && MYTEST)
+/// <- meta.preprocessor.cs meta.fold.block.end.cs punctuation.definition.preprocessor.cs - keyword
 ///          ^^ keyword.operator
         Console.WriteLine("DEBUG and MYTEST are defined");
 #else
+/// <- meta.preprocessor.cs meta.fold.block.end.cs punctuation.definition.preprocessor.cs - keyword
         Console.WriteLine("DEBUG and MYTEST are not defined");
 #endif
+/// <- meta.preprocessor.cs meta.fold.block.end.cs punctuation.definition.preprocessor.cs - keyword
+///^^^^ meta.preprocessor.cs - meta.preprocessor meta.preprocessor  - meta.fold
+///^^^ keyword.control.directive.conditional.end.cs
 
 #   if DEBUG
-/// ^^ meta.preprocessor keyword.control.preprocessor
-///    ^^ constant.other.flag
+/// <- meta.preprocessor.cs punctuation.definition.preprocessor.cs - meta.fold - keyword
+///^^^^^^^^^ meta.preprocessor.cs - meta.preprocessor meta.preprocessor  - meta.fold
+/// ^^ keyword.control.directive.conditional.if.cs
+///    ^^^^^ constant.other.preprocessor.cs
+///         ^ meta.preprocessor.cs meta.fold.block.begin.cs
 #error DEBUG is defined // comment
-/// ^^ meta.preprocessor keyword.other.preprocessor
-///    ^^ string.unquoted
-///                             ^^ string.unquoted
-///                     ^ - comment
+/// <- meta.preprocessor.cs punctuation.definition.preprocessor.cs - meta.fold - keyword
+///^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.preprocessor.cs - meta.preprocessor meta.preprocessor  - meta.fold
+///^^^  keyword.control.directive.error.cs
+///    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.cs string.unquoted.cs - comment
 
 #warning Deprecated code in this method.
+/// <- meta.preprocessor.cs punctuation.definition.preprocessor.cs - meta.fold - keyword
+///^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.preprocessor.cs - meta.preprocessor meta.preprocessor  - meta.fold
+///^^^^^ keyword.control.directive.warning.cs
+///      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.cs string.unquoted.cs
 #endif
+/// <- meta.preprocessor.cs meta.fold.block.end.cs punctuation.definition.preprocessor.cs - keyword
+///^^^ meta.preprocessor.cs - meta.preprocessor meta.preprocessor  - meta.fold
+///^^^ keyword.control.directive.conditional.end.cs
 
 #line 200 "Special"
-/// ^ meta.preprocessor keyword.other.preprocessor
-///   ^^^ constant.numeric
-///       ^^^^^^^^^ string
+/// <- punctuation.definition.preprocessor.cs
+///^^^^^^^^^^^^^^^^^ meta.preprocessor.cs - meta.preprocessor meta.preprocessor  - meta.fold
+///^^ keyword.control.directive.line.cs
+///   ^^^ meta.number.integer.decimal.cs constant.numeric.value.cs
+///       ^^^^^^^^^ meta.string.cs string.quoted.double.cs
+///       ^ punctuation.definition.string.begin.cs
+///               ^ punctuation.definition.string.end.cs
         int i;    // CS0168 on line 200
         int j;    // CS0168 on line 201
 #line default
-///   ^ meta.preprocessor keyword.other.preprocessor
+/// <- meta.preprocessor.cs punctuation.definition.preprocessor.cs - meta.fold - keyword
+///^^^^^^^^^^^ meta.preprocessor.cs - meta.preprocessor meta.preprocessor  - meta.fold
+///^^ keyword.control.directive.line.cs
+///   ^^^^^^^ constant.language.preprocessor.cs
         char c;   // CS0168 on line 31
         float f;  // CS0168 on line 32
 #line hidden // numbering not affected
-///   ^ meta.preprocessor keyword.other.preprocessor
+/// <- meta.preprocessor.cs punctuation.definition.preprocessor.cs - meta.fold - keyword
+///^^^^^^^^^ meta.preprocessor.cs - meta.preprocessor meta.preprocessor  - meta.fold
+///^^ keyword.control.directive.line.cs
+///   ^^^^^^ constant.language.preprocessor.cs
+///         ^ - comment - meta.preprocessor
+///          ^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.cs - meta.preprocessor
         string s;
         double d; // CS0168 on line 35
     }
 }
 #endregion a / b
-/// ^^ keyword.other.preprocessor
-///        ^^^^^ variable.other.section
-///             ^ meta.preprocessor.region meta.fold.end
+/// <- meta.preprocessor.cs meta.fold.block.end.cs punctuation.definition.preprocessor.cs - keyword
+///^^^^^^^^^^^^^^ meta.preprocessor.cs - meta.preprocessor meta.preprocessor  - meta.fold
+///^^^^^^^ keyword.control.directive.endregion.cs
+///       ^ - keyword - variable
+///        ^^^^^ variable.other.section.cs
+///             ^ - variable
 #endregion
-/// ^^ keyword.other.preprocessor
-///       ^ meta.preprocessor.region meta.fold.end
+/// <- meta.preprocessor.cs meta.fold.block.end.cs punctuation.definition.preprocessor.cs - keyword
+///^^^^^^^^ meta.preprocessor.cs - meta.preprocessor meta.preprocessor  - meta.fold
+///^^^^^^^ keyword.control.directive.endregion.cs
 
 #nullable enable
-/// ^^ meta.preprocessor keyword.other.preprocessor
-///       ^^ meta.preprocessor keyword.other.preprocessor
+/// <- meta.preprocessor.cs punctuation.definition.preprocessor.cs - meta.fold - keyword
+///^^^^^^^^^^^^^^ meta.preprocessor.cs
+///^^^^^^ keyword.control.directive.nullable.cs
+///       ^^^^^^ keyword.control.directive.other.cs
 
-#nullable disable
-/// ^^ meta.preprocessor keyword.other.preprocessor
-///       ^^ meta.preprocessor keyword.other.preprocessor
+#nullable disable // comment
+/// <- meta.preprocessor.cs punctuation.definition.preprocessor.cs - meta.fold - keyword
+///^^^^^^^^^^^^^^ meta.preprocessor.cs - meta.preprocessor meta.preprocessor  - meta.fold
+///^^^^^^ keyword.control.directive.nullable.cs
+///       ^^^^^^^ keyword.control.directive.other.cs
+///              ^ - comment - meta.preprocessor
+///               ^^^^^^^^^^^ comment.line.double-slash.cs - meta.preprocessor
+///               ^^ punctuation.definition.comment.cs
 
 #nullable restore
-/// ^^ meta.preprocessor keyword.other.preprocessor
-///       ^^ meta.preprocessor keyword.other.preprocessor
+/// <- meta.preprocessor.cs punctuation.definition.preprocessor.cs - meta.fold - keyword
+///^^^^^^^^^^^^^^^ meta.preprocessor.cs - meta.preprocessor meta.preprocessor  - meta.fold
+///^^^^^^ keyword.control.directive.nullable.cs
+///       ^^^^^^^ keyword.control.directive.other.cs
 
 #nullable enable annotations
-/// ^^ meta.preprocessor keyword.other.preprocessor
-///       ^^ meta.preprocessor keyword.other.preprocessor
-///              ^^ meta.preprocessor keyword.other.preprocessor
+/// <- meta.preprocessor.cs punctuation.definition.preprocessor.cs - meta.fold - keyword
+///^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.preprocessor.cs - meta.preprocessor meta.preprocessor  - meta.fold
+///^^^^^^ keyword.control.directive.nullable.cs
+///       ^^^^^^ keyword.control.directive.other.cs
+///              ^^^^^^^^^^^ constant.language.messages.cs
 
 #nullable disable warnings
-/// ^^ meta.preprocessor keyword.other.preprocessor
-///       ^^ meta.preprocessor keyword.other.preprocessor
-///               ^^ meta.preprocessor keyword.other.preprocessor
+/// <- meta.preprocessor.cs punctuation.definition.preprocessor.cs - meta.fold - keyword
+///^^^^^^^^^^^^^^^^^^^^^^^^ meta.preprocessor.cs - meta.preprocessor meta.preprocessor  - meta.fold
+///^^^^^^ keyword.control.directive.nullable.cs
+///       ^^^^^^^ keyword.control.directive.other.cs
+///               ^^^^^^^^ constant.language.messages.cs

--- a/C#/tests/syntax_test_dotnetrun.cs
+++ b/C#/tests/syntax_test_dotnetrun.cs
@@ -8,21 +8,29 @@
 #:package Humanizer@2.14.1
 #!^^^^^^^^^^^^^^^^^^^^^^^^ meta.preprocessor.cs
 #!^^^^^^^ variable.language.cs
-#!       ^^^^^^^^^^^^^^^^^ - variable - invalid
+#!       ^ - string - variable - invalid
+#!        ^^^^^^^^^^^^^^^^ meta.string.cs string.unquoted.cs - variable - invalid
+#!                        ^ - string - variable - invalid
 #:sdk Microsoft.NET.Sdk.Web
 #!^^^^^^^^^^^^^^^^^^^^^^^^^ meta.preprocessor.cs
 #!^^^ variable.language.cs
-#!   ^^^^^^^^^^^^^^^^^^^^^^^ - variable - invalid
+#!   ^ - string - variable - invalid
+#!    ^^^^^^^^^^^^^^^^^^^^^ meta.string.cs string.unquoted.cs - variable - invalid
+#!                         ^ - string - variable - invalid
 #:property LangVersion preview
 #!^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.preprocessor.cs
 #!^^^^^^^^ variable.language.cs
-#!        ^^^^^^^^^^^^^^^^^^^^^ - variable - invalid
+#!        ^ - string - variable - invalid
+#!         ^^^^^^^^^^^^^^^^^^^ meta.string.cs string.unquoted.cs - variable - invalid
+#!                            ^ - string - variable - invalid
 
   #:package Microsoft.AspNetCore.OpenApi@10.*-*
 #!^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.preprocessor.cs
-#!^ keyword.other.preprocessor.cs punctuation.definition.preprocessor.cs
-#! ^ punctuation.definition.preprocessor.cs
+#!^^ punctuation.definition.preprocessor.cs
 #!  ^^^^^^^ variable.language.cs
+#!         ^ - string - variable - invalid
+#!          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.cs string.unquoted.cs - variable - invalid
+#!                                             ^ - string - variable - invalid
 
 
 var builder = WebApplication.CreateBuilder();


### PR DESCRIPTION
This PR...

1. replace all anonymous by named contexts
2. scope preprocessor keywords `keyword.control.directive` (following RFC #1860)
3. add support for syntax based folding of `#if..#elif..#else..#end` blocks

Note: 

This commit takes a more conservative way with regards to scoping directive keywords, compared to #4502, which introduces `keyword.directive`, to provide a possibility to compare them. Both approaches seem reasonable having pros and cons each.

Pros of `keyword.control.directive`:

- is used in VS Code
- is used in more syntaxes, than `keyword.directive`
- probably aligns better with `keyword.control.import` for import time keywords

Cons:

- more verbose
- preprocessor directives may not be considdered normal control flow as those apply to compile time, if that's important.

Finally both PRs should use same keyword scopes.
