### PR TITLE
[BatchFile] Align script parameter scope with ShellScript

### DIFF
--- a/Batch File/Batch File.sublime-syntax
+++ b/Batch File/Batch File.sublime-syntax
@@ -1827,7 +1827,7 @@ contexts:
     - match: '{{parameter}}'
       scope:
         meta.interpolation.dosbatch
-        variable.parameter.dosbatch
+        variable.language.positional.dosbatch
       captures:
         1: punctuation.definition.variable.dosbatch
       push: clear-string-scope

--- a/Batch File/tests/syntax_test_batch_file.bat
+++ b/Batch File/tests/syntax_test_batch_file.bat
@@ -728,7 +728,7 @@ ECHO : Not a comment ^
 ::      ^ punctuation.definition.label.dosbatch
 ::      ^^^^ variable.label.dosbatch - keyword
 ::           ^^ meta.number.integer.decimal.dosbatch constant.numeric.value.dosbatch
-::              ^^ variable.parameter.dosbatch
+::              ^^ variable.language.positional.dosbatch
 
    CALL :foo%bar% 10
 ::^ - meta.function-call
@@ -2355,7 +2355,7 @@ put arg1 arg2
 ::      ^^^ meta.function-call.identifier.dosbatch - meta.interpolation
 ::         ^^^^^^^^^^ meta.function-call.arguments.dosbatch
 :: ^ punctuation.definition.variable.dosbatch
-::  ^^^^ variable.parameter.dosbatch
+::  ^^^^ variable.language.positional.dosbatch
 ::      ^^^ variable.function.dosbatch
 
    %out%put arg1 arg2
@@ -2451,7 +2451,7 @@ put arg1 arg2
 
    %~dp0..\cmd
 :: ^^^^^^^^^^^ meta.function-call.identifier.dosbatch
-:: ^^^^^ meta.interpolation.dosbatch variable.parameter.dosbatch
+:: ^^^^^ meta.interpolation.dosbatch variable.language.positional.dosbatch
 ::      ^^ constant.other.path.parent.dosbatch
 ::        ^ punctuation.separator.path.dosbatch
 ::         ^^^ variable.function.dosbatch
@@ -3171,17 +3171,17 @@ no continuation
 ::                        ^ meta.string.dosbatch - meta.interpolation
 ::                         ^^^ meta.string.dosbatch meta.interpolation.dosbatch
 ::                            ^ - meta.string - meta.interpolation
-::      ^ variable.parameter.dosbatch punctuation.definition.variable.dosbatch
-::       ^ variable.parameter.dosbatch - punctuation
+::      ^ variable.language.positional.dosbatch punctuation.definition.variable.dosbatch
+::       ^ variable.language.positional.dosbatch - punctuation
 ::        ^ string.unquoted.dosbatch - variable
-::         ^ variable.parameter.dosbatch punctuation.definition.variable.dosbatch
-::          ^ variable.parameter.dosbatch - punctuation
+::         ^ variable.language.positional.dosbatch punctuation.definition.variable.dosbatch
+::          ^ variable.language.positional.dosbatch - punctuation
 ::           ^ string.unquoted.dosbatch - variable
-::            ^ variable.parameter.dosbatch punctuation.definition.variable.dosbatch
-::             ^^^^^^^^^^^ variable.parameter.dosbatch - punctuation
+::            ^ variable.language.positional.dosbatch punctuation.definition.variable.dosbatch
+::             ^^^^^^^^^^^ variable.language.positional.dosbatch - punctuation
 ::                        ^ string.unquoted.dosbatch - variable
-::                         ^ variable.parameter.dosbatch punctuation.definition.variable.dosbatch
-::                          ^^ variable.parameter.dosbatch - punctuation
+::                         ^ variable.language.positional.dosbatch punctuation.definition.variable.dosbatch
+::                          ^^ variable.language.positional.dosbatch - punctuation
 ::                            ^ - string - variable
 
    ECHO %errorlevel% !errorlevel!


### PR DESCRIPTION
This PR changes scope of global positional CLI arguments such as `%1` to `variable.language.positional` - the scope ShellScript package uses.

Reasons:
1. Those are language defined variables holding the CLI arguments.
2. `variable.parameter` is primarily used in parameter declarations or named argument assignments in function calls.
3. Argument references instead are scoped normal variables.
4. Align highlighting with ShellScript package.