### PR TITLE
[C#] Simplify `name` pattern

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -2946,7 +2946,7 @@ variables:
   type_suffix_capture: '(\?)?{{brackets_capture}}?(?:\s*(\*))?'
 
   reserved: '(?:abstract|as|base|break|case|catch|checked|class|const|continue|default|delegate|do|else|enum|event|explicit|extern|finally|fixed|for|foreach|goto|if|implicit|in|interface|internal|is|lock|nameof|namespace|new|not|null|operator|out|override|params|private|protected|public|readonly|ref|required|return|sealed|sizeof|stackalloc|static|string|struct|switch|this|throw|try|typeof|unchecked|unsafe|using|virtual|volatile|while)'
-  name: '(?:@{{reserved}}|@{{base_type}}|@var|@?{{name_normal}})'
+  name: '(?:@?{{name_normal}})'
   namespaced_name: (?:(?:{{name}}{{generic_declaration}}\s*\.\s*)*{{name}}{{generic_declaration}})
 
   start_char: '(?:{{unicode_char}}|[_\p{L}])'


### PR DESCRIPTION
This commit removes redundant patterns from `name`.

Alternation with explicit patterns, such as `@{{reserved}}` is redundant as `@?{{name_normal}}` matches all reserved keywords, already.

If the goal was to exclude reserved words from `name` if not preceded by `@` the pattern needs another fix. This is not scope of this PR, though as it requires further changes to succeed.

This commit reduces syntax cache size from about 1.5MB to 0.9MB without changing any behavior.