### PR TITLE
[Haskell] Fix typo in syntax test scope name

### DIFF
--- a/Haskell/tests/syntax_test_haskell.hs
+++ b/Haskell/tests/syntax_test_haskell.hs
@@ -2345,7 +2345,7 @@
 --     ^ meta.function.identifier.haskell
 --      ^^^^^^^^^^^^^ - meta.function
 --      ^^ punctuation.separator.type.haskell
---         ^ variable.other..haskell
+--         ^ variable.other.haskell
 --           ^^ keyword.operator.arrow.haskell
 --              ^^^^ support.type.prelude.haskell
 


### PR DESCRIPTION
Fixes a `variable.other..haskell` → `variable.other.haskell` typo (extra dot) in `Haskell/tests/syntax_test_haskell.hs`. Spotted in review on #2679: https://github.com/sublimehq/Packages/pull/2679#discussion_r3112692340