### PR TITLE
[C++] Fix parentheses in macro arguments (#4525)

### DIFF
--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -73,6 +73,11 @@ variables:
   modifiers: '{{storage_classes}}|{{type_qualifier}}|{{compiler_directive}}|{{constant_expression_specifiers}}'
   non_angle_brackets: '(?=<<|<=)'
   module_identifier: '{{identifier}}(?:\.{{identifier}})*'
+  # A single token inside a macro argument list: a non-paren character, or a
+  # balanced parenthesised group with one level of further nesting. Repeated,
+  # this matches macro arguments with up to two levels of nested parentheses
+  # (e.g. `FOO(a = (b))`).
+  nested_parens: '(?:[^()]|\((?:[^()]|\([^()]*\))*\))'
 
   regular: '[^(){}&;*^%=<>-]*'
   regular_plus: '[^(){}&;*^%=<>-]+'
@@ -1149,7 +1154,7 @@ contexts:
     - include: angle-brackets
     - include: types
     # Allow a macro call
-    - match: '({{identifier}})\s*(\()(?=[^\)]+\))'
+    - match: '({{identifier}})\s*(\()(?={{nested_parens}}+\))'
       captures:
         1: variable.function.c++
         2: meta.group.c++ punctuation.section.group.begin.c++
@@ -1340,7 +1345,7 @@ contexts:
     - match: ({{macro_identifier}})(?=\s+~?{{identifier}})
       captures:
         1: meta.assumed-macro.c
-    - match: '({{macro_identifier}})\s*(\()(?=[^\)]+\))'
+    - match: '({{macro_identifier}})\s*(\()(?={{nested_parens}}+\))'
       captures:
         1: variable.function.c++
         2: meta.group.c++ punctuation.section.group.begin.c++

--- a/C++/C.sublime-syntax
+++ b/C++/C.sublime-syntax
@@ -59,6 +59,11 @@ variables:
   compiler_directive: 'inline|restrict|__restrict__|__restrict|_Noreturn|noreturn'
   modifiers: '{{storage_classes}}|{{type_qualifier}}|{{compiler_directive}}'
   non_func_keywords: 'if|for|switch|while|decltype|typeof|typeof_unqual|_Atomic|_BitInt|sizeof|alignof|_Alignof|alignas|_Alignas|static_assert|_Static_assert|__declspec|__attribute__'
+  # A single token inside a macro argument list: a non-paren character, or a
+  # balanced parenthesised group with one level of further nesting. Repeated,
+  # this matches macro arguments with up to two levels of nested parentheses
+  # (e.g. Unreal Engine's `USTRUCT(meta = (Abstract))`).
+  nested_parens: '(?:[^()]|\((?:[^()]|\([^()]*\))*\))'
 
 contexts:
   main:
@@ -625,7 +630,7 @@ contexts:
     - match: '(?=\s)'
       set: global-maybe-function
     # Allow a macro call
-    - match: '({{identifier}})\s*(\()(?=[^\)]+\))'
+    - match: '({{identifier}})\s*(\()(?={{nested_parens}}+\))'
       captures:
         1: variable.function.c
         2: meta.group.c punctuation.section.group.begin.c
@@ -1433,7 +1438,7 @@ contexts:
 
 
   preprocessor-convention-ignore-uppercase-calls-without-semicolon:
-    - match: ^\s*({{macro_identifier}})\s*(\()(?=[^)]*\)\s*$)
+    - match: ^\s*({{macro_identifier}})\s*(\()(?={{nested_parens}}*\)\s*$)
       captures:
         1: variable.function.assumed-macro.c
         2: punctuation.section.group.begin.c

--- a/C++/tests/syntax_test_parentheses_in_macro_arguments.h
+++ b/C++/tests/syntax_test_parentheses_in_macro_arguments.h
@@ -1,0 +1,20 @@
+// SYNTAX TEST "Packages/C++/C++.sublime-syntax"
+
+// Test: macros with nested parentheses (e.g. Unreal Engine USTRUCT)
+// should not break highlighting of subsequent struct members.
+
+struct MyPlainStruct
+{
+public:
+// <- storage.modifier.c++
+};
+
+USTRUCT(meta = (Abstract))
+// <- meta.assumed-macro.c variable.function.assumed-macro.c
+struct MyUStruct
+// <- keyword.declaration.struct.type.c++
+//     ^ meta.struct.c++ entity.name.struct.c++
+{
+public:
+// <- storage.modifier.c++
+};


### PR DESCRIPTION
Fixes parentheses in macro arguments breaking the syntax highlighting (see #4525).