### PR TITLE
[C#] Fix pragma warning values

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -364,7 +364,7 @@ contexts:
 
   preprocessor_pragma_warning_args:
     - meta_content_scope: meta.preprocessor.cs
-    - match: (disable|restore)(?:\s+([\p{L}_-]+))?
+    - match: (disable|restore)(?:\s+([\w-]+))?
       scope: meta.preprocessor.cs
       captures:
         1: keyword.control.directive.other.cs

--- a/C#/tests/syntax_test_PreprocessorDirectives.cs
+++ b/C#/tests/syntax_test_PreprocessorDirectives.cs
@@ -28,7 +28,14 @@ using System;
 ///     ^^^^^^^ entity.name.pragma.warning.cs
 ///             ^^^^^^^ keyword.control.directive.other.cs
 ///                     ^^^^^^^^^^^^ meta.string.cs string.unquoted.cs
-#pragma warning restore warning-list
+
+#pragma warning restore CS8618
+///^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.preprocessor.cs - meta.preprocessor meta.preprocessor  - meta.fold
+///^^^^ keyword.control.directive.pragma.cs
+///     ^^^^^^^ entity.name.pragma.warning.cs
+///             ^^^^^^^ keyword.control.directive.other.cs
+///                     ^^^^^^ meta.string.cs string.unquoted.cs
+
 #pragma checksum "file.cs" "{3673e4ca-6098-4ec1-890f-8fceb2a794a2}" "{012345678AB}" // New checksum
 ///^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.preprocessor.cs - meta.preprocessor meta.preprocessor  - meta.fold
 ///^^^^ keyword.control.directive.pragma.cs


### PR DESCRIPTION
Fixes #4536

This PR enables digits in pragma warning values.