### PR TITLE
[Python] Fix key bindings

### DIFF
--- a/Python/Default.sublime-keymap
+++ b/Python/Default.sublime-keymap
@@ -24,6 +24,23 @@
             { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|\\}|\\.|,|:|;|$)", "match_all": true }
         ]
     },
+    { "keys": ["\""], "command": "insert_snippet", "args": {"contents": "\"${0:$SELECTION}\""}, "context":
+        [
+            { "key": "setting.auto_match_enabled" },
+            { "key": "selector", "operand": "source.python" },
+            { "key": "selection_empty", "operand": false, "match_all": true }
+        ]
+    },
+    { "keys": ["\""], "command": "move", "args": {"by": "characters", "forward": true}, "context":
+        [
+            { "key": "setting.auto_match_enabled" },
+            { "key": "selector", "operand": "source.python" },
+            { "key": "selection_empty", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^\"", "match_all": true },
+            { "key": "selector", "operator": "not_equal", "operand": "punctuation.definition.string.begin", "match_all": true },
+            { "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.double - punctuation.definition.string.end", "match_all": true },
+        ]
+    },
 
     // Suppress default auto-pairing bindings to avoid unwanted interference
     { "keys": ["'"], "command": "insert", "args": {"characters": "'"}, "context":
@@ -48,6 +65,23 @@
             { "key": "selection_empty", "match_all": true },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "(?i:^|[^'\\w\\\\]|\\b[bfru]+)$", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|\\}|\\.|,|:|;|$)", "match_all": true }
+        ]
+    },
+    { "keys": ["'"], "command": "insert_snippet", "args": {"contents": "'${0:$SELECTION}'"}, "context":
+        [
+            { "key": "setting.auto_match_enabled" },
+            { "key": "selector", "operand": "source.python" },
+            { "key": "selection_empty", "operand": false, "match_all": true }
+        ]
+    },
+    { "keys": ["'"], "command": "move", "args": {"by": "characters", "forward": true}, "context":
+        [
+            { "key": "setting.auto_match_enabled" },
+            { "key": "selector", "operand": "source.python" },
+            { "key": "selection_empty", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^'", "match_all": true },
+            { "key": "selector", "operator": "not_equal", "operand": "punctuation.definition.string.begin", "match_all": true },
+            { "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.single - punctuation.definition.string.end", "match_all": true },
         ]
     },
 


### PR DESCRIPTION
Fixes #4535

This PR adds missing key bindings to fully align Python's quotation pairing behavior with defaults.

Initial `"` and `'` rules override all default bindings in `source.python` scope. Thus all related bindings must explicitly be redefined.