### PR TITLE
[C#] Fix empty block comments

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -39,6 +39,8 @@ contexts:
     - match: //
       scope: punctuation.definition.comment.cs
       push: inside_line_comment
+    - match: /\*\*+/
+      scope: comment.block.empty.cs punctuation.definition.comment.cs
     - match: /\*+
       scope: punctuation.definition.comment.begin.cs
       push: inside_block_comment

--- a/C#/tests/syntax_test_Comments.cs
+++ b/C#/tests/syntax_test_Comments.cs
@@ -94,25 +94,83 @@ namespace HelloWorld
     /// git+https://hoster.com/user/repo
 //*     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.cs
 
+    /**/
+//* ^^^^ comment.block.empty.cs punctuation.definition.comment.cs
+//*     ^ - comment
+
+    /***/
+//* ^^^^^ comment.block.empty.cs punctuation.definition.comment.cs
+//*      ^ - comment
+
+    /*comment*/
+//* ^^^^^^^^^^^ comment.block.cs
+//* ^^ punctuation.definition.comment.begin.cs
+//*          ^^ punctuation.definition.comment.end.cs
+
+    /**comment**/
+//* ^^^^^^^^^^^^^ comment.block.cs
+//* ^^^ punctuation.definition.comment.begin.cs
+//*           ^^^ punctuation.definition.comment.end.cs
+
+    /***comment***/
+//* ^^^^^^^^^^^^^^^ comment.block.cs
+//* ^^^^ punctuation.definition.comment.begin.cs
+//*            ^^^^ punctuation.definition.comment.end.cs
+
+    /*
+//* ^^^ comment.block.cs
+//* ^^ punctuation.definition.comment.begin.cs
+    comment
+//*^^^^^^^^^ comment.block.cs
+    *
+//*^^^^ comment.block.cs
+//* ^ punctuation.definition.comment.cs
+    */
+//*^^^ comment.block.cs
+//* ^^ punctuation.definition.comment.end.cs
+
     /**
-        *
-//*     ^ meta.namespace meta.block comment.block punctuation.definition.comment
+//* ^^^^ comment.block.cs
+//* ^^^ punctuation.definition.comment.begin.cs
+    *
+//* ^ comment.block.cs punctuation.definition.comment.cs
+     *
+//*  ^ comment.block.cs punctuation.definition.comment.cs
+      *
+//*   ^ comment.block.cs punctuation.definition.comment.cs
+       *
+//*    ^ comment.block.cs punctuation.definition.comment.cs
     **/
 //*^^^^ comment.block.cs
 //* ^^^ punctuation.definition.comment.end.cs
+//*    ^ - comment
     class Hello
     {
         /// <summary>
         /// Computes matrix-matrix product of a sparse matrix stored in the CSC format.
         /// </summary>
-        void dcscmm(Transpose TransA, int m, int n, int k,
-            double alpha,
-            double[] val, int offsetval,
-            int[] idx, int offsetidx,
-            int[] pntrb, int offsetpntrb,
+//*^^^^^^^^^^^^^^^^^^^^ comment.line.documentation.cs
+//*     ^^^ punctuation.definition.comment.documentation.cs
+//*         ^^^^^^^^^^ meta.tag.xml
+//*         ^^ punctuation.definition.tag.begin.cs
+//*           ^^^^^^^ entity.name.tag.end.cs
+//*                  ^ punctuation.definition.tag.end.cs
+        void dcscmm(/**/Transpose/**/ TransA, /**/ int /**/m,/**/int /**/ n /**/,/**/ int /**/k/**/, /**/
+//*                 ^^^^ comment.block.empty.cs punctuation.definition.comment.cs
+//*                              ^^^^ comment.block.empty.cs punctuation.definition.comment.cs
+//*                                           ^^^^ comment.block.empty.cs punctuation.definition.comment.cs
+//*                                                    ^^^^ comment.block.empty.cs punctuation.definition.comment.cs
+//*                                                          ^^^^ comment.block.empty.cs punctuation.definition.comment.cs
+//*                                                                  ^^^^ comment.block.empty.cs punctuation.definition.comment.cs
+//*                                                                         ^^^^ comment.block.empty.cs punctuation.definition.comment.cs
+//*                                                                              ^^^^ comment.block.empty.cs punctuation.definition.comment.cs
+//*                                                                                       ^^^^ comment.block.empty.cs punctuation.definition.comment.cs
+//*                                                                                            ^^^^ comment.block.empty.cs punctuation.definition.comment.cs
+//*                                                                                                  ^^^^ comment.block.empty.cs punctuation.definition.comment.cs
             //int[] pntre, int offsetpntre,
-            double[] b, int offsetb, int ldb,
-            double beta,
-            double[] c, int offsetc, int ldc);
+//*         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.cs
+//*         ^^ punctuation.definition.comment.cs
+        ); /**/
+//*        ^^^^ comment.block.empty.cs punctuation.definition.comment.cs
     }
 }


### PR DESCRIPTION
This PR copies empty block comment pattern from Java to fix syntax highlighting breaking after `/**/`.