### PR TITLE
[Python] Adjust type patterns

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -4134,7 +4134,7 @@ variables:
   identifier_start: '[[:alpha:]_]'
   identifier_char: '[[:alnum:]_]'
   identifier_class: '_?[[:upper:]](?:[[:upper:][:digit:]]*[[:lower:]]+[[:alnum:]]*)?\b'
-  identifier_constant: '(?:[\p{Lu}_][\p{Lu}_\d]*)?[\p{Lu}]{2,}[\p{Lu}_\d]*\b'  # require 2 consecutive upper-case letters
+  identifier_constant: '(?:[_[:upper:]][_[:upper:][:digit:]]*)?[[:upper:]]{2,}[_[:upper:][:digit:]]*\b'  # require 2 consecutive upper-case letters
 
   illegal_names: (?:and|as|assert|break|class|continue|def|del|elif|else|except|finally|for|from|global|if|import|in|is|lambda|not|or|pass|raise|return|try|while|with|yield)\b
 

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -4133,7 +4133,7 @@ variables:
   identifier: '{{identifier_start}}{{identifier_char}}*'
   identifier_start: '[[:alpha:]_]'
   identifier_char: '[[:alnum:]_]'
-  identifier_class: '_?[[:upper:]](?:[[:upper:][:digit:]]*[[:lower:]]+[[:alnum:]]*)?\b'
+  identifier_class: '_?[[:upper:]](?:[[:upper:][:digit:]]*[[:lower:]]+[[:alnum:]]*)\b'
   identifier_constant: '(?:[_[:upper:]][_[:upper:][:digit:]]*)?[[:upper:]]{2,}[_[:upper:][:digit:]]*\b'  # require 2 consecutive upper-case letters
 
   illegal_names: (?:and|as|assert|break|class|continue|def|del|elif|else|except|finally|for|from|global|if|import|in|is|lambda|not|or|pass|raise|return|try|while|with|yield)\b

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -4133,7 +4133,7 @@ variables:
   identifier: '{{identifier_start}}{{identifier_char}}*'
   identifier_start: '[[:alpha:]_]'
   identifier_char: '[[:alnum:]_]'
-  identifier_class: '_?\p{Lu}(?:[\p{Lu}\d_]*\p{Ll}+\w*)?\b'
+  identifier_class: '_?[[:upper:]](?:[[:upper:][:digit:]]*[[:lower:]]+[[:alnum:]]*)?\b'
   identifier_constant: '(?:[\p{Lu}_][\p{Lu}_\d]*)?[\p{Lu}]{2,}[\p{Lu}_\d]*\b'  # require 2 consecutive upper-case letters
 
   illegal_names: (?:and|as|assert|break|class|continue|def|del|elif|else|except|finally|for|from|global|if|import|in|is|lambda|not|or|pass|raise|return|try|while|with|yield)\b

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -4133,7 +4133,7 @@ variables:
   identifier: '{{identifier_start}}{{identifier_char}}*'
   identifier_start: '[[:alpha:]_]'
   identifier_char: '[[:alnum:]_]'
-  identifier_class: '_?[[:upper:]](?:[[:upper:][:digit:]]*[[:lower:]]+[[:alnum:]]*)\b'
+  identifier_class: '_?(?:[[:upper:]]+[[:digit:][:lower:]]+)+\b'
   identifier_constant: '(?:[_[:upper:]][_[:upper:][:digit:]]*)?[[:upper:]]{2,}[_[:upper:][:digit:]]*\b'  # require 2 consecutive upper-case letters
 
   illegal_names: (?:and|as|assert|break|class|continue|def|del|elif|else|except|finally|for|from|global|if|import|in|is|lambda|not|or|pass|raise|return|try|while|with|yield)\b

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -4133,7 +4133,7 @@ variables:
   identifier: '{{identifier_start}}{{identifier_char}}*'
   identifier_start: '[[:alpha:]_]'
   identifier_char: '[[:alnum:]_]'
-  identifier_class: '_?(?:[[:upper:]]+[[:digit:][:lower:]]+)+\b'
+  identifier_class: '_?[[:upper:]](?:[[:upper:][:digit:]]*[[:lower:]]+[[:alnum:]]*)\b'
   identifier_constant: '(?:[_[:upper:]][_[:upper:][:digit:]]*)?[[:upper:]]{2,}[_[:upper:][:digit:]]*\b'  # require 2 consecutive upper-case letters
 
   illegal_names: (?:and|as|assert|break|class|continue|def|del|elif|else|except|finally|for|from|global|if|import|in|is|lambda|not|or|pass|raise|return|try|while|with|yield)\b

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -573,26 +573,47 @@ MClassName0 module.MClassName0
 #                 ^ punctuation.accessor.dot.python
 #                  ^^^^^^^^^^^ support.class.python
 
-M_Class module.M_Class
-#^^^^^^ support.class.python
-#       ^^^^^^^^^^^^^^ meta.path.python
-#       ^^^^^^ variable.other.python
-#             ^ punctuation.accessor.dot.python
-#              ^^^^^^^ support.class.python
-
-M0_Class module.M0_Class
-#^^^^^^^ support.class.python
-#        ^^^^^^^^^^^^^^^ meta.path.python
-#        ^^^^^^ variable.other.python
-#              ^ punctuation.accessor.dot.python
-#               ^^^^^^^^ support.class.python
-
-ANY_CLASs module.ANY_CLASs
+MyClassV0 module.MyClassV0
 #^^^^^^^^ support.class.python
 #         ^^^^^^^^^^^^^^^^ meta.path.python
 #         ^^^^^^ variable.other.python
 #               ^ punctuation.accessor.dot.python
 #                ^^^^^^^^^ support.class.python
+
+M_Class module.M_Class
+#^^^^^^ variable.other.python
+#       ^^^^^^^^^^^^^^ meta.path.python
+#       ^^^^^^ variable.other.python
+#             ^ punctuation.accessor.dot.python
+#              ^^^^^^^ variable.other.python
+
+M0_Class module.M0_Class
+#^^^^^^^ variable.other.python
+#        ^^^^^^^^^^^^^^^ meta.path.python
+#        ^^^^^^ variable.other.python
+#              ^ punctuation.accessor.dot.python
+#               ^^^^^^^^ variable.other.python
+
+ANY_CLASs module.ANY_CLASs
+#^^^^^^^^ variable.other.python
+#         ^^^^^^^^^^^^^^^^ meta.path.python
+#         ^^^^^^ variable.other.python
+#               ^ punctuation.accessor.dot.python
+#                ^^^^^^^^^ variable.other.python
+
+AnyClass_0 module.AnyClass_0
+#^^^^^^^^^ variable.other.python
+#          ^^^^^^^^^^^^^^^^ meta.path.python
+#          ^^^^^^ variable.other.python
+#                ^ punctuation.accessor.dot.python
+#                 ^^^^^^^^^^ variable.other.python
+
+Any_Class0 module.Any_Class0
+#^^^^^^^^^ variable.other.python
+#          ^^^^^^^^^^^^^^^^ meta.path.python
+#          ^^^^^^ variable.other.python
+#                ^ punctuation.accessor.dot.python
+#                 ^^^^^^^^^^ variable.other.python
 
 _0variable module._0variable
 #^^^^^^^^^ variable.other.python

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -622,6 +622,20 @@ _0variable module._0variable
 #                ^ punctuation.accessor.dot.python
 #                 ^^^^^^^^^^ variable.other.python
 
+NaN module.NaN
+#^^ variable.other.python
+#   ^^^^^^^^^^ meta.path.python
+#   ^^^^^^ variable.other.python
+#         ^ punctuation.accessor.dot.python
+#          ^^^ variable.other.python
+
+NaT module.NaT
+#^^ variable.other.python
+#   ^^^^^^^^^^ meta.path.python
+#   ^^^^^^ variable.other.python
+#         ^ punctuation.accessor.dot.python
+#          ^^^ variable.other.python
+
 open.open.open.
 # <- meta.path.python variable.other.python
 #^^^^^^^^^^^^^^ meta.path.python - keyword - support

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -525,18 +525,18 @@ __bool__ abc.__nonzero__
 #            ^^^^^^^^^^^ support.function.magic
 
 T module.T  # most commonly used in generics
-# <- support.class.python
+# <- variable.other.python
 # ^^^^^^^^ meta.path.python
 # ^^^^^^ variable.other.python
 #       ^ punctuation.accessor.dot.python
-#        ^ support.class.python
+#        ^ variable.other.python
 
 _T module._T
-#^ support.class.python
+#^ variable.other.python
 #  ^^^^^^^^^ meta.path.python
 #  ^^^^^^ variable.other.python
 #        ^ punctuation.accessor.dot.python
-#         ^^ support.class.python
+#         ^^ variable.other.python
 
 TypeError module.TypeError
 #^^^^^^^^ support.class.exception - meta.path
@@ -2561,13 +2561,13 @@ def f[T: Hashable, U: (int, str), *V, **P](x: T = SOME_CONSTANT, y: U, *args: *T
 #                                         ^ punctuation.section.parameters.begin.python
 #                                          ^ variable.parameter.python - variable.other
 #                                           ^ punctuation.separator.annotation.python
-#                                             ^ meta.type.python support.class.python - meta.path
+#                                             ^ meta.type.python variable.other.python - meta.path
 #                                               ^ meta.function.parameters.default-value.python keyword.operator.assignment.python
 #                                                 ^^^^^^^^^^^^^ variable.other.constant.python - meta.path
 #                                                              ^ punctuation.separator.parameters.python
 #                                                                ^ variable.parameter.python - variable.other
 #                                                                 ^ punctuation.separator.annotation.python
-#                                                                   ^ meta.type.python support.class.python - meta.path
+#                                                                   ^ meta.type.python variable.other.python - meta.path
 #                                                                    ^ punctuation.separator.parameters.python
 #                                                                      ^ keyword.operator.unpacking.sequence.python
 #                                                                       ^^^^ variable.parameter.python - variable.other
@@ -2578,12 +2578,12 @@ def f[T: Hashable, U: (int, str), *V, **P](x: T = SOME_CONSTANT, y: U, *args: *T
 #                                                                                  ^^ keyword.operator.unpacking.mapping.python
 #                                                                                    ^^^^^^ variable.parameter.python - variable.other
 #                                                                                          ^ punctuation.separator.annotation.python
-#                                                                                            ^ meta.type.python meta.path.python support.class.python
+#                                                                                            ^ meta.type.python meta.path.python variable.other.python
 #                                                                                             ^ meta.type.python meta.path.python punctuation.accessor.dot.python
 #                                                                                              ^^^^^^ meta.type.python meta.path.python variable.other.python
 #                                                                                                    ^ punctuation.section.parameters.end.python
 #                                                                                                      ^^ punctuation.separator.return-type.python
-#                                                                                                         ^ meta.type.python support.class.python - meta.path
+#                                                                                                         ^ meta.type.python variable.other.python - meta.path
 
 def f[
 # ^^^ meta.function.python - meta.generic
@@ -2621,7 +2621,7 @@ def f[
 #    ^ punctuation.section.parameters.begin.python
 #     ^ punctuation.section.parameters.end.python
 #       ^^ punctuation.separator.return-type.python
-#          ^ meta.type.python support.class.python - meta.path
+#          ^ meta.type.python variable.other.python - meta.path
 #           ^ meta.function.python punctuation.section.block.begin.python
 
 match test:
@@ -2800,7 +2800,7 @@ class GenericClass[T: X, **U]:
 #                 ^ punctuation.definition.generic.begin.python
 #                  ^ variable.parameter.type.python
 #                   ^ punctuation.separator.bound.python
-#                     ^ support.class.python - meta.path
+#                     ^ variable.other.python - meta.path
 #                      ^ punctuation.separator.parameters.python
 #                        ^^ keyword.operator.unpacking.mapping.python
 #                          ^ variable.parameter.type.python
@@ -2820,7 +2820,7 @@ class GenericClass[T: X, **U]:
     def method(arg: T):
 #   ^^^^^^^^^^ meta.function.python
 #             ^^^^^^^^ meta.function.parameters
-#                   ^ meta.type.python support.class.python - meta.path
+#                   ^ meta.type.python variable.other.python - meta.path
 
 match test:
     case "class":
@@ -2885,7 +2885,7 @@ type Alias[T: int] = list[T]
 #                    ^^^^ support.type.python
 #                        ^^^ meta.brackets.python
 #                        ^ punctuation.section.brackets.begin.python
-#                         ^ support.class.python
+#                         ^ variable.other.python
 #                          ^ punctuation.section.brackets.end.python
 
 type \
@@ -2902,7 +2902,7 @@ type \
 #                ^^^^ support.type.python
 #                    ^^^ meta.brackets.python
 #                    ^ punctuation.section.brackets.begin.python
-#                     ^ support.class.python
+#                     ^ variable.other.python
 #                      ^ punctuation.section.brackets.end.python
 
 type \
@@ -2919,7 +2919,7 @@ type \
 #           ^^^^ support.type.python
 #               ^^^ meta.brackets.python
 #               ^ punctuation.section.brackets.begin.python
-#                ^ support.class.python
+#                ^ variable.other.python
 #                 ^ punctuation.section.brackets.end.python
 
 type \
@@ -2931,7 +2931,7 @@ type \
 #  ^^^^ support.type.python
 #      ^^^ meta.brackets.python
 #      ^ punctuation.section.brackets.begin.python
-#       ^ support.class.python
+#       ^ variable.other.python
 #        ^ punctuation.section.brackets.end.python
 
   type Alias

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -622,20 +622,6 @@ _0variable module._0variable
 #                ^ punctuation.accessor.dot.python
 #                 ^^^^^^^^^^ variable.other.python
 
-NaN module.NaN
-#^^ variable.other.python
-#   ^^^^^^^^^^ meta.path.python
-#   ^^^^^^ variable.other.python
-#         ^ punctuation.accessor.dot.python
-#          ^^^ variable.other.python
-
-NaT module.NaT
-#^^ variable.other.python
-#   ^^^^^^^^^^ meta.path.python
-#   ^^^^^^ variable.other.python
-#         ^ punctuation.accessor.dot.python
-#          ^^^ variable.other.python
-
 open.open.open.
 # <- meta.path.python variable.other.python
 #^^^^^^^^^^^^^^ meta.path.python - keyword - support


### PR DESCRIPTION
Addresses #4540

This PR restricts which tokens are scoped `support.class`.

Scope tokens as type only, if they

1. follow `PascalCase` or `_PascalCase` without underscores in between.
2. consist of at least 2 chars
~~3. do not end with uppercase letter~~

Single char upper case tokens are now scoped `variable.other`, which is probably an appropriate scope for "type variables" in generics as well.

_It would be possible to keep them scoped `support.type` in type annotations with further adjustments to related contexts. Those currently use normal expression rules, which causes some ambiguities to resolve - especially with regards to `after-expression` context._