### PR TITLE
[SQL] correctly scope comments stored as part of column definitions in MySQL

### DIFF
--- a/SQL/MySQL.sublime-syntax
+++ b/SQL/MySQL.sublime-syntax
@@ -1202,6 +1202,9 @@ contexts:
       push: generated-always-as-expression
     - match: \b(?i:stored|virtual)\b
       scope: storage.modifier.sql
+    - match: \b(?i:comment)\b
+      scope: keyword.other.sql
+      push: single-string
 
   generated-always-as-expression:
     - include: maybe-group

--- a/SQL/tests/syntax/syntax_test_mysql.sql
+++ b/SQL/tests/syntax/syntax_test_mysql.sql
@@ -1215,7 +1215,17 @@ create table IF NOT EXISTS `testing123` (
     `fkey` INT UNSIGNED NULL REFERENCES test2(id),
 --                           ^^^^^^^^^^ storage.modifier.sql
     `version` tinytext DEFAULT NULL COMMENT 'important clarification',
+--  ^^^^^^^^^ meta.column-name.sql variable.other.member.declaration.sql
+--  ^ punctuation.definition.identifier.begin.sql
+--          ^ punctuation.definition.identifier.end.sql
 --            ^^^^^^^^ storage.type.sql
+--                     ^^^^^^^ storage.modifier.sql
+--                             ^^^^ constant.language.null.sql
+--                                  ^^^^^^^ keyword.other.sql
+--                                          ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.sql string.quoted.single.sql
+--                                          ^ punctuation.definition.string.begin.sql
+--                                                                  ^ punctuation.definition.string.end.sql
+--                                                                   ^ punctuation.separator.sequence.sql
     `percentage` float DEFAULT '0',
 
     `set` SET ('value1', 'value2') NOT NULL,


### PR DESCRIPTION
we scope them as strings because semantically that is what they are - metadata to be stored against the column definition