### PR TITLE
[Python] Fix commit autocompletion with enter after control flow keywords

### DIFF
--- a/Python/Default.sublime-keymap
+++ b/Python/Default.sublime-keymap
@@ -152,4 +152,14 @@
             { "key": "preceding_text", "operator": "regex_match", "operand": "^\\s+(?:break|continue|pass|return\\b.*)$", "match_all": true }
         ],
     },
+    { "keys": ["keypad_enter"], "command": "run_macro_file", "args": {"file": "Packages/Python/Add Dedented Line.sublime-macro"}, "context":
+
+        [
+            { "key": "setting.auto_indent", "operand": true },
+            { "key": "selector", "operand": "source.python - source.python comment - source.python string" },
+            { "key": "selection_empty", "match_all": true },
+            { "key": "auto_complete_visible", "operand": false },
+            { "key": "preceding_text", "operator": "regex_match", "operand": "^\\s+(?:break|continue|pass|return\\b.*)$", "match_all": true }
+        ],
+    },
 ]

--- a/Python/Default.sublime-keymap
+++ b/Python/Default.sublime-keymap
@@ -148,7 +148,6 @@
             { "key": "setting.auto_indent", "operand": true },
             { "key": "selector", "operand": "source.python - source.python comment - source.python string" },
             { "key": "selection_empty", "match_all": true },
-            { "key": "auto_complete_visible", "operand": false },
             { "key": "preceding_text", "operator": "regex_match", "operand": "^\\s+(?:break|continue|pass|return\\b.*)$", "match_all": true }
         ],
     },
@@ -158,8 +157,23 @@
             { "key": "setting.auto_indent", "operand": true },
             { "key": "selector", "operand": "source.python - source.python comment - source.python string" },
             { "key": "selection_empty", "match_all": true },
-            { "key": "auto_complete_visible", "operand": false },
             { "key": "preceding_text", "operator": "regex_match", "operand": "^\\s+(?:break|continue|pass|return\\b.*)$", "match_all": true }
         ],
+    },
+
+    // Prefer committing completions if "auto_complete_commit_on_tab" is disabled
+    { "keys": ["enter"], "command": "commit_completion", "context":
+        [
+            { "key": "selector", "operand": "source.python - source.python comment - source.python string" },
+            { "key": "auto_complete_visible" },
+            { "key": "setting.auto_complete_commit_on_tab", "operand": false }
+        ]
+    },
+    { "keys": ["keypad_enter"], "command": "commit_completion", "context":
+        [
+            { "key": "selector", "operand": "source.python - source.python comment - source.python string" },
+            { "key": "auto_complete_visible" },
+            { "key": "setting.auto_complete_commit_on_tab", "operand": false }
+        ]
     },
 ]

--- a/Python/Default.sublime-keymap
+++ b/Python/Default.sublime-keymap
@@ -152,7 +152,6 @@
         ],
     },
     { "keys": ["keypad_enter"], "command": "run_macro_file", "args": {"file": "Packages/Python/Add Dedented Line.sublime-macro"}, "context":
-
         [
             { "key": "setting.auto_indent", "operand": true },
             { "key": "selector", "operand": "source.python - source.python comment - source.python string" },

--- a/Python/Default.sublime-keymap
+++ b/Python/Default.sublime-keymap
@@ -148,6 +148,7 @@
             { "key": "setting.auto_indent", "operand": true },
             { "key": "selector", "operand": "source.python - source.python comment - source.python string" },
             { "key": "selection_empty", "match_all": true },
+            { "key": "auto_complete_visible", "operand": false },
             { "key": "preceding_text", "operator": "regex_match", "operand": "^\\s+(?:break|continue|pass|return\\b.*)$", "match_all": true }
         ],
     },


### PR DESCRIPTION
Fixes #4543

This PR...

1. fixes `enter` not commiting completions after keywords like `return`.
2. adds `keypad_enter` binding to dedent next line for completeness.


It aligns `enter` behavior with that for all other languages, depending on value of `auto_complete_commit_on_tab` setting.