### PR TITLE
[Go] Extend struct tag key matching

### DIFF
--- a/Go/Go.sublime-syntax
+++ b/Go/Go.sublime-syntax
@@ -1548,12 +1548,12 @@ contexts:
     - match: '`'
       scope: punctuation.definition.annotation.end.go
       pop: 1
-    - match: (\w+)(:)
+    - match: ([\w-]+)(:)
       captures:
         1: meta.annotation.identifier.go variable.annotation.go
         2: meta.annotation.go punctuation.separator.key-value.go
       push: match-struct-tag-annotation-value
-    - match: (\w+)(?=[\s`])
+    - match: ([\w-]+)(?=[\s`])
       scope: meta.annotation.identifier.go variable.annotation.go
       push: pop-now-clear-scope
 

--- a/Go/tests/syntax_test_go.go
+++ b/Go/tests/syntax_test_go.go
@@ -1635,6 +1635,19 @@ by accident, but if necessary, such support could be sacrificed.
 //                                            ^ punctuation.definition.string.begin
 //                                                 ^ punctuation.definition.string.end
 //                                                  ^ punctuation.definition.annotation.end
+
+        field typ `API-v2_0:"field"`
+//      ^^^^^ meta.type.go variable.other.member.declaration.go
+//            ^^^ meta.type.go storage.type.go
+//                ^^^^^^^^^^^^^^^^^^ meta.type.go meta.annotation - meta.annotation meta.annotation
+//                ^ punctuation.definition.annotation.begin
+//                 ^^^^^^^^ meta.annotation.identifier variable.annotation
+//                         ^ punctuation.separator.key-value
+//                          ^ punctuation.definition.string.begin
+//                           ^^^^^ meta.annotation.parameters string.quoted.double
+//                                ^ punctuation.definition.string.end
+//                                 ^ punctuation.definition.annotation.end
+
         field /**/ typ /**/ `json:"field"`
 //      ^^^^^ meta.type.go variable.other.member.declaration.go
 //            ^^^^ meta.type.go comment.block.go


### PR DESCRIPTION
Some Go packages use hyphens in struct tag keys. For example, [cleanenv](https://github.com/ilyakaznacheev/cleanenv#read-configuration) uses \`env-default\`:
```go
type ConfigDatabase struct {
  Port string `yaml:"port" env:"PORT" env-default:"5432"`
  ...
}
```