### PR TITLE
[Go] Update switch snippet

### DIFF
--- a/Go/Snippets/go-switch.sublime-snippet
+++ b/Go/Snippets/go-switch.sublime-snippet
@@ -1,10 +1,9 @@
 <snippet>
 	<content><![CDATA[switch ${1:expression} {
-case condition:
-	${2:/* code */}
+case ${2:condition}:
+	${3:/* code */}
 default:
 	${0:/* code */}
-	return
 }]]></content>
 	<tabTrigger>switch</tabTrigger>
 	<scope>source.go</scope>


### PR DESCRIPTION
The switch snippet does not include a field marker for the case condition, so it is skipped in the tab order.
The return statement also seems redundant. I checked switch snippets for other languages and none of them use `return`
