### PR TITLE
[Python] Add support for explicit lazy imports

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -427,13 +427,17 @@ contexts:
 ###[ IMPORT STATEMENTS ]######################################################
 
   import-statements:
-    - match: import\b
-      scope: keyword.control.import.python
+    - match: (?:(lazy)\s+)?(import\b)
+      captures:
+        1: keyword.control.import.lazy.python
+        2: keyword.control.import.python
       push:
         - imports-import-body
         - expect-absolute-import
-    - match: from\b
-      scope: keyword.control.import.from.python
+    - match: (?:(lazy)\s+)?(from\b)
+      captures:
+        1: keyword.control.import.lazy.python
+        2: keyword.control.import.from.python
       push:
         - imports-from-body
         - maybe-relative-import

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -477,7 +477,6 @@ import .str
 import str
 #      ^^^ support.type.python
 
-
 lazy import
 #^^^^^^^^^^ meta.statement.import.python
 #^^^ keyword.control.import.lazy.python

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -477,6 +477,23 @@ import .str
 import str
 #      ^^^ support.type.python
 
+
+lazy import
+#^^^^^^^^^^ meta.statement.import.python
+#^^^ keyword.control.import.lazy.python
+#    ^^^^^^ keyword.control.import.python
+
+lazy import sys.path # comment
+#^^^^^^^^^^^^^^^^^^^ meta.statement.import.python
+#^^^ keyword.control.import.lazy.python
+#    ^^^^^^ keyword.control.import.python
+#           ^^^^^^^^ meta.path.python
+#           ^^^ variable.other.python
+#              ^ punctuation.accessor.dot.python
+#               ^^^^ variable.other.python
+#                    ^^^^^^^^^^ comment.line.number-sign.python
+#                    ^ punctuation.definition.comment.python
+
 from importlib import import_module
 # <- meta.statement.import.python keyword.control.import.from.python
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.import.python
@@ -484,6 +501,19 @@ from importlib import import_module
 #    ^^^^^^^^^ - keyword
 #              ^^^^^^ keyword.control.import.python
 #                     ^^^^^^^^^^^^^ - keyword
+
+lazy from
+#^^^^^^^^ meta.statement.import.python
+#^^^ keyword.control.import.lazy.python
+#    ^^^^ keyword.control.import.from.python
+
+lazy from importlib import import_module
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.import.python
+#^^^ keyword.control.import.lazy.python
+#    ^^^^ keyword.control.import.from.python
+#         ^^^^^^^^^ - keyword
+#                   ^^^^^^ keyword.control.import.python
+#                          ^^^^^^^^^^^^^ - keyword
 
 ##################
 # Identifiers


### PR DESCRIPTION
This PR implements https://peps.python.org/pep-0810/, which is supported as of python 3.15