### PR TITLE
[Python] Add new py315 built-in types

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -4282,8 +4282,8 @@ variables:
 
   builtin_types: |-
     (?x:
-      bool | bytearray | bytes | complex | dict | float | frozenset | int
-    | list | memoryview | object | set | slice | str | tuple
+      bool | bytearray | bytes | complex | dict | float | frozendict | frozenset
+    | int | list | memoryview | object | set | slice | str | tuple
     # Python 2 types
     | basestring | long | unicode
     # Python 2 types prone to conflicts

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -4283,7 +4283,7 @@ variables:
   builtin_types: |-
     (?x:
       bool | bytearray | bytes | complex | dict | float | frozendict | frozenset
-    | int | list | memoryview | object | set | slice | str | tuple
+    | int | list | memoryview | object | sentinel | set | slice | str | tuple
     # Python 2 types
     | basestring | long | unicode
     # Python 2 types prone to conflicts

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -530,6 +530,9 @@ frozendict
 frozenset
 #^^^^^^^^ support.type.python
 
+sentinel
+#^^^^^^^ support.type.python
+
 T module.T  # most commonly used in generics
 # <- variable.other.python
 # ^^^^^^^^ meta.path.python

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -524,6 +524,12 @@ __bool__ abc.__nonzero__
 #^^^^^^^ support.function.magic
 #            ^^^^^^^^^^^ support.function.magic
 
+frozendict
+#^^^^^^^^^ support.type.python
+
+frozenset
+#^^^^^^^^ support.type.python
+
 T module.T  # most commonly used in generics
 # <- variable.other.python
 # ^^^^^^^^ meta.path.python


### PR DESCRIPTION
This PR scopes `frozendict` and `sentinel` as `support.type` as they are built-in types as of Python 3.15

see:
- https://peps.python.org/pep-0661/
- https://peps.python.org/pep-0814/
