### PR TITLE
[Python] Fix type definition fallback

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -911,12 +911,13 @@ contexts:
     - include: immediately-pop
 
   type-definition-name:
-    - include: illegal-name
+    - match: (?={{illegal_names}})
+      fail: type-definitions
     - match: '{{identifier}}'
       scope: entity.name.type.alias.python
       pop: 1
     - include: line-continuations
-    - match: (?=\S)
+    - match: $|(?=\S)
       fail: type-definitions
 
   type-definition-value-assignment:

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -3009,6 +3009,18 @@ class Foo:
 #                      ^^^^ variable.other.python - meta.path
 #                          ^ punctuation.section.arguments.end.python
 
+class Test:
+    def __init__(self, type=None):
+        self.type = type
+#            ^^^^ meta.path.python variable.other.python
+#                   ^^^^ variable.other.python
+
+    def __repr__(self):
+#   ^^^^^^^^^^^^ meta.function.python
+#               ^^^^^^ meta.function.parameters.python
+#   ^^^ keyword.declaration.function.python
+        pass
+
 match test:
     case "type":
         type foo


### PR DESCRIPTION
This PR fixes type definition branch not failing, when `type` keyword is followed by function definition (or any other reserved word).

Reasons:

1. was missing failure upon end of line
2. was scoping reserved words illegal instead of failing type definition