### PR TITLE
[C#] Tweak qualified member access

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -2178,8 +2178,10 @@ contexts:
       push:
         - type-suffix
         - type-argument-list
-    - match: \.
-      scope: punctuation.accessor.dot.cs
+    - match: (\?)?(\.)
+      captures:
+        1: keyword.operator.null-coalescing.cs
+        2: punctuation.accessor.dot.cs
       push: member-access
     - include: expression-list
 
@@ -2203,8 +2205,10 @@ contexts:
     - include: expression-list
 
   maybe-member-access:
-    - match: \.
-      scope: punctuation.accessor.dot.cs
+    - match: (\?)?(\.)
+      captures:
+        1: keyword.operator.null-coalescing.cs
+        2: punctuation.accessor.dot.cs
       set: member-access
     - include: else-pop
 
@@ -2225,7 +2229,6 @@ contexts:
       scope: variable.other.member.cs
       set:
         - maybe-member-access
-        - type-suffix
         - type-argument-list
     - include: else-pop
 

--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -2209,15 +2209,22 @@ contexts:
     - include: else-pop
 
   member-access:
-    - include: accessors
-    - match: '{{unreserved_name}}(?=[<.])'
+    - match: '{{unreserved_name}}(?={{generic_declaration}}?\s*\()'
+      scope: meta.function-call.identifier.cs variable.function.cs
+      set:
+        - maybe-member-access
+        - function-call-argument-list
+        - type-argument-list
+    - match: '{{unreserved_name}}(?={{generic_declaration}})'
       scope: support.type.cs
-      push:
+      set:
+        - maybe-member-access
         - type-suffix
         - type-argument-list
     - match: '{{unreserved_name}}'
       scope: variable.other.member.cs
       set:
+        - maybe-member-access
         - type-suffix
         - type-argument-list
     - include: else-pop

--- a/C#/tests/syntax_test_scope_C#7.cs
+++ b/C#/tests/syntax_test_scope_C#7.cs
@@ -1099,6 +1099,39 @@ public readonly struct S
         this.Age = age;
         this.Name = name;
 ///     ^^^^ variable.language.this.cs
+///         ^ punctuation.accessor.dot.cs
+///          ^^^^ variable.other.member.cs
+///               ^ keyword.operator.assignment.cs
+///                 ^^^^ variable.other.cs
+///                     ^ punctuation.terminator.statement.cs
+        this.Func();
+///     ^^^^ variable.language.this.cs
+///         ^ punctuation.accessor.dot.cs
+///          ^^^^ meta.function-call.identifier.cs variable.function.cs
+///              ^^ meta.function-call.arguments.cs meta.group.cs
+///              ^ punctuation.section.group.begin.cs
+///               ^ punctuation.section.group.end.cs
+///                ^ punctuation.terminator.statement.cs
+
+        this.Name.Func();
+///     ^^^^ variable.language.this.cs
+///         ^ punctuation.accessor.dot.cs
+///          ^^^^ variable.other.member.cs
+///              ^ punctuation.accessor.dot.cs
+///               ^^^^ meta.function-call.identifier.cs variable.function.cs
+///                   ^^ meta.function-call.arguments.cs meta.group.cs
+///                   ^ punctuation.section.group.begin.cs
+///                    ^ punctuation.section.group.end.cs
+///                     ^ punctuation.terminator.statement.cs
+
+        Name.Func();
+///     ^^^^ variable.other.cs
+///         ^ punctuation.accessor.dot.cs
+///          ^^^^ meta.function-call.identifier.cs variable.function.cs
+///              ^^ meta.function-call.arguments.cs meta.group.cs
+///              ^ punctuation.section.group.begin.cs
+///               ^ punctuation.section.group.end.cs
+///                ^ punctuation.terminator.statement.cs
     }
 
     public S(S other)

--- a/C#/tests/syntax_test_scope_GeneralStructure.cs
+++ b/C#/tests/syntax_test_scope_GeneralStructure.cs
@@ -2822,7 +2822,7 @@ class TestControlStatements
 ///             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.case.pattern.cs
 ///              ^^^^^^^^^^^^^^^^^^^ support.type.cs
 ///                                 ^ punctuation.accessor.dot.cs
-///                                  ^^^^^^^^^^^ support.type.cs
+///                                  ^^^^^^^^^^^ variable.other.member.cs
 ///                                             ^ punctuation.accessor.dot.cs
 ///                                              ^^^^^ variable.other.member.cs
 ///                                                   ^ punctuation.separator.colon.cs

--- a/C#/tests/syntax_test_scope_Operators.cs
+++ b/C#/tests/syntax_test_scope_Operators.cs
@@ -466,3 +466,22 @@ A?.B?.C?[0] == E;
 ///       ^ punctuation.section.brackets.end
 ///         ^^ keyword.operator
 ///             ^ punctuation.terminator
+
+this?.Name?.Func();
+///^ variable.language.this.cs
+/// ^ keyword.operator.null-coalescing.cs
+///  ^ punctuation.accessor.dot.cs
+///   ^^^^ variable.other.member.cs
+///       ^ keyword.operator.null-coalescing.cs
+///        ^ punctuation.accessor.dot.cs
+///         ^^^^ meta.function-call.identifier.cs variable.function.cs
+///             ^^ meta.function-call.arguments.cs meta.group.cs
+///             ^ punctuation.section.group.begin.cs
+///              ^ punctuation.section.group.end.cs
+///               ^ punctuation.terminator.statement.cs
+
+var foo = { any?.var?.value };
+///            ^ keyword.operator.null-coalescing.cs
+///             ^ punctuation.accessor.dot.cs
+///                 ^ keyword.operator.null-coalescing.cs
+///                  ^ punctuation.accessor.dot.cs


### PR DESCRIPTION
Fixes #4558

This commit tweaks patterns related to qualified object member access, to prefer variable scope over type.