### PR TITLE
[JavaScript] Fix deadlock caused by failing react tag branch

### DIFF
--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -757,6 +757,7 @@ contexts:
         - ts-less-than
 
   ts-function-type-arguments:
+    - meta_include_prototype: false
     - match: '<'
       scope: punctuation.definition.generic.begin.js
       set:
@@ -781,6 +782,7 @@ contexts:
         - ts-type-expression-begin
 
   ts-less-than:
+    - meta_include_prototype: false
     - match: '<'
       scope: keyword.operator.comparison.js
       pop: 1

--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -757,7 +757,7 @@ contexts:
         - ts-less-than
 
   ts-function-type-arguments:
-    - match: \<(?!<)
+    - match: '<'
       scope: punctuation.definition.generic.begin.js
       set:
         - - match: (?=[\]()};,`])
@@ -783,7 +783,7 @@ contexts:
   ts-less-than:
     - match: '<'
       scope: keyword.operator.comparison.js
-      set: expression-begin
+      pop: 1
 
   ts-non-null-assertion:
     - match: '!(?!=)'


### PR DESCRIPTION
Fixes https://github.com/sublimehq/sublime_text/issues/6926

This commit ensures failing TSX tag branches (implemented in `expression-begin`) cause parser to continue with related `expression-end` context, instead of reentering `expression-begin`.