### PR TITLE
[JavaScript] Remove possibly stray branch failure

### DIFF
--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -847,12 +847,10 @@ contexts:
     - include: immediately-pop
 
   ts-type-expression-end:
-    - match: (?=\|\||&&)
-      fail: ts-function-type-arguments
-    - match: \&
+    - match: \&(?!\&)
       scope: keyword.operator.type.intersection.js
       push: [ts-type-expression-end-no-line-terminator, ts-type-expression-begin]
-    - match: \|
+    - match: \|(?!\|)
       scope: keyword.operator.type.union.js
       push: [ts-type-expression-end-no-line-terminator, ts-type-expression-begin]
     - match: is{{identifier_break}}

--- a/JavaScript/tests/syntax_test_typescript.ts
+++ b/JavaScript/tests/syntax_test_typescript.ts
@@ -391,6 +391,26 @@ import foo;
     declare();
 //  ^^^^^^^ meta.function-call variable.function
 
+    declare<T>();
+//         ^^^ meta.generic
+//         ^ punctuation.definition.generic.begin
+//          ^ support.class
+//           ^ punctuation.definition.generic.end
+
+    declare<T1 & T2>();
+//         ^^^^^^^^^ meta.generic.js
+//         ^ punctuation.definition.generic.begin.js
+//          ^^ support.class.js
+//             ^ keyword.operator.type.intersection.js
+//               ^^ support.class.js
+//                 ^ punctuation.definition.generic.end.js
+
+    declare<T1 && T2>();
+//         ^^^^^^^^^^ - meta.generic
+
+    declare<T1 & T2<T3 && T4>>();
+//         ^^^^^^^^^^^^^^^^^^^ - meta.generic
+
     declare con;
 //  ^^^^^^^ storage.modifier
 


### PR DESCRIPTION
This commit removes `ts-function-type-arguments` branch point failure from `ts-type-expression-end` as this context is also used in non-function-call expressions. Implementing failure outside of related branch points may have unpredictable side effects.

Instead add a negative lookahead to prevent `||` or `&&` being consumed as sequence of type operators. Possible branch point failure is to be handled by "calling" context after popping `ts-type-expression-end`.

Added tests should illustrate it not affecting syntax highlighting behavior of generic function calls.