### PR TITLE
[SQL] Fix possibly duplicate prototype contexts

### DIFF
--- a/SQL/SQL (basic).sublime-syntax
+++ b/SQL/SQL (basic).sublime-syntax
@@ -1064,6 +1064,7 @@ contexts:
 
   inside-user-type:
     # note: may contain foreign variable interpolation
+    - meta_include_prototype: false
     - meta_scope: support.type.sql
     - include: identifier-prototype
     - match: '{{simple_identifier_break}}'
@@ -1423,6 +1424,7 @@ contexts:
 
   inside-backtick-quoted-identifier-part:
     # note: may contain foreign variable interpolation
+    - meta_include_prototype: false
     - match: \`
       scope: punctuation.definition.identifier.end.sql
       pop: 1


### PR DESCRIPTION
This PR excludes global `prototype` context from those which already include a dedicated one, such as `identifier-prototype` in order to prevent two possibly conflicting ones being included by template languages.