### PR TITLE
[D] Fix `auto` attribute in if and while conditions

### DIFF
--- a/D/D.sublime-syntax
+++ b/D/D.sublime-syntax
@@ -2355,7 +2355,7 @@ contexts:
   condition-attribute:
     - match: '\bauto\b'
       scope: storage.modifier.d
-      pop: 1
+      pop: true
     - match: '(?=\S)'
       pop: true
 

--- a/D/D.sublime-syntax
+++ b/D/D.sublime-syntax
@@ -888,9 +888,6 @@ contexts:
         - match: '\('
           scope: punctuation.section.parens.begin.d
           set: [basic-type2, basic-type2-after-parens, typeof-value]
-    - match: '\bauto\b'
-      scope: keyword.other.d
-      pop: true
     - match: '\bmixin\b'
       scope: keyword.control.d
       set:

--- a/D/D.sublime-syntax
+++ b/D/D.sublime-syntax
@@ -2347,7 +2347,7 @@ contexts:
   condition:
     - match: '\('
       scope: punctuation.section.parens.begin.d
-      set: [condition-after, first-value]
+      set: [condition-after, first-value, condition-attribute]
     - include: not-whitespace-illegal-pop
   condition-after:
     - meta_scope: meta.parens.d
@@ -2355,6 +2355,12 @@ contexts:
       scope: punctuation.section.parens.end.d
       pop: true
     - include: not-whitespace-illegal-pop
+  condition-attribute:
+    - match: '\bauto\b'
+      scope: storage.modifier.d
+      pop: 1
+    - match: '(?=\S)'
+      pop: true
 
   identifier:
     - match: '\b{{name}}\b'

--- a/D/tests/syntax_test_d.d
+++ b/D/tests/syntax_test_d.d
@@ -2251,6 +2251,7 @@ extern(1)
 //               ^ meta.number.integer.decimal.d
   if (int a = 2) {}
 //^^ keyword.control.conditional.d
+//   ^^^^^^^^^^^ meta.parens.d
 //   ^ punctuation.section.parens.begin.d
 //    ^^^ storage.type.d
 //        ^ variable.other.d
@@ -2260,7 +2261,18 @@ extern(1)
 //               ^^ meta.block.d
 //               ^ punctuation.section.block.begin.d
 //                ^ punctuation.section.block.end.d
-
+  if (auto a = 2) {}
+//^^ keyword.control.conditional.d
+//   ^^^^^^^^^^^^ meta.parens.d
+//   ^ punctuation.section.parens.begin.d
+//    ^^^^ storage.modifier.d
+//         ^ variable.other.d
+//           ^ keyword.operator.assignment.d
+//             ^ meta.number.integer.decimal.d constant.numeric.value.d
+//              ^ punctuation.section.parens.end.d
+//                ^^ meta.block.d
+//                ^ punctuation.section.block.begin.d
+//                 ^ punctuation.section.block.end.d
   if (a in b) {}
 //^^ keyword.control.conditional.d
 //   ^ punctuation.section.parens.begin.d
@@ -2330,6 +2342,17 @@ extern(1)
 //                ^ punctuation.section.parens.end.d
 //                  ^ meta.path.d variable.other.d
 //                   ^ punctuation.terminator.d
+  while (auto a = 2) a;
+//^^^^^ keyword.control.loop.d
+//      ^^^^^^^^^^^^ meta.parens.d
+//      ^ punctuation.section.parens.begin.d
+//       ^^^^ storage.modifier.d
+//            ^ variable.other.d
+//              ^ keyword.operator.assignment.d
+//                ^ meta.number.integer.decimal.d constant.numeric.value.d
+//                 ^ punctuation.section.parens.end.d
+//                   ^ meta.path.d variable.other.d
+//                    ^ punctuation.terminator.d
   for (1; 2; 3) {
 //^^^ keyword.control.loop.d
 //    ^ punctuation.section.parens.begin.d


### PR DESCRIPTION
Fixes #4567

This PR removes a redundant `auto` pattern from `basic-type` context and adds a special `condition-attribute` context to consume it at the beginning of `if` and `while` conditions.

Note: Adding `condition-attribute` context is a conservative decision to avoid undesired side-effects. It may also be valid to prepend `auto` pattern to `first-value`.