### PR TITLE
[Git Formats] Add support for full glob patterns

### DIFF
--- a/Git Formats/Git Common.sublime-syntax
+++ b/Git Formats/Git Common.sublime-syntax
@@ -372,13 +372,13 @@ contexts:
     - match: $\n?     # class must end before end of line
       scope: invalid.illegal.unexpected.eol.glob.git
       pop: 1
-    - match: (\[\.)(\S*)(\.\])
+    - match: (\[\.)(\S*?)(\.\])
       scope: meta.character-class.glob.git
       captures:
         1: punctuation.definition.character-class.begin.glob.git
         2: constant.other.character-class.collate.glob.git
         3: punctuation.definition.character-class.end.glob.git
-    - match: (\[=)(\S*)(=\])
+    - match: (\[=)(\S*?)(=\])
       scope: meta.character-class.glob.git
       captures:
         1: punctuation.definition.character-class.begin.glob.git

--- a/Git Formats/Git Common.sublime-syntax
+++ b/Git Formats/Git Common.sublime-syntax
@@ -360,6 +360,13 @@ contexts:
       pop: 1
 
   fnmatch-character-class-start:
+    - match: (?:(\\.)|[^\\])(-)(?:(\\.)|[^\]])
+      scope: constant.other.range.glob.git
+      captures:
+        1: constant.character.escape.glob.git
+        2: punctuation.separator.sequence.glob.git
+        3: constant.character.escape.glob.git
+      pop: 1
     - match: '[]-]?'  # first unescaped '-' or ']' are matched literal
       scope: constant.character.character-class.glob.git
       pop: 1

--- a/Git Formats/Git Common.sublime-syntax
+++ b/Git Formats/Git Common.sublime-syntax
@@ -287,6 +287,8 @@ contexts:
 
 ###[ FNMATCH ]#################################################################
 
+  # https://www.man7.org/linux/man-pages/man7/glob.7.html
+
   # The first characters of a path pattern may have special meaning and
   # must therefore be treated differently. This scope finally pops off
   # if no more match is found. It must therefore be used as multi-push.
@@ -358,7 +360,7 @@ contexts:
       pop: 1
 
   fnmatch-char-class-start:
-    - match: \]?  # first unescaped ']' is matched as normal char
+    - match: '[]-]?'  # first unescaped '-' or ']' are matched literal
       scope: constant.character.char-class.fnmatch.git
       pop: 1
 
@@ -370,11 +372,36 @@ contexts:
     - match: $\n?     # class must end before end of line
       scope: invalid.illegal.unexpected.eol.fnmatch.git
       pop: 1
-    - match: '\\\]'   # backslash escapes only ']'
+    - match: (\[\.)(\S*)(\.\])
+      scope: meta.char-class.fnmatch.git
+      captures:
+        1: punctuation.definition.char-class.begin.fnmatch.git
+        2: support.class.character-class.collate.fnmatch.git
+        3: punctuation.definition.char-class.end.fnmatch.git
+    - match: (\[=)(\S*)(=\])
+      scope: meta.char-class.fnmatch.git
+      captures:
+        1: punctuation.definition.char-class.begin.fnmatch.git
+        2: support.class.character-class.equivalence.fnmatch.git
+        3: punctuation.definition.char-class.end.fnmatch.git
+    - match: (\[:)(?:({{posix_classes}})|(\S*?))(:\])
+      scope: meta.char-class.fnmatch.git
+      captures:
+        1: punctuation.definition.char-class.begin.fnmatch.git
+        2: support.class.character-class.posix.fnmatch.git
+        3: invalid.illegal.character-class.posix.fnmatch.git
+        4: punctuation.definition.char-class.end.fnmatch.git
+    - match: (?:(\\.)|[^\\\]])?(-)(?:(\\.)|[^\]])
+      scope: constant.other.range.fnmatch.git
+      captures:
+        1: constant.character.escape.fnmatch.git
+        2: punctuation.separator.sequence.fnmatch.git
+        3: constant.character.escape.fnmatch.git
+    - match: '\\.'
       scope: constant.character.escape.char-class.fnmatch.git
     - match: '[*?]'   # asterisk is ignored by fnmatch
       scope: invalid.illegal.unexpected.char-class.fnmatch.git
-    - match: \S
+    - match: .
       scope: constant.character.char-class.fnmatch.git
 
   fnmatch-quoted-file-extensions:
@@ -564,3 +591,7 @@ variables:
   month3: (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)
   pretty_formats_builtins: oneline|short|medium|fuller|full|email|raw|reference
   pretty_formats_empty_value_modifiers: '[-+ ]?'
+
+  posix_classes: |-
+    (?x: alnum | alpha | blank | cntrl | digit | graph
+    | lower | print | punct | space | upper | xdigit )

--- a/Git Formats/Git Common.sublime-syntax
+++ b/Git Formats/Git Common.sublime-syntax
@@ -376,19 +376,19 @@ contexts:
       scope: meta.char-class.fnmatch.git
       captures:
         1: punctuation.definition.char-class.begin.fnmatch.git
-        2: support.class.character-class.collate.fnmatch.git
+        2: support.class.char-class.collate.fnmatch.git
         3: punctuation.definition.char-class.end.fnmatch.git
     - match: (\[=)(\S*)(=\])
       scope: meta.char-class.fnmatch.git
       captures:
         1: punctuation.definition.char-class.begin.fnmatch.git
-        2: support.class.character-class.equivalence.fnmatch.git
+        2: support.class.char-class.equivalence.fnmatch.git
         3: punctuation.definition.char-class.end.fnmatch.git
     - match: (\[:)(?:({{posix_classes}})|(\S*?))(:\])
       scope: meta.char-class.fnmatch.git
       captures:
         1: punctuation.definition.char-class.begin.fnmatch.git
-        2: support.class.character-class.posix.fnmatch.git
+        2: support.class.char-class.posix.fnmatch.git
         3: invalid.illegal.character-class.posix.fnmatch.git
         4: punctuation.definition.char-class.end.fnmatch.git
     - match: (?:(\\.)|[^\\\]])?(-)(?:(\\.)|[^\]])

--- a/Git Formats/Git Common.sublime-syntax
+++ b/Git Formats/Git Common.sublime-syntax
@@ -310,12 +310,12 @@ contexts:
   # and the required bail-out scopes as they might be different and
   # therefore are not part of the following section.
   fnmatch-quoted-body:
-    - include: fnmatch-char-classes
+    - include: fnmatch-character-classes
     - include: fnmatch-quoted-file-extensions
     - include: fnmatch-common
 
   fnmatch-unquoted-body:
-    - include: fnmatch-char-classes
+    - include: fnmatch-character-classes
     - include: fnmatch-unquoted-file-extensions
     - include: fnmatch-common
 
@@ -346,51 +346,51 @@ contexts:
     - match: ''
       pop: 1
 
-  fnmatch-char-classes:
+  fnmatch-character-classes:
     - match: \[           # shell style character class
-      scope: punctuation.definition.char-class.begin.glob.git
+      scope: punctuation.definition.character-class.begin.glob.git
       push:
-        - fnmatch-char-class-body
-        - fnmatch-char-class-start
-        - fnmatch-char-class-operator
+        - fnmatch-character-class-body
+        - fnmatch-character-class-start
+        - fnmatch-character-class-operator
 
-  fnmatch-char-class-operator:
+  fnmatch-character-class-operator:
     - match: '[!^]?'  # optional pattern negation
       scope: keyword.operator.logical.glob.git
       pop: 1
 
-  fnmatch-char-class-start:
+  fnmatch-character-class-start:
     - match: '[]-]?'  # first unescaped '-' or ']' are matched literal
-      scope: constant.character.char-class.glob.git
+      scope: constant.character.character-class.glob.git
       pop: 1
 
-  fnmatch-char-class-body:
-    - meta_scope: meta.char-class.glob.git
+  fnmatch-character-class-body:
+    - meta_scope: meta.character-class.glob.git
     - match: \]
-      scope: punctuation.definition.char-class.end.glob.git
+      scope: punctuation.definition.character-class.end.glob.git
       pop: 1
     - match: $\n?     # class must end before end of line
       scope: invalid.illegal.unexpected.eol.glob.git
       pop: 1
     - match: (\[\.)(\S*)(\.\])
-      scope: meta.char-class.glob.git
+      scope: meta.character-class.glob.git
       captures:
-        1: punctuation.definition.char-class.begin.glob.git
-        2: support.class.char-class.collate.glob.git
-        3: punctuation.definition.char-class.end.glob.git
+        1: punctuation.definition.character-class.begin.glob.git
+        2: support.class.character-class.collate.glob.git
+        3: punctuation.definition.character-class.end.glob.git
     - match: (\[=)(\S*)(=\])
-      scope: meta.char-class.glob.git
+      scope: meta.character-class.glob.git
       captures:
-        1: punctuation.definition.char-class.begin.glob.git
-        2: support.class.char-class.equivalence.glob.git
-        3: punctuation.definition.char-class.end.glob.git
+        1: punctuation.definition.character-class.begin.glob.git
+        2: support.class.character-class.equivalence.glob.git
+        3: punctuation.definition.character-class.end.glob.git
     - match: (\[:)(?:({{posix_classes}})|(\S*?))(:\])
-      scope: meta.char-class.glob.git
+      scope: meta.character-class.glob.git
       captures:
-        1: punctuation.definition.char-class.begin.glob.git
-        2: support.class.char-class.posix.glob.git
+        1: punctuation.definition.character-class.begin.glob.git
+        2: support.class.character-class.posix.glob.git
         3: invalid.illegal.character-class.posix.glob.git
-        4: punctuation.definition.char-class.end.glob.git
+        4: punctuation.definition.character-class.end.glob.git
     - match: (?:(\\.)|[^\\\]])?(-)(?:(\\.)|[^\]])
       scope: constant.other.range.glob.git
       captures:
@@ -398,11 +398,11 @@ contexts:
         2: punctuation.separator.sequence.glob.git
         3: constant.character.escape.glob.git
     - match: '\\.'
-      scope: constant.character.escape.char-class.glob.git
+      scope: constant.character.escape.character-class.glob.git
     - match: '[*?]'   # asterisk is ignored by fnmatch
-      scope: invalid.illegal.unexpected.char-class.glob.git
+      scope: invalid.illegal.unexpected.character-class.glob.git
     - match: .
-      scope: constant.character.char-class.glob.git
+      scope: constant.character.character-class.glob.git
 
   fnmatch-quoted-file-extensions:
     - match: \.(?![^./"]*[./]) # the last dot not followed by path sep

--- a/Git Formats/Git Common.sublime-syntax
+++ b/Git Formats/Git Common.sublime-syntax
@@ -376,19 +376,19 @@ contexts:
       scope: meta.character-class.glob.git
       captures:
         1: punctuation.definition.character-class.begin.glob.git
-        2: support.class.character-class.collate.glob.git
+        2: constant.other.character-class.collate.glob.git
         3: punctuation.definition.character-class.end.glob.git
     - match: (\[=)(\S*)(=\])
       scope: meta.character-class.glob.git
       captures:
         1: punctuation.definition.character-class.begin.glob.git
-        2: support.class.character-class.equivalence.glob.git
+        2: constant.other.character-class.equivalence.glob.git
         3: punctuation.definition.character-class.end.glob.git
     - match: (\[:)(?:({{posix_classes}})|(\S*?))(:\])
       scope: meta.character-class.glob.git
       captures:
         1: punctuation.definition.character-class.begin.glob.git
-        2: support.class.character-class.posix.glob.git
+        2: constant.other.character-class.posix.glob.git
         3: invalid.illegal.character-class.posix.glob.git
         4: punctuation.definition.character-class.end.glob.git
     - match: (?:(\\.)|[^\\\]])?(-)(?:(\\.)|[^\]])

--- a/Git Formats/Git Common.sublime-syntax
+++ b/Git Formats/Git Common.sublime-syntax
@@ -346,7 +346,7 @@ contexts:
 
   fnmatch-char-classes:
     - match: \[           # shell style character class
-      scope: keyword.control.char-class.begin.fnmatch.git
+      scope: punctuation.definition.char-class.begin.fnmatch.git
       push:
         - fnmatch-char-class-body
         - fnmatch-char-class-start
@@ -365,7 +365,7 @@ contexts:
   fnmatch-char-class-body:
     - meta_scope: meta.char-class.fnmatch.git
     - match: \]
-      scope: keyword.control.char-class.end.fnmatch.git
+      scope: punctuation.definition.char-class.end.fnmatch.git
       pop: 1
     - match: $\n?     # class must end before end of line
       scope: invalid.illegal.unexpected.eol.fnmatch.git

--- a/Git Formats/Git Common.sublime-syntax
+++ b/Git Formats/Git Common.sublime-syntax
@@ -296,11 +296,11 @@ contexts:
     # windows drive letter and separator
     - match: '[A-Za-z](:)(?=/)'
       captures:
-        1: punctuation.separator.path.fnmatch.git
+        1: punctuation.separator.path.glob.git
       pop: 1
     # homedir tilde operator
     - match: ~(?=/)
-      scope: variable.language.environment.home.fnmatch.git
+      scope: variable.language.environment.home.glob.git
       pop: 1
     # any other directory pattern
     - include: fnmatch-dir-pattern
@@ -321,34 +321,34 @@ contexts:
 
   fnmatch-common:
     - match: '/'          # path separators
-      scope: punctuation.separator.path.fnmatch.git
+      scope: punctuation.separator.path.glob.git
       push: fnmatch-dir-pattern
     - match: \$\w+
-      scope: variable.language.environment.other.fnmatch.git
+      scope: variable.language.environment.other.glob.git
     - match: '\*'         # unescapable operators
-      scope: constant.other.wildcard.asterisk.fnmatch.git
+      scope: constant.other.wildcard.asterisk.glob.git
     - match: '\?'         # unescapable operators
-      scope: constant.other.wildcard.questionmark.fnmatch.git
+      scope: constant.other.wildcard.questionmark.glob.git
     - match: '\\[^$*?]'   # backslash escapes nearly everything
-      scope: constant.character.escape.path.fnmatch.git
+      scope: constant.character.escape.path.glob.git
     - match: ':'          # drive separators
-      scope: invalid.illegal.separator.path.fnmatch.git
+      scope: invalid.illegal.separator.path.glob.git
     - match: '\\(?=\s)'   # single backslash is invalid
-      scope: invalid.illegal.escape.path.fnmatch.git
+      scope: invalid.illegal.escape.path.glob.git
 
   fnmatch-dir-pattern:
     - match: \.\.(?=/)
-      scope: constant.other.path.parent.fnmatch.git
+      scope: constant.other.path.parent.glob.git
       pop: 1
     - match: \.(?=/)
-      scope: constant.other.path.self.fnmatch.git
+      scope: constant.other.path.self.glob.git
       pop: 1
     - match: ''
       pop: 1
 
   fnmatch-char-classes:
     - match: \[           # shell style character class
-      scope: punctuation.definition.char-class.begin.fnmatch.git
+      scope: punctuation.definition.char-class.begin.glob.git
       push:
         - fnmatch-char-class-body
         - fnmatch-char-class-start
@@ -356,61 +356,61 @@ contexts:
 
   fnmatch-char-class-operator:
     - match: '[!^]?'  # optional pattern negation
-      scope: keyword.operator.logical.fnmatch.git
+      scope: keyword.operator.logical.glob.git
       pop: 1
 
   fnmatch-char-class-start:
     - match: '[]-]?'  # first unescaped '-' or ']' are matched literal
-      scope: constant.character.char-class.fnmatch.git
+      scope: constant.character.char-class.glob.git
       pop: 1
 
   fnmatch-char-class-body:
-    - meta_scope: meta.char-class.fnmatch.git
+    - meta_scope: meta.char-class.glob.git
     - match: \]
-      scope: punctuation.definition.char-class.end.fnmatch.git
+      scope: punctuation.definition.char-class.end.glob.git
       pop: 1
     - match: $\n?     # class must end before end of line
-      scope: invalid.illegal.unexpected.eol.fnmatch.git
+      scope: invalid.illegal.unexpected.eol.glob.git
       pop: 1
     - match: (\[\.)(\S*)(\.\])
-      scope: meta.char-class.fnmatch.git
+      scope: meta.char-class.glob.git
       captures:
-        1: punctuation.definition.char-class.begin.fnmatch.git
-        2: support.class.char-class.collate.fnmatch.git
-        3: punctuation.definition.char-class.end.fnmatch.git
+        1: punctuation.definition.char-class.begin.glob.git
+        2: support.class.char-class.collate.glob.git
+        3: punctuation.definition.char-class.end.glob.git
     - match: (\[=)(\S*)(=\])
-      scope: meta.char-class.fnmatch.git
+      scope: meta.char-class.glob.git
       captures:
-        1: punctuation.definition.char-class.begin.fnmatch.git
-        2: support.class.char-class.equivalence.fnmatch.git
-        3: punctuation.definition.char-class.end.fnmatch.git
+        1: punctuation.definition.char-class.begin.glob.git
+        2: support.class.char-class.equivalence.glob.git
+        3: punctuation.definition.char-class.end.glob.git
     - match: (\[:)(?:({{posix_classes}})|(\S*?))(:\])
-      scope: meta.char-class.fnmatch.git
+      scope: meta.char-class.glob.git
       captures:
-        1: punctuation.definition.char-class.begin.fnmatch.git
-        2: support.class.char-class.posix.fnmatch.git
-        3: invalid.illegal.character-class.posix.fnmatch.git
-        4: punctuation.definition.char-class.end.fnmatch.git
+        1: punctuation.definition.char-class.begin.glob.git
+        2: support.class.char-class.posix.glob.git
+        3: invalid.illegal.character-class.posix.glob.git
+        4: punctuation.definition.char-class.end.glob.git
     - match: (?:(\\.)|[^\\\]])?(-)(?:(\\.)|[^\]])
-      scope: constant.other.range.fnmatch.git
+      scope: constant.other.range.glob.git
       captures:
-        1: constant.character.escape.fnmatch.git
-        2: punctuation.separator.sequence.fnmatch.git
-        3: constant.character.escape.fnmatch.git
+        1: constant.character.escape.glob.git
+        2: punctuation.separator.sequence.glob.git
+        3: constant.character.escape.glob.git
     - match: '\\.'
-      scope: constant.character.escape.char-class.fnmatch.git
+      scope: constant.character.escape.char-class.glob.git
     - match: '[*?]'   # asterisk is ignored by fnmatch
-      scope: invalid.illegal.unexpected.char-class.fnmatch.git
+      scope: invalid.illegal.unexpected.char-class.glob.git
     - match: .
-      scope: constant.character.char-class.fnmatch.git
+      scope: constant.character.char-class.glob.git
 
   fnmatch-quoted-file-extensions:
     - match: \.(?![^./"]*[./]) # the last dot not followed by path sep
-      scope: punctuation.separator.path.fnmatch.git
+      scope: punctuation.separator.path.glob.git
 
   fnmatch-unquoted-file-extensions:
     - match: \.(?!(?:\\\s|\S)*[./]) # the last dot not followed by path sep
-      scope: punctuation.separator.path.fnmatch.git
+      scope: punctuation.separator.path.glob.git
 
 ###[ PRETTY FORMATS ]##########################################################
 

--- a/Git Formats/Git Ignore.sublime-syntax
+++ b/Git Formats/Git Ignore.sublime-syntax
@@ -22,7 +22,7 @@ contexts:
   main:
     - include: Git Common.sublime-syntax#comments
     - match: '!|(?=\S)'   # optional pattern negation
-      scope: keyword.operator.logical.path.fnmatch.git.ignore
+      scope: keyword.operator.logical.path.glob.git.ignore
       push: [pattern-content, Git Common.sublime-syntax#fnmatch-start]
 
   pattern-content:

--- a/Git Formats/tests/syntax_test_git_attributes
+++ b/Git Formats/tests/syntax_test_git_attributes
@@ -86,13 +86,13 @@
 #^^^^^^^^^^^^^^^^^^^^^^^^^^ entity.name.pattern.git
 #  ^ constant.other.wildcard.questionmark.glob.git
 #    ^^ constant.character.escape.path.glob.git
-#       ^^^^ meta.char-class.glob.git
-#       ^ punctuation.definition.char-class.begin.glob.git
-#        ^^ constant.character.char-class.glob.git
-#          ^ punctuation.definition.char-class.end.glob.git
-#               ^ punctuation.definition.char-class.begin.glob.git
-#                ^^ constant.character.char-class.glob.git
-#                  ^ punctuation.definition.char-class.end.glob.git
+#       ^^^^ meta.character-class.glob.git
+#       ^ punctuation.definition.character-class.begin.glob.git
+#        ^^ constant.character.character-class.glob.git
+#          ^ punctuation.definition.character-class.end.glob.git
+#               ^ punctuation.definition.character-class.begin.glob.git
+#                ^^ constant.character.character-class.glob.git
+#                  ^ punctuation.definition.character-class.end.glob.git
 #                          ^ punctuation.definition.string.end.git.attributes
 #                           ^^^^^^^^^^^^^^^ meta.attributes-list.git.attributes
 #                           ^^^^^^^^^^^^^^^ meta.attribute

--- a/Git Formats/tests/syntax_test_git_attributes
+++ b/Git Formats/tests/syntax_test_git_attributes
@@ -87,12 +87,12 @@
 #  ^ constant.other.wildcard.questionmark.fnmatch.git
 #    ^^ constant.character.escape.path.fnmatch.git
 #       ^^^^ meta.char-class.fnmatch.git
-#       ^ keyword.control.char-class.begin.fnmatch.git
+#       ^ punctuation.definition.char-class.begin.fnmatch.git
 #        ^^ constant.character.char-class.fnmatch.git
-#          ^ keyword.control.char-class.end.fnmatch.git
-#               ^ keyword.control.char-class.begin.fnmatch.git
+#          ^ punctuation.definition.char-class.end.fnmatch.git
+#               ^ punctuation.definition.char-class.begin.fnmatch.git
 #                ^^ constant.character.char-class.fnmatch.git
-#                  ^ keyword.control.char-class.end.fnmatch.git
+#                  ^ punctuation.definition.char-class.end.fnmatch.git
 #                          ^ punctuation.definition.string.end.git.attributes
 #                           ^^^^^^^^^^^^^^^ meta.attributes-list.git.attributes
 #                           ^^^^^^^^^^^^^^^ meta.attribute

--- a/Git Formats/tests/syntax_test_git_attributes
+++ b/Git Formats/tests/syntax_test_git_attributes
@@ -84,15 +84,15 @@
 # <- string.quoted.double.git.attributes punctuation.definition.string.begin.git.attributes - entity.name.pattern.git
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.git.attributes
 #^^^^^^^^^^^^^^^^^^^^^^^^^^ entity.name.pattern.git
-#  ^ constant.other.wildcard.questionmark.fnmatch.git
-#    ^^ constant.character.escape.path.fnmatch.git
-#       ^^^^ meta.char-class.fnmatch.git
-#       ^ punctuation.definition.char-class.begin.fnmatch.git
-#        ^^ constant.character.char-class.fnmatch.git
-#          ^ punctuation.definition.char-class.end.fnmatch.git
-#               ^ punctuation.definition.char-class.begin.fnmatch.git
-#                ^^ constant.character.char-class.fnmatch.git
-#                  ^ punctuation.definition.char-class.end.fnmatch.git
+#  ^ constant.other.wildcard.questionmark.glob.git
+#    ^^ constant.character.escape.path.glob.git
+#       ^^^^ meta.char-class.glob.git
+#       ^ punctuation.definition.char-class.begin.glob.git
+#        ^^ constant.character.char-class.glob.git
+#          ^ punctuation.definition.char-class.end.glob.git
+#               ^ punctuation.definition.char-class.begin.glob.git
+#                ^^ constant.character.char-class.glob.git
+#                  ^ punctuation.definition.char-class.end.glob.git
 #                          ^ punctuation.definition.string.end.git.attributes
 #                           ^^^^^^^^^^^^^^^ meta.attributes-list.git.attributes
 #                           ^^^^^^^^^^^^^^^ meta.attribute
@@ -103,14 +103,14 @@
 
 # set binary content
 /path/*.pb?proj binary -text !indent eol=crlf attr=val1,-val2,!val3 !attr2 # no-comment
-# <- string.unquoted.git.attributes punctuation.separator.path.fnmatch.git
+# <- string.unquoted.git.attributes punctuation.separator.path.glob.git
 #^^^^^^^^^^^^^^ - meta.attributes-list.git.attributes
 #              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attributes-list.git.attributes - meta.pattern
 #^^^^^^^^^^^^^^ string.unquoted.git.attributes
-#    ^ punctuation.separator.path.fnmatch.git
-#     ^ constant.other.wildcard.asterisk.fnmatch.git
-#      ^ punctuation.separator.path.fnmatch.git
-#         ^ constant.other.wildcard.questionmark.fnmatch.git
+#    ^ punctuation.separator.path.glob.git
+#     ^ constant.other.wildcard.asterisk.glob.git
+#      ^ punctuation.separator.path.glob.git
+#         ^ constant.other.wildcard.questionmark.glob.git
 #              ^ - variable.language.attribute - keyword.operator.logical
 #               ^^^^^^ variable.language.attribute.git.attributes
 #                     ^ - variable.language.attribute - keyword.operator.logical

--- a/Git Formats/tests/syntax_test_git_codeowners
+++ b/Git Formats/tests/syntax_test_git_codeowners
@@ -9,7 +9,7 @@
 # These owners will be the default owners for everything in
 # the repo, unless a later match takes precedence.
 *       @global-owner1 @global-owner2
-# <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners constant.other.wildcard.asterisk.fnmatch.git
+# <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners constant.other.wildcard.asterisk.glob.git
 #^^^^^^^ - meta
 #       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.owners.git.codeowners
 #       ^^^^^^^^^^^^^^ meta.reference.username.git entity.name.reference.username.git
@@ -22,9 +22,9 @@
 # modifies JS files, only @js-owner and not the global
 # owner(s) will be requested for a review.
 *.js    @js-owner #This is an inline comment.
-# <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners constant.other.wildcard.asterisk.fnmatch.git
+# <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners constant.other.wildcard.asterisk.glob.git
 #^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
-#^ punctuation.separator.path.fnmatch.git
+#^ punctuation.separator.path.glob.git
 #   ^^^^ - meta
 #       ^^^^^^^^^ meta.owners.git.codeowners meta.reference.username.git entity.name.reference.username.git
 #       ^ punctuation.definition.reference.username.git
@@ -36,9 +36,9 @@
 # used to look up users just like we do for commit author
 # emails.
 *.go docs@example.com
-# <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners constant.other.wildcard.asterisk.fnmatch.git
+# <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners constant.other.wildcard.asterisk.glob.git
 #^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
-#^ punctuation.separator.path.fnmatch.git
+#^ punctuation.separator.path.glob.git
 #   ^ - meta
 #    ^^^^^^^^^^^^^^^^ meta.owners.git.codeowners meta.reference.email.git entity.name.reference.email.git
 
@@ -46,10 +46,10 @@
 # directory at the root of the repository and any of its
 # subdirectories.
 /build/logs/ @doctocat
-# <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners punctuation.separator.path.fnmatch.git
+# <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners punctuation.separator.path.glob.git
 #^^^^^^^^^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
-#     ^ punctuation.separator.path.fnmatch.git
-#          ^ punctuation.separator.path.fnmatch.git
+#     ^ punctuation.separator.path.glob.git
+#          ^ punctuation.separator.path.glob.git
 #           ^ - meta
 #            ^^^^^^^^^ meta.owners.git.codeowners meta.reference.username.git entity.name.reference.username.git
 #            ^ punctuation.definition.reference.username.git
@@ -60,8 +60,8 @@
 docs/*  docs@example.com
 # <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
 #^^^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
-#   ^ punctuation.separator.path.fnmatch.git
-#    ^ constant.other.wildcard.asterisk.fnmatch.git
+#   ^ punctuation.separator.path.glob.git
+#    ^ constant.other.wildcard.asterisk.glob.git
 #     ^^ - meta
 #       ^^^^^^^^^^^^^^^^ meta.owners.git.codeowners meta.reference.email.git entity.name.reference.email.git
 
@@ -70,7 +70,7 @@ docs/*  docs@example.com
 apps/ @octocat
 # <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
 #^^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
-#   ^ punctuation.separator.path.fnmatch.git
+#   ^ punctuation.separator.path.glob.git
 #    ^ - meta
 #     ^^^^^^^^ meta.owners.git.codeowners meta.reference.username.git entity.name.reference.username.git
 #     ^ punctuation.definition.reference.username.git
@@ -79,18 +79,18 @@ apps/ @octocat
 # directory in the root of your repository and any of its
 # subdirectories.
 /docs/ @doctocat
-# <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners punctuation.separator.path.fnmatch.git
+# <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners punctuation.separator.path.glob.git
 #^^^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
-#    ^ punctuation.separator.path.fnmatch.git
+#    ^ punctuation.separator.path.glob.git
 #     ^ - meta
 #      ^^^^^^^^^ meta.owners.git.codeowners meta.reference.username.git entity.name.reference.username.git
 
 # In this example, any change inside the `/scripts` directory
 # will require approval from @doctocat or @octocat.
 /scripts/ @doctocat @octocat
-# <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners punctuation.separator.path.fnmatch.git
+# <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners punctuation.separator.path.glob.git
 #^^^^^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
-#       ^ punctuation.separator.path.fnmatch.git
+#       ^ punctuation.separator.path.glob.git
 #        ^ - meta
 #         ^^^^^^^^^ meta.owners.git.codeowners meta.reference.username.git entity.name.reference.username.git
 #                  ^ - meta.reference - entity
@@ -100,9 +100,9 @@ apps/ @octocat
 # `/build/logs`, `/scripts/logs`, and `/deeply/nested/logs`. Any changes
 # in a `/logs` directory will require approval from @octocat.
 **/logs @octocat
-# <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners constant.other.wildcard.asterisk.fnmatch.git
-#^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners constant.other.wildcard.asterisk.fnmatch.git
-# ^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners punctuation.separator.path.fnmatch.git
+# <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners constant.other.wildcard.asterisk.glob.git
+#^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners constant.other.wildcard.asterisk.glob.git
+# ^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners punctuation.separator.path.glob.git
 #  ^^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
 #      ^ - meta
 #       ^^^^^^^^ meta.owners.git.codeowners meta.reference.username.git entity.name.reference.username.git
@@ -111,15 +111,15 @@ apps/ @octocat
 # directory in the root of your repository except for the `/apps/github`
 # subdirectory, as its owners are left empty.
 /apps/ @octocat
-# <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners punctuation.separator.path.fnmatch.git
+# <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners punctuation.separator.path.glob.git
 #^^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
-#    ^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners punctuation.separator.path.fnmatch.git
+#    ^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners punctuation.separator.path.glob.git
 #     ^ - meta
 #      ^^^^^^^^ meta.owners.git.codeowners meta.reference.username.git entity.name.reference.username.git
 /apps/github # Hi there.
-# <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners punctuation.separator.path.fnmatch.git
+# <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners punctuation.separator.path.glob.git
 #^^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
-#    ^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners punctuation.separator.path.fnmatch.git
+#    ^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners punctuation.separator.path.glob.git
 #     ^^^^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
 #           ^ - comment - invalid - meta - entity
 #            ^ punctuation.definition.comment.git
@@ -129,15 +129,15 @@ apps/ @octocat
 # directory in the root of your repository except for the `/apps/github`
 # subdirectory, as this subdirectory has its own owner @doctocat.
 /apps/ @octocat
-# <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners punctuation.separator.path.fnmatch.git
+# <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners punctuation.separator.path.glob.git
 #^^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
-#    ^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners punctuation.separator.path.fnmatch.git
+#    ^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners punctuation.separator.path.glob.git
 #     ^ - meta
 #      ^^^^^^^^ meta.owners.git.codeowners meta.reference.username.git entity.name.reference.username.git
 /apps/github @doctocat#Hello.
-# <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners punctuation.separator.path.fnmatch.git
+# <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners punctuation.separator.path.glob.git
 #^^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
-#    ^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners punctuation.separator.path.fnmatch.git
+#    ^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners punctuation.separator.path.glob.git
 #     ^^^^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
 #           ^ - meta
 #            ^^^^^^^^^ meta.owners.git.codeowners meta.reference.username.git entity.name.reference.username.git

--- a/Git Formats/tests/syntax_test_git_ignore
+++ b/Git Formats/tests/syntax_test_git_ignore
@@ -187,8 +187,7 @@
 #             ^ punctuation.definition.character-class.end.glob.git
 #               ^^^^^ meta.character-class.glob.git
 #               ^ punctuation.definition.character-class.begin.glob.git
-#                ^ constant.character.character-class.glob.git
-#                 ^^ constant.other.range.glob.git
+#                ^^^ constant.other.range.glob.git
 #                 ^ punctuation.separator.sequence.glob.git
 #                   ^ punctuation.definition.character-class.end.glob.git
 #                     ^^^^^ meta.character-class.glob.git
@@ -204,8 +203,7 @@
 #                                ^ punctuation.definition.character-class.end.glob.git
 #                                  ^^^^^ meta.character-class.glob.git
 #                                  ^ punctuation.definition.character-class.begin.glob.git
-#                                   ^ constant.character.character-class.glob.git
-#                                    ^^ constant.other.range.glob.git
+#                                   ^^^ constant.other.range.glob.git
 #                                    ^ punctuation.separator.sequence.glob.git
 #                                      ^ punctuation.definition.character-class.end.glob.git
 #                                        ^^^^^^ meta.character-class.glob.git

--- a/Git Formats/tests/syntax_test_git_ignore
+++ b/Git Formats/tests/syntax_test_git_ignore
@@ -81,222 +81,222 @@
 
 # CARACTER CLASS TESTS
   [
-# ^ meta.char-class.glob.git punctuation.definition.char-class.begin.glob.git
+# ^ meta.character-class.glob.git punctuation.definition.character-class.begin.glob.git
   ]
-# ^ string.unquoted.git - punctuation.definition.char-class
+# ^ string.unquoted.git - punctuation.definition.character-class
 
   [][]]
-# ^^^^ meta.char-class.glob.git
-#     ^ - meta.char-class.glob.git
-# ^ punctuation.definition.char-class.begin.glob.git
-#  ^^ constant.character.char-class.glob.git
-#    ^ punctuation.definition.char-class.end.glob.git
-#     ^ string.unquoted.git - punctuation.definition.char-class
+# ^^^^ meta.character-class.glob.git
+#     ^ - meta.character-class.glob.git
+# ^ punctuation.definition.character-class.begin.glob.git
+#  ^^ constant.character.character-class.glob.git
+#    ^ punctuation.definition.character-class.end.glob.git
+#     ^ string.unquoted.git - punctuation.definition.character-class
 
   [^[\]] [^[[] [^]\[] [^]]] [^^][^!]
-# ^^^^^^ meta.char-class.glob.git
-#       ^ - meta.char-class.glob.git
-#        ^^^^^ meta.char-class.glob.git
-#             ^ - meta.char-class.glob.git
-#              ^^^^^^ meta.char-class.glob.git
-#                    ^ - meta.char-class.glob.git
-#                     ^^^^ meta.char-class.glob.git
-#                         ^^ - meta.char-class.glob.git
-#                           ^^^^^^^^ meta.char-class.glob.git
-# ^ punctuation.definition.char-class.begin.glob.git
+# ^^^^^^ meta.character-class.glob.git
+#       ^ - meta.character-class.glob.git
+#        ^^^^^ meta.character-class.glob.git
+#             ^ - meta.character-class.glob.git
+#              ^^^^^^ meta.character-class.glob.git
+#                    ^ - meta.character-class.glob.git
+#                     ^^^^ meta.character-class.glob.git
+#                         ^^ - meta.character-class.glob.git
+#                           ^^^^^^^^ meta.character-class.glob.git
+# ^ punctuation.definition.character-class.begin.glob.git
 #  ^ keyword.operator.logical.glob.git
-#   ^ constant.character.char-class.glob.git - punctuation.definition.char-class
-#    ^^ constant.character.escape.char-class - punctuation.definition.char-class
-#      ^ punctuation.definition.char-class.end.glob.git
-#        ^ punctuation.definition.char-class.begin.glob.git
+#   ^ constant.character.character-class.glob.git - punctuation.definition.character-class
+#    ^^ constant.character.escape.character-class - punctuation.definition.character-class
+#      ^ punctuation.definition.character-class.end.glob.git
+#        ^ punctuation.definition.character-class.begin.glob.git
 #         ^ keyword.operator.logical.glob.git
-#          ^^ constant.character.char-class.glob.git - punctuation.definition.char-class
-#            ^ punctuation.definition.char-class.end.glob.git
-#              ^ punctuation.definition.char-class.begin.glob.git
+#          ^^ constant.character.character-class.glob.git - punctuation.definition.character-class
+#            ^ punctuation.definition.character-class.end.glob.git
+#              ^ punctuation.definition.character-class.begin.glob.git
 #               ^ keyword.operator.logical.glob.git
-#                ^ constant.character.char-class.glob.git - punctuation.definition.char-class
-#                 ^^ meta.char-class.glob.git constant.character.escape.char-class.glob.git
-#                   ^ punctuation.definition.char-class.end.glob.git
-#                     ^ punctuation.definition.char-class.begin.glob.git
+#                ^ constant.character.character-class.glob.git - punctuation.definition.character-class
+#                 ^^ meta.character-class.glob.git constant.character.escape.character-class.glob.git
+#                   ^ punctuation.definition.character-class.end.glob.git
+#                     ^ punctuation.definition.character-class.begin.glob.git
 #                      ^ keyword.operator.logical.glob.git
-#                       ^ constant.character.char-class.glob.git - punctuation.definition.char-class
-#                        ^ punctuation.definition.char-class.end.glob.git
-#                         ^ string.unquoted.git - punctuation.definition.char-class
-#                           ^ punctuation.definition.char-class.begin.glob.git
+#                       ^ constant.character.character-class.glob.git - punctuation.definition.character-class
+#                        ^ punctuation.definition.character-class.end.glob.git
+#                         ^ string.unquoted.git - punctuation.definition.character-class
+#                           ^ punctuation.definition.character-class.begin.glob.git
 #                            ^ keyword.operator.logical.glob.git
-#                             ^ constant.character.char-class.glob.git - keyword.operator
-#                              ^ punctuation.definition.char-class.end.glob.git
-#                               ^ punctuation.definition.char-class.begin.glob.git
+#                             ^ constant.character.character-class.glob.git - keyword.operator
+#                              ^ punctuation.definition.character-class.end.glob.git
+#                               ^ punctuation.definition.character-class.begin.glob.git
 #                                ^ keyword.operator.logical.glob.git
-#                                 ^ constant.character.char-class.glob.git - keyword.operator
-#                                  ^ punctuation.definition.char-class.end.glob.git
+#                                 ^ constant.character.character-class.glob.git - keyword.operator
+#                                  ^ punctuation.definition.character-class.end.glob.git
 
   [![\]] [![[] [!]\[] [!]]] [!!][!^]
-# ^^^^^^ meta.char-class.glob.git
-#       ^ - meta.char-class.glob.git
-#        ^^^^^ meta.char-class.glob.git
-#             ^ - meta.char-class.glob.git
-#              ^^^^^^ meta.char-class.glob.git
-#                    ^ - meta.char-class.glob.git
-#                     ^^^^ meta.char-class.glob.git
-#                         ^^ - meta.char-class.glob.git
-#                           ^^^^^^^^ meta.char-class.glob.git
-# ^ punctuation.definition.char-class.begin.glob.git
+# ^^^^^^ meta.character-class.glob.git
+#       ^ - meta.character-class.glob.git
+#        ^^^^^ meta.character-class.glob.git
+#             ^ - meta.character-class.glob.git
+#              ^^^^^^ meta.character-class.glob.git
+#                    ^ - meta.character-class.glob.git
+#                     ^^^^ meta.character-class.glob.git
+#                         ^^ - meta.character-class.glob.git
+#                           ^^^^^^^^ meta.character-class.glob.git
+# ^ punctuation.definition.character-class.begin.glob.git
 #  ^ keyword.operator.logical.glob.git
-#   ^ constant.character.char-class.glob.git - punctuation.definition.char-class
-#    ^^ constant.character.escape.char-class - punctuation.definition.char-class
-#      ^ punctuation.definition.char-class.end.glob.git
-#        ^ punctuation.definition.char-class.begin.glob.git
+#   ^ constant.character.character-class.glob.git - punctuation.definition.character-class
+#    ^^ constant.character.escape.character-class - punctuation.definition.character-class
+#      ^ punctuation.definition.character-class.end.glob.git
+#        ^ punctuation.definition.character-class.begin.glob.git
 #         ^ keyword.operator.logical.glob.git
-#          ^^ constant.character.char-class.glob.git - punctuation.definition.char-class
-#            ^ punctuation.definition.char-class.end.glob.git
-#              ^ punctuation.definition.char-class.begin.glob.git
+#          ^^ constant.character.character-class.glob.git - punctuation.definition.character-class
+#            ^ punctuation.definition.character-class.end.glob.git
+#              ^ punctuation.definition.character-class.begin.glob.git
 #               ^ keyword.operator.logical.glob.git
-#                ^ constant.character.char-class.glob.git - punctuation.definition.char-class
-#                 ^^ meta.char-class.glob.git constant.character.escape.char-class.glob.git - punctuation.definition.char-class
-#                   ^ punctuation.definition.char-class.end.glob.git
-#                     ^ punctuation.definition.char-class.begin.glob.git
+#                ^ constant.character.character-class.glob.git - punctuation.definition.character-class
+#                 ^^ meta.character-class.glob.git constant.character.escape.character-class.glob.git - punctuation.definition.character-class
+#                   ^ punctuation.definition.character-class.end.glob.git
+#                     ^ punctuation.definition.character-class.begin.glob.git
 #                      ^ keyword.operator.logical.glob.git
-#                       ^ constant.character.char-class.glob.git - punctuation.definition.char-class
-#                        ^ punctuation.definition.char-class.end.glob.git
-#                         ^ string.unquoted.git - punctuation.definition.char-class
-#                           ^ punctuation.definition.char-class.begin.glob.git
+#                       ^ constant.character.character-class.glob.git - punctuation.definition.character-class
+#                        ^ punctuation.definition.character-class.end.glob.git
+#                         ^ string.unquoted.git - punctuation.definition.character-class
+#                           ^ punctuation.definition.character-class.begin.glob.git
 #                            ^ keyword.operator.logical.glob.git
-#                             ^ constant.character.char-class.glob.git - keyword.operator
-#                              ^ punctuation.definition.char-class.end.glob.git
-#                               ^ punctuation.definition.char-class.begin.glob.git
+#                             ^ constant.character.character-class.glob.git - keyword.operator
+#                              ^ punctuation.definition.character-class.end.glob.git
+#                               ^ punctuation.definition.character-class.begin.glob.git
 #                                ^ keyword.operator.logical.glob.git
-#                                 ^ constant.character.char-class.glob.git - keyword.operator
-#                                  ^ punctuation.definition.char-class.end.glob.git
+#                                 ^ constant.character.character-class.glob.git - keyword.operator
+#                                  ^ punctuation.definition.character-class.end.glob.git
 
   [-] [!-] [^-] [---] [a-z] [a\-z] []-[] []\-[]
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.git.ignore entity.name.pattern.git.ignore
-# ^^^ meta.char-class.glob.git
-# ^ punctuation.definition.char-class.begin.glob.git
-#  ^ constant.character.char-class.glob.git
-#   ^ punctuation.definition.char-class.end.glob.git
-#     ^^^^ meta.char-class.glob.git
-#     ^ punctuation.definition.char-class.begin.glob.git
+# ^^^ meta.character-class.glob.git
+# ^ punctuation.definition.character-class.begin.glob.git
+#  ^ constant.character.character-class.glob.git
+#   ^ punctuation.definition.character-class.end.glob.git
+#     ^^^^ meta.character-class.glob.git
+#     ^ punctuation.definition.character-class.begin.glob.git
 #      ^ keyword.operator.logical.glob.git
-#       ^ constant.character.char-class.glob.git
-#        ^ punctuation.definition.char-class.end.glob.git
-#          ^^^^ meta.char-class.glob.git
-#          ^ punctuation.definition.char-class.begin.glob.git
+#       ^ constant.character.character-class.glob.git
+#        ^ punctuation.definition.character-class.end.glob.git
+#          ^^^^ meta.character-class.glob.git
+#          ^ punctuation.definition.character-class.begin.glob.git
 #           ^ keyword.operator.logical.glob.git
-#            ^ constant.character.char-class.glob.git
-#             ^ punctuation.definition.char-class.end.glob.git
-#               ^^^^^ meta.char-class.glob.git
-#               ^ punctuation.definition.char-class.begin.glob.git
-#                ^ constant.character.char-class.glob.git
+#            ^ constant.character.character-class.glob.git
+#             ^ punctuation.definition.character-class.end.glob.git
+#               ^^^^^ meta.character-class.glob.git
+#               ^ punctuation.definition.character-class.begin.glob.git
+#                ^ constant.character.character-class.glob.git
 #                 ^^ constant.other.range.glob.git
 #                 ^ punctuation.separator.sequence.glob.git
-#                   ^ punctuation.definition.char-class.end.glob.git
-#                     ^^^^^ meta.char-class.glob.git
-#                     ^ punctuation.definition.char-class.begin.glob.git
+#                   ^ punctuation.definition.character-class.end.glob.git
+#                     ^^^^^ meta.character-class.glob.git
+#                     ^ punctuation.definition.character-class.begin.glob.git
 #                      ^^^ constant.other.range.glob.git
 #                       ^ punctuation.separator.sequence.glob.git
-#                         ^ punctuation.definition.char-class.end.glob.git
-#                           ^^^^^^ meta.char-class.glob.git
-#                           ^ punctuation.definition.char-class.begin.glob.git
-#                            ^ constant.character.char-class.glob.git
-#                             ^^ constant.character.escape.char-class.glob.git
-#                               ^ constant.character.char-class.glob.git
-#                                ^ punctuation.definition.char-class.end.glob.git
-#                                  ^^^^^ meta.char-class.glob.git
-#                                  ^ punctuation.definition.char-class.begin.glob.git
-#                                   ^ constant.character.char-class.glob.git
+#                         ^ punctuation.definition.character-class.end.glob.git
+#                           ^^^^^^ meta.character-class.glob.git
+#                           ^ punctuation.definition.character-class.begin.glob.git
+#                            ^ constant.character.character-class.glob.git
+#                             ^^ constant.character.escape.character-class.glob.git
+#                               ^ constant.character.character-class.glob.git
+#                                ^ punctuation.definition.character-class.end.glob.git
+#                                  ^^^^^ meta.character-class.glob.git
+#                                  ^ punctuation.definition.character-class.begin.glob.git
+#                                   ^ constant.character.character-class.glob.git
 #                                    ^^ constant.other.range.glob.git
 #                                    ^ punctuation.separator.sequence.glob.git
-#                                      ^ punctuation.definition.char-class.end.glob.git
-#                                        ^^^^^^ meta.char-class.glob.git
-#                                        ^ punctuation.definition.char-class.begin.glob.git
-#                                         ^ constant.character.char-class.glob.git
-#                                          ^^ constant.character.escape.char-class.glob.git
-#                                            ^ constant.character.char-class.glob.git
-#                                             ^ punctuation.definition.char-class.end.glob.git
+#                                      ^ punctuation.definition.character-class.end.glob.git
+#                                        ^^^^^^ meta.character-class.glob.git
+#                                        ^ punctuation.definition.character-class.begin.glob.git
+#                                         ^ constant.character.character-class.glob.git
+#                                          ^^ constant.character.escape.character-class.glob.git
+#                                            ^ constant.character.character-class.glob.git
+#                                             ^ punctuation.definition.character-class.end.glob.git
 
   # unknown escape sequences resolve to their literal equivalent
   [0123456789abcde-z \t\n\\\"\'./()'-:,.;<>~!@#$%&*|+=\[\]{}`~?]
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.char-class.glob.git
-# ^ punctuation.definition.char-class.begin.glob.git
-#  ^^^^^^^^^^^^^^ constant.character.char-class.glob.git
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.character-class.glob.git
+# ^ punctuation.definition.character-class.begin.glob.git
+#  ^^^^^^^^^^^^^^ constant.character.character-class.glob.git
 #                ^^^ constant.other.range.glob.git
-#                   ^ constant.character.char-class.glob.git
-#                    ^^^^^^^^^^ constant.character.escape.char-class.glob.git
-#                              ^^^^ constant.character.char-class.glob.git
+#                   ^ constant.character.character-class.glob.git
+#                    ^^^^^^^^^^ constant.character.escape.character-class.glob.git
+#                              ^^^^ constant.character.character-class.glob.git
 #                                  ^^^ constant.other.range.glob.git
-#                                     ^^^^^^^^^^^^ constant.character.char-class.glob.git
-#                                                 ^ invalid.illegal.unexpected.char-class.glob.git
-#                                                  ^^^ constant.character.char-class.glob.git
-#                                                     ^^^^ constant.character.escape.char-class.glob.git
-#                                                         ^^^^ constant.character.char-class.glob.git
-#                                                             ^ invalid.illegal.unexpected.char-class.glob.git
-#                                                              ^ punctuation.definition.char-class.end.glob.git
+#                                     ^^^^^^^^^^^^ constant.character.character-class.glob.git
+#                                                 ^ invalid.illegal.unexpected.character-class.glob.git
+#                                                  ^^^ constant.character.character-class.glob.git
+#                                                     ^^^^ constant.character.escape.character-class.glob.git
+#                                                         ^^^^ constant.character.character-class.glob.git
+#                                                             ^ invalid.illegal.unexpected.character-class.glob.git
+#                                                              ^ punctuation.definition.character-class.end.glob.git
 
   [[.collate.]] [[=equi-valence=]]
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.git.ignore entity.name.pattern.git.ignore
-# ^ meta.char-class.glob.git - meta.char-class meta.char-class
-#  ^^^^^^^^^^^ meta.char-class.glob.git meta.char-class.glob.git
-#             ^ meta.char-class.glob.git - meta.char-class meta.char-class
-# ^^^ punctuation.definition.char-class.begin.glob.git
-#    ^^^^^^^ support.class.char-class.collate.glob.git
-#           ^^^ punctuation.definition.char-class.end.glob.git
-#               ^ meta.char-class.glob.git - meta.char-class meta.char-class
-#                ^^^^^^^^^^^^^^^^ meta.char-class.glob.git meta.char-class.glob.git
-#                                ^ meta.char-class.glob.git - meta.char-class meta.char-class
-#               ^^^ punctuation.definition.char-class.begin.glob.git
-#                  ^^^^^^^^^^^^ support.class.char-class.equivalence.glob.git
-#                              ^^^ punctuation.definition.char-class.end.glob.git
+# ^ meta.character-class.glob.git - meta.character-class meta.character-class
+#  ^^^^^^^^^^^ meta.character-class.glob.git meta.character-class.glob.git
+#             ^ meta.character-class.glob.git - meta.character-class meta.character-class
+# ^^^ punctuation.definition.character-class.begin.glob.git
+#    ^^^^^^^ support.class.character-class.collate.glob.git
+#           ^^^ punctuation.definition.character-class.end.glob.git
+#               ^ meta.character-class.glob.git - meta.character-class meta.character-class
+#                ^^^^^^^^^^^^^^^^ meta.character-class.glob.git meta.character-class.glob.git
+#                                ^ meta.character-class.glob.git - meta.character-class meta.character-class
+#               ^^^ punctuation.definition.character-class.begin.glob.git
+#                  ^^^^^^^^^^^^ support.class.character-class.equivalence.glob.git
+#                              ^^^ punctuation.definition.character-class.end.glob.git
 
   # Note: :ascii: and :word: are ST specific posix classes, unsupported by ordinary shells
   [[:ascii:][:alnum:][:alpha:][:blank:][:cntrl:][:digit:][:graph:][:lower:][:print:][:punct:][:space:][:upper:][:word:][:xdigit:][:inval:]]
-# ^ string.unquoted.git.ignore entity.name.pattern.git.ignore meta.char-class.glob.git - meta.char-class meta.char-class
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.git.ignore entity.name.pattern.git.ignore meta.char-class.glob.git meta.char-class.glob.git
-#                                                                                                                                         ^ string.unquoted.git.ignore entity.name.pattern.git.ignore meta.char-class.glob.git - meta.char-class meta.char-class
-# ^ punctuation.definition.char-class.begin.glob.git
-#  ^^ punctuation.definition.char-class.begin.glob.git
+# ^ string.unquoted.git.ignore entity.name.pattern.git.ignore meta.character-class.glob.git - meta.character-class meta.character-class
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.git.ignore entity.name.pattern.git.ignore meta.character-class.glob.git meta.character-class.glob.git
+#                                                                                                                                         ^ string.unquoted.git.ignore entity.name.pattern.git.ignore meta.character-class.glob.git - meta.character-class meta.character-class
+# ^ punctuation.definition.character-class.begin.glob.git
+#  ^^ punctuation.definition.character-class.begin.glob.git
 #    ^^^^^ invalid.illegal.character-class.posix.glob.git
-#         ^^ punctuation.definition.char-class.end.glob.git
-#           ^^ punctuation.definition.char-class.begin.glob.git
-#             ^^^^^ support.class.char-class.posix.glob.git
-#                  ^^ punctuation.definition.char-class.end.glob.git
-#                    ^^ punctuation.definition.char-class.begin.glob.git
-#                      ^^^^^ support.class.char-class.posix.glob.git
-#                           ^^ punctuation.definition.char-class.end.glob.git
-#                             ^^ punctuation.definition.char-class.begin.glob.git
-#                               ^^^^^ support.class.char-class.posix.glob.git
-#                                    ^^ punctuation.definition.char-class.end.glob.git
-#                                      ^^ punctuation.definition.char-class.begin.glob.git
-#                                        ^^^^^ support.class.char-class.posix.glob.git
-#                                             ^^ punctuation.definition.char-class.end.glob.git
-#                                               ^^ punctuation.definition.char-class.begin.glob.git
-#                                                 ^^^^^ support.class.char-class.posix.glob.git
-#                                                      ^^ punctuation.definition.char-class.end.glob.git
-#                                                        ^^ punctuation.definition.char-class.begin.glob.git
-#                                                          ^^^^^ support.class.char-class.posix.glob.git
-#                                                               ^^ punctuation.definition.char-class.end.glob.git
-#                                                                 ^^ punctuation.definition.char-class.begin.glob.git
-#                                                                   ^^^^^ support.class.char-class.posix.glob.git
-#                                                                        ^^ punctuation.definition.char-class.end.glob.git
-#                                                                          ^^ punctuation.definition.char-class.begin.glob.git
-#                                                                            ^^^^^ support.class.char-class.posix.glob.git
-#                                                                                 ^^ punctuation.definition.char-class.end.glob.git
-#                                                                                   ^^ punctuation.definition.char-class.begin.glob.git
-#                                                                                     ^^^^^ support.class.char-class.posix.glob.git
-#                                                                                          ^^ punctuation.definition.char-class.end.glob.git
-#                                                                                            ^^ punctuation.definition.char-class.begin.glob.git
-#                                                                                              ^^^^^ support.class.char-class.posix.glob.git
-#                                                                                                   ^^ punctuation.definition.char-class.end.glob.git
-#                                                                                                     ^^ punctuation.definition.char-class.begin.glob.git
-#                                                                                                       ^^^^^ support.class.char-class.posix.glob.git
-#                                                                                                            ^^ punctuation.definition.char-class.end.glob.git
-#                                                                                                              ^^ punctuation.definition.char-class.begin.glob.git
+#         ^^ punctuation.definition.character-class.end.glob.git
+#           ^^ punctuation.definition.character-class.begin.glob.git
+#             ^^^^^ support.class.character-class.posix.glob.git
+#                  ^^ punctuation.definition.character-class.end.glob.git
+#                    ^^ punctuation.definition.character-class.begin.glob.git
+#                      ^^^^^ support.class.character-class.posix.glob.git
+#                           ^^ punctuation.definition.character-class.end.glob.git
+#                             ^^ punctuation.definition.character-class.begin.glob.git
+#                               ^^^^^ support.class.character-class.posix.glob.git
+#                                    ^^ punctuation.definition.character-class.end.glob.git
+#                                      ^^ punctuation.definition.character-class.begin.glob.git
+#                                        ^^^^^ support.class.character-class.posix.glob.git
+#                                             ^^ punctuation.definition.character-class.end.glob.git
+#                                               ^^ punctuation.definition.character-class.begin.glob.git
+#                                                 ^^^^^ support.class.character-class.posix.glob.git
+#                                                      ^^ punctuation.definition.character-class.end.glob.git
+#                                                        ^^ punctuation.definition.character-class.begin.glob.git
+#                                                          ^^^^^ support.class.character-class.posix.glob.git
+#                                                               ^^ punctuation.definition.character-class.end.glob.git
+#                                                                 ^^ punctuation.definition.character-class.begin.glob.git
+#                                                                   ^^^^^ support.class.character-class.posix.glob.git
+#                                                                        ^^ punctuation.definition.character-class.end.glob.git
+#                                                                          ^^ punctuation.definition.character-class.begin.glob.git
+#                                                                            ^^^^^ support.class.character-class.posix.glob.git
+#                                                                                 ^^ punctuation.definition.character-class.end.glob.git
+#                                                                                   ^^ punctuation.definition.character-class.begin.glob.git
+#                                                                                     ^^^^^ support.class.character-class.posix.glob.git
+#                                                                                          ^^ punctuation.definition.character-class.end.glob.git
+#                                                                                            ^^ punctuation.definition.character-class.begin.glob.git
+#                                                                                              ^^^^^ support.class.character-class.posix.glob.git
+#                                                                                                   ^^ punctuation.definition.character-class.end.glob.git
+#                                                                                                     ^^ punctuation.definition.character-class.begin.glob.git
+#                                                                                                       ^^^^^ support.class.character-class.posix.glob.git
+#                                                                                                            ^^ punctuation.definition.character-class.end.glob.git
+#                                                                                                              ^^ punctuation.definition.character-class.begin.glob.git
 #                                                                                                                ^^^^ invalid.illegal.character-class.posix.glob.git
-#                                                                                                                    ^^ punctuation.definition.char-class.end.glob.git
-#                                                                                                                      ^^ punctuation.definition.char-class.begin.glob.git
-#                                                                                                                        ^^^^^^ support.class.char-class.posix.glob.git
-#                                                                                                                              ^^ punctuation.definition.char-class.end.glob.git
-#                                                                                                                                ^^ punctuation.definition.char-class.begin.glob.git
+#                                                                                                                    ^^ punctuation.definition.character-class.end.glob.git
+#                                                                                                                      ^^ punctuation.definition.character-class.begin.glob.git
+#                                                                                                                        ^^^^^^ support.class.character-class.posix.glob.git
+#                                                                                                                              ^^ punctuation.definition.character-class.end.glob.git
+#                                                                                                                                ^^ punctuation.definition.character-class.begin.glob.git
 #                                                                                                                                  ^^^^^ invalid.illegal.character-class.posix.glob.git
-#                                                                                                                                       ^^ punctuation.definition.char-class.end.glob.git
-#                                                                                                                                         ^ punctuation.definition.char-class.end.glob.git
+#                                                                                                                                       ^^ punctuation.definition.character-class.end.glob.git
+#                                                                                                                                         ^ punctuation.definition.character-class.end.glob.git

--- a/Git Formats/tests/syntax_test_git_ignore
+++ b/Git Formats/tests/syntax_test_git_ignore
@@ -248,7 +248,7 @@
 #                  ^^^^^^^^^^^^ support.class.character-class.equivalence.fnmatch.git
 #                              ^^^ punctuation.definition.char-class.end.fnmatch.git
 
-  # Note: :ascii: and :word: are  ST specific posix classes, unsupported by ordinary shells
+  # Note: :ascii: and :word: are ST specific posix classes, unsupported by ordinary shells
   [[:ascii:][:alnum:][:alpha:][:blank:][:cntrl:][:digit:][:graph:][:lower:][:print:][:punct:][:space:][:upper:][:word:][:xdigit:][:inval:]]
 # ^ string.unquoted.git.ignore entity.name.pattern.git.ignore meta.char-class.fnmatch.git - meta.char-class meta.char-class
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.git.ignore entity.name.pattern.git.ignore meta.char-class.fnmatch.git meta.char-class.fnmatch.git

--- a/Git Formats/tests/syntax_test_git_ignore
+++ b/Git Formats/tests/syntax_test_git_ignore
@@ -239,13 +239,13 @@
 #  ^^^^^^^^^^^ meta.character-class.glob.git meta.character-class.glob.git
 #             ^ meta.character-class.glob.git - meta.character-class meta.character-class
 # ^^^ punctuation.definition.character-class.begin.glob.git
-#    ^^^^^^^ support.class.character-class.collate.glob.git
+#    ^^^^^^^ constant.other.character-class.collate.glob.git
 #           ^^^ punctuation.definition.character-class.end.glob.git
 #               ^ meta.character-class.glob.git - meta.character-class meta.character-class
 #                ^^^^^^^^^^^^^^^^ meta.character-class.glob.git meta.character-class.glob.git
 #                                ^ meta.character-class.glob.git - meta.character-class meta.character-class
 #               ^^^ punctuation.definition.character-class.begin.glob.git
-#                  ^^^^^^^^^^^^ support.class.character-class.equivalence.glob.git
+#                  ^^^^^^^^^^^^ constant.other.character-class.equivalence.glob.git
 #                              ^^^ punctuation.definition.character-class.end.glob.git
 
   # Note: :ascii: and :word: are ST specific posix classes, unsupported by ordinary shells
@@ -258,43 +258,43 @@
 #    ^^^^^ invalid.illegal.character-class.posix.glob.git
 #         ^^ punctuation.definition.character-class.end.glob.git
 #           ^^ punctuation.definition.character-class.begin.glob.git
-#             ^^^^^ support.class.character-class.posix.glob.git
+#             ^^^^^ constant.other.character-class.posix.glob.git
 #                  ^^ punctuation.definition.character-class.end.glob.git
 #                    ^^ punctuation.definition.character-class.begin.glob.git
-#                      ^^^^^ support.class.character-class.posix.glob.git
+#                      ^^^^^ constant.other.character-class.posix.glob.git
 #                           ^^ punctuation.definition.character-class.end.glob.git
 #                             ^^ punctuation.definition.character-class.begin.glob.git
-#                               ^^^^^ support.class.character-class.posix.glob.git
+#                               ^^^^^ constant.other.character-class.posix.glob.git
 #                                    ^^ punctuation.definition.character-class.end.glob.git
 #                                      ^^ punctuation.definition.character-class.begin.glob.git
-#                                        ^^^^^ support.class.character-class.posix.glob.git
+#                                        ^^^^^ constant.other.character-class.posix.glob.git
 #                                             ^^ punctuation.definition.character-class.end.glob.git
 #                                               ^^ punctuation.definition.character-class.begin.glob.git
-#                                                 ^^^^^ support.class.character-class.posix.glob.git
+#                                                 ^^^^^ constant.other.character-class.posix.glob.git
 #                                                      ^^ punctuation.definition.character-class.end.glob.git
 #                                                        ^^ punctuation.definition.character-class.begin.glob.git
-#                                                          ^^^^^ support.class.character-class.posix.glob.git
+#                                                          ^^^^^ constant.other.character-class.posix.glob.git
 #                                                               ^^ punctuation.definition.character-class.end.glob.git
 #                                                                 ^^ punctuation.definition.character-class.begin.glob.git
-#                                                                   ^^^^^ support.class.character-class.posix.glob.git
+#                                                                   ^^^^^ constant.other.character-class.posix.glob.git
 #                                                                        ^^ punctuation.definition.character-class.end.glob.git
 #                                                                          ^^ punctuation.definition.character-class.begin.glob.git
-#                                                                            ^^^^^ support.class.character-class.posix.glob.git
+#                                                                            ^^^^^ constant.other.character-class.posix.glob.git
 #                                                                                 ^^ punctuation.definition.character-class.end.glob.git
 #                                                                                   ^^ punctuation.definition.character-class.begin.glob.git
-#                                                                                     ^^^^^ support.class.character-class.posix.glob.git
+#                                                                                     ^^^^^ constant.other.character-class.posix.glob.git
 #                                                                                          ^^ punctuation.definition.character-class.end.glob.git
 #                                                                                            ^^ punctuation.definition.character-class.begin.glob.git
-#                                                                                              ^^^^^ support.class.character-class.posix.glob.git
+#                                                                                              ^^^^^ constant.other.character-class.posix.glob.git
 #                                                                                                   ^^ punctuation.definition.character-class.end.glob.git
 #                                                                                                     ^^ punctuation.definition.character-class.begin.glob.git
-#                                                                                                       ^^^^^ support.class.character-class.posix.glob.git
+#                                                                                                       ^^^^^ constant.other.character-class.posix.glob.git
 #                                                                                                            ^^ punctuation.definition.character-class.end.glob.git
 #                                                                                                              ^^ punctuation.definition.character-class.begin.glob.git
 #                                                                                                                ^^^^ invalid.illegal.character-class.posix.glob.git
 #                                                                                                                    ^^ punctuation.definition.character-class.end.glob.git
 #                                                                                                                      ^^ punctuation.definition.character-class.begin.glob.git
-#                                                                                                                        ^^^^^^ support.class.character-class.posix.glob.git
+#                                                                                                                        ^^^^^^ constant.other.character-class.posix.glob.git
 #                                                                                                                              ^^ punctuation.definition.character-class.end.glob.git
 #                                                                                                                                ^^ punctuation.definition.character-class.begin.glob.git
 #                                                                                                                                  ^^^^^ invalid.illegal.character-class.posix.glob.git

--- a/Git Formats/tests/syntax_test_git_ignore
+++ b/Git Formats/tests/syntax_test_git_ignore
@@ -81,16 +81,16 @@
 
 # CARACTER CLASS TESTS
   [
-# ^ meta.char-class.fnmatch.git keyword.control.char-class.begin.fnmatch.git
+# ^ meta.char-class.fnmatch.git punctuation.definition.char-class.begin.fnmatch.git
   ]
-# ^ string.unquoted.git - keyword.control.char-class
+# ^ string.unquoted.git - punctuation.definition.char-class
   [][]]
 # ^^^^ meta.char-class.fnmatch.git
 #     ^ - meta.char-class.fnmatch.git
-# ^ keyword.control.char-class.begin.fnmatch.git
+# ^ punctuation.definition.char-class.begin.fnmatch.git
 #  ^^ constant.character.char-class.fnmatch.git
-#    ^ keyword.control.char-class.end.fnmatch.git
-#     ^ string.unquoted.git - keyword.control.char-class
+#    ^ punctuation.definition.char-class.end.fnmatch.git
+#     ^ string.unquoted.git - punctuation.definition.char-class
   [^[\]] [^[[] [^]\[] [^]]] [^^][^!]
 # ^^^^^^ meta.char-class.fnmatch.git
 #       ^ - meta.char-class.fnmatch.git
@@ -101,32 +101,32 @@
 #                     ^^^^ meta.char-class.fnmatch.git
 #                         ^^ - meta.char-class.fnmatch.git
 #                           ^^^^^^^^ meta.char-class.fnmatch.git
-# ^ keyword.control.char-class.begin.fnmatch.git
+# ^ punctuation.definition.char-class.begin.fnmatch.git
 #  ^ keyword.operator.logical.fnmatch.git
-#   ^ constant.character.char-class.fnmatch.git - keyword.control.char-class.begin.fnmatch.git
-#    ^^ constant.character.escape.char-class - keyword.control.char-class.end.fnmatch.git
-#      ^ keyword.control.char-class.end.fnmatch.git
-#        ^ keyword.control.char-class.begin.fnmatch.git
+#   ^ constant.character.char-class.fnmatch.git - punctuation.definition.char-class.begin.fnmatch.git
+#    ^^ constant.character.escape.char-class - punctuation.definition.char-class.end.fnmatch.git
+#      ^ punctuation.definition.char-class.end.fnmatch.git
+#        ^ punctuation.definition.char-class.begin.fnmatch.git
 #         ^ keyword.operator.logical.fnmatch.git
-#          ^^ constant.character.char-class.fnmatch.git - keyword.control.char-class.begin.fnmatch.git
-#            ^ keyword.control.char-class.end.fnmatch.git
-#              ^ keyword.control.char-class.begin.fnmatch.git
+#          ^^ constant.character.char-class.fnmatch.git - punctuation.definition.char-class.begin.fnmatch.git
+#            ^ punctuation.definition.char-class.end.fnmatch.git
+#              ^ punctuation.definition.char-class.begin.fnmatch.git
 #               ^ keyword.operator.logical.fnmatch.git
-#                ^^^ constant.character.char-class.fnmatch.git - keyword.control.char-class.end.fnmatch.git
-#                   ^ keyword.control.char-class.end.fnmatch.git
-#                     ^ keyword.control.char-class.begin.fnmatch.git
+#                ^^^ constant.character.char-class.fnmatch.git - punctuation.definition.char-class.end.fnmatch.git
+#                   ^ punctuation.definition.char-class.end.fnmatch.git
+#                     ^ punctuation.definition.char-class.begin.fnmatch.git
 #                      ^ keyword.operator.logical.fnmatch.git
-#                       ^ constant.character.char-class.fnmatch.git - keyword.control.char-class.end.fnmatch.git
-#                        ^ keyword.control.char-class.end.fnmatch.git
-#                         ^ string.unquoted.git - keyword.control.char-class
-#                           ^ keyword.control.char-class.begin.fnmatch.git
+#                       ^ constant.character.char-class.fnmatch.git - punctuation.definition.char-class.end.fnmatch.git
+#                        ^ punctuation.definition.char-class.end.fnmatch.git
+#                         ^ string.unquoted.git - punctuation.definition.char-class
+#                           ^ punctuation.definition.char-class.begin.fnmatch.git
 #                            ^ keyword.operator.logical.fnmatch.git
 #                             ^ constant.character.char-class.fnmatch.git - keyword.operator
-#                              ^ keyword.control.char-class.end.fnmatch.git
-#                               ^ keyword.control.char-class.begin.fnmatch.git
+#                              ^ punctuation.definition.char-class.end.fnmatch.git
+#                               ^ punctuation.definition.char-class.begin.fnmatch.git
 #                                ^ keyword.operator.logical.fnmatch.git
 #                                 ^ constant.character.char-class.fnmatch.git - keyword.operator
-#                                  ^ keyword.control.char-class.end.fnmatch.git
+#                                  ^ punctuation.definition.char-class.end.fnmatch.git
   [![\]] [![[] [!]\[] [!]]] [!!][!^]
 # ^^^^^^ meta.char-class.fnmatch.git
 #       ^ - meta.char-class.fnmatch.git
@@ -137,36 +137,36 @@
 #                     ^^^^ meta.char-class.fnmatch.git
 #                         ^^ - meta.char-class.fnmatch.git
 #                           ^^^^^^^^ meta.char-class.fnmatch.git
-# ^ keyword.control.char-class.begin.fnmatch.git
+# ^ punctuation.definition.char-class.begin.fnmatch.git
 #  ^ keyword.operator.logical.fnmatch.git
-#   ^ constant.character.char-class.fnmatch.git - keyword.control.char-class.begin.fnmatch.git
-#    ^^ constant.character.escape.char-class - keyword.control.char-class.end.fnmatch.git
-#      ^ keyword.control.char-class.end.fnmatch.git
-#        ^ keyword.control.char-class.begin.fnmatch.git
+#   ^ constant.character.char-class.fnmatch.git - punctuation.definition.char-class.begin.fnmatch.git
+#    ^^ constant.character.escape.char-class - punctuation.definition.char-class.end.fnmatch.git
+#      ^ punctuation.definition.char-class.end.fnmatch.git
+#        ^ punctuation.definition.char-class.begin.fnmatch.git
 #         ^ keyword.operator.logical.fnmatch.git
-#          ^^ constant.character.char-class.fnmatch.git - keyword.control.char-class.begin.fnmatch.git
-#            ^ keyword.control.char-class.end.fnmatch.git
-#              ^ keyword.control.char-class.begin.fnmatch.git
+#          ^^ constant.character.char-class.fnmatch.git - punctuation.definition.char-class.begin.fnmatch.git
+#            ^ punctuation.definition.char-class.end.fnmatch.git
+#              ^ punctuation.definition.char-class.begin.fnmatch.git
 #               ^ keyword.operator.logical.fnmatch.git
-#                ^^^ constant.character.char-class.fnmatch.git - keyword.control.char-class.end.fnmatch.git
-#                   ^ keyword.control.char-class.end.fnmatch.git
-#                     ^ keyword.control.char-class.begin.fnmatch.git
+#                ^^^ constant.character.char-class.fnmatch.git - punctuation.definition.char-class.end.fnmatch.git
+#                   ^ punctuation.definition.char-class.end.fnmatch.git
+#                     ^ punctuation.definition.char-class.begin.fnmatch.git
 #                      ^ keyword.operator.logical.fnmatch.git
-#                       ^ constant.character.char-class.fnmatch.git - keyword.control.char-class.end.fnmatch.git
-#                        ^ keyword.control.char-class.end.fnmatch.git
-#                         ^ string.unquoted.git - keyword.control.char-class
-#                           ^ keyword.control.char-class.begin.fnmatch.git
+#                       ^ constant.character.char-class.fnmatch.git - punctuation.definition.char-class.end.fnmatch.git
+#                        ^ punctuation.definition.char-class.end.fnmatch.git
+#                         ^ string.unquoted.git - punctuation.definition.char-class
+#                           ^ punctuation.definition.char-class.begin.fnmatch.git
 #                            ^ keyword.operator.logical.fnmatch.git
 #                             ^ constant.character.char-class.fnmatch.git - keyword.operator
-#                              ^ keyword.control.char-class.end.fnmatch.git
-#                               ^ keyword.control.char-class.begin.fnmatch.git
+#                              ^ punctuation.definition.char-class.end.fnmatch.git
+#                               ^ punctuation.definition.char-class.begin.fnmatch.git
 #                                ^ keyword.operator.logical.fnmatch.git
 #                                 ^ constant.character.char-class.fnmatch.git - keyword.operator
-#                                  ^ keyword.control.char-class.end.fnmatch.git
+#                                  ^ punctuation.definition.char-class.end.fnmatch.git
 # The only escape is \]. All other \ are expanded to \\ by fnmatch.
   [0123456789abcde-z \t\n\\\"\'./()'-:,.;<>~!@#$%&*|+=\[\]{}`~?]
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.char-class.fnmatch.git
-# ^ keyword.control.char-class.begin.fnmatch.git
+# ^ punctuation.definition.char-class.begin.fnmatch.git
 #  ^^^^^^^^^^^^^^^^^ constant.character.char-class.fnmatch.git
 #                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.character.char-class.fnmatch.git
 #                                                 ^ invalid.illegal.unexpected.char-class.fnmatch.git
@@ -174,4 +174,4 @@
 #                                                       ^^ constant.character.escape.char-class.fnmatch.git
 #                                                         ^^^^ constant.character.char-class.fnmatch.git
 #                                                             ^ invalid.illegal.unexpected.char-class.fnmatch.git
-#                                                              ^ keyword.control.char-class.end.fnmatch.git
+#                                                              ^ punctuation.definition.char-class.end.fnmatch.git

--- a/Git Formats/tests/syntax_test_git_ignore
+++ b/Git Formats/tests/syntax_test_git_ignore
@@ -248,6 +248,33 @@
 #                  ^^^^^^^^^^^^ constant.other.character-class.equivalence.glob.git
 #                              ^^^ punctuation.definition.character-class.end.glob.git
 
+  [[.a.][.b.]] [[=a=][=b=]]
+# ^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.git.ignore entity.name.pattern.git.ignore
+# ^ meta.character-class.glob.git - meta.character-class meta.character-class
+#  ^^^^^^^^^^ meta.character-class.glob.git meta.character-class.glob.git
+#            ^ meta.character-class.glob.git - meta.character-class meta.character-class
+#             ^ - meta.character-class
+#              ^ meta.character-class.glob.git - meta.character-class meta.character-class
+#               ^^^^^^^^^^ meta.character-class.glob.git meta.character-class.glob.git
+#                         ^ meta.character-class.glob.git - meta.character-class meta.character-class
+#                          ^ - meta.character-class
+# ^ punctuation.definition.character-class.begin.glob.git
+#  ^^ punctuation.definition.character-class.begin.glob.git
+#    ^ constant.other.character-class.collate.glob.git
+#     ^^ punctuation.definition.character-class.end.glob.git
+#       ^^ punctuation.definition.character-class.begin.glob.git
+#         ^ constant.other.character-class.collate.glob.git
+#          ^^ punctuation.definition.character-class.end.glob.git
+#            ^ punctuation.definition.character-class.end.glob.git
+#              ^ punctuation.definition.character-class.begin.glob.git
+#               ^^ punctuation.definition.character-class.begin.glob.git
+#                 ^ constant.other.character-class.equivalence.glob.git
+#                  ^^ punctuation.definition.character-class.end.glob.git
+#                    ^^ punctuation.definition.character-class.begin.glob.git
+#                      ^ constant.other.character-class.equivalence.glob.git
+#                       ^^ punctuation.definition.character-class.end.glob.git
+#                         ^ punctuation.definition.character-class.end.glob.git
+
   # Note: :ascii: and :word: are ST specific posix classes, unsupported by ordinary shells
   [[:ascii:][:alnum:][:alpha:][:blank:][:cntrl:][:digit:][:graph:][:lower:][:print:][:punct:][:space:][:upper:][:word:][:xdigit:][:inval:]]
 # ^ string.unquoted.git.ignore entity.name.pattern.git.ignore meta.character-class.glob.git - meta.character-class meta.character-class

--- a/Git Formats/tests/syntax_test_git_ignore
+++ b/Git Formats/tests/syntax_test_git_ignore
@@ -239,13 +239,13 @@
 #  ^^^^^^^^^^^ meta.char-class.fnmatch.git meta.char-class.fnmatch.git
 #             ^ meta.char-class.fnmatch.git - meta.char-class meta.char-class
 # ^^^ punctuation.definition.char-class.begin.fnmatch.git
-#    ^^^^^^^ support.class.character-class.collate.fnmatch.git
+#    ^^^^^^^ support.class.char-class.collate.fnmatch.git
 #           ^^^ punctuation.definition.char-class.end.fnmatch.git
 #               ^ meta.char-class.fnmatch.git - meta.char-class meta.char-class
 #                ^^^^^^^^^^^^^^^^ meta.char-class.fnmatch.git meta.char-class.fnmatch.git
 #                                ^ meta.char-class.fnmatch.git - meta.char-class meta.char-class
 #               ^^^ punctuation.definition.char-class.begin.fnmatch.git
-#                  ^^^^^^^^^^^^ support.class.character-class.equivalence.fnmatch.git
+#                  ^^^^^^^^^^^^ support.class.char-class.equivalence.fnmatch.git
 #                              ^^^ punctuation.definition.char-class.end.fnmatch.git
 
   # Note: :ascii: and :word: are ST specific posix classes, unsupported by ordinary shells
@@ -258,43 +258,43 @@
 #    ^^^^^ invalid.illegal.character-class.posix.fnmatch.git
 #         ^^ punctuation.definition.char-class.end.fnmatch.git
 #           ^^ punctuation.definition.char-class.begin.fnmatch.git
-#             ^^^^^ support.class.character-class.posix.fnmatch.git
+#             ^^^^^ support.class.char-class.posix.fnmatch.git
 #                  ^^ punctuation.definition.char-class.end.fnmatch.git
 #                    ^^ punctuation.definition.char-class.begin.fnmatch.git
-#                      ^^^^^ support.class.character-class.posix.fnmatch.git
+#                      ^^^^^ support.class.char-class.posix.fnmatch.git
 #                           ^^ punctuation.definition.char-class.end.fnmatch.git
 #                             ^^ punctuation.definition.char-class.begin.fnmatch.git
-#                               ^^^^^ support.class.character-class.posix.fnmatch.git
+#                               ^^^^^ support.class.char-class.posix.fnmatch.git
 #                                    ^^ punctuation.definition.char-class.end.fnmatch.git
 #                                      ^^ punctuation.definition.char-class.begin.fnmatch.git
-#                                        ^^^^^ support.class.character-class.posix.fnmatch.git
+#                                        ^^^^^ support.class.char-class.posix.fnmatch.git
 #                                             ^^ punctuation.definition.char-class.end.fnmatch.git
 #                                               ^^ punctuation.definition.char-class.begin.fnmatch.git
-#                                                 ^^^^^ support.class.character-class.posix.fnmatch.git
+#                                                 ^^^^^ support.class.char-class.posix.fnmatch.git
 #                                                      ^^ punctuation.definition.char-class.end.fnmatch.git
 #                                                        ^^ punctuation.definition.char-class.begin.fnmatch.git
-#                                                          ^^^^^ support.class.character-class.posix.fnmatch.git
+#                                                          ^^^^^ support.class.char-class.posix.fnmatch.git
 #                                                               ^^ punctuation.definition.char-class.end.fnmatch.git
 #                                                                 ^^ punctuation.definition.char-class.begin.fnmatch.git
-#                                                                   ^^^^^ support.class.character-class.posix.fnmatch.git
+#                                                                   ^^^^^ support.class.char-class.posix.fnmatch.git
 #                                                                        ^^ punctuation.definition.char-class.end.fnmatch.git
 #                                                                          ^^ punctuation.definition.char-class.begin.fnmatch.git
-#                                                                            ^^^^^ support.class.character-class.posix.fnmatch.git
+#                                                                            ^^^^^ support.class.char-class.posix.fnmatch.git
 #                                                                                 ^^ punctuation.definition.char-class.end.fnmatch.git
 #                                                                                   ^^ punctuation.definition.char-class.begin.fnmatch.git
-#                                                                                     ^^^^^ support.class.character-class.posix.fnmatch.git
+#                                                                                     ^^^^^ support.class.char-class.posix.fnmatch.git
 #                                                                                          ^^ punctuation.definition.char-class.end.fnmatch.git
 #                                                                                            ^^ punctuation.definition.char-class.begin.fnmatch.git
-#                                                                                              ^^^^^ support.class.character-class.posix.fnmatch.git
+#                                                                                              ^^^^^ support.class.char-class.posix.fnmatch.git
 #                                                                                                   ^^ punctuation.definition.char-class.end.fnmatch.git
 #                                                                                                     ^^ punctuation.definition.char-class.begin.fnmatch.git
-#                                                                                                       ^^^^^ support.class.character-class.posix.fnmatch.git
+#                                                                                                       ^^^^^ support.class.char-class.posix.fnmatch.git
 #                                                                                                            ^^ punctuation.definition.char-class.end.fnmatch.git
 #                                                                                                              ^^ punctuation.definition.char-class.begin.fnmatch.git
 #                                                                                                                ^^^^ invalid.illegal.character-class.posix.fnmatch.git
 #                                                                                                                    ^^ punctuation.definition.char-class.end.fnmatch.git
 #                                                                                                                      ^^ punctuation.definition.char-class.begin.fnmatch.git
-#                                                                                                                        ^^^^^^ support.class.character-class.posix.fnmatch.git
+#                                                                                                                        ^^^^^^ support.class.char-class.posix.fnmatch.git
 #                                                                                                                              ^^ punctuation.definition.char-class.end.fnmatch.git
 #                                                                                                                                ^^ punctuation.definition.char-class.begin.fnmatch.git
 #                                                                                                                                  ^^^^^ invalid.illegal.character-class.posix.fnmatch.git

--- a/Git Formats/tests/syntax_test_git_ignore
+++ b/Git Formats/tests/syntax_test_git_ignore
@@ -4,299 +4,299 @@
   !~/.fo?d[a-a]r/*.dub
 # <- - meta - string
 # ^^^^^^^^^^^^^^^^^^^^ string.unquoted.git.ignore entity.name.pattern.git.ignore
-# ^ keyword.operator.logical.path.fnmatch.git
-#  ^ variable.language.environment.home.fnmatch.git
-#   ^ punctuation.separator.path.fnmatch.git
+# ^ keyword.operator.logical.path.glob.git
+#  ^ variable.language.environment.home.glob.git
+#   ^ punctuation.separator.path.glob.git
 #    ^ - constant
-#       ^ constant.other.wildcard.questionmark.fnmatch.git
-#               ^ punctuation.separator.path.fnmatch.git
-#                ^ constant.other.wildcard.asterisk.fnmatch.git
-#                 ^ punctuation.separator.path.fnmatch.git
+#       ^ constant.other.wildcard.questionmark.glob.git
+#               ^ punctuation.separator.path.glob.git
+#                ^ constant.other.wildcard.asterisk.glob.git
+#                 ^ punctuation.separator.path.glob.git
 
   ~/../f..o\'ld\"er/fo\*l\?der/fol../der
 #^ - entity.name.pattern
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^ entity.name.pattern
-# ^ variable.language.environment.home.fnmatch.git
-#   ^^ constant.other.path.parent.fnmatch.git
-#       ^^ - constant.other.path.parent.fnmatch.git
-#          ^^ constant.character.escape.path.fnmatch.git
-#              ^^ constant.character.escape.path.fnmatch.git
-#                     ^ - constant.character.escape.path.fnmatch.git - punctuation.separator.path.fnmatch.git
-#                      ^ constant.other.wildcard.asterisk.fnmatch.git
-#                        ^ - constant.character.escape.path.fnmatch.git - punctuation.separator.path.fnmatch.git
-#                         ^ constant.other.wildcard.questionmark.fnmatch.git
-#                                 ^^ - constant.other.path.parent.fnmatch.git
+# ^ variable.language.environment.home.glob.git
+#   ^^ constant.other.path.parent.glob.git
+#       ^^ - constant.other.path.parent.glob.git
+#          ^^ constant.character.escape.path.glob.git
+#              ^^ constant.character.escape.path.glob.git
+#                     ^ - constant.character.escape.path.glob.git - punctuation.separator.path.glob.git
+#                      ^ constant.other.wildcard.asterisk.glob.git
+#                        ^ - constant.character.escape.path.glob.git - punctuation.separator.path.glob.git
+#                         ^ constant.other.wildcard.questionmark.glob.git
+#                                 ^^ - constant.other.path.parent.glob.git
 #                                       ^ - entity.name.pattern
 
 # NO HOME pattern
   ~fname~1.~e*
 # ^^^^^^^^^^^^ string.unquoted.git.ignore entity.name.pattern.git.ignore
-# ^ - variable.language.environment.home.fnmatch.git
-#       ^ - variable.language.environment.home.fnmatch.git
-#         ^ punctuation.separator.path.fnmatch.git
-#          ^ - variable.language.environment.home.fnmatch.git
-#            ^ constant.other.wildcard.asterisk.fnmatch.git
+# ^ - variable.language.environment.home.glob.git
+#       ^ - variable.language.environment.home.glob.git
+#         ^ punctuation.separator.path.glob.git
+#          ^ - variable.language.environment.home.glob.git
+#            ^ constant.other.wildcard.asterisk.glob.git
   ~..fname
 # ^^^^^^^^ string.unquoted.git.ignore entity.name.pattern.git.ignore
-# ^ - variable.language.environment.home.fnmatch.git
-#  ^^ - constant.other.path.parent.fnmatch.git
+# ^ - variable.language.environment.home.glob.git
+#  ^^ - constant.other.path.parent.glob.git
   ~../fname
 # ^^^^^^^^^ string.unquoted.git.ignore entity.name.pattern.git.ignore
-# ^ - variable.language.environment.home.fnmatch.git
-#  ^^ - constant.other.path.parent.fnmatch.git
-#    ^ punctuation.separator.path.fnmatch.git
+# ^ - variable.language.environment.home.glob.git
+#  ^^ - constant.other.path.parent.glob.git
+#    ^ punctuation.separator.path.glob.git
 
 # PARENT DIR TESTS
   ../..fname../../
 # ^^^^^^^^^^^^^^^^ string.unquoted.git.ignore entity.name.pattern.git.ignore
-# ^^ constant.other.path.parent.fnmatch.git
-#   ^ punctuation.separator.path.fnmatch.git
-#    ^^ - constant.other.path.parent.fnmatch.git
-#           ^^ - constant.other.path.parent.fnmatch.git
-#             ^ punctuation.separator.path.fnmatch.git
-#              ^^ constant.other.path.parent.fnmatch.git
-#                ^ punctuation.separator.path.fnmatch.git
+# ^^ constant.other.path.parent.glob.git
+#   ^ punctuation.separator.path.glob.git
+#    ^^ - constant.other.path.parent.glob.git
+#           ^^ - constant.other.path.parent.glob.git
+#             ^ punctuation.separator.path.glob.git
+#              ^^ constant.other.path.parent.glob.git
+#                ^ punctuation.separator.path.glob.git
   ..fname../..
 # ^^^^^^^^^^^^ string.unquoted.git.ignore entity.name.pattern.git.ignore
-#        ^^ - constant.other.path.parent.fnmatch.git
-#           ^^ - constant.other.path.parent.fnmatch.git
+#        ^^ - constant.other.path.parent.glob.git
+#           ^^ - constant.other.path.parent.glob.git
 
 # DRIVE SEPARATOR TESTS
   c:/fo:lder:/
 # ^^^^^^^^^^^^ string.unquoted.git.ignore entity.name.pattern.git.ignore
-#  ^ punctuation.separator.path.fnmatch.git
-#   ^ punctuation.separator.path.fnmatch.git
-#      ^ invalid.illegal.separator.path.fnmatch.git
-#           ^ invalid.illegal.separator.path.fnmatch.git
-#            ^ punctuation.separator.path.fnmatch.git
+#  ^ punctuation.separator.path.glob.git
+#   ^ punctuation.separator.path.glob.git
+#      ^ invalid.illegal.separator.path.glob.git
+#           ^ invalid.illegal.separator.path.glob.git
+#            ^ punctuation.separator.path.glob.git
   cd:/folder
 # ^^^^^^^^^^ string.unquoted.git.ignore entity.name.pattern.git.ignore
-#   ^ invalid.illegal.separator.path.fnmatch.git
-#    ^ punctuation.separator.path.fnmatch.git
+#   ^ invalid.illegal.separator.path.glob.git
+#    ^ punctuation.separator.path.glob.git
   :/folder
 # ^^^^^^^^ string.unquoted.git.ignore entity.name.pattern.git.ignore
-# ^ invalid.illegal.separator.path.fnmatch.git
-#  ^ punctuation.separator.path.fnmatch.git
+# ^ invalid.illegal.separator.path.glob.git
+#  ^ punctuation.separator.path.glob.git
 
 
 # CARACTER CLASS TESTS
   [
-# ^ meta.char-class.fnmatch.git punctuation.definition.char-class.begin.fnmatch.git
+# ^ meta.char-class.glob.git punctuation.definition.char-class.begin.glob.git
   ]
 # ^ string.unquoted.git - punctuation.definition.char-class
 
   [][]]
-# ^^^^ meta.char-class.fnmatch.git
-#     ^ - meta.char-class.fnmatch.git
-# ^ punctuation.definition.char-class.begin.fnmatch.git
-#  ^^ constant.character.char-class.fnmatch.git
-#    ^ punctuation.definition.char-class.end.fnmatch.git
+# ^^^^ meta.char-class.glob.git
+#     ^ - meta.char-class.glob.git
+# ^ punctuation.definition.char-class.begin.glob.git
+#  ^^ constant.character.char-class.glob.git
+#    ^ punctuation.definition.char-class.end.glob.git
 #     ^ string.unquoted.git - punctuation.definition.char-class
 
   [^[\]] [^[[] [^]\[] [^]]] [^^][^!]
-# ^^^^^^ meta.char-class.fnmatch.git
-#       ^ - meta.char-class.fnmatch.git
-#        ^^^^^ meta.char-class.fnmatch.git
-#             ^ - meta.char-class.fnmatch.git
-#              ^^^^^^ meta.char-class.fnmatch.git
-#                    ^ - meta.char-class.fnmatch.git
-#                     ^^^^ meta.char-class.fnmatch.git
-#                         ^^ - meta.char-class.fnmatch.git
-#                           ^^^^^^^^ meta.char-class.fnmatch.git
-# ^ punctuation.definition.char-class.begin.fnmatch.git
-#  ^ keyword.operator.logical.fnmatch.git
-#   ^ constant.character.char-class.fnmatch.git - punctuation.definition.char-class
+# ^^^^^^ meta.char-class.glob.git
+#       ^ - meta.char-class.glob.git
+#        ^^^^^ meta.char-class.glob.git
+#             ^ - meta.char-class.glob.git
+#              ^^^^^^ meta.char-class.glob.git
+#                    ^ - meta.char-class.glob.git
+#                     ^^^^ meta.char-class.glob.git
+#                         ^^ - meta.char-class.glob.git
+#                           ^^^^^^^^ meta.char-class.glob.git
+# ^ punctuation.definition.char-class.begin.glob.git
+#  ^ keyword.operator.logical.glob.git
+#   ^ constant.character.char-class.glob.git - punctuation.definition.char-class
 #    ^^ constant.character.escape.char-class - punctuation.definition.char-class
-#      ^ punctuation.definition.char-class.end.fnmatch.git
-#        ^ punctuation.definition.char-class.begin.fnmatch.git
-#         ^ keyword.operator.logical.fnmatch.git
-#          ^^ constant.character.char-class.fnmatch.git - punctuation.definition.char-class
-#            ^ punctuation.definition.char-class.end.fnmatch.git
-#              ^ punctuation.definition.char-class.begin.fnmatch.git
-#               ^ keyword.operator.logical.fnmatch.git
-#                ^ constant.character.char-class.fnmatch.git - punctuation.definition.char-class
-#                 ^^ meta.char-class.fnmatch.git constant.character.escape.char-class.fnmatch.git
-#                   ^ punctuation.definition.char-class.end.fnmatch.git
-#                     ^ punctuation.definition.char-class.begin.fnmatch.git
-#                      ^ keyword.operator.logical.fnmatch.git
-#                       ^ constant.character.char-class.fnmatch.git - punctuation.definition.char-class
-#                        ^ punctuation.definition.char-class.end.fnmatch.git
+#      ^ punctuation.definition.char-class.end.glob.git
+#        ^ punctuation.definition.char-class.begin.glob.git
+#         ^ keyword.operator.logical.glob.git
+#          ^^ constant.character.char-class.glob.git - punctuation.definition.char-class
+#            ^ punctuation.definition.char-class.end.glob.git
+#              ^ punctuation.definition.char-class.begin.glob.git
+#               ^ keyword.operator.logical.glob.git
+#                ^ constant.character.char-class.glob.git - punctuation.definition.char-class
+#                 ^^ meta.char-class.glob.git constant.character.escape.char-class.glob.git
+#                   ^ punctuation.definition.char-class.end.glob.git
+#                     ^ punctuation.definition.char-class.begin.glob.git
+#                      ^ keyword.operator.logical.glob.git
+#                       ^ constant.character.char-class.glob.git - punctuation.definition.char-class
+#                        ^ punctuation.definition.char-class.end.glob.git
 #                         ^ string.unquoted.git - punctuation.definition.char-class
-#                           ^ punctuation.definition.char-class.begin.fnmatch.git
-#                            ^ keyword.operator.logical.fnmatch.git
-#                             ^ constant.character.char-class.fnmatch.git - keyword.operator
-#                              ^ punctuation.definition.char-class.end.fnmatch.git
-#                               ^ punctuation.definition.char-class.begin.fnmatch.git
-#                                ^ keyword.operator.logical.fnmatch.git
-#                                 ^ constant.character.char-class.fnmatch.git - keyword.operator
-#                                  ^ punctuation.definition.char-class.end.fnmatch.git
+#                           ^ punctuation.definition.char-class.begin.glob.git
+#                            ^ keyword.operator.logical.glob.git
+#                             ^ constant.character.char-class.glob.git - keyword.operator
+#                              ^ punctuation.definition.char-class.end.glob.git
+#                               ^ punctuation.definition.char-class.begin.glob.git
+#                                ^ keyword.operator.logical.glob.git
+#                                 ^ constant.character.char-class.glob.git - keyword.operator
+#                                  ^ punctuation.definition.char-class.end.glob.git
 
   [![\]] [![[] [!]\[] [!]]] [!!][!^]
-# ^^^^^^ meta.char-class.fnmatch.git
-#       ^ - meta.char-class.fnmatch.git
-#        ^^^^^ meta.char-class.fnmatch.git
-#             ^ - meta.char-class.fnmatch.git
-#              ^^^^^^ meta.char-class.fnmatch.git
-#                    ^ - meta.char-class.fnmatch.git
-#                     ^^^^ meta.char-class.fnmatch.git
-#                         ^^ - meta.char-class.fnmatch.git
-#                           ^^^^^^^^ meta.char-class.fnmatch.git
-# ^ punctuation.definition.char-class.begin.fnmatch.git
-#  ^ keyword.operator.logical.fnmatch.git
-#   ^ constant.character.char-class.fnmatch.git - punctuation.definition.char-class
+# ^^^^^^ meta.char-class.glob.git
+#       ^ - meta.char-class.glob.git
+#        ^^^^^ meta.char-class.glob.git
+#             ^ - meta.char-class.glob.git
+#              ^^^^^^ meta.char-class.glob.git
+#                    ^ - meta.char-class.glob.git
+#                     ^^^^ meta.char-class.glob.git
+#                         ^^ - meta.char-class.glob.git
+#                           ^^^^^^^^ meta.char-class.glob.git
+# ^ punctuation.definition.char-class.begin.glob.git
+#  ^ keyword.operator.logical.glob.git
+#   ^ constant.character.char-class.glob.git - punctuation.definition.char-class
 #    ^^ constant.character.escape.char-class - punctuation.definition.char-class
-#      ^ punctuation.definition.char-class.end.fnmatch.git
-#        ^ punctuation.definition.char-class.begin.fnmatch.git
-#         ^ keyword.operator.logical.fnmatch.git
-#          ^^ constant.character.char-class.fnmatch.git - punctuation.definition.char-class
-#            ^ punctuation.definition.char-class.end.fnmatch.git
-#              ^ punctuation.definition.char-class.begin.fnmatch.git
-#               ^ keyword.operator.logical.fnmatch.git
-#                ^ constant.character.char-class.fnmatch.git - punctuation.definition.char-class
-#                 ^^ meta.char-class.fnmatch.git constant.character.escape.char-class.fnmatch.git - punctuation.definition.char-class
-#                   ^ punctuation.definition.char-class.end.fnmatch.git
-#                     ^ punctuation.definition.char-class.begin.fnmatch.git
-#                      ^ keyword.operator.logical.fnmatch.git
-#                       ^ constant.character.char-class.fnmatch.git - punctuation.definition.char-class
-#                        ^ punctuation.definition.char-class.end.fnmatch.git
+#      ^ punctuation.definition.char-class.end.glob.git
+#        ^ punctuation.definition.char-class.begin.glob.git
+#         ^ keyword.operator.logical.glob.git
+#          ^^ constant.character.char-class.glob.git - punctuation.definition.char-class
+#            ^ punctuation.definition.char-class.end.glob.git
+#              ^ punctuation.definition.char-class.begin.glob.git
+#               ^ keyword.operator.logical.glob.git
+#                ^ constant.character.char-class.glob.git - punctuation.definition.char-class
+#                 ^^ meta.char-class.glob.git constant.character.escape.char-class.glob.git - punctuation.definition.char-class
+#                   ^ punctuation.definition.char-class.end.glob.git
+#                     ^ punctuation.definition.char-class.begin.glob.git
+#                      ^ keyword.operator.logical.glob.git
+#                       ^ constant.character.char-class.glob.git - punctuation.definition.char-class
+#                        ^ punctuation.definition.char-class.end.glob.git
 #                         ^ string.unquoted.git - punctuation.definition.char-class
-#                           ^ punctuation.definition.char-class.begin.fnmatch.git
-#                            ^ keyword.operator.logical.fnmatch.git
-#                             ^ constant.character.char-class.fnmatch.git - keyword.operator
-#                              ^ punctuation.definition.char-class.end.fnmatch.git
-#                               ^ punctuation.definition.char-class.begin.fnmatch.git
-#                                ^ keyword.operator.logical.fnmatch.git
-#                                 ^ constant.character.char-class.fnmatch.git - keyword.operator
-#                                  ^ punctuation.definition.char-class.end.fnmatch.git
+#                           ^ punctuation.definition.char-class.begin.glob.git
+#                            ^ keyword.operator.logical.glob.git
+#                             ^ constant.character.char-class.glob.git - keyword.operator
+#                              ^ punctuation.definition.char-class.end.glob.git
+#                               ^ punctuation.definition.char-class.begin.glob.git
+#                                ^ keyword.operator.logical.glob.git
+#                                 ^ constant.character.char-class.glob.git - keyword.operator
+#                                  ^ punctuation.definition.char-class.end.glob.git
 
   [-] [!-] [^-] [---] [a-z] [a\-z] []-[] []\-[]
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.git.ignore entity.name.pattern.git.ignore
-# ^^^ meta.char-class.fnmatch.git
-# ^ punctuation.definition.char-class.begin.fnmatch.git
-#  ^ constant.character.char-class.fnmatch.git
-#   ^ punctuation.definition.char-class.end.fnmatch.git
-#     ^^^^ meta.char-class.fnmatch.git
-#     ^ punctuation.definition.char-class.begin.fnmatch.git
-#      ^ keyword.operator.logical.fnmatch.git
-#       ^ constant.character.char-class.fnmatch.git
-#        ^ punctuation.definition.char-class.end.fnmatch.git
-#          ^^^^ meta.char-class.fnmatch.git
-#          ^ punctuation.definition.char-class.begin.fnmatch.git
-#           ^ keyword.operator.logical.fnmatch.git
-#            ^ constant.character.char-class.fnmatch.git
-#             ^ punctuation.definition.char-class.end.fnmatch.git
-#               ^^^^^ meta.char-class.fnmatch.git
-#               ^ punctuation.definition.char-class.begin.fnmatch.git
-#                ^ constant.character.char-class.fnmatch.git
-#                 ^^ constant.other.range.fnmatch.git
-#                 ^ punctuation.separator.sequence.fnmatch.git
-#                   ^ punctuation.definition.char-class.end.fnmatch.git
-#                     ^^^^^ meta.char-class.fnmatch.git
-#                     ^ punctuation.definition.char-class.begin.fnmatch.git
-#                      ^^^ constant.other.range.fnmatch.git
-#                       ^ punctuation.separator.sequence.fnmatch.git
-#                         ^ punctuation.definition.char-class.end.fnmatch.git
-#                           ^^^^^^ meta.char-class.fnmatch.git
-#                           ^ punctuation.definition.char-class.begin.fnmatch.git
-#                            ^ constant.character.char-class.fnmatch.git
-#                             ^^ constant.character.escape.char-class.fnmatch.git
-#                               ^ constant.character.char-class.fnmatch.git
-#                                ^ punctuation.definition.char-class.end.fnmatch.git
-#                                  ^^^^^ meta.char-class.fnmatch.git
-#                                  ^ punctuation.definition.char-class.begin.fnmatch.git
-#                                   ^ constant.character.char-class.fnmatch.git
-#                                    ^^ constant.other.range.fnmatch.git
-#                                    ^ punctuation.separator.sequence.fnmatch.git
-#                                      ^ punctuation.definition.char-class.end.fnmatch.git
-#                                        ^^^^^^ meta.char-class.fnmatch.git
-#                                        ^ punctuation.definition.char-class.begin.fnmatch.git
-#                                         ^ constant.character.char-class.fnmatch.git
-#                                          ^^ constant.character.escape.char-class.fnmatch.git
-#                                            ^ constant.character.char-class.fnmatch.git
-#                                             ^ punctuation.definition.char-class.end.fnmatch.git
+# ^^^ meta.char-class.glob.git
+# ^ punctuation.definition.char-class.begin.glob.git
+#  ^ constant.character.char-class.glob.git
+#   ^ punctuation.definition.char-class.end.glob.git
+#     ^^^^ meta.char-class.glob.git
+#     ^ punctuation.definition.char-class.begin.glob.git
+#      ^ keyword.operator.logical.glob.git
+#       ^ constant.character.char-class.glob.git
+#        ^ punctuation.definition.char-class.end.glob.git
+#          ^^^^ meta.char-class.glob.git
+#          ^ punctuation.definition.char-class.begin.glob.git
+#           ^ keyword.operator.logical.glob.git
+#            ^ constant.character.char-class.glob.git
+#             ^ punctuation.definition.char-class.end.glob.git
+#               ^^^^^ meta.char-class.glob.git
+#               ^ punctuation.definition.char-class.begin.glob.git
+#                ^ constant.character.char-class.glob.git
+#                 ^^ constant.other.range.glob.git
+#                 ^ punctuation.separator.sequence.glob.git
+#                   ^ punctuation.definition.char-class.end.glob.git
+#                     ^^^^^ meta.char-class.glob.git
+#                     ^ punctuation.definition.char-class.begin.glob.git
+#                      ^^^ constant.other.range.glob.git
+#                       ^ punctuation.separator.sequence.glob.git
+#                         ^ punctuation.definition.char-class.end.glob.git
+#                           ^^^^^^ meta.char-class.glob.git
+#                           ^ punctuation.definition.char-class.begin.glob.git
+#                            ^ constant.character.char-class.glob.git
+#                             ^^ constant.character.escape.char-class.glob.git
+#                               ^ constant.character.char-class.glob.git
+#                                ^ punctuation.definition.char-class.end.glob.git
+#                                  ^^^^^ meta.char-class.glob.git
+#                                  ^ punctuation.definition.char-class.begin.glob.git
+#                                   ^ constant.character.char-class.glob.git
+#                                    ^^ constant.other.range.glob.git
+#                                    ^ punctuation.separator.sequence.glob.git
+#                                      ^ punctuation.definition.char-class.end.glob.git
+#                                        ^^^^^^ meta.char-class.glob.git
+#                                        ^ punctuation.definition.char-class.begin.glob.git
+#                                         ^ constant.character.char-class.glob.git
+#                                          ^^ constant.character.escape.char-class.glob.git
+#                                            ^ constant.character.char-class.glob.git
+#                                             ^ punctuation.definition.char-class.end.glob.git
 
   # unknown escape sequences resolve to their literal equivalent
   [0123456789abcde-z \t\n\\\"\'./()'-:,.;<>~!@#$%&*|+=\[\]{}`~?]
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.char-class.fnmatch.git
-# ^ punctuation.definition.char-class.begin.fnmatch.git
-#  ^^^^^^^^^^^^^^ constant.character.char-class.fnmatch.git
-#                ^^^ constant.other.range.fnmatch.git
-#                   ^ constant.character.char-class.fnmatch.git
-#                    ^^^^^^^^^^ constant.character.escape.char-class.fnmatch.git
-#                              ^^^^ constant.character.char-class.fnmatch.git
-#                                  ^^^ constant.other.range.fnmatch.git
-#                                     ^^^^^^^^^^^^ constant.character.char-class.fnmatch.git
-#                                                 ^ invalid.illegal.unexpected.char-class.fnmatch.git
-#                                                  ^^^ constant.character.char-class.fnmatch.git
-#                                                     ^^^^ constant.character.escape.char-class.fnmatch.git
-#                                                         ^^^^ constant.character.char-class.fnmatch.git
-#                                                             ^ invalid.illegal.unexpected.char-class.fnmatch.git
-#                                                              ^ punctuation.definition.char-class.end.fnmatch.git
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.char-class.glob.git
+# ^ punctuation.definition.char-class.begin.glob.git
+#  ^^^^^^^^^^^^^^ constant.character.char-class.glob.git
+#                ^^^ constant.other.range.glob.git
+#                   ^ constant.character.char-class.glob.git
+#                    ^^^^^^^^^^ constant.character.escape.char-class.glob.git
+#                              ^^^^ constant.character.char-class.glob.git
+#                                  ^^^ constant.other.range.glob.git
+#                                     ^^^^^^^^^^^^ constant.character.char-class.glob.git
+#                                                 ^ invalid.illegal.unexpected.char-class.glob.git
+#                                                  ^^^ constant.character.char-class.glob.git
+#                                                     ^^^^ constant.character.escape.char-class.glob.git
+#                                                         ^^^^ constant.character.char-class.glob.git
+#                                                             ^ invalid.illegal.unexpected.char-class.glob.git
+#                                                              ^ punctuation.definition.char-class.end.glob.git
 
   [[.collate.]] [[=equi-valence=]]
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.git.ignore entity.name.pattern.git.ignore
-# ^ meta.char-class.fnmatch.git - meta.char-class meta.char-class
-#  ^^^^^^^^^^^ meta.char-class.fnmatch.git meta.char-class.fnmatch.git
-#             ^ meta.char-class.fnmatch.git - meta.char-class meta.char-class
-# ^^^ punctuation.definition.char-class.begin.fnmatch.git
-#    ^^^^^^^ support.class.char-class.collate.fnmatch.git
-#           ^^^ punctuation.definition.char-class.end.fnmatch.git
-#               ^ meta.char-class.fnmatch.git - meta.char-class meta.char-class
-#                ^^^^^^^^^^^^^^^^ meta.char-class.fnmatch.git meta.char-class.fnmatch.git
-#                                ^ meta.char-class.fnmatch.git - meta.char-class meta.char-class
-#               ^^^ punctuation.definition.char-class.begin.fnmatch.git
-#                  ^^^^^^^^^^^^ support.class.char-class.equivalence.fnmatch.git
-#                              ^^^ punctuation.definition.char-class.end.fnmatch.git
+# ^ meta.char-class.glob.git - meta.char-class meta.char-class
+#  ^^^^^^^^^^^ meta.char-class.glob.git meta.char-class.glob.git
+#             ^ meta.char-class.glob.git - meta.char-class meta.char-class
+# ^^^ punctuation.definition.char-class.begin.glob.git
+#    ^^^^^^^ support.class.char-class.collate.glob.git
+#           ^^^ punctuation.definition.char-class.end.glob.git
+#               ^ meta.char-class.glob.git - meta.char-class meta.char-class
+#                ^^^^^^^^^^^^^^^^ meta.char-class.glob.git meta.char-class.glob.git
+#                                ^ meta.char-class.glob.git - meta.char-class meta.char-class
+#               ^^^ punctuation.definition.char-class.begin.glob.git
+#                  ^^^^^^^^^^^^ support.class.char-class.equivalence.glob.git
+#                              ^^^ punctuation.definition.char-class.end.glob.git
 
   # Note: :ascii: and :word: are ST specific posix classes, unsupported by ordinary shells
   [[:ascii:][:alnum:][:alpha:][:blank:][:cntrl:][:digit:][:graph:][:lower:][:print:][:punct:][:space:][:upper:][:word:][:xdigit:][:inval:]]
-# ^ string.unquoted.git.ignore entity.name.pattern.git.ignore meta.char-class.fnmatch.git - meta.char-class meta.char-class
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.git.ignore entity.name.pattern.git.ignore meta.char-class.fnmatch.git meta.char-class.fnmatch.git
-#                                                                                                                                         ^ string.unquoted.git.ignore entity.name.pattern.git.ignore meta.char-class.fnmatch.git - meta.char-class meta.char-class
-# ^ punctuation.definition.char-class.begin.fnmatch.git
-#  ^^ punctuation.definition.char-class.begin.fnmatch.git
-#    ^^^^^ invalid.illegal.character-class.posix.fnmatch.git
-#         ^^ punctuation.definition.char-class.end.fnmatch.git
-#           ^^ punctuation.definition.char-class.begin.fnmatch.git
-#             ^^^^^ support.class.char-class.posix.fnmatch.git
-#                  ^^ punctuation.definition.char-class.end.fnmatch.git
-#                    ^^ punctuation.definition.char-class.begin.fnmatch.git
-#                      ^^^^^ support.class.char-class.posix.fnmatch.git
-#                           ^^ punctuation.definition.char-class.end.fnmatch.git
-#                             ^^ punctuation.definition.char-class.begin.fnmatch.git
-#                               ^^^^^ support.class.char-class.posix.fnmatch.git
-#                                    ^^ punctuation.definition.char-class.end.fnmatch.git
-#                                      ^^ punctuation.definition.char-class.begin.fnmatch.git
-#                                        ^^^^^ support.class.char-class.posix.fnmatch.git
-#                                             ^^ punctuation.definition.char-class.end.fnmatch.git
-#                                               ^^ punctuation.definition.char-class.begin.fnmatch.git
-#                                                 ^^^^^ support.class.char-class.posix.fnmatch.git
-#                                                      ^^ punctuation.definition.char-class.end.fnmatch.git
-#                                                        ^^ punctuation.definition.char-class.begin.fnmatch.git
-#                                                          ^^^^^ support.class.char-class.posix.fnmatch.git
-#                                                               ^^ punctuation.definition.char-class.end.fnmatch.git
-#                                                                 ^^ punctuation.definition.char-class.begin.fnmatch.git
-#                                                                   ^^^^^ support.class.char-class.posix.fnmatch.git
-#                                                                        ^^ punctuation.definition.char-class.end.fnmatch.git
-#                                                                          ^^ punctuation.definition.char-class.begin.fnmatch.git
-#                                                                            ^^^^^ support.class.char-class.posix.fnmatch.git
-#                                                                                 ^^ punctuation.definition.char-class.end.fnmatch.git
-#                                                                                   ^^ punctuation.definition.char-class.begin.fnmatch.git
-#                                                                                     ^^^^^ support.class.char-class.posix.fnmatch.git
-#                                                                                          ^^ punctuation.definition.char-class.end.fnmatch.git
-#                                                                                            ^^ punctuation.definition.char-class.begin.fnmatch.git
-#                                                                                              ^^^^^ support.class.char-class.posix.fnmatch.git
-#                                                                                                   ^^ punctuation.definition.char-class.end.fnmatch.git
-#                                                                                                     ^^ punctuation.definition.char-class.begin.fnmatch.git
-#                                                                                                       ^^^^^ support.class.char-class.posix.fnmatch.git
-#                                                                                                            ^^ punctuation.definition.char-class.end.fnmatch.git
-#                                                                                                              ^^ punctuation.definition.char-class.begin.fnmatch.git
-#                                                                                                                ^^^^ invalid.illegal.character-class.posix.fnmatch.git
-#                                                                                                                    ^^ punctuation.definition.char-class.end.fnmatch.git
-#                                                                                                                      ^^ punctuation.definition.char-class.begin.fnmatch.git
-#                                                                                                                        ^^^^^^ support.class.char-class.posix.fnmatch.git
-#                                                                                                                              ^^ punctuation.definition.char-class.end.fnmatch.git
-#                                                                                                                                ^^ punctuation.definition.char-class.begin.fnmatch.git
-#                                                                                                                                  ^^^^^ invalid.illegal.character-class.posix.fnmatch.git
-#                                                                                                                                       ^^ punctuation.definition.char-class.end.fnmatch.git
-#                                                                                                                                         ^ punctuation.definition.char-class.end.fnmatch.git
+# ^ string.unquoted.git.ignore entity.name.pattern.git.ignore meta.char-class.glob.git - meta.char-class meta.char-class
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.git.ignore entity.name.pattern.git.ignore meta.char-class.glob.git meta.char-class.glob.git
+#                                                                                                                                         ^ string.unquoted.git.ignore entity.name.pattern.git.ignore meta.char-class.glob.git - meta.char-class meta.char-class
+# ^ punctuation.definition.char-class.begin.glob.git
+#  ^^ punctuation.definition.char-class.begin.glob.git
+#    ^^^^^ invalid.illegal.character-class.posix.glob.git
+#         ^^ punctuation.definition.char-class.end.glob.git
+#           ^^ punctuation.definition.char-class.begin.glob.git
+#             ^^^^^ support.class.char-class.posix.glob.git
+#                  ^^ punctuation.definition.char-class.end.glob.git
+#                    ^^ punctuation.definition.char-class.begin.glob.git
+#                      ^^^^^ support.class.char-class.posix.glob.git
+#                           ^^ punctuation.definition.char-class.end.glob.git
+#                             ^^ punctuation.definition.char-class.begin.glob.git
+#                               ^^^^^ support.class.char-class.posix.glob.git
+#                                    ^^ punctuation.definition.char-class.end.glob.git
+#                                      ^^ punctuation.definition.char-class.begin.glob.git
+#                                        ^^^^^ support.class.char-class.posix.glob.git
+#                                             ^^ punctuation.definition.char-class.end.glob.git
+#                                               ^^ punctuation.definition.char-class.begin.glob.git
+#                                                 ^^^^^ support.class.char-class.posix.glob.git
+#                                                      ^^ punctuation.definition.char-class.end.glob.git
+#                                                        ^^ punctuation.definition.char-class.begin.glob.git
+#                                                          ^^^^^ support.class.char-class.posix.glob.git
+#                                                               ^^ punctuation.definition.char-class.end.glob.git
+#                                                                 ^^ punctuation.definition.char-class.begin.glob.git
+#                                                                   ^^^^^ support.class.char-class.posix.glob.git
+#                                                                        ^^ punctuation.definition.char-class.end.glob.git
+#                                                                          ^^ punctuation.definition.char-class.begin.glob.git
+#                                                                            ^^^^^ support.class.char-class.posix.glob.git
+#                                                                                 ^^ punctuation.definition.char-class.end.glob.git
+#                                                                                   ^^ punctuation.definition.char-class.begin.glob.git
+#                                                                                     ^^^^^ support.class.char-class.posix.glob.git
+#                                                                                          ^^ punctuation.definition.char-class.end.glob.git
+#                                                                                            ^^ punctuation.definition.char-class.begin.glob.git
+#                                                                                              ^^^^^ support.class.char-class.posix.glob.git
+#                                                                                                   ^^ punctuation.definition.char-class.end.glob.git
+#                                                                                                     ^^ punctuation.definition.char-class.begin.glob.git
+#                                                                                                       ^^^^^ support.class.char-class.posix.glob.git
+#                                                                                                            ^^ punctuation.definition.char-class.end.glob.git
+#                                                                                                              ^^ punctuation.definition.char-class.begin.glob.git
+#                                                                                                                ^^^^ invalid.illegal.character-class.posix.glob.git
+#                                                                                                                    ^^ punctuation.definition.char-class.end.glob.git
+#                                                                                                                      ^^ punctuation.definition.char-class.begin.glob.git
+#                                                                                                                        ^^^^^^ support.class.char-class.posix.glob.git
+#                                                                                                                              ^^ punctuation.definition.char-class.end.glob.git
+#                                                                                                                                ^^ punctuation.definition.char-class.begin.glob.git
+#                                                                                                                                  ^^^^^ invalid.illegal.character-class.posix.glob.git
+#                                                                                                                                       ^^ punctuation.definition.char-class.end.glob.git
+#                                                                                                                                         ^ punctuation.definition.char-class.end.glob.git

--- a/Git Formats/tests/syntax_test_git_ignore
+++ b/Git Formats/tests/syntax_test_git_ignore
@@ -84,6 +84,7 @@
 # ^ meta.char-class.fnmatch.git punctuation.definition.char-class.begin.fnmatch.git
   ]
 # ^ string.unquoted.git - punctuation.definition.char-class
+
   [][]]
 # ^^^^ meta.char-class.fnmatch.git
 #     ^ - meta.char-class.fnmatch.git
@@ -91,6 +92,7 @@
 #  ^^ constant.character.char-class.fnmatch.git
 #    ^ punctuation.definition.char-class.end.fnmatch.git
 #     ^ string.unquoted.git - punctuation.definition.char-class
+
   [^[\]] [^[[] [^]\[] [^]]] [^^][^!]
 # ^^^^^^ meta.char-class.fnmatch.git
 #       ^ - meta.char-class.fnmatch.git
@@ -103,20 +105,21 @@
 #                           ^^^^^^^^ meta.char-class.fnmatch.git
 # ^ punctuation.definition.char-class.begin.fnmatch.git
 #  ^ keyword.operator.logical.fnmatch.git
-#   ^ constant.character.char-class.fnmatch.git - punctuation.definition.char-class.begin.fnmatch.git
-#    ^^ constant.character.escape.char-class - punctuation.definition.char-class.end.fnmatch.git
+#   ^ constant.character.char-class.fnmatch.git - punctuation.definition.char-class
+#    ^^ constant.character.escape.char-class - punctuation.definition.char-class
 #      ^ punctuation.definition.char-class.end.fnmatch.git
 #        ^ punctuation.definition.char-class.begin.fnmatch.git
 #         ^ keyword.operator.logical.fnmatch.git
-#          ^^ constant.character.char-class.fnmatch.git - punctuation.definition.char-class.begin.fnmatch.git
+#          ^^ constant.character.char-class.fnmatch.git - punctuation.definition.char-class
 #            ^ punctuation.definition.char-class.end.fnmatch.git
 #              ^ punctuation.definition.char-class.begin.fnmatch.git
 #               ^ keyword.operator.logical.fnmatch.git
-#                ^^^ constant.character.char-class.fnmatch.git - punctuation.definition.char-class.end.fnmatch.git
+#                ^ constant.character.char-class.fnmatch.git - punctuation.definition.char-class
+#                 ^^ meta.char-class.fnmatch.git constant.character.escape.char-class.fnmatch.git
 #                   ^ punctuation.definition.char-class.end.fnmatch.git
 #                     ^ punctuation.definition.char-class.begin.fnmatch.git
 #                      ^ keyword.operator.logical.fnmatch.git
-#                       ^ constant.character.char-class.fnmatch.git - punctuation.definition.char-class.end.fnmatch.git
+#                       ^ constant.character.char-class.fnmatch.git - punctuation.definition.char-class
 #                        ^ punctuation.definition.char-class.end.fnmatch.git
 #                         ^ string.unquoted.git - punctuation.definition.char-class
 #                           ^ punctuation.definition.char-class.begin.fnmatch.git
@@ -127,6 +130,7 @@
 #                                ^ keyword.operator.logical.fnmatch.git
 #                                 ^ constant.character.char-class.fnmatch.git - keyword.operator
 #                                  ^ punctuation.definition.char-class.end.fnmatch.git
+
   [![\]] [![[] [!]\[] [!]]] [!!][!^]
 # ^^^^^^ meta.char-class.fnmatch.git
 #       ^ - meta.char-class.fnmatch.git
@@ -139,20 +143,21 @@
 #                           ^^^^^^^^ meta.char-class.fnmatch.git
 # ^ punctuation.definition.char-class.begin.fnmatch.git
 #  ^ keyword.operator.logical.fnmatch.git
-#   ^ constant.character.char-class.fnmatch.git - punctuation.definition.char-class.begin.fnmatch.git
-#    ^^ constant.character.escape.char-class - punctuation.definition.char-class.end.fnmatch.git
+#   ^ constant.character.char-class.fnmatch.git - punctuation.definition.char-class
+#    ^^ constant.character.escape.char-class - punctuation.definition.char-class
 #      ^ punctuation.definition.char-class.end.fnmatch.git
 #        ^ punctuation.definition.char-class.begin.fnmatch.git
 #         ^ keyword.operator.logical.fnmatch.git
-#          ^^ constant.character.char-class.fnmatch.git - punctuation.definition.char-class.begin.fnmatch.git
+#          ^^ constant.character.char-class.fnmatch.git - punctuation.definition.char-class
 #            ^ punctuation.definition.char-class.end.fnmatch.git
 #              ^ punctuation.definition.char-class.begin.fnmatch.git
 #               ^ keyword.operator.logical.fnmatch.git
-#                ^^^ constant.character.char-class.fnmatch.git - punctuation.definition.char-class.end.fnmatch.git
+#                ^ constant.character.char-class.fnmatch.git - punctuation.definition.char-class
+#                 ^^ meta.char-class.fnmatch.git constant.character.escape.char-class.fnmatch.git - punctuation.definition.char-class
 #                   ^ punctuation.definition.char-class.end.fnmatch.git
 #                     ^ punctuation.definition.char-class.begin.fnmatch.git
 #                      ^ keyword.operator.logical.fnmatch.git
-#                       ^ constant.character.char-class.fnmatch.git - punctuation.definition.char-class.end.fnmatch.git
+#                       ^ constant.character.char-class.fnmatch.git - punctuation.definition.char-class
 #                        ^ punctuation.definition.char-class.end.fnmatch.git
 #                         ^ string.unquoted.git - punctuation.definition.char-class
 #                           ^ punctuation.definition.char-class.begin.fnmatch.git
@@ -163,15 +168,135 @@
 #                                ^ keyword.operator.logical.fnmatch.git
 #                                 ^ constant.character.char-class.fnmatch.git - keyword.operator
 #                                  ^ punctuation.definition.char-class.end.fnmatch.git
-# The only escape is \]. All other \ are expanded to \\ by fnmatch.
+
+  [-] [!-] [^-] [---] [a-z] [a\-z] []-[] []\-[]
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.git.ignore entity.name.pattern.git.ignore
+# ^^^ meta.char-class.fnmatch.git
+# ^ punctuation.definition.char-class.begin.fnmatch.git
+#  ^ constant.character.char-class.fnmatch.git
+#   ^ punctuation.definition.char-class.end.fnmatch.git
+#     ^^^^ meta.char-class.fnmatch.git
+#     ^ punctuation.definition.char-class.begin.fnmatch.git
+#      ^ keyword.operator.logical.fnmatch.git
+#       ^ constant.character.char-class.fnmatch.git
+#        ^ punctuation.definition.char-class.end.fnmatch.git
+#          ^^^^ meta.char-class.fnmatch.git
+#          ^ punctuation.definition.char-class.begin.fnmatch.git
+#           ^ keyword.operator.logical.fnmatch.git
+#            ^ constant.character.char-class.fnmatch.git
+#             ^ punctuation.definition.char-class.end.fnmatch.git
+#               ^^^^^ meta.char-class.fnmatch.git
+#               ^ punctuation.definition.char-class.begin.fnmatch.git
+#                ^ constant.character.char-class.fnmatch.git
+#                 ^^ constant.other.range.fnmatch.git
+#                 ^ punctuation.separator.sequence.fnmatch.git
+#                   ^ punctuation.definition.char-class.end.fnmatch.git
+#                     ^^^^^ meta.char-class.fnmatch.git
+#                     ^ punctuation.definition.char-class.begin.fnmatch.git
+#                      ^^^ constant.other.range.fnmatch.git
+#                       ^ punctuation.separator.sequence.fnmatch.git
+#                         ^ punctuation.definition.char-class.end.fnmatch.git
+#                           ^^^^^^ meta.char-class.fnmatch.git
+#                           ^ punctuation.definition.char-class.begin.fnmatch.git
+#                            ^ constant.character.char-class.fnmatch.git
+#                             ^^ constant.character.escape.char-class.fnmatch.git
+#                               ^ constant.character.char-class.fnmatch.git
+#                                ^ punctuation.definition.char-class.end.fnmatch.git
+#                                  ^^^^^ meta.char-class.fnmatch.git
+#                                  ^ punctuation.definition.char-class.begin.fnmatch.git
+#                                   ^ constant.character.char-class.fnmatch.git
+#                                    ^^ constant.other.range.fnmatch.git
+#                                    ^ punctuation.separator.sequence.fnmatch.git
+#                                      ^ punctuation.definition.char-class.end.fnmatch.git
+#                                        ^^^^^^ meta.char-class.fnmatch.git
+#                                        ^ punctuation.definition.char-class.begin.fnmatch.git
+#                                         ^ constant.character.char-class.fnmatch.git
+#                                          ^^ constant.character.escape.char-class.fnmatch.git
+#                                            ^ constant.character.char-class.fnmatch.git
+#                                             ^ punctuation.definition.char-class.end.fnmatch.git
+
+  # unknown escape sequences resolve to their literal equivalent
   [0123456789abcde-z \t\n\\\"\'./()'-:,.;<>~!@#$%&*|+=\[\]{}`~?]
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.char-class.fnmatch.git
 # ^ punctuation.definition.char-class.begin.fnmatch.git
-#  ^^^^^^^^^^^^^^^^^ constant.character.char-class.fnmatch.git
-#                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.character.char-class.fnmatch.git
+#  ^^^^^^^^^^^^^^ constant.character.char-class.fnmatch.git
+#                ^^^ constant.other.range.fnmatch.git
+#                   ^ constant.character.char-class.fnmatch.git
+#                    ^^^^^^^^^^ constant.character.escape.char-class.fnmatch.git
+#                              ^^^^ constant.character.char-class.fnmatch.git
+#                                  ^^^ constant.other.range.fnmatch.git
+#                                     ^^^^^^^^^^^^ constant.character.char-class.fnmatch.git
 #                                                 ^ invalid.illegal.unexpected.char-class.fnmatch.git
-#                                                  ^^^^^ constant.character.char-class.fnmatch.git
-#                                                       ^^ constant.character.escape.char-class.fnmatch.git
+#                                                  ^^^ constant.character.char-class.fnmatch.git
+#                                                     ^^^^ constant.character.escape.char-class.fnmatch.git
 #                                                         ^^^^ constant.character.char-class.fnmatch.git
 #                                                             ^ invalid.illegal.unexpected.char-class.fnmatch.git
 #                                                              ^ punctuation.definition.char-class.end.fnmatch.git
+
+  [[.collate.]] [[=equi-valence=]]
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.git.ignore entity.name.pattern.git.ignore
+# ^ meta.char-class.fnmatch.git - meta.char-class meta.char-class
+#  ^^^^^^^^^^^ meta.char-class.fnmatch.git meta.char-class.fnmatch.git
+#             ^ meta.char-class.fnmatch.git - meta.char-class meta.char-class
+# ^^^ punctuation.definition.char-class.begin.fnmatch.git
+#    ^^^^^^^ support.class.character-class.collate.fnmatch.git
+#           ^^^ punctuation.definition.char-class.end.fnmatch.git
+#               ^ meta.char-class.fnmatch.git - meta.char-class meta.char-class
+#                ^^^^^^^^^^^^^^^^ meta.char-class.fnmatch.git meta.char-class.fnmatch.git
+#                                ^ meta.char-class.fnmatch.git - meta.char-class meta.char-class
+#               ^^^ punctuation.definition.char-class.begin.fnmatch.git
+#                  ^^^^^^^^^^^^ support.class.character-class.equivalence.fnmatch.git
+#                              ^^^ punctuation.definition.char-class.end.fnmatch.git
+
+  # Note: :ascii: and :word: are  ST specific posix classes, unsupported by ordinary shells
+  [[:ascii:][:alnum:][:alpha:][:blank:][:cntrl:][:digit:][:graph:][:lower:][:print:][:punct:][:space:][:upper:][:word:][:xdigit:][:inval:]]
+# ^ string.unquoted.git.ignore entity.name.pattern.git.ignore meta.char-class.fnmatch.git - meta.char-class meta.char-class
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.git.ignore entity.name.pattern.git.ignore meta.char-class.fnmatch.git meta.char-class.fnmatch.git
+#                                                                                                                                         ^ string.unquoted.git.ignore entity.name.pattern.git.ignore meta.char-class.fnmatch.git - meta.char-class meta.char-class
+# ^ punctuation.definition.char-class.begin.fnmatch.git
+#  ^^ punctuation.definition.char-class.begin.fnmatch.git
+#    ^^^^^ invalid.illegal.character-class.posix.fnmatch.git
+#         ^^ punctuation.definition.char-class.end.fnmatch.git
+#           ^^ punctuation.definition.char-class.begin.fnmatch.git
+#             ^^^^^ support.class.character-class.posix.fnmatch.git
+#                  ^^ punctuation.definition.char-class.end.fnmatch.git
+#                    ^^ punctuation.definition.char-class.begin.fnmatch.git
+#                      ^^^^^ support.class.character-class.posix.fnmatch.git
+#                           ^^ punctuation.definition.char-class.end.fnmatch.git
+#                             ^^ punctuation.definition.char-class.begin.fnmatch.git
+#                               ^^^^^ support.class.character-class.posix.fnmatch.git
+#                                    ^^ punctuation.definition.char-class.end.fnmatch.git
+#                                      ^^ punctuation.definition.char-class.begin.fnmatch.git
+#                                        ^^^^^ support.class.character-class.posix.fnmatch.git
+#                                             ^^ punctuation.definition.char-class.end.fnmatch.git
+#                                               ^^ punctuation.definition.char-class.begin.fnmatch.git
+#                                                 ^^^^^ support.class.character-class.posix.fnmatch.git
+#                                                      ^^ punctuation.definition.char-class.end.fnmatch.git
+#                                                        ^^ punctuation.definition.char-class.begin.fnmatch.git
+#                                                          ^^^^^ support.class.character-class.posix.fnmatch.git
+#                                                               ^^ punctuation.definition.char-class.end.fnmatch.git
+#                                                                 ^^ punctuation.definition.char-class.begin.fnmatch.git
+#                                                                   ^^^^^ support.class.character-class.posix.fnmatch.git
+#                                                                        ^^ punctuation.definition.char-class.end.fnmatch.git
+#                                                                          ^^ punctuation.definition.char-class.begin.fnmatch.git
+#                                                                            ^^^^^ support.class.character-class.posix.fnmatch.git
+#                                                                                 ^^ punctuation.definition.char-class.end.fnmatch.git
+#                                                                                   ^^ punctuation.definition.char-class.begin.fnmatch.git
+#                                                                                     ^^^^^ support.class.character-class.posix.fnmatch.git
+#                                                                                          ^^ punctuation.definition.char-class.end.fnmatch.git
+#                                                                                            ^^ punctuation.definition.char-class.begin.fnmatch.git
+#                                                                                              ^^^^^ support.class.character-class.posix.fnmatch.git
+#                                                                                                   ^^ punctuation.definition.char-class.end.fnmatch.git
+#                                                                                                     ^^ punctuation.definition.char-class.begin.fnmatch.git
+#                                                                                                       ^^^^^ support.class.character-class.posix.fnmatch.git
+#                                                                                                            ^^ punctuation.definition.char-class.end.fnmatch.git
+#                                                                                                              ^^ punctuation.definition.char-class.begin.fnmatch.git
+#                                                                                                                ^^^^ invalid.illegal.character-class.posix.fnmatch.git
+#                                                                                                                    ^^ punctuation.definition.char-class.end.fnmatch.git
+#                                                                                                                      ^^ punctuation.definition.char-class.begin.fnmatch.git
+#                                                                                                                        ^^^^^^ support.class.character-class.posix.fnmatch.git
+#                                                                                                                              ^^ punctuation.definition.char-class.end.fnmatch.git
+#                                                                                                                                ^^ punctuation.definition.char-class.begin.fnmatch.git
+#                                                                                                                                  ^^^^^ invalid.illegal.character-class.posix.fnmatch.git
+#                                                                                                                                       ^^ punctuation.definition.char-class.end.fnmatch.git
+#                                                                                                                                         ^ punctuation.definition.char-class.end.fnmatch.git


### PR DESCRIPTION
Fixes #4526

This PR...

1. implements https://www.man7.org/linux/man-pages/man7/glob.7.html for fnmatch patterns in .gitignore and .gitattributes

2. fixes bracket scopes (`keyword.control` -> `punctuation.definition`)

Note: This commit is inspired by Bash. Once approved, choosen/simplified scopes are backported to Bash.