### PR TITLE
[ShellScript] Separate glob and regexp scopes

### DIFF
--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -2705,7 +2705,10 @@ contexts:
     - clear_scopes: 1  # clear `string.unquoted`
     - meta_include_prototype: false
     - meta_scope: meta.group.regexp.shell string.unquoted.shell
-    - include: pattern-group-end
+    - match: \)
+      scope: punctuation.section.group.end.regexp.shell
+      pop: 1
+    - include: line-continuations
     - include: eregexp-group-content
 
   eregexp-group-content:
@@ -2732,15 +2735,15 @@ contexts:
         2: keyword.operator.logical.regexp.shell
       set:
         - eregexp-charset-body
-        - pattern-charset-begin
+        - eregexp-charset-begin
 
   eregexp-charset-body:
     - meta_include_prototype: false
     - meta_scope: meta.character-class.regexp.shell
     - match: (?!\S) # also fail at eof
       fail: eregexp-charset
-    - include: pattern-charset-end
-    - include: pattern-charset-content
+    - include: eregexp-charset-end
+    - include: eregexp-charset-content
 
   eregexp-group-charsets:
     - match: (?=\[)
@@ -2756,15 +2759,92 @@ contexts:
         2: keyword.operator.logical.regexp.shell
       set:
         - eregexp-group-charset-body
-        - pattern-charset-begin
+        - eregexp-charset-begin
 
   eregexp-group-charset-body:
     - meta_include_prototype: false
     - meta_scope: meta.character-class.regexp.shell
     - match: (?=\))
       fail: eregexp-group-charset
-    - include: pattern-charset-end
-    - include: pattern-charset-content
+    - include: eregexp-charset-end
+    - include: eregexp-charset-content
+
+  eregexp-charset-begin:
+    - meta_include_prototype: false
+    # a range may start with `]` at the beginning of a set
+    - match: (?:(\\.)|.)(-)(?:(\\.)|[^\]$]|(?!\]))
+      scope: constant.other.range.regexp.shell
+      captures:
+        1: constant.character.escape.regexp.shell
+        2: punctuation.separator.sequence.regexp.shell
+        3: constant.character.escape.regexp.shell
+      pop: 1
+    # the following are treated literal at the beginning of a set
+    - match: '[]-]'
+      pop: 1
+    - include: immediately-pop
+
+  eregexp-charset-end:
+    - match: \]
+      scope: punctuation.definition.character-class.end.regexp.shell
+      pop: 1
+
+  eregexp-charset-fallback:
+    - meta_include_prototype: false
+    - match: \[
+      pop: 1
+
+  eregexp-charset-content:
+    - match: \[\.(?=\S*\.\])
+      scope: punctuation.definition.character-class.begin.regexp.shell
+      push: eregexp-charset-collate-body
+    - match: \[=(?=\S*=\])
+      scope: punctuation.definition.character-class.begin.regexp.shell
+      push: eregexp-charset-equivalence-body
+    - match: \[:(?=(?:{{posix_classes}}|\$+(?:\{.*?\}|\w+)):\])
+      scope: punctuation.definition.character-class.begin.regexp.shell
+      push: eregexp-charset-posix-body
+    - match: (?:(\\.)|[^\\\]])?(-)(?:(\\.)|[^\]$]|(?!\]))
+      scope: constant.other.range.regexp.shell
+      captures:
+        1: constant.character.escape.regexp.shell
+        2: punctuation.separator.sequence.regexp.shell
+        3: constant.character.escape.regexp.shell
+    - include: any-escapes
+    - include: variable-expansions
+    - include: eol-pop
+
+  eregexp-charset-collate-body:
+    - meta_scope: meta.character-class.regexp.shell
+    - meta_content_scope: constant.other.character-class.collate.regexp.shell
+    - match: \.\]
+      scope: punctuation.definition.character-class.end.regexp.shell
+      pop: 1
+    - include: any-escapes
+    - include: variable-expansions
+    - include: eol-pop
+
+  eregexp-charset-equivalence-body:
+    - meta_scope: meta.character-class.regexp.shell
+    - meta_content_scope: constant.other.character-class.equivalence.regexp.shell
+    - match: =\]
+      scope: punctuation.definition.character-class.end.regexp.shell
+      pop: 1
+    - include: any-escapes
+    - include: variable-expansions
+    - include: eol-pop
+
+  eregexp-charset-posix-body:
+    - meta_scope: meta.character-class.regexp.shell
+    - meta_content_scope: constant.other.character-class.posix.regexp.shell
+    - match: ({{posix_classes}}?)(:\])
+      captures:
+        1: constant.other.character-class.posix.regexp.shell
+        2: punctuation.definition.character-class.end.regexp.shell
+      pop: 1
+    - include: any-escapes
+    - include: variable-expansions
+    - include: eol-pop
 
   eregexp-anchors:
     - match: '[$^]'

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -2526,14 +2526,14 @@ contexts:
   pattern-charset:
     - match: (\[)([!^]?)
       captures:
-        1: punctuation.definition.character-class.begin.regexp.shell
-        2: keyword.operator.logical.regexp.shell
+        1: punctuation.definition.character-class.begin.glob.shell
+        2: keyword.operator.logical.glob.shell
       set:
         - pattern-charset-body
         - pattern-charset-begin
 
   pattern-charset-body:
-    - meta_scope: meta.character-class.regexp.shell
+    - meta_scope: meta.character-class.glob.shell
     - match: (?!\S) # also fail at eof
       fail: pattern-charset
     - include: pattern-charset-end
@@ -2543,11 +2543,11 @@ contexts:
     - meta_include_prototype: false
     # a range may start with `]` at the beginning of a set
     - match: (?:(\\.)|.)(-)(?:(\\.)|[^\]$]|(?!\]))
-      scope: constant.other.range.regexp.shell
+      scope: constant.other.range.glob.shell
       captures:
-        1: constant.character.escape.regexp.shell
-        2: punctuation.separator.sequence.regexp.shell
-        3: constant.character.escape.regexp.shell
+        1: constant.character.escape.glob.shell
+        2: punctuation.separator.sequence.glob.shell
+        3: constant.character.escape.glob.shell
       pop: 1
     # the following are treated literal at the beginning of a set
     - match: '[]-]'
@@ -2556,7 +2556,7 @@ contexts:
 
   pattern-charset-end:
     - match: \]
-      scope: punctuation.definition.character-class.end.regexp.shell
+      scope: punctuation.definition.character-class.end.glob.shell
       pop: 1
 
   pattern-charset-fallback:
@@ -2566,51 +2566,51 @@ contexts:
 
   pattern-charset-content:
     - match: \[\.(?=\S*\.\])
-      scope: punctuation.definition.character-class.begin.regexp.shell
+      scope: punctuation.definition.character-class.begin.glob.shell
       push: pattern-charset-collate-body
     - match: \[=(?=\S*=\])
-      scope: punctuation.definition.character-class.begin.regexp.shell
+      scope: punctuation.definition.character-class.begin.glob.shell
       push: pattern-charset-equivalence-body
     - match: \[:(?=(?:{{posix_classes}}|\$+(?:\{.*?\}|\w+)):\])
-      scope: punctuation.definition.character-class.begin.regexp.shell
+      scope: punctuation.definition.character-class.begin.glob.shell
       push: pattern-charset-posix-body
     - match: (?:(\\.)|[^\\\]])?(-)(?:(\\.)|[^\]$]|(?!\]))
-      scope: constant.other.range.regexp.shell
+      scope: constant.other.range.glob.shell
       captures:
-        1: constant.character.escape.regexp.shell
-        2: punctuation.separator.sequence.regexp.shell
-        3: constant.character.escape.regexp.shell
+        1: constant.character.escape.glob.shell
+        2: punctuation.separator.sequence.glob.shell
+        3: constant.character.escape.glob.shell
     - include: any-escapes
     - include: variable-expansions
     - include: eol-pop
 
   pattern-charset-collate-body:
-    - meta_scope: meta.character-class.regexp.shell
-    - meta_content_scope: constant.other.character-class.collate.regexp.shell
+    - meta_scope: meta.character-class.glob.shell
+    - meta_content_scope: constant.other.character-class.collate.glob.shell
     - match: \.\]
-      scope: punctuation.definition.character-class.end.regexp.shell
+      scope: punctuation.definition.character-class.end.glob.shell
       pop: 1
     - include: any-escapes
     - include: variable-expansions
     - include: eol-pop
 
   pattern-charset-equivalence-body:
-    - meta_scope: meta.character-class.regexp.shell
-    - meta_content_scope: constant.other.character-class.equivalence.regexp.shell
+    - meta_scope: meta.character-class.glob.shell
+    - meta_content_scope: constant.other.character-class.equivalence.glob.shell
     - match: =\]
-      scope: punctuation.definition.character-class.end.regexp.shell
+      scope: punctuation.definition.character-class.end.glob.shell
       pop: 1
     - include: any-escapes
     - include: variable-expansions
     - include: eol-pop
 
   pattern-charset-posix-body:
-    - meta_scope: meta.character-class.regexp.shell
-    - meta_content_scope: constant.other.character-class.posix.regexp.shell
+    - meta_scope: meta.character-class.glob.shell
+    - meta_content_scope: constant.other.character-class.posix.glob.shell
     - match: ({{posix_classes}}?)(:\])
       captures:
-        1: constant.other.character-class.posix.regexp.shell
-        2: punctuation.definition.character-class.end.regexp.shell
+        1: constant.other.character-class.posix.glob.shell
+        2: punctuation.definition.character-class.end.glob.shell
       pop: 1
     - include: any-escapes
     - include: variable-expansions
@@ -2623,25 +2623,25 @@ contexts:
   pattern-groups:
     # included in contexts, Zsh supports bare glob qualifiers in
     - match: '[?*+@!](?=\()'
-      scope: keyword.operator.quantifier.regexp.shell
+      scope: keyword.operator.quantifier.glob.shell
       push: pattern-group
 
   pattern-group:
     - meta_include_prototype: false
     - match: \(
-      scope: punctuation.section.group.begin.regexp.shell
+      scope: punctuation.section.group.begin.glob.shell
       set: pattern-group-body
 
   pattern-group-body:
     - clear_scopes: 1  # clear `string.unquoted`
     - meta_include_prototype: false
-    - meta_scope: meta.group.regexp.shell string.unquoted.shell
+    - meta_scope: meta.group.glob.shell string.unquoted.shell
     - include: pattern-group-end
     - include: pattern-group-content
 
   pattern-group-end:
     - match: \)
-      scope: punctuation.section.group.end.regexp.shell
+      scope: punctuation.section.group.end.glob.shell
       pop: 1
     - include: line-continuations
 
@@ -2662,14 +2662,14 @@ contexts:
   pattern-group-charset:
     - match: (\[)([!^]?)
       captures:
-        1: punctuation.definition.character-class.begin.regexp.shell
-        2: keyword.operator.logical.regexp.shell
+        1: punctuation.definition.character-class.begin.glob.shell
+        2: keyword.operator.logical.glob.shell
       set:
         - pattern-group-charset-body
         - pattern-charset-begin
 
   pattern-group-charset-body:
-    - meta_scope: meta.character-class.regexp.shell
+    - meta_scope: meta.character-class.glob.shell
     - match: (?=\))
       fail: pattern-group-charset
     - include: pattern-charset-end
@@ -2677,7 +2677,7 @@ contexts:
 
   pattern-group-operators:
     - match: \|
-      scope: keyword.operator.alternation.regexp.shell
+      scope: keyword.operator.alternation.glob.shell
 
   pattern-common:
     - match: \*
@@ -3248,7 +3248,7 @@ contexts:
   parameter-expansion-substitution-pattern:
     # [3.5.8.1] Pattern Matching in parameter expansions' substitutions
     - meta_include_prototype: false
-    - meta_content_scope: meta.string.regexp.shell string.unquoted.shell
+    - meta_content_scope: meta.string.glob.shell string.unquoted.shell
     - match: /
       scope: keyword.operator.substitution.shell
       set: parameter-expansion-string
@@ -3257,7 +3257,7 @@ contexts:
   parameter-expansion-pattern:
     # [3.5.8.1] Pattern Matching in parameter expansions
     - meta_include_prototype: false
-    - meta_content_scope: meta.string.regexp.shell string.unquoted.shell
+    - meta_content_scope: meta.string.glob.shell string.unquoted.shell
     - include: parameter-expansion-end
     - include: string-unquoted-content
     - include: parameter-expansion-pattern-charsets
@@ -3274,14 +3274,14 @@ contexts:
   parameter-expansion-pattern-charset:
     - match: (\[)([!^]?)
       captures:
-        1: punctuation.definition.character-class.begin.regexp.shell
-        2: keyword.operator.logical.regexp.shell
+        1: punctuation.definition.character-class.begin.glob.shell
+        2: keyword.operator.logical.glob.shell
       set:
         - parameter-expansion-pattern-charset-body
         - pattern-charset-begin
 
   parameter-expansion-pattern-charset-body:
-    - meta_scope: meta.character-class.regexp.shell
+    - meta_scope: meta.character-class.glob.shell
     - match: $|(?=\}) # bailout at end parameter
       fail: parameter-expansion-pattern-charset
     - include: pattern-charset-end
@@ -3289,19 +3289,19 @@ contexts:
 
   parameter-expansion-pattern-groups:
     - match: '[?*+@!]?(?=\()'
-      scope: keyword.operator.quantifier.regexp.shell
+      scope: keyword.operator.quantifier.glob.shell
       push: parameter-expansion-pattern-group
 
   parameter-expansion-pattern-group:
     - meta_include_prototype: false
     - match: \(
-      scope: punctuation.section.group.begin.regexp.shell
+      scope: punctuation.section.group.begin.glob.shell
       set: parameter-expansion-pattern-group-body
 
   parameter-expansion-pattern-group-body:
     - clear_scopes: 1  # clear `string.unquoted`
     - meta_include_prototype: false
-    - meta_scope: meta.group.regexp.shell string.unquoted.shell
+    - meta_scope: meta.group.glob.shell string.unquoted.shell
     - include: pattern-group-end
     - include: parameter-expansion-pattern-group-content
     - include: brace-pop
@@ -3323,14 +3323,14 @@ contexts:
   parameter-expansion-pattern-group-charset:
     - match: (\[)([!^]?)
       captures:
-        1: punctuation.definition.character-class.begin.regexp.shell
-        2: keyword.operator.logical.regexp.shell
+        1: punctuation.definition.character-class.begin.glob.shell
+        2: keyword.operator.logical.glob.shell
       set:
         - parameter-expansion-pattern-group-charset-body
         - pattern-charset-begin
 
   parameter-expansion-pattern-group-charset-body:
-    - meta_scope: meta.character-class.regexp.shell
+    - meta_scope: meta.character-class.glob.shell
     - match: $|(?=[)}]) # bailout at end of group or parameter
       fail: parameter-expansion-pattern-group-charset
     - include: pattern-charset-end

--- a/ShellScript/Bash.sublime-syntax
+++ b/ShellScript/Bash.sublime-syntax
@@ -2526,14 +2526,14 @@ contexts:
   pattern-charset:
     - match: (\[)([!^]?)
       captures:
-        1: punctuation.definition.set.begin.regexp.shell
+        1: punctuation.definition.character-class.begin.regexp.shell
         2: keyword.operator.logical.regexp.shell
       set:
         - pattern-charset-body
         - pattern-charset-begin
 
   pattern-charset-body:
-    - meta_scope: meta.set.regexp.shell
+    - meta_scope: meta.character-class.regexp.shell
     - match: (?!\S) # also fail at eof
       fail: pattern-charset
     - include: pattern-charset-end
@@ -2556,7 +2556,7 @@ contexts:
 
   pattern-charset-end:
     - match: \]
-      scope: punctuation.definition.set.end.regexp.shell
+      scope: punctuation.definition.character-class.end.regexp.shell
       pop: 1
 
   pattern-charset-fallback:
@@ -2565,22 +2565,16 @@ contexts:
       pop: 1
 
   pattern-charset-content:
-    - match: (\[)(\.)(?=\S*\.\])
-      captures:
-        1: punctuation.definition.set.begin.regexp.shell
-        2: constant.character.collate.regexp.shell punctuation.definition.collate.begin.regexp.shell
+    - match: \[\.(?=\S*\.\])
+      scope: punctuation.definition.character-class.begin.regexp.shell
       push: pattern-charset-collate-body
-    - match: (\[)(=)(?=\S*=\])
-      captures:
-        1: punctuation.definition.set.begin.regexp.shell
-        2: constant.character.equivalence-class.regexp.shell punctuation.definition.class.begin.regexp.shell
+    - match: \[=(?=\S*=\])
+      scope: punctuation.definition.character-class.begin.regexp.shell
       push: pattern-charset-equivalence-body
-    - match: (\[)(:)(?=(?:{{posix_classes}}|\$+(?:\{.*?\}|\w+)):\])
-      captures:
-        1: punctuation.definition.set.begin.regexp.shell
-        2: constant.other.posix-class.regexp.shell punctuation.definition.class.begin.regexp.shell
+    - match: \[:(?=(?:{{posix_classes}}|\$+(?:\{.*?\}|\w+)):\])
+      scope: punctuation.definition.character-class.begin.regexp.shell
       push: pattern-charset-posix-body
-    - match: (?:(\\.)|[^\]])?(-)(?:(\\.)|[^\]$]|(?!\]))
+    - match: (?:(\\.)|[^\\\]])?(-)(?:(\\.)|[^\]$]|(?!\]))
       scope: constant.other.range.regexp.shell
       captures:
         1: constant.character.escape.regexp.shell
@@ -2591,37 +2585,32 @@ contexts:
     - include: eol-pop
 
   pattern-charset-collate-body:
-    - meta_scope: meta.set.regexp.shell
-    - meta_content_scope: constant.character.collate.regexp.shell
-    - match: (\.)(\])
-      captures:
-        1: constant.character.collate.regexp.shell punctuation.definition.collate.end.regexp.shell
-        2: punctuation.definition.set.end.regexp.shell
+    - meta_scope: meta.character-class.regexp.shell
+    - meta_content_scope: constant.other.character-class.collate.regexp.shell
+    - match: \.\]
+      scope: punctuation.definition.character-class.end.regexp.shell
       pop: 1
     - include: any-escapes
     - include: variable-expansions
     - include: eol-pop
 
   pattern-charset-equivalence-body:
-    - meta_scope: meta.set.regexp.shell
-    - meta_content_scope: constant.character.equivalence-class.regexp.shell
-    - match: (=)(\])
-      captures:
-        1: constant.character.equivalence-class.regexp.shell punctuation.definition.class.end.regexp.shell
-        2: punctuation.definition.set.end.regexp.shell
+    - meta_scope: meta.character-class.regexp.shell
+    - meta_content_scope: constant.other.character-class.equivalence.regexp.shell
+    - match: =\]
+      scope: punctuation.definition.character-class.end.regexp.shell
       pop: 1
     - include: any-escapes
     - include: variable-expansions
     - include: eol-pop
 
   pattern-charset-posix-body:
-    - meta_scope: meta.set.regexp.shell
-    - meta_content_scope: constant.other.posix-class.regexp.shell
-    - match: ({{posix_classes}}?(:))(\])
+    - meta_scope: meta.character-class.regexp.shell
+    - meta_content_scope: constant.other.character-class.posix.regexp.shell
+    - match: ({{posix_classes}}?)(:\])
       captures:
-        1: constant.other.posix-class.regexp.shell
-        2: punctuation.definition.class.end.regexp.shell
-        3: punctuation.definition.set.end.regexp.shell
+        1: constant.other.character-class.posix.regexp.shell
+        2: punctuation.definition.character-class.end.regexp.shell
       pop: 1
     - include: any-escapes
     - include: variable-expansions
@@ -2673,14 +2662,14 @@ contexts:
   pattern-group-charset:
     - match: (\[)([!^]?)
       captures:
-        1: punctuation.definition.set.begin.regexp.shell
+        1: punctuation.definition.character-class.begin.regexp.shell
         2: keyword.operator.logical.regexp.shell
       set:
         - pattern-group-charset-body
         - pattern-charset-begin
 
   pattern-group-charset-body:
-    - meta_scope: meta.set.regexp.shell
+    - meta_scope: meta.character-class.regexp.shell
     - match: (?=\))
       fail: pattern-group-charset
     - include: pattern-charset-end
@@ -2739,7 +2728,7 @@ contexts:
     - meta_include_prototype: false
     - match: (\[)(\^?)
       captures:
-        1: punctuation.definition.set.begin.regexp.shell
+        1: punctuation.definition.character-class.begin.regexp.shell
         2: keyword.operator.logical.regexp.shell
       set:
         - eregexp-charset-body
@@ -2747,7 +2736,7 @@ contexts:
 
   eregexp-charset-body:
     - meta_include_prototype: false
-    - meta_scope: meta.set.regexp.shell
+    - meta_scope: meta.character-class.regexp.shell
     - match: (?!\S) # also fail at eof
       fail: eregexp-charset
     - include: pattern-charset-end
@@ -2763,7 +2752,7 @@ contexts:
   eregexp-group-charset:
     - match: (\[)(\^?)
       captures:
-        1: punctuation.definition.set.begin.regexp.shell
+        1: punctuation.definition.character-class.begin.regexp.shell
         2: keyword.operator.logical.regexp.shell
       set:
         - eregexp-group-charset-body
@@ -2771,7 +2760,7 @@ contexts:
 
   eregexp-group-charset-body:
     - meta_include_prototype: false
-    - meta_scope: meta.set.regexp.shell
+    - meta_scope: meta.character-class.regexp.shell
     - match: (?=\))
       fail: eregexp-group-charset
     - include: pattern-charset-end
@@ -3205,14 +3194,14 @@ contexts:
   parameter-expansion-pattern-charset:
     - match: (\[)([!^]?)
       captures:
-        1: punctuation.definition.set.begin.regexp.shell
+        1: punctuation.definition.character-class.begin.regexp.shell
         2: keyword.operator.logical.regexp.shell
       set:
         - parameter-expansion-pattern-charset-body
         - pattern-charset-begin
 
   parameter-expansion-pattern-charset-body:
-    - meta_scope: meta.set.regexp.shell
+    - meta_scope: meta.character-class.regexp.shell
     - match: $|(?=\}) # bailout at end parameter
       fail: parameter-expansion-pattern-charset
     - include: pattern-charset-end
@@ -3254,14 +3243,14 @@ contexts:
   parameter-expansion-pattern-group-charset:
     - match: (\[)([!^]?)
       captures:
-        1: punctuation.definition.set.begin.regexp.shell
+        1: punctuation.definition.character-class.begin.regexp.shell
         2: keyword.operator.logical.regexp.shell
       set:
         - parameter-expansion-pattern-group-charset-body
         - pattern-charset-begin
 
   parameter-expansion-pattern-group-charset-body:
-    - meta_scope: meta.set.regexp.shell
+    - meta_scope: meta.character-class.regexp.shell
     - match: $|(?=[)}]) # bailout at end of group or parameter
       fail: parameter-expansion-pattern-group-charset
     - include: pattern-charset-end

--- a/ShellScript/Bash/tests/syntax_test_scope.bash
+++ b/ShellScript/Bash/tests/syntax_test_scope.bash
@@ -593,10 +593,10 @@ $e'ch'o Hello, world!
 #^ constant.other.path.parent.shell
 # ^ punctuation.separator.path.shell
 #    ^ constant.other.wildcard.questionmark.shell
-#           ^^^^^ meta.character-class.regexp.shell
-#           ^ punctuation.definition.character-class.begin.regexp.shell
-#            ^^^ constant.other.range.regexp.shell
-#               ^ punctuation.definition.character-class.end.regexp.shell
+#           ^^^^^ meta.character-class.glob.shell
+#           ^ punctuation.definition.character-class.begin.glob.shell
+#            ^^^ constant.other.range.glob.shell
+#               ^ punctuation.definition.character-class.end.glob.shell
 #                 ^ constant.other.wildcard.asterisk.shell
 
 "../my?script[1-9].*"   # no pattern matching within quotes
@@ -605,7 +605,7 @@ $e'ch'o Hello, world!
 #^^ constant.other.path.parent.shell
 #  ^ punctuation.separator.path.shell
 #     ^ - constant
-#            ^^^^^ - meta.character-class.regexp - punctuation
+#            ^^^^^ - meta.character-class - punctuation
 #                  ^ - constant
 #                   ^ punctuation.definition.quoted.end.shell
 
@@ -858,9 +858,9 @@ sleep 2 & jobs
 #                    ^^ - variable
 
 [foo] -o
-# <- meta.function-call.identifier.shell meta.command.shell variable.function.shell meta.character-class.regexp.shell punctuation.definition.character-class.begin.regexp.shell
-#^^^ meta.function-call.identifier.shell meta.command.shell variable.function.shell meta.character-class.regexp.shell - punctuation
-#   ^ meta.function-call.identifier.shell meta.command.shell variable.function.shell meta.character-class.regexp.shell punctuation.definition.character-class.end.regexp.shell
+# <- meta.function-call.identifier.shell meta.command.shell variable.function.shell meta.character-class.glob.shell punctuation.definition.character-class.begin.glob.shell
+#^^^ meta.function-call.identifier.shell meta.command.shell variable.function.shell meta.character-class.glob.shell - punctuation
+#   ^ meta.function-call.identifier.shell meta.command.shell variable.function.shell meta.character-class.glob.shell punctuation.definition.character-class.end.glob.shell
 #    ^^^ meta.function-call.arguments.shell
 
 $foo -o
@@ -2343,17 +2343,17 @@ case $TERM in
         #   ^^^^ meta.clause.patterns.shell meta.string.glob.shell string.unquoted.shell
         #       ^ meta.clause.patterns.shell - meta.string - meta.group - string
         #        ^ meta.clause.patterns.shell meta.string.glob.shell string.unquoted.shell
-        #         ^^^^^^^^ meta.clause.patterns.shell meta.string.glob.shell meta.group.regexp.shell string.unquoted.shell
+        #         ^^^^^^^^ meta.clause.patterns.shell meta.string.glob.shell meta.group.glob.shell string.unquoted.shell
         #                 ^^^^ meta.clause.patterns.shell meta.string.glob.shell string.unquoted.shell
         #                     ^ meta.clause.patterns.shell - meta.string - meta.group - string
         # ^ constant.other.wildcard.asterisk.shell
         #  ^ keyword.operator.logical.shell
         #       ^ keyword.operator.logical.shell
-        #        ^ keyword.operator.quantifier.regexp.shell
-        #         ^ punctuation.section.group.begin.regexp.shell
-        #            ^ keyword.operator.alternation.regexp.shell
-        #              ^ keyword.operator.alternation.regexp.shell
-        #                ^ punctuation.section.group.end.regexp.shell
+        #        ^ keyword.operator.quantifier.glob.shell
+        #         ^ punctuation.section.group.begin.glob.shell
+        #            ^ keyword.operator.alternation.glob.shell
+        #              ^ keyword.operator.alternation.glob.shell
+        #                ^ punctuation.section.group.end.glob.shell
         #                     ^ punctuation.section.patterns.end.shell
         update_terminal_cwd() { print -Pn "\e]2;%~\a" };;
         #                                             ^ meta.function punctuation.section.block.end.shell
@@ -2371,44 +2371,44 @@ case $SERVER in
 # <- keyword.control.conditional.case.shell
 ws-+([0-9]).host.com) echo "Web Server"
 #^^^ meta.clause.patterns.shell meta.string.glob.shell - meta.group
-#   ^^^^^^^ meta.clause.patterns.shell meta.string.glob.shell meta.group.regexp.shell
+#   ^^^^^^^ meta.clause.patterns.shell meta.string.glob.shell meta.group.glob.shell
 #          ^^^^^^^^^ meta.clause.patterns.shell meta.string.glob.shell - meta.group
 #                   ^ meta.clause.patterns.shell - meta.string - meta.group - string
 #^^^^^^^^^^^^^^^^^^^ string.unquoted.shell
-#  ^ keyword.operator.quantifier.regexp.shell
-#   ^ punctuation.section.group.begin.regexp.shell
-#    ^ punctuation.definition.character-class.begin.regexp.shell
-#     ^^^ constant.other.range.regexp.shell
-#      ^ punctuation.separator.sequence.regexp.shell
-#        ^ punctuation.definition.character-class.end.regexp.shell
-#         ^ punctuation.section.group.end.regexp.shell
+#  ^ keyword.operator.quantifier.glob.shell
+#   ^ punctuation.section.group.begin.glob.shell
+#    ^ punctuation.definition.character-class.begin.glob.shell
+#     ^^^ constant.other.range.glob.shell
+#      ^ punctuation.separator.sequence.glob.shell
+#        ^ punctuation.definition.character-class.end.glob.shell
+#         ^ punctuation.section.group.end.glob.shell
 #                   ^ punctuation.section.patterns.end.shell
 ;;
 # <- punctuation.terminator.clause.shell
 #^ punctuation.terminator.clause.shell
 db-+([0-9])\.host\.com) echo "DB server"
 #^^^ meta.clause.patterns.shell meta.string.glob.shell - meta.group
-#   ^^^^^^^ meta.clause.patterns.shell meta.string.glob.shell meta.group.regexp.shell
+#   ^^^^^^^ meta.clause.patterns.shell meta.string.glob.shell meta.group.glob.shell
 #          ^^^^^^^^^^^ meta.clause.patterns.shell meta.string.glob.shell - meta.group
-#  ^ keyword.operator.quantifier.regexp.shell
-#   ^ punctuation.section.group.begin.regexp.shell
-#    ^ punctuation.definition.character-class.begin.regexp.shell
-#     ^^^ constant.other.range.regexp.shell
-#      ^ punctuation.separator.sequence.regexp.shell
-#        ^ punctuation.definition.character-class.end.regexp.shell
-#         ^ punctuation.section.group.end.regexp.shell
+#  ^ keyword.operator.quantifier.glob.shell
+#   ^ punctuation.section.group.begin.glob.shell
+#    ^ punctuation.definition.character-class.begin.glob.shell
+#     ^^^ constant.other.range.glob.shell
+#      ^ punctuation.separator.sequence.glob.shell
+#        ^ punctuation.definition.character-class.end.glob.shell
+#         ^ punctuation.section.group.end.glob.shell
 #                     ^ punctuation.section.patterns.end.shell
 ;;
 # <- punctuation.terminator.clause.shell
 #^ punctuation.terminator.clause.shell
 bk-+([0-9])\.host\.com) echo "Backup server"
-#  ^ keyword.operator.quantifier.regexp.shell
-#   ^ punctuation.section.group.begin.regexp.shell
-#    ^ punctuation.definition.character-class.begin.regexp.shell
-#     ^^^ constant.other.range.regexp.shell
-#      ^ punctuation.separator.sequence.regexp.shell
-#        ^ punctuation.definition.character-class.end.regexp.shell
-#         ^ punctuation.section.group.end.regexp.shell
+#  ^ keyword.operator.quantifier.glob.shell
+#   ^ punctuation.section.group.begin.glob.shell
+#    ^ punctuation.definition.character-class.begin.glob.shell
+#     ^^^ constant.other.range.glob.shell
+#      ^ punctuation.separator.sequence.glob.shell
+#        ^ punctuation.definition.character-class.end.glob.shell
+#         ^ punctuation.section.group.end.glob.shell
 #                     ^ punctuation.section.patterns.end.shell
 #                       ^^^^ support.function.shell
 ;;
@@ -2427,9 +2427,9 @@ esac
 
 case $_G_unquoted_arg in
 *[\[\~\#\&\*\(\)\{\}\|\;\<\>\?\'\ ]*|*]*|"")
-#^ punctuation.definition.character-class.begin.regexp.shell
+#^ punctuation.definition.character-class.begin.glob.shell
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.character.escape.shell
-#                                 ^ punctuation.definition.character-class.end.regexp.shell
+#                                 ^ punctuation.definition.character-class.end.glob.shell
 #                                     ^ - keyword.control
   _G_quoted_arg=\"$_G_unquoted_arg\"
   ;;
@@ -2439,9 +2439,9 @@ case $_G_unquoted_arg in
 esac
 case $1 in
 *[\\\`\"\$]*)
-#^ punctuation.definition.character-class.begin.regexp.shell
+#^ punctuation.definition.character-class.begin.glob.shell
 # ^^^^^^^^ constant.character.escape.shell
-#         ^ punctuation.definition.character-class.end.regexp.shell
+#         ^ punctuation.definition.character-class.end.glob.shell
   _G_unquoted_arg=`printf '%s\n' "$1" |$SED "$sed_quote_subst"` ;;
 *)
   _G_unquoted_arg=$1 ;;
@@ -6886,7 +6886,7 @@ foo}
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^ variable.language.special.shell
 #    ^ keyword.operator.substitution.shell
-#     ^^^ meta.string.regexp.shell
+#     ^^^ meta.string.glob.shell
 #        ^ keyword.operator.substitution.shell
 #         ^^^ meta.string.glob.shell string.unquoted.shell
 #            ^ punctuation.section.interpolation.end.shell
@@ -6898,7 +6898,7 @@ foo}
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^ variable.language.special.shell
 #    ^ keyword.operator.substitution.shell
-#     ^^^ meta.string.regexp.shell
+#     ^^^ meta.string.glob.shell
 #        ^ keyword.operator.substitution.shell
 #         ^^^ meta.string.glob.shell string.unquoted.shell
 #            ^ punctuation.section.interpolation.end.shell
@@ -6910,7 +6910,7 @@ foo}
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^ variable.language.special.shell
 #    ^ keyword.operator.substitution.shell
-#     ^^^ meta.string.regexp.shell
+#     ^^^ meta.string.glob.shell
 #        ^ keyword.operator.substitution.shell
 #         ^^^ meta.string.glob.shell string.unquoted.shell
 #            ^ punctuation.section.interpolation.end.shell
@@ -6922,7 +6922,7 @@ foo}
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^ variable.language.special.shell
 #    ^ keyword.operator.substitution.shell
-#     ^^^ meta.string.regexp.shell
+#     ^^^ meta.string.glob.shell
 #        ^ keyword.operator.substitution.shell
 #         ^^^ meta.string.glob.shell string.unquoted.shell
 #            ^ punctuation.section.interpolation.end.shell
@@ -6934,7 +6934,7 @@ foo}
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^ variable.language.special.shell
 #    ^ keyword.operator.substitution.shell
-#     ^^^ meta.string.regexp.shell
+#     ^^^ meta.string.glob.shell
 #        ^ keyword.operator.substitution.shell
 #         ^^^ meta.string.glob.shell string.unquoted.shell
 #            ^ punctuation.section.interpolation.end.shell
@@ -6946,7 +6946,7 @@ foo}
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^ variable.language.special.shell
 #    ^ keyword.operator.substitution.shell
-#     ^^^ meta.string.regexp.shell
+#     ^^^ meta.string.glob.shell
 #        ^ keyword.operator.substitution.shell
 #         ^^^ meta.string.glob.shell string.unquoted.shell
 #            ^ punctuation.section.interpolation.end.shell
@@ -6958,7 +6958,7 @@ foo}
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^ variable.language.special.shell
 #    ^ keyword.operator.substitution.shell
-#     ^^^ meta.string.regexp.shell
+#     ^^^ meta.string.glob.shell
 #        ^ keyword.operator.substitution.shell
 #         ^^^ meta.string.glob.shell string.unquoted.shell
 #            ^ punctuation.section.interpolation.end.shell
@@ -6970,7 +6970,7 @@ foo}
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^ variable.language.builtin.shell
 #    ^ keyword.operator.substitution.shell
-#     ^^^ meta.string.regexp.shell
+#     ^^^ meta.string.glob.shell
 #        ^ keyword.operator.substitution.shell
 #         ^^^ meta.string.glob.shell string.unquoted.shell
 #            ^ punctuation.section.interpolation.end.shell
@@ -6982,7 +6982,7 @@ foo}
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^^^ variable.other.readwrite.shell
 #      ^ keyword.operator.substitution.shell
-#       ^^^ meta.string.regexp.shell
+#       ^^^ meta.string.glob.shell
 #          ^ keyword.operator.substitution.shell
 #           ^^^ meta.string.glob.shell string.unquoted.shell
 #              ^ punctuation.section.interpolation.end.shell
@@ -6995,7 +6995,7 @@ foo}
 #   ^^^ variable.other.readwrite.shell
 #      ^ variable.language.special.shell
 #       ^ keyword.operator.substitution.shell
-#        ^^^ meta.string.regexp.shell
+#        ^^^ meta.string.glob.shell
 #           ^ keyword.operator.substitution.shell
 #            ^^^ meta.string.glob.shell string.unquoted.shell
 #               ^ punctuation.section.interpolation.end.shell
@@ -7008,7 +7008,7 @@ foo}
 #   ^^^ variable.other.readwrite.shell
 #      ^ variable.language.special.shell
 #       ^ keyword.operator.substitution.shell
-#        ^^^ meta.string.regexp.shell
+#        ^^^ meta.string.glob.shell
 #           ^ keyword.operator.substitution.shell
 #            ^^^ meta.string.glob.shell string.unquoted.shell
 #               ^ punctuation.section.interpolation.end.shell
@@ -7023,7 +7023,7 @@ foo}
 #       ^ variable.language.array.shell
 #        ^ punctuation.section.item-access.end.shell
 #         ^ keyword.operator.substitution.shell
-#          ^^^ meta.string.regexp.shell
+#          ^^^ meta.string.glob.shell
 #             ^ keyword.operator.substitution.shell
 #              ^^^ meta.string.glob.shell string.unquoted.shell
 #                 ^ punctuation.section.interpolation.end.shell
@@ -7038,7 +7038,7 @@ foo}
 #       ^ variable.language.array.shell
 #        ^ punctuation.section.item-access.end.shell
 #         ^ keyword.operator.substitution.shell
-#          ^^^ meta.string.regexp.shell
+#          ^^^ meta.string.glob.shell
 #             ^ keyword.operator.substitution.shell
 #              ^^^ meta.string.glob.shell string.unquoted.shell
 #                 ^ punctuation.section.interpolation.end.shell
@@ -7176,8 +7176,8 @@ foo}
 
 : ${foo//\
 a\/b/c/d}
-# <- meta.interpolation.parameter.shell meta.string.regexp.shell
-#^^^ meta.interpolation.parameter.shell meta.string.regexp.shell
+# <- meta.interpolation.parameter.shell meta.string.glob.shell
+#^^^ meta.interpolation.parameter.shell meta.string.glob.shell
 #   ^ meta.interpolation.parameter.shell - meta.interpolation.parameter.shell meta.string
 #    ^^^ meta.interpolation.parameter.shell meta.string.shell
 #       ^ meta.interpolation.parameter.shell - meta.interpolation.parameter.shell meta.string
@@ -7242,52 +7242,52 @@ a\/b/c/d}
 
 : ${foo//+([a-:/\}} # incomplete charset in incomplete group
 # ^^^^^^^^ meta.interpolation.parameter.shell - meta.group
-#         ^^^^^^^^ meta.interpolation.parameter.shell meta.group.regexp.shell
+#         ^^^^^^^^ meta.interpolation.parameter.shell meta.group.glob.shell
 #                 ^ meta.interpolation.parameter.shell - meta.group
 #                  ^ - meta.interpolation
 # ^ punctuation.definition.variable.shell
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^^^ variable.other.readwrite.shell
 #      ^^ keyword.operator.substitution.shell
-#        ^ keyword.operator.quantifier.regexp.shell
-#         ^ punctuation.section.group.begin.regexp.shell
+#        ^ keyword.operator.quantifier.glob.shell
+#         ^ punctuation.section.group.begin.glob.shell
 #          ^^^^^ - constant - punctuation
 #               ^^ constant.character.escape.shell
 #                 ^ punctuation.section.interpolation.end.shell
 
 : ${foo//+([a|&)/\}} # incomplete charset in group
 # ^^^^^^^^ meta.interpolation.parameter.shell - meta.group
-#         ^^^^^^ meta.interpolation.parameter.shell meta.group.regexp.shell
+#         ^^^^^^ meta.interpolation.parameter.shell meta.group.glob.shell
 #               ^^^^ meta.interpolation.parameter.shell - meta.group
 #                   ^ - meta.interpolation
 # ^ punctuation.definition.variable.shell
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^^^ variable.other.readwrite.shell
 #      ^^ keyword.operator.substitution.shell
-#        ^ keyword.operator.quantifier.regexp.shell
-#         ^ punctuation.section.group.begin.regexp.shell
+#        ^ keyword.operator.quantifier.glob.shell
+#         ^ punctuation.section.group.begin.glob.shell
 #          ^^^^ - constant - punctuation
-#            ^ keyword.operator.alternation.regexp.shell
-#              ^ punctuation.section.group.end.regexp.shell
+#            ^ keyword.operator.alternation.glob.shell
+#              ^ punctuation.section.group.end.glob.shell
 #               ^ keyword.operator.substitution.shell
 #                ^^ constant.character.escape.shell
 #                  ^ punctuation.section.interpolation.end.shell
 
 : ${foo//[abc[]/x}  # `[` has no meaning within charsets
 # ^^^^^^^ meta.interpolation.parameter.shell - meta.string meta.character-class
-#        ^^^^^^ meta.interpolation.parameter.shell meta.string.regexp.shell meta.character-class.regexp.shell
+#        ^^^^^^ meta.interpolation.parameter.shell meta.string.glob.shell meta.character-class.glob.shell
 #              ^^^ meta.interpolation.parameter.shell - meta.string meta.character-class
 #      ^^ keyword.operator.substitution.shell
-#        ^ punctuation.definition.character-class.begin.regexp.shell
+#        ^ punctuation.definition.character-class.begin.glob.shell
 #            ^ - keyword - punctuation
-#             ^ punctuation.definition.character-class.end.regexp.shell
+#             ^ punctuation.definition.character-class.end.glob.shell
 #              ^ keyword.operator.substitution.shell
 #                ^ punctuation.section.interpolation.end.shell
 
 : ${var//f|o/b|ar}  # `|` has no meaning in patterns or replacement strings
 # ^^^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #      ^^ keyword.operator.substitution.shell
-#        ^^^ meta.string.regexp.shell string.unquoted.shell - keyword - punctuation
+#        ^^^ meta.string.glob.shell string.unquoted.shell - keyword - punctuation
 #           ^ keyword.operator.substitution.shell
 #            ^^^^ meta.string.glob.shell string.unquoted.shell - keyword - punctuation
 #                ^ punctuation.section.interpolation.end.shell
@@ -7295,7 +7295,7 @@ a\/b/c/d}
 : ${var//f&o/b&ar}  # `&` has no meaning in patterns or replacement strings
 # ^^^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #      ^^ keyword.operator.substitution.shell
-#        ^^^ meta.string.regexp.shell string.unquoted.shell - keyword - punctuation
+#        ^^^ meta.string.glob.shell string.unquoted.shell - keyword - punctuation
 #           ^ keyword.operator.substitution.shell
 #            ^^^^ meta.string.glob.shell string.unquoted.shell - keyword - punctuation
 #                ^ punctuation.section.interpolation.end.shell
@@ -7303,7 +7303,7 @@ a\/b/c/d}
 : ${var//f>o/b>ar}  # `>` has no meaning in patterns or replacement strings
 # ^^^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #      ^^ keyword.operator.substitution.shell
-#        ^^^ meta.string.regexp.shell string.unquoted.shell - keyword - punctuation
+#        ^^^ meta.string.glob.shell string.unquoted.shell - keyword - punctuation
 #           ^ keyword.operator.substitution.shell
 #            ^^^^ meta.string.glob.shell string.unquoted.shell - keyword - punctuation
 #                ^ punctuation.section.interpolation.end.shell
@@ -7311,7 +7311,7 @@ a\/b/c/d}
 : ${var//f<o/b<ar}  # `<` has no meaning in patterns or replacement strings
 # ^^^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #      ^^ keyword.operator.substitution.shell
-#        ^^^ meta.string.regexp.shell string.unquoted.shell - keyword - punctuation
+#        ^^^ meta.string.glob.shell string.unquoted.shell - keyword - punctuation
 #           ^ keyword.operator.substitution.shell
 #            ^^^^ meta.string.glob.shell string.unquoted.shell - keyword - punctuation
 #                ^ punctuation.section.interpolation.end.shell
@@ -7319,7 +7319,7 @@ a\/b/c/d}
 : ${var//f;o/b;ar}  # `;` has no meaning in patterns or replacement strings
 # ^^^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #      ^^ keyword.operator.substitution.shell
-#        ^^^ meta.string.regexp.shell string.unquoted.shell - keyword - punctuation
+#        ^^^ meta.string.glob.shell string.unquoted.shell - keyword - punctuation
 #           ^ keyword.operator.substitution.shell
 #            ^^^^ meta.string.glob.shell string.unquoted.shell - keyword - punctuation
 #                ^ punctuation.section.interpolation.end.shell
@@ -7332,7 +7332,7 @@ a\/b/c/d}
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^^^ variable.other.readwrite.shell
 #      ^ keyword.operator.substitution.shell
-#       ^ meta.string.regexp.shell variable.language.tilde.shell
+#       ^ meta.string.glob.shell variable.language.tilde.shell
 #        ^ keyword.operator.substitution.shell
 #         ^ punctuation.section.interpolation.end.shell
 
@@ -7352,7 +7352,7 @@ a\/b/c/d}
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^^^ variable.other.readwrite.shell
 #      ^ keyword.operator.substitution.shell
-#       ^^^^^^^ meta.string.regexp.shell
+#       ^^^^^^^ meta.string.glob.shell
 #       ^ meta.interpolation.tilde.shell variable.language.tilde.shell
 #        ^^ constant.character.escape.shell - meta.interpolation.tilde
 #          ^^ constant.other.wildcard.asterisk.shell
@@ -7367,7 +7367,7 @@ a\/b/c/d}
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^^^ variable.other.readwrite.shell
 #      ^ keyword.operator.substitution.shell
-#       ^^ meta.string.regexp.shell variable.language.tilde.shell
+#       ^^ meta.string.glob.shell variable.language.tilde.shell
 #         ^ keyword.operator.substitution.shell
 #          ^ punctuation.section.interpolation.end.shell
 
@@ -7377,7 +7377,7 @@ a\/b/c/d}
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^^^ variable.other.readwrite.shell
 #      ^ keyword.operator.substitution.shell
-#       ^^^^^ meta.string.regexp.shell meta.interpolation.tilde.shell
+#       ^^^^^ meta.string.glob.shell meta.interpolation.tilde.shell
 #       ^ variable.language.tilde.shell
 #        ^^^^ meta.string.glob.shell constant.other.username.shell
 #            ^ keyword.operator.substitution.shell
@@ -7391,49 +7391,49 @@ a\/b/c/d}
 # ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^ keyword.operator.expansion.shell
-#     ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#     ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${*#pattern}
 # ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^ keyword.operator.expansion.shell
-#     ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#     ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${##pattern}
 # ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^ keyword.operator.expansion.shell
-#     ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#     ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${?#pattern}
 # ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^ keyword.operator.expansion.shell
-#     ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#     ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${$#pattern}
 # ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^ keyword.operator.expansion.shell
-#     ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#     ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${-#pattern}
 # ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^ keyword.operator.expansion.shell
-#     ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#     ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${!#pattern}  # bad substitution
 # ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ keyword.operator.expansion.indirection.shell
 #    ^ keyword.operator.expansion.shell
-#     ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#     ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${_#pattern}
 # ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.builtin.shell
 #    ^ keyword.operator.expansion.shell
-#     ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#     ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${foo#}
 # ^^^^^^^ meta.interpolation.parameter.shell
@@ -7448,7 +7448,7 @@ a\/b/c/d}
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^^^ variable.other.readwrite.shell
 #      ^ keyword.operator.expansion.shell
-#       ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#       ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 #              ^ punctuation.section.interpolation.end.shell
 
 : ${foo@#pattern}
@@ -7458,7 +7458,7 @@ a\/b/c/d}
 #   ^^^ variable.other.readwrite.shell
 #      ^ variable.language.special.shell
 #       ^ keyword.operator.expansion.shell
-#        ^^^^^^^ meta.string.regexp.shell
+#        ^^^^^^^ meta.string.glob.shell
 #               ^ punctuation.section.interpolation.end.shell
 
 : ${foo*#pattern}
@@ -7468,7 +7468,7 @@ a\/b/c/d}
 #   ^^^ variable.other.readwrite.shell
 #      ^ variable.language.special.shell
 #       ^ keyword.operator.expansion.shell
-#        ^^^^^^^ meta.string.regexp.shell
+#        ^^^^^^^ meta.string.glob.shell
 #               ^ punctuation.section.interpolation.end.shell
 
 : ${foo[@]#pattern}
@@ -7481,7 +7481,7 @@ a\/b/c/d}
 #       ^ variable.language.array.shell
 #        ^ punctuation.section.item-access.end.shell
 #         ^ keyword.operator.expansion.shell
-#          ^^^^^^^ meta.string.regexp.shell
+#          ^^^^^^^ meta.string.glob.shell
 #                 ^ punctuation.section.interpolation.end.shell
 
 : ${foo[@]#pattern}
@@ -7494,7 +7494,7 @@ a\/b/c/d}
 #       ^ variable.language.array.shell
 #        ^ punctuation.section.item-access.end.shell
 #         ^ keyword.operator.expansion.shell
-#          ^^^^^^^ meta.string.regexp.shell
+#          ^^^^^^^ meta.string.glob.shell
 #                 ^ punctuation.section.interpolation.end.shell
 
 : ${foo# #pattern} # comment
@@ -7503,7 +7503,7 @@ a\/b/c/d}
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^^^ variable.other.readwrite.shell
 #      ^ keyword.operator.expansion.shell
-#       ^^^^^^^^^ meta.string.regexp.shell
+#       ^^^^^^^^^ meta.string.glob.shell
 #        ^ - comment - keyword
 #                ^ punctuation.section.interpolation.end.shell
 #                  ^^^^^^^^^^ comment.line.number-sign.shell
@@ -7512,7 +7512,7 @@ a\/b/c/d}
 # ^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^^^ variable.other.readwrite.shell
 #      ^ keyword.operator.expansion.shell
-#       ^^ meta.string.regexp.shell
+#       ^^ meta.string.glob.shell
 #        ^ - comment.line
 #         ^ punctuation.section.interpolation.end.shell
 #           ^ comment.line punctuation
@@ -7529,15 +7529,15 @@ a\/b/c/d}
 : ${foo#~+/*bar}
 # ^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #      ^ keyword.operator.expansion.shell
-#       ^^ meta.string.regexp.shell meta.interpolation.tilde.shell variable.language.tilde.shell
-#         ^^^^^ meta.interpolation.parameter.shell meta.string.regexp.shell string.unquoted.shell
+#       ^^ meta.string.glob.shell meta.interpolation.tilde.shell variable.language.tilde.shell
+#         ^^^^^ meta.interpolation.parameter.shell meta.string.glob.shell string.unquoted.shell
 #          ^ constant.other.wildcard.asterisk.shell
 #              ^ punctuation.section.interpolation.end.shell
 
 : ${foo#m~+/*bar}
 # ^^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #      ^ keyword.operator.expansion.shell
-#       ^^^^^^^^ meta.string.regexp.shell
+#       ^^^^^^^^ meta.string.glob.shell
 #        ^^ - variable
 #           ^ constant.other.wildcard.asterisk.shell
 
@@ -7548,66 +7548,66 @@ a\/b/c/d}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^^ keyword.operator.expansion.shell
-#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#      ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${*##pattern}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^^ keyword.operator.expansion.shell
-#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#      ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${###pattern}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^^ keyword.operator.expansion.shell
 #     ^ keyword.operator.expansion.shell
-#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#      ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${?##pattern}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^^ keyword.operator.expansion.shell
-#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#      ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${$##pattern}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^^ keyword.operator.expansion.shell
-#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#      ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${-##pattern}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^^ keyword.operator.expansion.shell
-#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#      ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${!##pattern}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ keyword.operator.expansion.indirection.shell
 #    ^ variable.language.special.shell
 #     ^ keyword.operator.expansion.shell
-#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#      ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${!###pattern}
 # ^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ keyword.operator.expansion.indirection.shell
 #    ^ variable.language.special.shell
 #     ^^ keyword.operator.expansion.shell
-#       ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#       ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${!####pattern}
 # ^^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ keyword.operator.expansion.indirection.shell
 #    ^ variable.language.special.shell
 #     ^^ keyword.operator.expansion.shell
-#       ^^^^^^^^ meta.string.regexp.shell
+#       ^^^^^^^^ meta.string.glob.shell
 #       ^ - keyword
 
 : ${_##pattern}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.builtin.shell
 #    ^^ keyword.operator.expansion.shell
-#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#      ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${foo##}
 # ^^^^^^^^ meta.interpolation.parameter.shell
@@ -7622,7 +7622,7 @@ a\/b/c/d}
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^^^ variable.other.readwrite.shell
 #      ^^ keyword.operator.expansion.shell
-#        ^^^^^^^ meta.string.regexp.shell
+#        ^^^^^^^ meta.string.glob.shell
 #               ^ punctuation.section.interpolation.end.shell
 
 : ${foo###pattern}
@@ -7631,7 +7631,7 @@ a\/b/c/d}
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^^^ variable.other.readwrite.shell
 #      ^^ keyword.operator.expansion.shell
-#        ^^^^^^^^ meta.string.regexp.shell
+#        ^^^^^^^^ meta.string.glob.shell
 #        ^ - keyword
 #                ^ punctuation.section.interpolation.end.shell
 
@@ -7642,7 +7642,7 @@ a\/b/c/d}
 #   ^^^ variable.other.readwrite.shell
 #      ^ variable.language.special.shell
 #       ^^ keyword.operator.expansion.shell
-#         ^^^^^^^ meta.string.regexp.shell
+#         ^^^^^^^ meta.string.glob.shell
 #                ^ punctuation.section.interpolation.end.shell
 
 : ${foo*##pattern}
@@ -7652,7 +7652,7 @@ a\/b/c/d}
 #   ^^^ variable.other.readwrite.shell
 #      ^ variable.language.special.shell
 #       ^^ keyword.operator.expansion.shell
-#         ^^^^^^^ meta.string.regexp.shell
+#         ^^^^^^^ meta.string.glob.shell
 #                ^ punctuation.section.interpolation.end.shell
 
 : ${foo[@]##pattern}
@@ -7665,7 +7665,7 @@ a\/b/c/d}
 #       ^ variable.language.array.shell
 #        ^ punctuation.section.item-access.end.shell
 #         ^^ keyword.operator.expansion.shell
-#           ^^^^^^^ meta.string.regexp.shell
+#           ^^^^^^^ meta.string.glob.shell
 #                  ^ punctuation.section.interpolation.end.shell
 
 : ${foo[@]##pattern}
@@ -7678,7 +7678,7 @@ a\/b/c/d}
 #       ^ variable.language.array.shell
 #        ^ punctuation.section.item-access.end.shell
 #         ^^ keyword.operator.expansion.shell
-#           ^^^^^^^ meta.string.regexp.shell
+#           ^^^^^^^ meta.string.glob.shell
 #                  ^ punctuation.section.interpolation.end.shell
 
 : ${foo## #pattern} # comment
@@ -7686,7 +7686,7 @@ a\/b/c/d}
 # ^ punctuation.definition.variable.shell
 #  ^ punctuation.section.interpolation.begin.shell
 #      ^^ keyword.operator.expansion.shell
-#        ^^^^^^^^^ meta.string.regexp.shell
+#        ^^^^^^^^^ meta.string.glob.shell
 #         ^ - comment - keyword
 #                 ^ punctuation.section.interpolation.end.shell
 #                   ^^^^^^^^^^ comment.line.number-sign.shell
@@ -7694,7 +7694,7 @@ a\/b/c/d}
 : ${foo##~+/*bar}
 # ^^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #      ^^ keyword.operator.expansion.shell
-#        ^^^^^^^ meta.string.regexp.shell
+#        ^^^^^^^ meta.string.glob.shell
 #        ^^ variable.language.tilde.shell
 #           ^ constant.other.wildcard.asterisk.shell
 #               ^ punctuation.section.interpolation.end.shell
@@ -7702,7 +7702,7 @@ a\/b/c/d}
 : ${foo##m~+/*bar}
 # ^^^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #      ^^ keyword.operator.expansion.shell
-#        ^^^^^^^^ meta.string.regexp.shell
+#        ^^^^^^^^ meta.string.glob.shell
 #         ^^ - variable
 #            ^ constant.other.wildcard.asterisk.shell
 
@@ -7771,7 +7771,7 @@ a\/b/c/d}
 #   ^^^ variable.other.readwrite.shell
 #      ^ variable.language.special.shell
 #       ^ keyword.operator.expansion.shell
-#        ^^^^^^^ meta.string.regexp.shell
+#        ^^^^^^^ meta.string.glob.shell
 #               ^ punctuation.section.interpolation.end.shell
 
 : ${foo*%pattern}
@@ -7781,7 +7781,7 @@ a\/b/c/d}
 #   ^^^ variable.other.readwrite.shell
 #      ^ variable.language.special.shell
 #       ^ keyword.operator.expansion.shell
-#        ^^^^^^^ meta.string.regexp.shell
+#        ^^^^^^^ meta.string.glob.shell
 #               ^ punctuation.section.interpolation.end.shell
 
 : ${foo[@]%pattern}
@@ -7794,7 +7794,7 @@ a\/b/c/d}
 #       ^ variable.language.array.shell
 #        ^ punctuation.section.item-access.end.shell
 #         ^ keyword.operator.expansion.shell
-#          ^^^^^^^ meta.string.regexp.shell
+#          ^^^^^^^ meta.string.glob.shell
 #                 ^ punctuation.section.interpolation.end.shell
 
 : ${foo[@]%pattern}
@@ -7807,7 +7807,7 @@ a\/b/c/d}
 #       ^ variable.language.array.shell
 #        ^ punctuation.section.item-access.end.shell
 #         ^ keyword.operator.expansion.shell
-#          ^^^^^^^ meta.string.regexp.shell
+#          ^^^^^^^ meta.string.glob.shell
 #                 ^ punctuation.section.interpolation.end.shell
 
 : ${foo% #pattern} # comment
@@ -7827,7 +7827,7 @@ a\/b/c/d}
 
 : ${foo%\ \#} # hello
 #      ^ keyword.operator.expansion.shell
-#       ^^^^ meta.string.regexp.shell constant.character.escape.shell
+#       ^^^^ meta.string.glob.shell constant.character.escape.shell
 #          ^ - comment.line
 #           ^ punctuation.section.interpolation.end.shell
 #             ^ comment.line punctuation
@@ -7835,15 +7835,15 @@ a\/b/c/d}
 : ${foo%~+/*bar}
 # ^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #      ^ keyword.operator.expansion.shell
-#       ^^ meta.string.regexp.shell meta.interpolation.tilde.shell variable.language.tilde.shell
-#         ^^^^^ meta.interpolation.parameter.shell meta.string.regexp.shell string.unquoted.shell
+#       ^^ meta.string.glob.shell meta.interpolation.tilde.shell variable.language.tilde.shell
+#         ^^^^^ meta.interpolation.parameter.shell meta.string.glob.shell string.unquoted.shell
 #          ^ constant.other.wildcard.asterisk.shell
 #              ^ punctuation.section.interpolation.end.shell
 
 : ${foo%m~+/*bar}
 # ^^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #      ^ keyword.operator.expansion.shell
-#       ^^^^^^^^ meta.string.regexp.shell
+#       ^^^^^^^^ meta.string.glob.shell
 #        ^^ - variable
 #           ^ constant.other.wildcard.asterisk.shell
 
@@ -7854,49 +7854,49 @@ a\/b/c/d}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^^ keyword.operator.expansion.shell
-#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#      ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${*%%pattern}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^^ keyword.operator.expansion.shell
-#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#      ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${#%%pattern}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^^ keyword.operator.expansion.shell
-#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#      ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${?%%pattern}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^^ keyword.operator.expansion.shell
-#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#      ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${$%%pattern}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^^ keyword.operator.expansion.shell
-#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#      ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${-%%pattern}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^^ keyword.operator.expansion.shell
-#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#      ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${!%%pattern}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^^ keyword.operator.expansion.shell
-#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#      ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${_%%pattern}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.builtin.shell
 #    ^^ keyword.operator.expansion.shell
-#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#      ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${foo%%}
 # ^^^^^^^^ meta.interpolation.parameter.shell
@@ -7910,7 +7910,7 @@ a\/b/c/d}
 # ^ punctuation.definition.variable.shell
 #  ^ punctuation.section.interpolation.begin.shell
 #      ^^ keyword.operator.expansion.shell
-#        ^^^^^^^ meta.string.regexp.shell
+#        ^^^^^^^ meta.string.glob.shell
 #               ^ punctuation.section.interpolation.end.shell
 
 : ${foo%%%pattern}
@@ -7918,7 +7918,7 @@ a\/b/c/d}
 # ^ punctuation.definition.variable.shell
 #  ^ punctuation.section.interpolation.begin.shell
 #      ^^ keyword.operator.expansion.shell
-#        ^^^^^^^^ meta.string.regexp.shell
+#        ^^^^^^^^ meta.string.glob.shell
 #        ^ - keyword
 #                ^ punctuation.section.interpolation.end.shell
 
@@ -7929,7 +7929,7 @@ a\/b/c/d}
 #   ^^^ variable.other.readwrite.shell
 #      ^ variable.language.special.shell
 #       ^^ keyword.operator.expansion.shell
-#         ^^^^^^^ meta.string.regexp.shell
+#         ^^^^^^^ meta.string.glob.shell
 #                ^ punctuation.section.interpolation.end.shell
 
 : ${foo*%%pattern}
@@ -7939,7 +7939,7 @@ a\/b/c/d}
 #   ^^^ variable.other.readwrite.shell
 #      ^ variable.language.special.shell
 #       ^^ keyword.operator.expansion.shell
-#         ^^^^^^^ meta.string.regexp.shell
+#         ^^^^^^^ meta.string.glob.shell
 #                ^ punctuation.section.interpolation.end.shell
 
 : ${foo[@]%%pattern}
@@ -7952,7 +7952,7 @@ a\/b/c/d}
 #       ^ variable.language.array.shell
 #        ^ punctuation.section.item-access.end.shell
 #         ^^ keyword.operator.expansion.shell
-#           ^^^^^^^ meta.string.regexp.shell
+#           ^^^^^^^ meta.string.glob.shell
 #                  ^ punctuation.section.interpolation.end.shell
 
 : ${foo[@]%%pattern}
@@ -7965,7 +7965,7 @@ a\/b/c/d}
 #       ^ variable.language.array.shell
 #        ^ punctuation.section.item-access.end.shell
 #         ^^ keyword.operator.expansion.shell
-#           ^^^^^^^ meta.string.regexp.shell
+#           ^^^^^^^ meta.string.glob.shell
 #                  ^ punctuation.section.interpolation.end.shell
 
 : ${foo%%~}
@@ -7977,7 +7977,7 @@ a\/b/c/d}
 : ${foo%%~+/*bar}
 # ^^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #      ^^ keyword.operator.expansion.shell
-#        ^^^^^^^ meta.string.regexp.shell
+#        ^^^^^^^ meta.string.glob.shell
 #        ^^ variable.language.tilde.shell
 #           ^ constant.other.wildcard.asterisk.shell
 #               ^ punctuation.section.interpolation.end.shell
@@ -7985,7 +7985,7 @@ a\/b/c/d}
 : ${foo%%m~+/*bar}
 # ^^^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #      ^^ keyword.operator.expansion.shell
-#        ^^^^^^^^ meta.string.regexp.shell
+#        ^^^^^^^^ meta.string.glob.shell
 #         ^^ - variable
 #            ^ constant.other.wildcard.asterisk.shell
 
@@ -7996,49 +7996,49 @@ a\/b/c/d}
 # ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^ keyword.operator.expansion.shell
-#     ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#     ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${*,pattern}
 # ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^ keyword.operator.expansion.shell
-#     ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#     ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${#,pattern}
 # ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^ keyword.operator.expansion.shell
-#     ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#     ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${?,pattern}
 # ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^ keyword.operator.expansion.shell
-#     ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#     ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${$,pattern}
 # ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^ keyword.operator.expansion.shell
-#     ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#     ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${-,pattern}
 # ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^ keyword.operator.expansion.shell
-#     ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#     ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${!,pattern}
 # ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^ keyword.operator.expansion.shell
-#     ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#     ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${_,pattern}
 # ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.builtin.shell
 #    ^ keyword.operator.expansion.shell
-#     ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#     ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${foo,}
 # ^^^^^^^ meta.interpolation.parameter.shell
@@ -8052,7 +8052,7 @@ a\/b/c/d}
 # ^ punctuation.definition.variable.shell
 #  ^ punctuation.section.interpolation.begin.shell
 #      ^ keyword.operator.expansion.shell
-#       ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#       ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 #              ^ punctuation.section.interpolation.end.shell
 
 : ${foo@,pattern}
@@ -8062,7 +8062,7 @@ a\/b/c/d}
 #   ^^^ variable.other.readwrite.shell
 #      ^ variable.language.special.shell
 #       ^ keyword.operator.expansion.shell
-#        ^^^^^^^ meta.string.regexp.shell
+#        ^^^^^^^ meta.string.glob.shell
 #               ^ punctuation.section.interpolation.end.shell
 
 : ${foo*,pattern}
@@ -8072,7 +8072,7 @@ a\/b/c/d}
 #   ^^^ variable.other.readwrite.shell
 #      ^ variable.language.special.shell
 #       ^ keyword.operator.expansion.shell
-#        ^^^^^^^ meta.string.regexp.shell
+#        ^^^^^^^ meta.string.glob.shell
 #               ^ punctuation.section.interpolation.end.shell
 
 : ${foo[@],pattern}
@@ -8085,7 +8085,7 @@ a\/b/c/d}
 #       ^ variable.language.array.shell
 #        ^ punctuation.section.item-access.end.shell
 #         ^ keyword.operator.expansion.shell
-#          ^^^^^^^ meta.string.regexp.shell
+#          ^^^^^^^ meta.string.glob.shell
 #                 ^ punctuation.section.interpolation.end.shell
 
 : ${foo[@],pattern}
@@ -8098,7 +8098,7 @@ a\/b/c/d}
 #       ^ variable.language.array.shell
 #        ^ punctuation.section.item-access.end.shell
 #         ^ keyword.operator.expansion.shell
-#          ^^^^^^^ meta.string.regexp.shell
+#          ^^^^^^^ meta.string.glob.shell
 #                 ^ punctuation.section.interpolation.end.shell
 
 : ${foo, #pattern} # comment
@@ -8106,21 +8106,21 @@ a\/b/c/d}
 # ^ punctuation.definition.variable.shell
 #  ^ punctuation.section.interpolation.begin.shell
 #      ^ keyword.operator.expansion.shell
-#       ^^^^^^^^^ meta.string.regexp.shell
+#       ^^^^^^^^^ meta.string.glob.shell
 #        ^ - comment - keyword
 #                ^ punctuation.section.interpolation.end.shell
 #                  ^^^^^^^^^^ comment.line.number-sign.shell
 
 : ${foo, #} # hello
 #      ^ keyword.operator.expansion.shell
-#       ^^ meta.string.regexp.shell
+#       ^^ meta.string.glob.shell
 #        ^ - comment.line
 #         ^ punctuation.section.interpolation.end.shell
 #           ^ comment.line punctuation
 
 : ${foo,\ \#} # hello
 #      ^ keyword.operator.expansion.shell
-#       ^^^^ meta.string.regexp.shell constant.character.escape.shell
+#       ^^^^ meta.string.glob.shell constant.character.escape.shell
 #          ^ - comment.line
 #           ^ punctuation.section.interpolation.end.shell
 #             ^ comment.line punctuation
@@ -8128,13 +8128,13 @@ a\/b/c/d}
 : ${foo,~}
 # ^^^^^^^^ meta.interpolation.parameter.shell
 #      ^ keyword.operator.expansion.shell
-#       ^ meta.string.regexp.shell string.unquoted.shell
+#       ^ meta.string.glob.shell string.unquoted.shell
 #        ^ punctuation.section.interpolation.end.shell
 
 : ${foo,[abx]}
 # ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #      ^ keyword.operator.expansion.shell
-#       ^^^^^ meta.string.regexp.shell string.unquoted.shell meta.character-class.regexp.shell
+#       ^^^^^ meta.string.glob.shell string.unquoted.shell meta.character-class.glob.shell
 
 ################################
 # ${parameter,,pattern}
@@ -8143,49 +8143,49 @@ a\/b/c/d}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^^ keyword.operator.expansion.shell
-#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#      ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${*,,pattern}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^^ keyword.operator.expansion.shell
-#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#      ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${#,,pattern}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^^ keyword.operator.expansion.shell
-#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#      ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${?,,pattern}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^^ keyword.operator.expansion.shell
-#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#      ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${$,,pattern}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^^ keyword.operator.expansion.shell
-#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#      ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${-,,pattern}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^^ keyword.operator.expansion.shell
-#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#      ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${!,,pattern}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^^ keyword.operator.expansion.shell
-#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#      ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${_,,pattern}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.builtin.shell
 #    ^^ keyword.operator.expansion.shell
-#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#      ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${foo,,}
 # ^^^^^^^^ meta.interpolation.parameter.shell
@@ -8199,7 +8199,7 @@ a\/b/c/d}
 # ^ punctuation.definition.variable.shell
 #  ^ punctuation.section.interpolation.begin.shell
 #      ^^ keyword.operator.expansion.shell
-#        ^^^^^^^ meta.string.regexp.shell
+#        ^^^^^^^ meta.string.glob.shell
 #               ^ punctuation.section.interpolation.end.shell
 
 : ${foo,,,pattern}
@@ -8207,7 +8207,7 @@ a\/b/c/d}
 # ^ punctuation.definition.variable.shell
 #  ^ punctuation.section.interpolation.begin.shell
 #      ^^ keyword.operator.expansion.shell
-#        ^^^^^^^^ meta.string.regexp.shell
+#        ^^^^^^^^ meta.string.glob.shell
 #        ^ - keyword
 #                ^ punctuation.section.interpolation.end.shell
 
@@ -8218,7 +8218,7 @@ a\/b/c/d}
 #   ^^^ variable.other.readwrite.shell
 #      ^ variable.language.special.shell
 #       ^^ keyword.operator.expansion.shell
-#         ^^^^^^^ meta.string.regexp.shell
+#         ^^^^^^^ meta.string.glob.shell
 #                ^ punctuation.section.interpolation.end.shell
 
 : ${foo*,,pattern}
@@ -8228,7 +8228,7 @@ a\/b/c/d}
 #   ^^^ variable.other.readwrite.shell
 #      ^ variable.language.special.shell
 #       ^^ keyword.operator.expansion.shell
-#         ^^^^^^^ meta.string.regexp.shell
+#         ^^^^^^^ meta.string.glob.shell
 #                ^ punctuation.section.interpolation.end.shell
 
 : ${foo[@],,pattern}
@@ -8241,7 +8241,7 @@ a\/b/c/d}
 #       ^ variable.language.array.shell
 #        ^ punctuation.section.item-access.end.shell
 #         ^^ keyword.operator.expansion.shell
-#           ^^^^^^^ meta.string.regexp.shell
+#           ^^^^^^^ meta.string.glob.shell
 #                  ^ punctuation.section.interpolation.end.shell
 
 : ${foo[@],,pattern}
@@ -8254,19 +8254,19 @@ a\/b/c/d}
 #       ^ variable.language.array.shell
 #        ^ punctuation.section.item-access.end.shell
 #         ^^ keyword.operator.expansion.shell
-#           ^^^^^^^ meta.string.regexp.shell
+#           ^^^^^^^ meta.string.glob.shell
 #                  ^ punctuation.section.interpolation.end.shell
 
 : ${foo,,~}
 # ^^^^^^^^^ meta.interpolation.parameter.shell
 #      ^^ keyword.operator.expansion.shell
-#        ^ meta.string.regexp.shell string.unquoted.shell
+#        ^ meta.string.glob.shell string.unquoted.shell
 #         ^ punctuation.section.interpolation.end.shell
 
 : ${foo,,[abx]}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #      ^^ keyword.operator.expansion.shell
-#        ^^^^^ meta.string.regexp.shell string.unquoted.shell meta.character-class.regexp.shell
+#        ^^^^^ meta.string.glob.shell string.unquoted.shell meta.character-class.glob.shell
 
 ################################
 # ${parameter^pattern}
@@ -8275,49 +8275,49 @@ a\/b/c/d}
 # ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^ keyword.operator.expansion.shell
-#     ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#     ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${*^pattern}
 # ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^ keyword.operator.expansion.shell
-#     ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#     ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${#^pattern}
 # ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^ keyword.operator.expansion.shell
-#     ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#     ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${?^pattern}
 # ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^ keyword.operator.expansion.shell
-#     ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#     ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${$^pattern}
 # ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^ keyword.operator.expansion.shell
-#     ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#     ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${-^pattern}
 # ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^ keyword.operator.expansion.shell
-#     ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#     ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${!^pattern}
 # ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^ keyword.operator.expansion.shell
-#     ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#     ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${_^pattern}
 # ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.builtin.shell
 #    ^ keyword.operator.expansion.shell
-#     ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#     ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${foo^}
 # ^^^^^^^ meta.interpolation.parameter.shell
@@ -8331,7 +8331,7 @@ a\/b/c/d}
 # ^ punctuation.definition.variable.shell
 #  ^ punctuation.section.interpolation.begin.shell
 #      ^ keyword.operator.expansion.shell
-#       ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#       ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 #              ^ punctuation.section.interpolation.end.shell
 
 : ${foo@^pattern}
@@ -8341,7 +8341,7 @@ a\/b/c/d}
 #   ^^^ variable.other.readwrite.shell
 #      ^ variable.language.special.shell
 #       ^ keyword.operator.expansion.shell
-#        ^^^^^^^ meta.string.regexp.shell
+#        ^^^^^^^ meta.string.glob.shell
 #               ^ punctuation.section.interpolation.end.shell
 
 : ${foo*^pattern}
@@ -8351,7 +8351,7 @@ a\/b/c/d}
 #   ^^^ variable.other.readwrite.shell
 #      ^ variable.language.special.shell
 #       ^ keyword.operator.expansion.shell
-#        ^^^^^^^ meta.string.regexp.shell
+#        ^^^^^^^ meta.string.glob.shell
 #               ^ punctuation.section.interpolation.end.shell
 
 : ${foo[@]^pattern}
@@ -8364,7 +8364,7 @@ a\/b/c/d}
 #       ^ variable.language.array.shell
 #        ^ punctuation.section.item-access.end.shell
 #         ^ keyword.operator.expansion.shell
-#          ^^^^^^^ meta.string.regexp.shell
+#          ^^^^^^^ meta.string.glob.shell
 #                 ^ punctuation.section.interpolation.end.shell
 
 : ${foo[@]^pattern}
@@ -8377,7 +8377,7 @@ a\/b/c/d}
 #       ^ variable.language.array.shell
 #        ^ punctuation.section.item-access.end.shell
 #         ^ keyword.operator.expansion.shell
-#          ^^^^^^^ meta.string.regexp.shell
+#          ^^^^^^^ meta.string.glob.shell
 #                 ^ punctuation.section.interpolation.end.shell
 
 : ${foo^ #pattern} # comment
@@ -8385,21 +8385,21 @@ a\/b/c/d}
 # ^ punctuation.definition.variable.shell
 #  ^ punctuation.section.interpolation.begin.shell
 #      ^ keyword.operator.expansion.shell
-#       ^^^^^^^^^ meta.string.regexp.shell
+#       ^^^^^^^^^ meta.string.glob.shell
 #        ^ - comment - keyword
 #                ^ punctuation.section.interpolation.end.shell
 #                  ^^^^^^^^^^ comment.line.number-sign.shell
 
 : ${foo^ #} # hello
 #      ^ keyword.operator.expansion.shell
-#       ^^ meta.string.regexp.shell
+#       ^^ meta.string.glob.shell
 #        ^ - comment.line
 #         ^ punctuation.section.interpolation.end.shell
 #           ^ comment.line punctuation
 
 : ${foo^\ \#} # hello
 #      ^ keyword.operator.expansion.shell
-#       ^^^^ meta.string.regexp.shell constant.character.escape.shell
+#       ^^^^ meta.string.glob.shell constant.character.escape.shell
 #          ^ - comment.line
 #           ^ punctuation.section.interpolation.end.shell
 #             ^ comment.line punctuation
@@ -8407,13 +8407,13 @@ a\/b/c/d}
 : ${foo^~}
 # ^^^^^^^^ meta.interpolation.parameter.shell
 #      ^ keyword.operator.expansion.shell
-#       ^ meta.string.regexp.shell string.unquoted.shell
+#       ^ meta.string.glob.shell string.unquoted.shell
 #        ^ punctuation.section.interpolation.end.shell
 
 : ${foo^[abx]}
 # ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #      ^ keyword.operator.expansion.shell
-#       ^^^^^ meta.string.regexp.shell string.unquoted.shell meta.character-class.regexp.shell
+#       ^^^^^ meta.string.glob.shell string.unquoted.shell meta.character-class.glob.shell
 
 ################################
 # ${parameter^^pattern}
@@ -8422,49 +8422,49 @@ a\/b/c/d}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^^ keyword.operator.expansion.shell
-#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#      ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${*^^pattern}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^^ keyword.operator.expansion.shell
-#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#      ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${#^^pattern}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^^ keyword.operator.expansion.shell
-#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#      ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${?^^pattern}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^^ keyword.operator.expansion.shell
-#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#      ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${$^^pattern}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^^ keyword.operator.expansion.shell
-#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#      ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${-^^pattern}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^^ keyword.operator.expansion.shell
-#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#      ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${!^^pattern}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^^ keyword.operator.expansion.shell
-#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#      ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${_^^pattern}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.builtin.shell
 #    ^^ keyword.operator.expansion.shell
-#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#      ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${foo^^}
 # ^^^^^^^^ meta.interpolation.parameter.shell
@@ -8478,7 +8478,7 @@ a\/b/c/d}
 # ^ punctuation.definition.variable.shell
 #  ^ punctuation.section.interpolation.begin.shell
 #      ^^ keyword.operator.expansion.shell
-#        ^^^^^^^ meta.string.regexp.shell
+#        ^^^^^^^ meta.string.glob.shell
 #               ^ punctuation.section.interpolation.end.shell
 
 : ${foo^^^pattern}
@@ -8486,7 +8486,7 @@ a\/b/c/d}
 # ^ punctuation.definition.variable.shell
 #  ^ punctuation.section.interpolation.begin.shell
 #      ^^ keyword.operator.expansion.shell
-#        ^^^^^^^^ meta.string.regexp.shell
+#        ^^^^^^^^ meta.string.glob.shell
 #        ^ - keyword
 #                ^ punctuation.section.interpolation.end.shell
 
@@ -8497,7 +8497,7 @@ a\/b/c/d}
 #   ^^^ variable.other.readwrite.shell
 #      ^ variable.language.special.shell
 #       ^^ keyword.operator.expansion.shell
-#         ^^^^^^^ meta.string.regexp.shell
+#         ^^^^^^^ meta.string.glob.shell
 #                ^ punctuation.section.interpolation.end.shell
 
 : ${foo*^^pattern}
@@ -8507,7 +8507,7 @@ a\/b/c/d}
 #   ^^^ variable.other.readwrite.shell
 #      ^ variable.language.special.shell
 #       ^^ keyword.operator.expansion.shell
-#         ^^^^^^^ meta.string.regexp.shell
+#         ^^^^^^^ meta.string.glob.shell
 #                ^ punctuation.section.interpolation.end.shell
 
 : ${foo[@]^^pattern}
@@ -8520,7 +8520,7 @@ a\/b/c/d}
 #       ^ variable.language.array.shell
 #        ^ punctuation.section.item-access.end.shell
 #         ^^ keyword.operator.expansion.shell
-#           ^^^^^^^ meta.string.regexp.shell
+#           ^^^^^^^ meta.string.glob.shell
 #                  ^ punctuation.section.interpolation.end.shell
 
 : ${foo[@]^^pattern}
@@ -8533,19 +8533,19 @@ a\/b/c/d}
 #       ^ variable.language.array.shell
 #        ^ punctuation.section.item-access.end.shell
 #         ^^ keyword.operator.expansion.shell
-#           ^^^^^^^ meta.string.regexp.shell
+#           ^^^^^^^ meta.string.glob.shell
 #                  ^ punctuation.section.interpolation.end.shell
 
 : ${foo^^~}
 # ^^^^^^^^^ meta.interpolation.parameter.shell
 #      ^^ keyword.operator.expansion.shell
-#        ^ meta.string.regexp.shell string.unquoted.shell
+#        ^ meta.string.glob.shell string.unquoted.shell
 #         ^ punctuation.section.interpolation.end.shell
 
 : ${foo^^[abx]}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #      ^^ keyword.operator.expansion.shell
-#        ^^^^^ meta.string.regexp.shell string.unquoted.shell meta.character-class.regexp.shell
+#        ^^^^^ meta.string.glob.shell string.unquoted.shell meta.character-class.glob.shell
 
 ################################
 # ${parameter~pattern}
@@ -8554,49 +8554,49 @@ a\/b/c/d}
 # ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^ keyword.operator.expansion.shell
-#     ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#     ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${*~pattern}
 # ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^ keyword.operator.expansion.shell
-#     ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#     ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${#~pattern}
 # ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^ keyword.operator.expansion.shell
-#     ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#     ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${?~pattern}
 # ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^ keyword.operator.expansion.shell
-#     ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#     ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${$~pattern}
 # ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^ keyword.operator.expansion.shell
-#     ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#     ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${-~pattern}
 # ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^ keyword.operator.expansion.shell
-#     ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#     ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${!~pattern}
 # ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^ keyword.operator.expansion.shell
-#     ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#     ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${_~pattern}
 # ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.builtin.shell
 #    ^ keyword.operator.expansion.shell
-#     ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#     ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${foo~}
 # ^^^^^^^ meta.interpolation.parameter.shell
@@ -8610,7 +8610,7 @@ a\/b/c/d}
 # ^ punctuation.definition.variable.shell
 #  ^ punctuation.section.interpolation.begin.shell
 #      ^ keyword.operator.expansion.shell
-#       ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#       ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 #              ^ punctuation.section.interpolation.end.shell
 
 : ${foo@~pattern}
@@ -8620,7 +8620,7 @@ a\/b/c/d}
 #   ^^^ variable.other.readwrite.shell
 #      ^ variable.language.special.shell
 #       ^ keyword.operator.expansion.shell
-#        ^^^^^^^ meta.string.regexp.shell
+#        ^^^^^^^ meta.string.glob.shell
 #               ^ punctuation.section.interpolation.end.shell
 
 : ${foo*~pattern}
@@ -8630,7 +8630,7 @@ a\/b/c/d}
 #   ^^^ variable.other.readwrite.shell
 #      ^ variable.language.special.shell
 #       ^ keyword.operator.expansion.shell
-#        ^^^^^^^ meta.string.regexp.shell
+#        ^^^^^^^ meta.string.glob.shell
 #               ^ punctuation.section.interpolation.end.shell
 
 : ${foo[@]~pattern}
@@ -8643,7 +8643,7 @@ a\/b/c/d}
 #       ^ variable.language.array.shell
 #        ^ punctuation.section.item-access.end.shell
 #         ^ keyword.operator.expansion.shell
-#          ^^^^^^^ meta.string.regexp.shell
+#          ^^^^^^^ meta.string.glob.shell
 #                 ^ punctuation.section.interpolation.end.shell
 
 : ${foo[@]~pattern}
@@ -8656,7 +8656,7 @@ a\/b/c/d}
 #       ^ variable.language.array.shell
 #        ^ punctuation.section.item-access.end.shell
 #         ^ keyword.operator.expansion.shell
-#          ^^^^^^^ meta.string.regexp.shell
+#          ^^^^^^^ meta.string.glob.shell
 #                 ^ punctuation.section.interpolation.end.shell
 
 : ${foo~ #pattern} # comment
@@ -8664,21 +8664,21 @@ a\/b/c/d}
 # ^ punctuation.definition.variable.shell
 #  ^ punctuation.section.interpolation.begin.shell
 #      ^ keyword.operator.expansion.shell
-#       ^^^^^^^^^ meta.string.regexp.shell
+#       ^^^^^^^^^ meta.string.glob.shell
 #        ^ - comment - keyword
 #                ^ punctuation.section.interpolation.end.shell
 #                  ^^^^^^^^^^ comment.line.number-sign.shell
 
 : ${foo~ #} # hello
 #      ^ keyword.operator.expansion.shell
-#       ^^ meta.string.regexp.shell
+#       ^^ meta.string.glob.shell
 #        ^ - comment.line
 #         ^ punctuation.section.interpolation.end.shell
 #           ^ comment.line punctuation
 
 : ${foo~\ \#} # hello
 #      ^ keyword.operator.expansion.shell
-#       ^^^^ meta.string.regexp.shell constant.character.escape.shell
+#       ^^^^ meta.string.glob.shell constant.character.escape.shell
 #          ^ - comment.line
 #           ^ punctuation.section.interpolation.end.shell
 #             ^ comment.line punctuation
@@ -8691,7 +8691,7 @@ a\/b/c/d}
 : ${foo~[abx]}
 # ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #      ^ keyword.operator.expansion.shell
-#       ^^^^^ meta.string.regexp.shell string.unquoted.shell meta.character-class.regexp.shell
+#       ^^^^^ meta.string.glob.shell string.unquoted.shell meta.character-class.glob.shell
 
 ################################
 # ${parameter~~pattern}
@@ -8700,49 +8700,49 @@ a\/b/c/d}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^^ keyword.operator.expansion.shell
-#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#      ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${*~~pattern}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^^ keyword.operator.expansion.shell
-#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#      ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${#~~pattern}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^^ keyword.operator.expansion.shell
-#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#      ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${?~~pattern}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^^ keyword.operator.expansion.shell
-#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#      ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${$~~pattern}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^^ keyword.operator.expansion.shell
-#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#      ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${-~~pattern}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^^ keyword.operator.expansion.shell
-#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#      ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${!~~pattern}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.special.shell
 #    ^^ keyword.operator.expansion.shell
-#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#      ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${_~~pattern}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #   ^ variable.language.builtin.shell
 #    ^^ keyword.operator.expansion.shell
-#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#      ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 
 : ${foo~~}
 # ^^^^^^^^ meta.interpolation.parameter.shell
@@ -8756,7 +8756,7 @@ a\/b/c/d}
 # ^ punctuation.definition.variable.shell
 #  ^ punctuation.section.interpolation.begin.shell
 #      ^^ keyword.operator.expansion.shell
-#        ^^^^^^^ meta.string.regexp.shell
+#        ^^^^^^^ meta.string.glob.shell
 #               ^ punctuation.section.interpolation.end.shell
 
 : ${foo~~~pattern}
@@ -8764,7 +8764,7 @@ a\/b/c/d}
 # ^ punctuation.definition.variable.shell
 #  ^ punctuation.section.interpolation.begin.shell
 #      ^^ keyword.operator.expansion.shell
-#        ^^^^^^^^ meta.string.regexp.shell
+#        ^^^^^^^^ meta.string.glob.shell
 #        ^ - keyword
 #                ^ punctuation.section.interpolation.end.shell
 
@@ -8775,7 +8775,7 @@ a\/b/c/d}
 #   ^^^ variable.other.readwrite.shell
 #      ^ variable.language.special.shell
 #       ^^ keyword.operator.expansion.shell
-#         ^^^^^^^ meta.string.regexp.shell
+#         ^^^^^^^ meta.string.glob.shell
 #                ^ punctuation.section.interpolation.end.shell
 
 : ${foo*~~pattern}
@@ -8785,7 +8785,7 @@ a\/b/c/d}
 #   ^^^ variable.other.readwrite.shell
 #      ^ variable.language.special.shell
 #       ^^ keyword.operator.expansion.shell
-#         ^^^^^^^ meta.string.regexp.shell
+#         ^^^^^^^ meta.string.glob.shell
 #                ^ punctuation.section.interpolation.end.shell
 
 : ${foo[@]~~pattern}
@@ -8798,7 +8798,7 @@ a\/b/c/d}
 #       ^ variable.language.array.shell
 #        ^ punctuation.section.item-access.end.shell
 #         ^^ keyword.operator.expansion.shell
-#           ^^^^^^^ meta.string.regexp.shell
+#           ^^^^^^^ meta.string.glob.shell
 #                  ^ punctuation.section.interpolation.end.shell
 
 : ${foo[@]~~pattern}
@@ -8811,19 +8811,19 @@ a\/b/c/d}
 #       ^ variable.language.array.shell
 #        ^ punctuation.section.item-access.end.shell
 #         ^^ keyword.operator.expansion.shell
-#           ^^^^^^^ meta.string.regexp.shell
+#           ^^^^^^^ meta.string.glob.shell
 #                  ^ punctuation.section.interpolation.end.shell
 
 : ${foo~~~}
 # ^^^^^^^^^ meta.interpolation.parameter.shell
 #      ^^ keyword.operator.expansion.shell
-#        ^ meta.string.regexp.shell string.unquoted.shell
+#        ^ meta.string.glob.shell string.unquoted.shell
 #         ^ punctuation.section.interpolation.end.shell
 
 : ${foo~~[abx]}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #      ^^ keyword.operator.expansion.shell
-#        ^^^^^ meta.string.regexp.shell string.unquoted.shell meta.character-class.regexp.shell
+#        ^^^^^ meta.string.glob.shell string.unquoted.shell meta.character-class.glob.shell
 
 ################################
 # ${parameter@operator}
@@ -9036,9 +9036,9 @@ a\/b/c/d}
 status="${status#"${status%%[![:space:]]*}"}"
 #      ^ meta.string.glob.shell string.quoted.double.shell - meta.interpolation
 #       ^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.interpolation meta.interpolation
-#                ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.string.regexp.shell - meta.interpolation meta.interpolation
-#                 ^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.string.regexp.shell meta.interpolation.parameter.shell
-#                                         ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.string.regexp.shell - meta.interpolation meta.interpolation
+#                ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.string.glob.shell - meta.interpolation meta.interpolation
+#                 ^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.string.glob.shell meta.interpolation.parameter.shell
+#                                         ^ meta.string.glob.shell meta.interpolation.parameter.shell meta.string.glob.shell - meta.interpolation meta.interpolation
 #                                          ^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.interpolation meta.interpolation
 #                                           ^ meta.string.glob.shell string.quoted.double.shell - meta.interpolation
 #                                            ^ - meta - string
@@ -9046,11 +9046,11 @@ status="${status#"${status%%[![:space:]]*}"}"
 #               ^ keyword.operator.expansion.shell
 #                ^ punctuation.definition.string.begin.shell
 #                         ^^ keyword.operator.expansion.shell
-#                           ^ punctuation.definition.character-class.begin.regexp.shell
-#                            ^ keyword.operator.logical.regexp.shell
-#                             ^^ punctuation.definition.character-class.begin.regexp.shell
-#                               ^^^^^ constant.other.character-class.posix.regexp.shell
-#                                    ^^^ punctuation.definition.character-class.end.regexp.shell
+#                           ^ punctuation.definition.character-class.begin.glob.shell
+#                            ^ keyword.operator.logical.glob.shell
+#                             ^^ punctuation.definition.character-class.begin.glob.shell
+#                               ^^^^^ constant.other.character-class.posix.glob.shell
+#                                    ^^^ punctuation.definition.character-class.end.glob.shell
 #                                       ^ constant.other.wildcard.asterisk.shell
 #                                        ^ punctuation.section.interpolation.end.shell
 #                                         ^ punctuation.definition.string.end.shell
@@ -9059,26 +9059,26 @@ status="${status#"${status%%[![:space:]]*}"}"
 status="${status#${status%%[![:space:]]*}}"
 #      ^ meta.string.glob.shell string.quoted.double.shell - meta.interpolation
 #       ^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell - meta.interpolation meta.interpolation
-#                ^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.string.regexp.shell meta.interpolation.parameter.shell
+#                ^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell meta.string.glob.shell meta.interpolation.parameter.shell
 #                                        ^ meta.string.glob.shell meta.interpolation.parameter.shell
 #                                         ^ meta.string.glob.shell string.quoted.double.shell - meta.interpolation
 #                                          ^ - meta - string
 #     ^ keyword.operator.assignment.shell
 #               ^ keyword.operator.expansion.shell
 #                        ^^ keyword.operator.expansion.shell
-#                          ^ punctuation.definition.character-class.begin.regexp.shell
-#                           ^ keyword.operator.logical.regexp.shell
-#                            ^ punctuation.definition.character-class.begin.regexp.shell
-#                                    ^^ punctuation.definition.character-class.end.regexp.shell
+#                          ^ punctuation.definition.character-class.begin.glob.shell
+#                           ^ keyword.operator.logical.glob.shell
+#                            ^ punctuation.definition.character-class.begin.glob.shell
+#                                    ^^ punctuation.definition.character-class.end.glob.shell
 #                                      ^ constant.other.wildcard.asterisk.shell
 
 CURPOS=${CURPOS#*[}
 #               ^ constant.other.wildcard.asterisk.shell
-#                ^ - keyword.control.regexp.shell
+#                ^ - keyword.control.glob.shell
 
 echo "${ROW#*[}"
 #           ^ constant.other.wildcard.asterisk.shell
-#            ^ - keyword.control.regexp.shell
+#            ^ - keyword.control.glob.shell
 
 echo ca{${x/z/t}" "{legs,f${o//a/o}d,f${o:0:1}t},r" "{tires,wh${o//a/e}ls}}
 #      ^ punctuation.section.interpolation.begin.shell
@@ -9300,145 +9300,145 @@ $[var + 1]
 
 : @([^:]*)
 #^^^^^^^^^ meta.function-call.arguments.shell
-# ^ keyword.operator.quantifier.regexp.shell
-#  ^ punctuation.section.group.begin.regexp.shell
-#   ^ punctuation.definition.character-class.begin.regexp.shell
-#    ^ keyword.operator.logical.regexp.shell
-#      ^ punctuation.definition.character-class.end.regexp.shell
+# ^ keyword.operator.quantifier.glob.shell
+#  ^ punctuation.section.group.begin.glob.shell
+#   ^ punctuation.definition.character-class.begin.glob.shell
+#    ^ keyword.operator.logical.glob.shell
+#      ^ punctuation.definition.character-class.end.glob.shell
 #       ^ constant.other.wildcard.asterisk.shell
-#        ^ punctuation.section.group.end.regexp.shell
+#        ^ punctuation.section.group.end.glob.shell
 
 : @([[] []] [![] [!]] [^[] [^]])
-#   ^^^ meta.group.regexp.shell meta.character-class.regexp.shell
-#   ^ punctuation.definition.character-class.begin.regexp.shell
+#   ^^^ meta.group.glob.shell meta.character-class.glob.shell
+#   ^ punctuation.definition.character-class.begin.glob.shell
 #    ^ - punctuation
-#     ^ punctuation.definition.character-class.end.regexp.shell
-#       ^^^ meta.group.regexp.shell meta.character-class.regexp.shell
-#       ^ punctuation.definition.character-class.begin.regexp.shell
+#     ^ punctuation.definition.character-class.end.glob.shell
+#       ^^^ meta.group.glob.shell meta.character-class.glob.shell
+#       ^ punctuation.definition.character-class.begin.glob.shell
 #        ^ - punctuation
-#         ^ punctuation.definition.character-class.end.regexp.shell
-#           ^^^^ meta.group.regexp.shell meta.character-class.regexp.shell
-#           ^ punctuation.definition.character-class.begin.regexp.shell
-#            ^ keyword.operator.logical.regexp.shell
+#         ^ punctuation.definition.character-class.end.glob.shell
+#           ^^^^ meta.group.glob.shell meta.character-class.glob.shell
+#           ^ punctuation.definition.character-class.begin.glob.shell
+#            ^ keyword.operator.logical.glob.shell
 #             ^ - punctuation
-#              ^ punctuation.definition.character-class.end.regexp.shell
-#                ^^^^ meta.group.regexp.shell meta.character-class.regexp.shell
-#                ^ punctuation.definition.character-class.begin.regexp.shell
-#                 ^ keyword.operator.logical.regexp.shell
+#              ^ punctuation.definition.character-class.end.glob.shell
+#                ^^^^ meta.group.glob.shell meta.character-class.glob.shell
+#                ^ punctuation.definition.character-class.begin.glob.shell
+#                 ^ keyword.operator.logical.glob.shell
 #                  ^ - punctuation
-#                   ^ punctuation.definition.character-class.end.regexp.shell
-#                     ^^^^ meta.group.regexp.shell meta.character-class.regexp.shell
-#                     ^ punctuation.definition.character-class.begin.regexp.shell
-#                      ^ keyword.operator.logical.regexp.shell
+#                   ^ punctuation.definition.character-class.end.glob.shell
+#                     ^^^^ meta.group.glob.shell meta.character-class.glob.shell
+#                     ^ punctuation.definition.character-class.begin.glob.shell
+#                      ^ keyword.operator.logical.glob.shell
 #                       ^ - punctuation
-#                        ^ punctuation.definition.character-class.end.regexp.shell
-#                          ^^^^ meta.group.regexp.shell meta.character-class.regexp.shell
-#                          ^ punctuation.definition.character-class.begin.regexp.shell
-#                           ^ keyword.operator.logical.regexp.shell
+#                        ^ punctuation.definition.character-class.end.glob.shell
+#                          ^^^^ meta.group.glob.shell meta.character-class.glob.shell
+#                          ^ punctuation.definition.character-class.begin.glob.shell
+#                           ^ keyword.operator.logical.glob.shell
 #                            ^ - punctuation
-#                             ^ punctuation.definition.character-class.end.regexp.shell
+#                             ^ punctuation.definition.character-class.end.glob.shell
 
 : @([-[] [-]] [[-)] []-)] [!-[] [!-]] [^-[] [^-]])
-#   ^^^^ meta.group.regexp.shell meta.character-class.regexp.shell
-#   ^ punctuation.definition.character-class.begin.regexp.shell
+#   ^^^^ meta.group.glob.shell meta.character-class.glob.shell
+#   ^ punctuation.definition.character-class.begin.glob.shell
 #    ^^ - punctuation
-#      ^ punctuation.definition.character-class.end.regexp.shell
-#        ^^^ meta.group.regexp.shell meta.character-class.regexp.shell
-#        ^ punctuation.definition.character-class.begin.regexp.shell
+#      ^ punctuation.definition.character-class.end.glob.shell
+#        ^^^ meta.group.glob.shell meta.character-class.glob.shell
+#        ^ punctuation.definition.character-class.begin.glob.shell
 #         ^ - punctuation
-#          ^ punctuation.definition.character-class.end.regexp.shell
+#          ^ punctuation.definition.character-class.end.glob.shell
 #           ^ - punctuation
-#             ^^^^^ meta.group.regexp.shell meta.character-class.regexp.shell
-#             ^ punctuation.definition.character-class.begin.regexp.shell
-#              ^^^ constant.other.range.regexp.shell
-#                 ^ punctuation.definition.character-class.end.regexp.shell
-#                   ^^^^^ meta.group.regexp.shell meta.character-class.regexp.shell
-#                   ^ punctuation.definition.character-class.begin.regexp.shell
-#                    ^^^ constant.other.range.regexp.shell
-#                       ^ punctuation.definition.character-class.end.regexp.shell
-#                         ^^^^^ meta.group.regexp.shell meta.character-class.regexp.shell
-#                         ^ punctuation.definition.character-class.begin.regexp.shell
-#                          ^ keyword.operator.logical.regexp.shell
+#             ^^^^^ meta.group.glob.shell meta.character-class.glob.shell
+#             ^ punctuation.definition.character-class.begin.glob.shell
+#              ^^^ constant.other.range.glob.shell
+#                 ^ punctuation.definition.character-class.end.glob.shell
+#                   ^^^^^ meta.group.glob.shell meta.character-class.glob.shell
+#                   ^ punctuation.definition.character-class.begin.glob.shell
+#                    ^^^ constant.other.range.glob.shell
+#                       ^ punctuation.definition.character-class.end.glob.shell
+#                         ^^^^^ meta.group.glob.shell meta.character-class.glob.shell
+#                         ^ punctuation.definition.character-class.begin.glob.shell
+#                          ^ keyword.operator.logical.glob.shell
 #                           ^^ - punctuation
-#                             ^ punctuation.definition.character-class.end.regexp.shell
-#                               ^^^^ meta.group.regexp.shell meta.character-class.regexp.shell
-#                               ^ punctuation.definition.character-class.begin.regexp.shell
-#                                ^ keyword.operator.logical.regexp.shell
+#                             ^ punctuation.definition.character-class.end.glob.shell
+#                               ^^^^ meta.group.glob.shell meta.character-class.glob.shell
+#                               ^ punctuation.definition.character-class.begin.glob.shell
+#                                ^ keyword.operator.logical.glob.shell
 #                                 ^ - punctuation
-#                                  ^ punctuation.definition.character-class.end.regexp.shell
+#                                  ^ punctuation.definition.character-class.end.glob.shell
 #                                   ^ - punctuation
-#                                     ^^^^^ meta.group.regexp.shell meta.character-class.regexp.shell
-#                                     ^ punctuation.definition.character-class.begin.regexp.shell
-#                                      ^ keyword.operator.logical.regexp.shell
+#                                     ^^^^^ meta.group.glob.shell meta.character-class.glob.shell
+#                                     ^ punctuation.definition.character-class.begin.glob.shell
+#                                      ^ keyword.operator.logical.glob.shell
 #                                       ^^ - punctuation
-#                                         ^ punctuation.definition.character-class.end.regexp.shell
-#                                           ^^^^ meta.group.regexp.shell meta.character-class.regexp.shell
-#                                           ^ punctuation.definition.character-class.begin.regexp.shell
-#                                            ^ keyword.operator.logical.regexp.shell
+#                                         ^ punctuation.definition.character-class.end.glob.shell
+#                                           ^^^^ meta.group.glob.shell meta.character-class.glob.shell
+#                                           ^ punctuation.definition.character-class.begin.glob.shell
+#                                            ^ keyword.operator.logical.glob.shell
 #                                             ^ - punctuation
-#                                              ^ punctuation.definition.character-class.end.regexp.shell
+#                                              ^ punctuation.definition.character-class.end.glob.shell
 #                                               ^ - punctuation
 
 : @([.c.] [.c. ] [[.c.]] [^[.c.]] [[^.c.]])
-#   ^^^^^ meta.character-class.regexp.shell
+#   ^^^^^ meta.character-class.glob.shell
 #        ^ - meta.character-class
-#         ^^^^^^ meta.character-class.regexp.shell
+#         ^^^^^^ meta.character-class.glob.shell
 #               ^ - meta.character-class
-#                ^ meta.character-class.regexp.shell - meta.character-class meta.character-class
-#                 ^^^^^ meta.character-class.regexp.shell meta.character-class.regexp.shell
-#                      ^ meta.character-class.regexp.shell - meta.character-class meta.character-class
+#                ^ meta.character-class.glob.shell - meta.character-class meta.character-class
+#                 ^^^^^ meta.character-class.glob.shell meta.character-class.glob.shell
+#                      ^ meta.character-class.glob.shell - meta.character-class meta.character-class
 #                       ^ - meta.character-class
-#                        ^^ meta.character-class.regexp.shell - meta.character-class meta.character-class
-#                          ^^^^^ meta.character-class.regexp.shell meta.character-class.regexp.shell
-#                               ^ meta.character-class.regexp.shell - meta.character-class meta.character-class
+#                        ^^ meta.character-class.glob.shell - meta.character-class meta.character-class
+#                          ^^^^^ meta.character-class.glob.shell meta.character-class.glob.shell
+#                               ^ meta.character-class.glob.shell - meta.character-class meta.character-class
 #                                ^ - meta.character-class
-#                                 ^^^^^^^ meta.character-class.regexp.shell - meta.character-class meta.character-class
+#                                 ^^^^^^^ meta.character-class.glob.shell - meta.character-class meta.character-class
 #                                        ^^ - meta.character-class
-#   ^ punctuation.definition.character-class.begin.regexp.shell
+#   ^ punctuation.definition.character-class.begin.glob.shell
 #    ^^^ - constant.character
-#       ^ punctuation.definition.character-class.end.regexp.shell
-#         ^ punctuation.definition.character-class.begin.regexp.shell
+#       ^ punctuation.definition.character-class.end.glob.shell
+#         ^ punctuation.definition.character-class.begin.glob.shell
 #          ^^^^ - constant.character.collate
-#              ^ punctuation.definition.character-class.end.regexp.shell
-#                ^^^ punctuation.definition.character-class.begin.regexp.shell
-#                   ^ constant.other.character-class.collate.regexp.shell
-#                    ^^^ punctuation.definition.character-class.end.regexp.shell
-#                        ^ punctuation.definition.character-class.begin.regexp.shell
-#                         ^ keyword.operator.logical.regexp.shell
-#                          ^^ punctuation.definition.character-class.begin.regexp.shell
-#                            ^ constant.other.character-class.collate.regexp.shell
-#                             ^^^ punctuation.definition.character-class.end.regexp.shell
-#                                 ^ punctuation.definition.character-class.begin.regexp.shell
+#              ^ punctuation.definition.character-class.end.glob.shell
+#                ^^^ punctuation.definition.character-class.begin.glob.shell
+#                   ^ constant.other.character-class.collate.glob.shell
+#                    ^^^ punctuation.definition.character-class.end.glob.shell
+#                        ^ punctuation.definition.character-class.begin.glob.shell
+#                         ^ keyword.operator.logical.glob.shell
+#                          ^^ punctuation.definition.character-class.begin.glob.shell
+#                            ^ constant.other.character-class.collate.glob.shell
+#                             ^^^ punctuation.definition.character-class.end.glob.shell
+#                                 ^ punctuation.definition.character-class.begin.glob.shell
 #                                  ^^^^^ - keyword - punctuation - constant
-#                                       ^ punctuation.definition.character-class.end.regexp.shell
+#                                       ^ punctuation.definition.character-class.end.glob.shell
 #                                        ^ - punctuation
 
 : @([[=c=]] [[=c=illegal]])
-#   ^^^ punctuation.definition.character-class.begin.regexp.shell
-#      ^ constant.other.character-class.equivalence.regexp.shell - punctuation
-#       ^^^ punctuation.definition.character-class.end.regexp.shell
-#           ^ punctuation.definition.character-class.begin.regexp.shell
+#   ^^^ punctuation.definition.character-class.begin.glob.shell
+#      ^ constant.other.character-class.equivalence.glob.shell - punctuation
+#       ^^^ punctuation.definition.character-class.end.glob.shell
+#           ^ punctuation.definition.character-class.begin.glob.shell
 #            ^^^^^^^^^^^ - constant.character.equivalence-class
-#                       ^ punctuation.definition.character-class.end.regexp.shell
+#                       ^ punctuation.definition.character-class.end.glob.shell
 #                        ^ - punctuation
 
 : @([[:alnum:]] [[:alnum]] [[alnum:]] [[alnum]] [[:alnum:other]])
-#   ^^^ punctuation.definition.character-class.begin.regexp.shell
-#      ^^^^^ constant.other.character-class.posix.regexp.shell - punctuation
-#           ^^^ punctuation.definition.character-class.end.regexp.shell
+#   ^^^ punctuation.definition.character-class.begin.glob.shell
+#      ^^^^^ constant.other.character-class.posix.glob.shell - punctuation
+#           ^^^ punctuation.definition.character-class.end.glob.shell
 #               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - constant.other.posix-class
 
 : *(g[[:${charclass/\}/l}:]]*)
 #^^ meta.function-call.arguments.shell - meta.group
-#  ^^ meta.function-call.arguments.shell meta.group.regexp.shell - meta.character-class
-#    ^^^ meta.function-call.arguments.shell meta.string.glob.shell meta.group.regexp.shell meta.character-class.regexp.shell
-#       ^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell meta.string.glob.shell meta.group.regexp.shell meta.character-class.regexp.shell meta.character-class.regexp.shell meta.interpolation.parameter.shell
-#                        ^^^ meta.function-call.arguments.shell meta.string.glob.shell meta.group.regexp.shell meta.character-class.regexp.shell
-#                           ^^ meta.function-call.arguments.shell meta.string.glob.shell meta.group.regexp.shell - meta.character-class
+#  ^^ meta.function-call.arguments.shell meta.group.glob.shell - meta.character-class
+#    ^^^ meta.function-call.arguments.shell meta.string.glob.shell meta.group.glob.shell meta.character-class.glob.shell
+#       ^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell meta.string.glob.shell meta.group.glob.shell meta.character-class.glob.shell meta.character-class.glob.shell meta.interpolation.parameter.shell
+#                        ^^^ meta.function-call.arguments.shell meta.string.glob.shell meta.group.glob.shell meta.character-class.glob.shell
+#                           ^^ meta.function-call.arguments.shell meta.string.glob.shell meta.group.glob.shell - meta.character-class
 #                             ^ - meta.function-call - meta.group
-# ^ keyword.operator.quantifier.regexp.shell
-#  ^ punctuation.section.group.begin.regexp.shell
-#    ^^^ punctuation.definition.character-class.begin.regexp.shell
+# ^ keyword.operator.quantifier.glob.shell
+#  ^ punctuation.section.group.begin.glob.shell
+#    ^^^ punctuation.definition.character-class.begin.glob.shell
 #       ^ punctuation.definition.variable.shell
 #        ^ punctuation.section.interpolation.begin.shell
 #         ^^^^^^^^^ variable.other.readwrite.shell
@@ -9446,87 +9446,87 @@ $[var + 1]
 #                   ^^ constant.character.escape.shell
 #                     ^ keyword.operator.substitution.shell
 #                       ^ punctuation.section.interpolation.end.shell
-#                        ^^^ punctuation.definition.character-class.end.regexp.shell
+#                        ^^^ punctuation.definition.character-class.end.glob.shell
 #                           ^ constant.other.wildcard.asterisk.shell
-#                            ^ punctuation.section.group.end.regexp.shell
+#                            ^ punctuation.section.group.end.glob.shell
 
 : ?([[:alpha:]]|[[:digit:]]|[[:unknown:]])*
 #^^ meta.function-call.arguments.shell - meta.group
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell meta.group.regexp.shell
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell meta.group.glob.shell
 #                                         ^ meta.function-call.arguments.shell - meta.group
 #                                          ^ - meta.function-call - meta.group
-# ^ keyword.operator.quantifier.regexp.shell
-#  ^ punctuation.section.group.begin.regexp.shell
-#   ^^^ punctuation.definition.character-class.begin.regexp.shell
-#      ^^^^^ constant.other.character-class.posix.regexp.shell - punctuation
-#           ^^^ punctuation.definition.character-class.end.regexp.shell
-#              ^ keyword.operator.alternation.regexp.shell
-#               ^^^ punctuation.definition.character-class.begin.regexp.shell
-#                  ^^^^^ constant.other.character-class.posix.regexp.shell - punctuation
-#                       ^^^ punctuation.definition.character-class.end.regexp.shell
-#                          ^ keyword.operator.alternation.regexp.shell
-#                           ^ punctuation.definition.character-class.begin.regexp.shell
+# ^ keyword.operator.quantifier.glob.shell
+#  ^ punctuation.section.group.begin.glob.shell
+#   ^^^ punctuation.definition.character-class.begin.glob.shell
+#      ^^^^^ constant.other.character-class.posix.glob.shell - punctuation
+#           ^^^ punctuation.definition.character-class.end.glob.shell
+#              ^ keyword.operator.alternation.glob.shell
+#               ^^^ punctuation.definition.character-class.begin.glob.shell
+#                  ^^^^^ constant.other.character-class.posix.glob.shell - punctuation
+#                       ^^^ punctuation.definition.character-class.end.glob.shell
+#                          ^ keyword.operator.alternation.glob.shell
+#                           ^ punctuation.definition.character-class.begin.glob.shell
 #                            ^^^^^^^^^^ - constant.other.posix-class
-#                                      ^ punctuation.definition.character-class.end.regexp.shell
+#                                      ^ punctuation.definition.character-class.end.glob.shell
 #                                       ^ - punctuation
-#                                        ^ punctuation.section.group.end.regexp.shell
+#                                        ^ punctuation.section.group.end.glob.shell
 #                                         ^ constant.other.wildcard.asterisk.shell
 
 : @(foo*)*
 #^^ meta.function-call.arguments.shell - meta.group
-#  ^^^^^^ meta.function-call.arguments.shell meta.group.regexp.shell
+#  ^^^^^^ meta.function-call.arguments.shell meta.group.glob.shell
 #        ^ meta.function-call.arguments.shell - meta.group
 #         ^ - meta.function-call - meta.group
-# ^ keyword.operator.quantifier.regexp.shell
-#  ^ punctuation.section.group.begin.regexp.shell
+# ^ keyword.operator.quantifier.glob.shell
+#  ^ punctuation.section.group.begin.glob.shell
 #      ^ constant.other.wildcard.asterisk.shell
-#       ^ punctuation.section.group.end.regexp.shell
+#       ^ punctuation.section.group.end.glob.shell
 #        ^ constant.other.wildcard.asterisk.shell
 
 : +(foo|bar)|baz
 #^^ meta.function-call.arguments.shell - meta.group
-#  ^^^^^^^^^ meta.function-call.arguments.shell meta.group.regexp.shell
+#  ^^^^^^^^^ meta.function-call.arguments.shell meta.group.glob.shell
 #           ^ - meta.function-call - meta.group
-# ^ keyword.operator.quantifier.regexp.shell
-#  ^ punctuation.section.group.begin.regexp.shell
-#      ^ keyword.operator.alternation.regexp.shell
-#          ^ punctuation.section.group.end.regexp.shell
+# ^ keyword.operator.quantifier.glob.shell
+#  ^ punctuation.section.group.begin.glob.shell
+#      ^ keyword.operator.alternation.glob.shell
+#          ^ punctuation.section.group.end.glob.shell
 #           ^ keyword.operator.assignment.pipe.shell
 #            ^^^ variable.function.shell
 
 : +(foo&bar)|baz  # `&` terminates group and command arguments
-#  ^^^^^^^^^ meta.group.regexp.shell string.unquoted.shell
+#  ^^^^^^^^^ meta.group.glob.shell string.unquoted.shell
 #           ^^^^^ - meta.group
-#  ^ punctuation.section.group.begin.regexp.shell
+#  ^ punctuation.section.group.begin.glob.shell
 #      ^ - keyword
-#          ^ punctuation.section.group.end.regexp.shell
+#          ^ punctuation.section.group.end.glob.shell
 #           ^ keyword.operator.assignment.pipe.shell
 #            ^^^ variable.function.shell
 
 : +(foo;bar)|baz  # `;` terminates group and command arguments
-#  ^^^^^^^^^ meta.group.regexp.shell string.unquoted.shell
+#  ^^^^^^^^^ meta.group.glob.shell string.unquoted.shell
 #           ^^^^^ - meta.group
-#  ^ punctuation.section.group.begin.regexp.shell
+#  ^ punctuation.section.group.begin.glob.shell
 #      ^ - keyword
-#          ^ punctuation.section.group.end.regexp.shell
+#          ^ punctuation.section.group.end.glob.shell
 #           ^ keyword.operator.assignment.pipe.shell
 #            ^^^ variable.function.shell
 
 : +(foo>bar)|baz  # `>` terminates group and command arguments
-#  ^^^^^^^^^ meta.group.regexp.shell string.unquoted.shell
+#  ^^^^^^^^^ meta.group.glob.shell string.unquoted.shell
 #           ^^^^^ - meta.group
-#  ^ punctuation.section.group.begin.regexp.shell
+#  ^ punctuation.section.group.begin.glob.shell
 #      ^ - keyword
-#          ^ punctuation.section.group.end.regexp.shell
+#          ^ punctuation.section.group.end.glob.shell
 #           ^ keyword.operator.assignment.pipe.shell
 #            ^^^ variable.function.shell
 
 : +(foo<bar)|baz  # `<` terminates group and command arguments
-#  ^^^^^^^^^ meta.group.regexp.shell string.unquoted.shell
+#  ^^^^^^^^^ meta.group.glob.shell string.unquoted.shell
 #           ^^^^^ - meta.group
-#  ^ punctuation.section.group.begin.regexp.shell
+#  ^ punctuation.section.group.begin.glob.shell
 #      ^ - keyword
-#          ^ punctuation.section.group.end.regexp.shell
+#          ^ punctuation.section.group.end.glob.shell
 #           ^ keyword.operator.assignment.pipe.shell
 #            ^^^ variable.function.shell
 
@@ -9539,54 +9539,54 @@ $[var + 1]
 
 [[ abc == ?[a-z]? ]]  # evaluates to true
 #         ^ meta.string.glob.shell - meta.character-class
-#          ^^^^^ meta.string.glob.shell meta.character-class.regexp.shell
+#          ^^^^^ meta.string.glob.shell meta.character-class.glob.shell
 #               ^ meta.string.glob.shell - meta.character-class
 #                ^ - meta.string
 #         ^ constant.other.wildcard.questionmark.shell
-#          ^ punctuation.definition.character-class.begin.regexp.shell
-#           ^^^ constant.other.range.regexp.shell
-#              ^ punctuation.definition.character-class.end.regexp.shell
+#          ^ punctuation.definition.character-class.begin.glob.shell
+#           ^^^ constant.other.range.glob.shell
+#              ^ punctuation.definition.character-class.end.glob.shell
 #               ^ constant.other.wildcard.questionmark.shell
 
 [[ abc == ??[a-z] ]]  # evaluates to true
 #         ^^ meta.string.glob.shell - meta.character-class
-#           ^^^^^ meta.string.glob.shell meta.character-class.regexp.shell
+#           ^^^^^ meta.string.glob.shell meta.character-class.glob.shell
 #                ^ - meta.string
 #         ^^ constant.other.wildcard.questionmark.shell
-#           ^ punctuation.definition.character-class.begin.regexp.shell
-#            ^^^ constant.other.range.regexp.shell
-#               ^ punctuation.definition.character-class.end.regexp.shell
+#           ^ punctuation.definition.character-class.begin.glob.shell
+#            ^^^ constant.other.range.glob.shell
+#               ^ punctuation.definition.character-class.end.glob.shell
 
 [[ abc == [a-z]?? ]]  # evaluates to true
-#         ^^^^^ meta.string.glob.shell meta.character-class.regexp.shell
+#         ^^^^^ meta.string.glob.shell meta.character-class.glob.shell
 #              ^^ meta.string.glob.shell - meta.character-class
 #                ^ - meta.string
-#         ^ punctuation.definition.character-class.begin.regexp.shell
-#          ^^^ constant.other.range.regexp.shell
-#             ^ punctuation.definition.character-class.end.regexp.shell
+#         ^ punctuation.definition.character-class.begin.glob.shell
+#          ^^^ constant.other.range.glob.shell
+#             ^ punctuation.definition.character-class.end.glob.shell
 #              ^^ constant.other.wildcard.questionmark.shell
 
 [[ abc == *[a-z] ]]  # evaluates to true
 #         ^ meta.string.glob.shell - meta.character-class
-#          ^^^^^ meta.string.glob.shell meta.character-class.regexp.shell
+#          ^^^^^ meta.string.glob.shell meta.character-class.glob.shell
 #               ^ - meta.string
 #         ^ constant.other.wildcard.asterisk.shell
-#          ^ punctuation.definition.character-class.begin.regexp.shell
-#           ^^^ constant.other.range.regexp.shell
-#              ^ punctuation.definition.character-class.end.regexp.shell
+#          ^ punctuation.definition.character-class.begin.glob.shell
+#           ^^^ constant.other.range.glob.shell
+#              ^ punctuation.definition.character-class.end.glob.shell
 
 [[ abc == ?(?[a-z]?) ]]  # evaluates to true
 #         ^ meta.string.glob.shell - meta.group
-#          ^^ meta.string.glob.shell meta.group.regexp.shell - meta.character-class
-#            ^^^^^ meta.string.glob.shell meta.group.regexp.shell meta.character-class.regexp.shell
-#                 ^^ meta.string.glob.shell meta.group.regexp.shell - meta.character-class
+#          ^^ meta.string.glob.shell meta.group.glob.shell - meta.character-class
+#            ^^^^^ meta.string.glob.shell meta.group.glob.shell meta.character-class.glob.shell
+#                 ^^ meta.string.glob.shell meta.group.glob.shell - meta.character-class
 #                   ^ - meta.string
-#         ^ keyword.operator.quantifier.regexp.shell
-#          ^ punctuation.section.group.begin.regexp.shell
+#         ^ keyword.operator.quantifier.glob.shell
+#          ^ punctuation.section.group.begin.glob.shell
 #           ^ constant.other.wildcard.questionmark.shell
-#            ^ punctuation.definition.character-class.begin.regexp.shell
-#             ^^^ constant.other.range.regexp.shell
-#                ^ punctuation.definition.character-class.end.regexp.shell
+#            ^ punctuation.definition.character-class.begin.glob.shell
+#             ^^^ constant.other.range.glob.shell
+#                ^ punctuation.definition.character-class.end.glob.shell
 #                 ^ constant.other.wildcard.questionmark.shell
 
 [[ abc == ^abc|bca$ ]]
@@ -9623,21 +9623,21 @@ $[var + 1]
 [[ $foo == !(foo|bar|???|*|'?'|'*') ]]
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
 #          ^ meta.string.glob.shell
-#           ^^^^^^^^^^^^^^^^^^^^^^^ meta.string.glob.shell meta.group.regexp.shell
-#          ^ keyword.operator.quantifier.regexp.shell
-#           ^ punctuation.section.group.begin.regexp.shell
-#               ^ keyword.operator.alternation.regexp.shell
-#                   ^ keyword.operator.alternation.regexp.shell
+#           ^^^^^^^^^^^^^^^^^^^^^^^ meta.string.glob.shell meta.group.glob.shell
+#          ^ keyword.operator.quantifier.glob.shell
+#           ^ punctuation.section.group.begin.glob.shell
+#               ^ keyword.operator.alternation.glob.shell
+#                   ^ keyword.operator.alternation.glob.shell
 #                    ^^^ constant.other.wildcard.questionmark.shell
-#                       ^ keyword.operator.alternation.regexp.shell
+#                       ^ keyword.operator.alternation.glob.shell
 #                        ^ constant.other.wildcard.asterisk.shell
-#                         ^ keyword.operator.alternation.regexp.shell
+#                         ^ keyword.operator.alternation.glob.shell
 #                          ^ punctuation.definition.string.begin.shell
 #                            ^ punctuation.definition.string.end.shell
-#                             ^ keyword.operator.alternation.regexp.shell
+#                             ^ keyword.operator.alternation.glob.shell
 #                              ^ punctuation.definition.string.begin.shell
 #                                ^ punctuation.definition.string.end.shell
-#                                 ^ punctuation.section.group.end.regexp.shell
+#                                 ^ punctuation.section.group.end.glob.shell
 #                                   ^^ punctuation.section.compound.end.shell
 
 [[ ( $foo == *
@@ -9659,7 +9659,7 @@ $[var + 1]
 [[ ( $foo == *\
 [^0-9]? ) ]]   # note: line continuation is only valid without leading whitespace, but we ignore it
 # <- meta.compound.conditional.shell meta.group.shell meta.string.glob.shell
-#^^^^^ meta.compound.conditional.shell meta.group.shell meta.string.glob.shell meta.character-class.regexp.shell
+#^^^^^ meta.compound.conditional.shell meta.group.shell meta.string.glob.shell meta.character-class.glob.shell
 #     ^ meta.compound.conditional.shell meta.group.shell meta.string.glob.shell - meta.character-class
 #      ^^ meta.compound.conditional.shell meta.group.shell - meta.string
 #        ^^^ meta.compound.conditional.shell - meta.group
@@ -9684,22 +9684,22 @@ $[var + 1]
 #  ^^^^ meta.compound.conditional.shell meta.string.glob.shell meta.interpolation.parameter.shell variable.other.readwrite.shell
 #      ^^^^ meta.compound.conditional.shell - meta.string - meta.group
 #          ^ meta.compound.conditional.shell meta.string.glob.shell - meta.group
-#           ^^^^^ meta.compound.conditional.shell meta.string.glob.shell meta.group.regexp.shell
-#          ^ keyword.operator.quantifier.regexp.shell
-#           ^ punctuation.section.group.begin.regexp.shell
+#           ^^^^^ meta.compound.conditional.shell meta.string.glob.shell meta.group.glob.shell
+#          ^ keyword.operator.quantifier.glob.shell
+#           ^ punctuation.section.group.begin.glob.shell
 #             ^^ - punctuation
    [!0-9]+ ) ]]
-# <- meta.compound.conditional.shell meta.string.glob.shell meta.group.regexp.shell
-#^^ meta.compound.conditional.shell meta.string.glob.shell meta.group.regexp.shell - meta.character-class
-#  ^^^^^^ meta.compound.conditional.shell meta.string.glob.shell meta.group.regexp.shell meta.character-class.regexp.shell
-#        ^^^ meta.compound.conditional.shell meta.string.glob.shell meta.group.regexp.shell - meta.character-class
-#           ^^^ - meta.string.regexp
-#  ^ punctuation.definition.character-class.begin.regexp.shell
-#   ^ keyword.operator.logical.regexp.shell
-#    ^^^ constant.other.range.regexp.shell
-#       ^ punctuation.definition.character-class.end.regexp.shell
+# <- meta.compound.conditional.shell meta.string.glob.shell meta.group.glob.shell
+#^^ meta.compound.conditional.shell meta.string.glob.shell meta.group.glob.shell - meta.character-class
+#  ^^^^^^ meta.compound.conditional.shell meta.string.glob.shell meta.group.glob.shell meta.character-class.glob.shell
+#        ^^^ meta.compound.conditional.shell meta.string.glob.shell meta.group.glob.shell - meta.character-class
+#           ^^^ - meta.string.glob
+#  ^ punctuation.definition.character-class.begin.glob.shell
+#   ^ keyword.operator.logical.glob.shell
+#    ^^^ constant.other.range.glob.shell
+#       ^ punctuation.definition.character-class.end.glob.shell
 #        ^ - constant - keyword
-#          ^ punctuation.section.group.end.regexp.shell
+#          ^ punctuation.section.group.end.glob.shell
 #            ^^ punctuation.section.compound.end.shell
 
 [[ $path == /dev/null ]]
@@ -11294,7 +11294,7 @@ EOF
 #                ^^^^^^^^^^^^^^^^ meta.string.glob.shell
 #                ^ variable.language.tilde.shell
 #                  ^^ constant.other.wildcard.asterisk.shell
-#                     ^^^^ meta.character-class.regexp.shell
+#                     ^^^^ meta.character-class.glob.shell
 #                           ^ constant.other.wildcard.questionmark.shell
 
 : <<< "word --opt ~/**/[Ff]oo?.bar"
@@ -13816,7 +13816,7 @@ test var[0] != var[^0-9]*$
 #^^^ meta.function-call.identifier.shell support.function.shell
 #   ^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell
 #    ^^^^^^ meta.string.glob.shell string.unquoted.shell
-#       ^^^ meta.character-class.regexp.shell
+#       ^^^ meta.character-class.glob.shell
 #           ^^ keyword.operator.comparison.shell
 #              ^^^^^^^^^^^ meta.string.glob.shell string.unquoted.shell - meta.string.regexp
 
@@ -13825,7 +13825,7 @@ test $var[0] != var[^0-9]*$
 #^^^ meta.function-call.identifier.shell support.function.shell
 #   ^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell
 #    ^^^^ meta.interpolation.parameter.shell variable.other.readwrite.shell
-#        ^^^ meta.character-class.regexp.shell
+#        ^^^ meta.character-class.glob.shell
 #            ^^ keyword.operator.comparison.shell
 #               ^^^^^^^^^^^ meta.string.glob.shell string.unquoted.shell - meta.string.regexp
 

--- a/ShellScript/Bash/tests/syntax_test_scope.bash
+++ b/ShellScript/Bash/tests/syntax_test_scope.bash
@@ -593,10 +593,10 @@ $e'ch'o Hello, world!
 #^ constant.other.path.parent.shell
 # ^ punctuation.separator.path.shell
 #    ^ constant.other.wildcard.questionmark.shell
-#           ^^^^^ meta.set.regexp.shell
-#           ^ punctuation.definition.set.begin.regexp.shell
+#           ^^^^^ meta.character-class.regexp.shell
+#           ^ punctuation.definition.character-class.begin.regexp.shell
 #            ^^^ constant.other.range.regexp.shell
-#               ^ punctuation.definition.set.end.regexp.shell
+#               ^ punctuation.definition.character-class.end.regexp.shell
 #                 ^ constant.other.wildcard.asterisk.shell
 
 "../my?script[1-9].*"   # no pattern matching within quotes
@@ -605,7 +605,7 @@ $e'ch'o Hello, world!
 #^^ constant.other.path.parent.shell
 #  ^ punctuation.separator.path.shell
 #     ^ - constant
-#            ^^^^^ - meta.set.regexp - punctuation
+#            ^^^^^ - meta.character-class.regexp - punctuation
 #                  ^ - constant
 #                   ^ punctuation.definition.quoted.end.shell
 
@@ -858,9 +858,9 @@ sleep 2 & jobs
 #                    ^^ - variable
 
 [foo] -o
-# <- meta.function-call.identifier.shell meta.command.shell variable.function.shell meta.set.regexp.shell punctuation.definition.set.begin.regexp.shell
-#^^^ meta.function-call.identifier.shell meta.command.shell variable.function.shell meta.set.regexp.shell - punctuation
-#   ^ meta.function-call.identifier.shell meta.command.shell variable.function.shell meta.set.regexp.shell punctuation.definition.set.end.regexp.shell
+# <- meta.function-call.identifier.shell meta.command.shell variable.function.shell meta.character-class.regexp.shell punctuation.definition.character-class.begin.regexp.shell
+#^^^ meta.function-call.identifier.shell meta.command.shell variable.function.shell meta.character-class.regexp.shell - punctuation
+#   ^ meta.function-call.identifier.shell meta.command.shell variable.function.shell meta.character-class.regexp.shell punctuation.definition.character-class.end.regexp.shell
 #    ^^^ meta.function-call.arguments.shell
 
 $foo -o
@@ -2377,10 +2377,10 @@ ws-+([0-9]).host.com) echo "Web Server"
 #^^^^^^^^^^^^^^^^^^^ string.unquoted.shell
 #  ^ keyword.operator.quantifier.regexp.shell
 #   ^ punctuation.section.group.begin.regexp.shell
-#    ^ punctuation.definition.set.begin.regexp.shell
+#    ^ punctuation.definition.character-class.begin.regexp.shell
 #     ^^^ constant.other.range.regexp.shell
 #      ^ punctuation.separator.sequence.regexp.shell
-#        ^ punctuation.definition.set.end.regexp.shell
+#        ^ punctuation.definition.character-class.end.regexp.shell
 #         ^ punctuation.section.group.end.regexp.shell
 #                   ^ punctuation.section.patterns.end.shell
 ;;
@@ -2392,10 +2392,10 @@ db-+([0-9])\.host\.com) echo "DB server"
 #          ^^^^^^^^^^^ meta.clause.patterns.shell meta.string.glob.shell - meta.group
 #  ^ keyword.operator.quantifier.regexp.shell
 #   ^ punctuation.section.group.begin.regexp.shell
-#    ^ punctuation.definition.set.begin.regexp.shell
+#    ^ punctuation.definition.character-class.begin.regexp.shell
 #     ^^^ constant.other.range.regexp.shell
 #      ^ punctuation.separator.sequence.regexp.shell
-#        ^ punctuation.definition.set.end.regexp.shell
+#        ^ punctuation.definition.character-class.end.regexp.shell
 #         ^ punctuation.section.group.end.regexp.shell
 #                     ^ punctuation.section.patterns.end.shell
 ;;
@@ -2404,10 +2404,10 @@ db-+([0-9])\.host\.com) echo "DB server"
 bk-+([0-9])\.host\.com) echo "Backup server"
 #  ^ keyword.operator.quantifier.regexp.shell
 #   ^ punctuation.section.group.begin.regexp.shell
-#    ^ punctuation.definition.set.begin.regexp.shell
+#    ^ punctuation.definition.character-class.begin.regexp.shell
 #     ^^^ constant.other.range.regexp.shell
 #      ^ punctuation.separator.sequence.regexp.shell
-#        ^ punctuation.definition.set.end.regexp.shell
+#        ^ punctuation.definition.character-class.end.regexp.shell
 #         ^ punctuation.section.group.end.regexp.shell
 #                     ^ punctuation.section.patterns.end.shell
 #                       ^^^^ support.function.shell
@@ -2427,9 +2427,9 @@ esac
 
 case $_G_unquoted_arg in
 *[\[\~\#\&\*\(\)\{\}\|\;\<\>\?\'\ ]*|*]*|"")
-#^ punctuation.definition.set.begin.regexp.shell
+#^ punctuation.definition.character-class.begin.regexp.shell
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.character.escape.shell
-#                                 ^ punctuation.definition.set.end.regexp.shell
+#                                 ^ punctuation.definition.character-class.end.regexp.shell
 #                                     ^ - keyword.control
   _G_quoted_arg=\"$_G_unquoted_arg\"
   ;;
@@ -2439,9 +2439,9 @@ case $_G_unquoted_arg in
 esac
 case $1 in
 *[\\\`\"\$]*)
-#^ punctuation.definition.set.begin.regexp.shell
+#^ punctuation.definition.character-class.begin.regexp.shell
 # ^^^^^^^^ constant.character.escape.shell
-#         ^ punctuation.definition.set.end.regexp.shell
+#         ^ punctuation.definition.character-class.end.regexp.shell
   _G_unquoted_arg=`printf '%s\n' "$1" |$SED "$sed_quote_subst"` ;;
 *)
   _G_unquoted_arg=$1 ;;
@@ -7207,7 +7207,7 @@ a\/b/c/d}
 
 : ${foo//:/[}]
 # ^^^^^^^^^^^ meta.interpolation.parameter.shell
-#          ^^^ - meta.string.regexp - meta.set
+#          ^^^ - meta.string.regexp - meta.character-class
 #            ^ - meta.interpolation
 # ^ punctuation.definition.variable.shell
 #  ^ punctuation.section.interpolation.begin.shell
@@ -7224,7 +7224,7 @@ a\/b/c/d}
 #   ^^^ variable.other.readwrite.shell
 #      ^^ keyword.operator.substitution.shell
 #         ^ keyword.operator.substitution.shell
-#          ^^^^ - meta.string.regexp - meta.set - punctuation
+#          ^^^^ - meta.string.regexp - meta.character-class - punctuation
 #           ^^ constant.character.escape.shell
 #              ^ punctuation.section.interpolation.end.shell
 
@@ -7235,7 +7235,7 @@ a\/b/c/d}
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^^^ variable.other.readwrite.shell
 #      ^^ keyword.operator.substitution.shell
-#        ^^^ - meta.set - punctuation
+#        ^^^ - meta.character-class - punctuation
 #           ^ keyword.operator.substitution.shell
 #            ^^ constant.character.escape.shell
 #              ^ punctuation.section.interpolation.end.shell
@@ -7274,13 +7274,13 @@ a\/b/c/d}
 #                  ^ punctuation.section.interpolation.end.shell
 
 : ${foo//[abc[]/x}  # `[` has no meaning within charsets
-# ^^^^^^^ meta.interpolation.parameter.shell - meta.string meta.set
-#        ^^^^^^ meta.interpolation.parameter.shell meta.string.regexp.shell meta.set.regexp.shell
-#              ^^^ meta.interpolation.parameter.shell - meta.string meta.set
+# ^^^^^^^ meta.interpolation.parameter.shell - meta.string meta.character-class
+#        ^^^^^^ meta.interpolation.parameter.shell meta.string.regexp.shell meta.character-class.regexp.shell
+#              ^^^ meta.interpolation.parameter.shell - meta.string meta.character-class
 #      ^^ keyword.operator.substitution.shell
-#        ^ punctuation.definition.set.begin.regexp.shell
+#        ^ punctuation.definition.character-class.begin.regexp.shell
 #            ^ - keyword - punctuation
-#             ^ punctuation.definition.set.end.regexp.shell
+#             ^ punctuation.definition.character-class.end.regexp.shell
 #              ^ keyword.operator.substitution.shell
 #                ^ punctuation.section.interpolation.end.shell
 
@@ -8134,7 +8134,7 @@ a\/b/c/d}
 : ${foo,[abx]}
 # ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #      ^ keyword.operator.expansion.shell
-#       ^^^^^ meta.string.regexp.shell string.unquoted.shell meta.set.regexp.shell
+#       ^^^^^ meta.string.regexp.shell string.unquoted.shell meta.character-class.regexp.shell
 
 ################################
 # ${parameter,,pattern}
@@ -8266,7 +8266,7 @@ a\/b/c/d}
 : ${foo,,[abx]}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #      ^^ keyword.operator.expansion.shell
-#        ^^^^^ meta.string.regexp.shell string.unquoted.shell meta.set.regexp.shell
+#        ^^^^^ meta.string.regexp.shell string.unquoted.shell meta.character-class.regexp.shell
 
 ################################
 # ${parameter^pattern}
@@ -8413,7 +8413,7 @@ a\/b/c/d}
 : ${foo^[abx]}
 # ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #      ^ keyword.operator.expansion.shell
-#       ^^^^^ meta.string.regexp.shell string.unquoted.shell meta.set.regexp.shell
+#       ^^^^^ meta.string.regexp.shell string.unquoted.shell meta.character-class.regexp.shell
 
 ################################
 # ${parameter^^pattern}
@@ -8545,7 +8545,7 @@ a\/b/c/d}
 : ${foo^^[abx]}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #      ^^ keyword.operator.expansion.shell
-#        ^^^^^ meta.string.regexp.shell string.unquoted.shell meta.set.regexp.shell
+#        ^^^^^ meta.string.regexp.shell string.unquoted.shell meta.character-class.regexp.shell
 
 ################################
 # ${parameter~pattern}
@@ -8691,7 +8691,7 @@ a\/b/c/d}
 : ${foo~[abx]}
 # ^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #      ^ keyword.operator.expansion.shell
-#       ^^^^^ meta.string.regexp.shell string.unquoted.shell meta.set.regexp.shell
+#       ^^^^^ meta.string.regexp.shell string.unquoted.shell meta.character-class.regexp.shell
 
 ################################
 # ${parameter~~pattern}
@@ -8823,7 +8823,7 @@ a\/b/c/d}
 : ${foo~~[abx]}
 # ^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #      ^^ keyword.operator.expansion.shell
-#        ^^^^^ meta.string.regexp.shell string.unquoted.shell meta.set.regexp.shell
+#        ^^^^^ meta.string.regexp.shell string.unquoted.shell meta.character-class.regexp.shell
 
 ################################
 # ${parameter@operator}
@@ -9046,13 +9046,11 @@ status="${status#"${status%%[![:space:]]*}"}"
 #               ^ keyword.operator.expansion.shell
 #                ^ punctuation.definition.string.begin.shell
 #                         ^^ keyword.operator.expansion.shell
-#                           ^ punctuation.definition.set.begin.regexp.shell
+#                           ^ punctuation.definition.character-class.begin.regexp.shell
 #                            ^ keyword.operator.logical.regexp.shell
-#                             ^ punctuation.definition.set.begin.regexp.shell
-#                              ^ punctuation.definition.class.begin.regexp.shell
-#                               ^^^^^^ constant.other.posix-class.regexp.shell
-#                                     ^ punctuation.definition.set.end.regexp.shell
-#                                     ^^ punctuation.definition.set.end.regexp.shell
+#                             ^^ punctuation.definition.character-class.begin.regexp.shell
+#                               ^^^^^ constant.other.character-class.posix.regexp.shell
+#                                    ^^^ punctuation.definition.character-class.end.regexp.shell
 #                                       ^ constant.other.wildcard.asterisk.shell
 #                                        ^ punctuation.section.interpolation.end.shell
 #                                         ^ punctuation.definition.string.end.shell
@@ -9068,10 +9066,10 @@ status="${status#${status%%[![:space:]]*}}"
 #     ^ keyword.operator.assignment.shell
 #               ^ keyword.operator.expansion.shell
 #                        ^^ keyword.operator.expansion.shell
-#                          ^ punctuation.definition.set.begin.regexp.shell
+#                          ^ punctuation.definition.character-class.begin.regexp.shell
 #                           ^ keyword.operator.logical.regexp.shell
-#                            ^ punctuation.definition.set.begin.regexp.shell
-#                                    ^^ punctuation.definition.set.end.regexp.shell
+#                            ^ punctuation.definition.character-class.begin.regexp.shell
+#                                    ^^ punctuation.definition.character-class.end.regexp.shell
 #                                      ^ constant.other.wildcard.asterisk.shell
 
 CURPOS=${CURPOS#*[}
@@ -9304,146 +9302,143 @@ $[var + 1]
 #^^^^^^^^^ meta.function-call.arguments.shell
 # ^ keyword.operator.quantifier.regexp.shell
 #  ^ punctuation.section.group.begin.regexp.shell
-#   ^ punctuation.definition.set.begin.regexp.shell
+#   ^ punctuation.definition.character-class.begin.regexp.shell
 #    ^ keyword.operator.logical.regexp.shell
-#      ^ punctuation.definition.set.end.regexp.shell
+#      ^ punctuation.definition.character-class.end.regexp.shell
 #       ^ constant.other.wildcard.asterisk.shell
 #        ^ punctuation.section.group.end.regexp.shell
 
 : @([[] []] [![] [!]] [^[] [^]])
-#   ^^^ meta.group.regexp.shell meta.set.regexp.shell
-#   ^ punctuation.definition.set.begin.regexp.shell
+#   ^^^ meta.group.regexp.shell meta.character-class.regexp.shell
+#   ^ punctuation.definition.character-class.begin.regexp.shell
 #    ^ - punctuation
-#     ^ punctuation.definition.set.end.regexp.shell
-#       ^^^ meta.group.regexp.shell meta.set.regexp.shell
-#       ^ punctuation.definition.set.begin.regexp.shell
+#     ^ punctuation.definition.character-class.end.regexp.shell
+#       ^^^ meta.group.regexp.shell meta.character-class.regexp.shell
+#       ^ punctuation.definition.character-class.begin.regexp.shell
 #        ^ - punctuation
-#         ^ punctuation.definition.set.end.regexp.shell
-#           ^^^^ meta.group.regexp.shell meta.set.regexp.shell
-#           ^ punctuation.definition.set.begin.regexp.shell
+#         ^ punctuation.definition.character-class.end.regexp.shell
+#           ^^^^ meta.group.regexp.shell meta.character-class.regexp.shell
+#           ^ punctuation.definition.character-class.begin.regexp.shell
 #            ^ keyword.operator.logical.regexp.shell
 #             ^ - punctuation
-#              ^ punctuation.definition.set.end.regexp.shell
-#                ^^^^ meta.group.regexp.shell meta.set.regexp.shell
-#                ^ punctuation.definition.set.begin.regexp.shell
+#              ^ punctuation.definition.character-class.end.regexp.shell
+#                ^^^^ meta.group.regexp.shell meta.character-class.regexp.shell
+#                ^ punctuation.definition.character-class.begin.regexp.shell
 #                 ^ keyword.operator.logical.regexp.shell
 #                  ^ - punctuation
-#                   ^ punctuation.definition.set.end.regexp.shell
-#                     ^^^^ meta.group.regexp.shell meta.set.regexp.shell
-#                     ^ punctuation.definition.set.begin.regexp.shell
+#                   ^ punctuation.definition.character-class.end.regexp.shell
+#                     ^^^^ meta.group.regexp.shell meta.character-class.regexp.shell
+#                     ^ punctuation.definition.character-class.begin.regexp.shell
 #                      ^ keyword.operator.logical.regexp.shell
 #                       ^ - punctuation
-#                        ^ punctuation.definition.set.end.regexp.shell
-#                          ^^^^ meta.group.regexp.shell meta.set.regexp.shell
-#                          ^ punctuation.definition.set.begin.regexp.shell
+#                        ^ punctuation.definition.character-class.end.regexp.shell
+#                          ^^^^ meta.group.regexp.shell meta.character-class.regexp.shell
+#                          ^ punctuation.definition.character-class.begin.regexp.shell
 #                           ^ keyword.operator.logical.regexp.shell
 #                            ^ - punctuation
-#                             ^ punctuation.definition.set.end.regexp.shell
+#                             ^ punctuation.definition.character-class.end.regexp.shell
 
 : @([-[] [-]] [[-)] []-)] [!-[] [!-]] [^-[] [^-]])
-#   ^^^^ meta.group.regexp.shell meta.set.regexp.shell
-#   ^ punctuation.definition.set.begin.regexp.shell
+#   ^^^^ meta.group.regexp.shell meta.character-class.regexp.shell
+#   ^ punctuation.definition.character-class.begin.regexp.shell
 #    ^^ - punctuation
-#      ^ punctuation.definition.set.end.regexp.shell
-#        ^^^ meta.group.regexp.shell meta.set.regexp.shell
-#        ^ punctuation.definition.set.begin.regexp.shell
+#      ^ punctuation.definition.character-class.end.regexp.shell
+#        ^^^ meta.group.regexp.shell meta.character-class.regexp.shell
+#        ^ punctuation.definition.character-class.begin.regexp.shell
 #         ^ - punctuation
-#          ^ punctuation.definition.set.end.regexp.shell
+#          ^ punctuation.definition.character-class.end.regexp.shell
 #           ^ - punctuation
-#             ^^^^^ meta.group.regexp.shell meta.set.regexp.shell
-#             ^ punctuation.definition.set.begin.regexp.shell
+#             ^^^^^ meta.group.regexp.shell meta.character-class.regexp.shell
+#             ^ punctuation.definition.character-class.begin.regexp.shell
 #              ^^^ constant.other.range.regexp.shell
-#                 ^ punctuation.definition.set.end.regexp.shell
-#                   ^^^^^ meta.group.regexp.shell meta.set.regexp.shell
-#                   ^ punctuation.definition.set.begin.regexp.shell
+#                 ^ punctuation.definition.character-class.end.regexp.shell
+#                   ^^^^^ meta.group.regexp.shell meta.character-class.regexp.shell
+#                   ^ punctuation.definition.character-class.begin.regexp.shell
 #                    ^^^ constant.other.range.regexp.shell
-#                       ^ punctuation.definition.set.end.regexp.shell
-#                         ^^^^^ meta.group.regexp.shell meta.set.regexp.shell
-#                         ^ punctuation.definition.set.begin.regexp.shell
+#                       ^ punctuation.definition.character-class.end.regexp.shell
+#                         ^^^^^ meta.group.regexp.shell meta.character-class.regexp.shell
+#                         ^ punctuation.definition.character-class.begin.regexp.shell
 #                          ^ keyword.operator.logical.regexp.shell
 #                           ^^ - punctuation
-#                             ^ punctuation.definition.set.end.regexp.shell
-#                               ^^^^ meta.group.regexp.shell meta.set.regexp.shell
-#                               ^ punctuation.definition.set.begin.regexp.shell
+#                             ^ punctuation.definition.character-class.end.regexp.shell
+#                               ^^^^ meta.group.regexp.shell meta.character-class.regexp.shell
+#                               ^ punctuation.definition.character-class.begin.regexp.shell
 #                                ^ keyword.operator.logical.regexp.shell
 #                                 ^ - punctuation
-#                                  ^ punctuation.definition.set.end.regexp.shell
+#                                  ^ punctuation.definition.character-class.end.regexp.shell
 #                                   ^ - punctuation
-#                                     ^^^^^ meta.group.regexp.shell meta.set.regexp.shell
-#                                     ^ punctuation.definition.set.begin.regexp.shell
+#                                     ^^^^^ meta.group.regexp.shell meta.character-class.regexp.shell
+#                                     ^ punctuation.definition.character-class.begin.regexp.shell
 #                                      ^ keyword.operator.logical.regexp.shell
 #                                       ^^ - punctuation
-#                                         ^ punctuation.definition.set.end.regexp.shell
-#                                           ^^^^ meta.group.regexp.shell meta.set.regexp.shell
-#                                           ^ punctuation.definition.set.begin.regexp.shell
+#                                         ^ punctuation.definition.character-class.end.regexp.shell
+#                                           ^^^^ meta.group.regexp.shell meta.character-class.regexp.shell
+#                                           ^ punctuation.definition.character-class.begin.regexp.shell
 #                                            ^ keyword.operator.logical.regexp.shell
 #                                             ^ - punctuation
-#                                              ^ punctuation.definition.set.end.regexp.shell
+#                                              ^ punctuation.definition.character-class.end.regexp.shell
 #                                               ^ - punctuation
 
 : @([.c.] [.c. ] [[.c.]] [^[.c.]] [[^.c.]])
-#   ^^^^^ meta.set.regexp.shell
-#        ^ - meta.set
-#         ^^^^^^ meta.set.regexp.shell
-#               ^ - meta.set
-#                ^ meta.set.regexp.shell - meta.set meta.set
-#                 ^^^^^ meta.set.regexp.shell meta.set.regexp.shell
-#                      ^ meta.set.regexp.shell - meta.set meta.set
-#                       ^ - meta.set
-#                        ^^ meta.set.regexp.shell - meta.set meta.set
-#                          ^^^^^ meta.set.regexp.shell meta.set.regexp.shell
-#                               ^ meta.set.regexp.shell - meta.set meta.set
-#                                ^ - meta.set
-#                                 ^^^^^^^ meta.set.regexp.shell - meta.set meta.set
-#                                        ^^ - meta.set
-#   ^ punctuation.definition.set.begin.regexp.shell
+#   ^^^^^ meta.character-class.regexp.shell
+#        ^ - meta.character-class
+#         ^^^^^^ meta.character-class.regexp.shell
+#               ^ - meta.character-class
+#                ^ meta.character-class.regexp.shell - meta.character-class meta.character-class
+#                 ^^^^^ meta.character-class.regexp.shell meta.character-class.regexp.shell
+#                      ^ meta.character-class.regexp.shell - meta.character-class meta.character-class
+#                       ^ - meta.character-class
+#                        ^^ meta.character-class.regexp.shell - meta.character-class meta.character-class
+#                          ^^^^^ meta.character-class.regexp.shell meta.character-class.regexp.shell
+#                               ^ meta.character-class.regexp.shell - meta.character-class meta.character-class
+#                                ^ - meta.character-class
+#                                 ^^^^^^^ meta.character-class.regexp.shell - meta.character-class meta.character-class
+#                                        ^^ - meta.character-class
+#   ^ punctuation.definition.character-class.begin.regexp.shell
 #    ^^^ - constant.character
-#       ^ punctuation.definition.set.end.regexp.shell
-#         ^ punctuation.definition.set.begin.regexp.shell
+#       ^ punctuation.definition.character-class.end.regexp.shell
+#         ^ punctuation.definition.character-class.begin.regexp.shell
 #          ^^^^ - constant.character.collate
-#              ^ punctuation.definition.set.end.regexp.shell
-#                ^^ punctuation.definition.set.begin.regexp.shell
-#                  ^^^ constant.character.collate.regexp.shell
-#                     ^^ punctuation.definition.set.end.regexp.shell
-#                        ^ punctuation.definition.set.begin.regexp.shell
+#              ^ punctuation.definition.character-class.end.regexp.shell
+#                ^^^ punctuation.definition.character-class.begin.regexp.shell
+#                   ^ constant.other.character-class.collate.regexp.shell
+#                    ^^^ punctuation.definition.character-class.end.regexp.shell
+#                        ^ punctuation.definition.character-class.begin.regexp.shell
 #                         ^ keyword.operator.logical.regexp.shell
-#                          ^ punctuation.definition.set.begin.regexp.shell
-#                           ^^^ constant.character.collate.regexp.shell
-#                              ^^ punctuation.definition.set.end.regexp.shell
-#                                 ^ punctuation.definition.set.begin.regexp.shell
+#                          ^^ punctuation.definition.character-class.begin.regexp.shell
+#                            ^ constant.other.character-class.collate.regexp.shell
+#                             ^^^ punctuation.definition.character-class.end.regexp.shell
+#                                 ^ punctuation.definition.character-class.begin.regexp.shell
 #                                  ^^^^^ - keyword - punctuation - constant
-#                                       ^ punctuation.definition.set.end.regexp.shell
+#                                       ^ punctuation.definition.character-class.end.regexp.shell
 #                                        ^ - punctuation
 
 : @([[=c=]] [[=c=illegal]])
-#   ^^ punctuation.definition.set.begin.regexp.shell
-#     ^ constant.character.equivalence-class.regexp.shell punctuation.definition.class.begin.regexp.shell
-#      ^ constant.character.equivalence-class.regexp.shell - punctuation
-#       ^ constant.character.equivalence-class.regexp.shell punctuation.definition.class.end.regexp.shell
-#        ^^ punctuation.definition.set.end.regexp.shell
-#           ^ punctuation.definition.set.begin.regexp.shell
+#   ^^^ punctuation.definition.character-class.begin.regexp.shell
+#      ^ constant.other.character-class.equivalence.regexp.shell - punctuation
+#       ^^^ punctuation.definition.character-class.end.regexp.shell
+#           ^ punctuation.definition.character-class.begin.regexp.shell
 #            ^^^^^^^^^^^ - constant.character.equivalence-class
-#                       ^ punctuation.definition.set.end.regexp.shell
+#                       ^ punctuation.definition.character-class.end.regexp.shell
 #                        ^ - punctuation
 
 : @([[:alnum:]] [[:alnum]] [[alnum:]] [[alnum]] [[:alnum:other]])
-#     ^ constant.other.posix-class.regexp.shell punctuation.definition.class.begin.regexp.shell
-#      ^^^^^ constant.other.posix-class.regexp.shell - punctuation
-#           ^ constant.other.posix-class.regexp.shell punctuation.definition.class.end.regexp.shell
+#   ^^^ punctuation.definition.character-class.begin.regexp.shell
+#      ^^^^^ constant.other.character-class.posix.regexp.shell - punctuation
+#           ^^^ punctuation.definition.character-class.end.regexp.shell
 #               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - constant.other.posix-class
 
 : *(g[[:${charclass/\}/l}:]]*)
 #^^ meta.function-call.arguments.shell - meta.group
-#  ^^ meta.function-call.arguments.shell meta.group.regexp.shell - meta.set
-#    ^^^ meta.function-call.arguments.shell meta.string.glob.shell meta.group.regexp.shell meta.set.regexp.shell
-#       ^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell meta.string.glob.shell meta.group.regexp.shell meta.set.regexp.shell meta.set.regexp.shell meta.interpolation.parameter.shell
-#                        ^^^ meta.function-call.arguments.shell meta.string.glob.shell meta.group.regexp.shell meta.set.regexp.shell
-#                           ^^ meta.function-call.arguments.shell meta.string.glob.shell meta.group.regexp.shell - meta.set
+#  ^^ meta.function-call.arguments.shell meta.group.regexp.shell - meta.character-class
+#    ^^^ meta.function-call.arguments.shell meta.string.glob.shell meta.group.regexp.shell meta.character-class.regexp.shell
+#       ^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell meta.string.glob.shell meta.group.regexp.shell meta.character-class.regexp.shell meta.character-class.regexp.shell meta.interpolation.parameter.shell
+#                        ^^^ meta.function-call.arguments.shell meta.string.glob.shell meta.group.regexp.shell meta.character-class.regexp.shell
+#                           ^^ meta.function-call.arguments.shell meta.string.glob.shell meta.group.regexp.shell - meta.character-class
 #                             ^ - meta.function-call - meta.group
 # ^ keyword.operator.quantifier.regexp.shell
 #  ^ punctuation.section.group.begin.regexp.shell
-#    ^^ punctuation.definition.set.begin.regexp.shell
-#      ^ constant.other.posix-class.regexp.shell
+#    ^^^ punctuation.definition.character-class.begin.regexp.shell
 #       ^ punctuation.definition.variable.shell
 #        ^ punctuation.section.interpolation.begin.shell
 #         ^^^^^^^^^ variable.other.readwrite.shell
@@ -9451,8 +9446,7 @@ $[var + 1]
 #                   ^^ constant.character.escape.shell
 #                     ^ keyword.operator.substitution.shell
 #                       ^ punctuation.section.interpolation.end.shell
-#                        ^ constant.other.posix-class.regexp.shell
-#                         ^^ punctuation.definition.set.end.regexp.shell
+#                        ^^^ punctuation.definition.character-class.end.regexp.shell
 #                           ^ constant.other.wildcard.asterisk.shell
 #                            ^ punctuation.section.group.end.regexp.shell
 
@@ -9463,21 +9457,17 @@ $[var + 1]
 #                                          ^ - meta.function-call - meta.group
 # ^ keyword.operator.quantifier.regexp.shell
 #  ^ punctuation.section.group.begin.regexp.shell
-#   ^^ punctuation.definition.set.begin.regexp.shell
-#     ^ constant.other.posix-class.regexp.shell punctuation.definition.class.begin.regexp.shell
-#      ^^^^^ constant.other.posix-class.regexp.shell - punctuation
-#           ^ constant.other.posix-class.regexp.shell punctuation.definition.class.end.regexp.shell
-#            ^^ punctuation.definition.set.end.regexp.shell
+#   ^^^ punctuation.definition.character-class.begin.regexp.shell
+#      ^^^^^ constant.other.character-class.posix.regexp.shell - punctuation
+#           ^^^ punctuation.definition.character-class.end.regexp.shell
 #              ^ keyword.operator.alternation.regexp.shell
-#               ^^ punctuation.definition.set.begin.regexp.shell
-#                 ^ constant.other.posix-class.regexp.shell punctuation.definition.class.begin.regexp.shell
-#                  ^^^^^ constant.other.posix-class.regexp.shell - punctuation
-#                       ^ constant.other.posix-class.regexp.shell punctuation.definition.class.end.regexp.shell
-#                        ^^ punctuation.definition.set.end.regexp.shell
+#               ^^^ punctuation.definition.character-class.begin.regexp.shell
+#                  ^^^^^ constant.other.character-class.posix.regexp.shell - punctuation
+#                       ^^^ punctuation.definition.character-class.end.regexp.shell
 #                          ^ keyword.operator.alternation.regexp.shell
-#                           ^ punctuation.definition.set.begin.regexp.shell
+#                           ^ punctuation.definition.character-class.begin.regexp.shell
 #                            ^^^^^^^^^^ - constant.other.posix-class
-#                                      ^ punctuation.definition.set.end.regexp.shell
+#                                      ^ punctuation.definition.character-class.end.regexp.shell
 #                                       ^ - punctuation
 #                                        ^ punctuation.section.group.end.regexp.shell
 #                                         ^ constant.other.wildcard.asterisk.shell
@@ -9548,55 +9538,55 @@ $[var + 1]
 ###############################################################################
 
 [[ abc == ?[a-z]? ]]  # evaluates to true
-#         ^ meta.string.glob.shell - meta.set
-#          ^^^^^ meta.string.glob.shell meta.set.regexp.shell
-#               ^ meta.string.glob.shell - meta.set
+#         ^ meta.string.glob.shell - meta.character-class
+#          ^^^^^ meta.string.glob.shell meta.character-class.regexp.shell
+#               ^ meta.string.glob.shell - meta.character-class
 #                ^ - meta.string
 #         ^ constant.other.wildcard.questionmark.shell
-#          ^ punctuation.definition.set.begin.regexp.shell
+#          ^ punctuation.definition.character-class.begin.regexp.shell
 #           ^^^ constant.other.range.regexp.shell
-#              ^ punctuation.definition.set.end.regexp.shell
+#              ^ punctuation.definition.character-class.end.regexp.shell
 #               ^ constant.other.wildcard.questionmark.shell
 
 [[ abc == ??[a-z] ]]  # evaluates to true
-#         ^^ meta.string.glob.shell - meta.set
-#           ^^^^^ meta.string.glob.shell meta.set.regexp.shell
+#         ^^ meta.string.glob.shell - meta.character-class
+#           ^^^^^ meta.string.glob.shell meta.character-class.regexp.shell
 #                ^ - meta.string
 #         ^^ constant.other.wildcard.questionmark.shell
-#           ^ punctuation.definition.set.begin.regexp.shell
+#           ^ punctuation.definition.character-class.begin.regexp.shell
 #            ^^^ constant.other.range.regexp.shell
-#               ^ punctuation.definition.set.end.regexp.shell
+#               ^ punctuation.definition.character-class.end.regexp.shell
 
 [[ abc == [a-z]?? ]]  # evaluates to true
-#         ^^^^^ meta.string.glob.shell meta.set.regexp.shell
-#              ^^ meta.string.glob.shell - meta.set
+#         ^^^^^ meta.string.glob.shell meta.character-class.regexp.shell
+#              ^^ meta.string.glob.shell - meta.character-class
 #                ^ - meta.string
-#         ^ punctuation.definition.set.begin.regexp.shell
+#         ^ punctuation.definition.character-class.begin.regexp.shell
 #          ^^^ constant.other.range.regexp.shell
-#             ^ punctuation.definition.set.end.regexp.shell
+#             ^ punctuation.definition.character-class.end.regexp.shell
 #              ^^ constant.other.wildcard.questionmark.shell
 
 [[ abc == *[a-z] ]]  # evaluates to true
-#         ^ meta.string.glob.shell - meta.set
-#          ^^^^^ meta.string.glob.shell meta.set.regexp.shell
+#         ^ meta.string.glob.shell - meta.character-class
+#          ^^^^^ meta.string.glob.shell meta.character-class.regexp.shell
 #               ^ - meta.string
 #         ^ constant.other.wildcard.asterisk.shell
-#          ^ punctuation.definition.set.begin.regexp.shell
+#          ^ punctuation.definition.character-class.begin.regexp.shell
 #           ^^^ constant.other.range.regexp.shell
-#              ^ punctuation.definition.set.end.regexp.shell
+#              ^ punctuation.definition.character-class.end.regexp.shell
 
 [[ abc == ?(?[a-z]?) ]]  # evaluates to true
 #         ^ meta.string.glob.shell - meta.group
-#          ^^ meta.string.glob.shell meta.group.regexp.shell - meta.set
-#            ^^^^^ meta.string.glob.shell meta.group.regexp.shell meta.set.regexp.shell
-#                 ^^ meta.string.glob.shell meta.group.regexp.shell - meta.set
+#          ^^ meta.string.glob.shell meta.group.regexp.shell - meta.character-class
+#            ^^^^^ meta.string.glob.shell meta.group.regexp.shell meta.character-class.regexp.shell
+#                 ^^ meta.string.glob.shell meta.group.regexp.shell - meta.character-class
 #                   ^ - meta.string
 #         ^ keyword.operator.quantifier.regexp.shell
 #          ^ punctuation.section.group.begin.regexp.shell
 #           ^ constant.other.wildcard.questionmark.shell
-#            ^ punctuation.definition.set.begin.regexp.shell
+#            ^ punctuation.definition.character-class.begin.regexp.shell
 #             ^^^ constant.other.range.regexp.shell
-#                ^ punctuation.definition.set.end.regexp.shell
+#                ^ punctuation.definition.character-class.end.regexp.shell
 #                 ^ constant.other.wildcard.questionmark.shell
 
 [[ abc == ^abc|bca$ ]]
@@ -9669,8 +9659,8 @@ $[var + 1]
 [[ ( $foo == *\
 [^0-9]? ) ]]   # note: line continuation is only valid without leading whitespace, but we ignore it
 # <- meta.compound.conditional.shell meta.group.shell meta.string.glob.shell
-#^^^^^ meta.compound.conditional.shell meta.group.shell meta.string.glob.shell meta.set.regexp.shell
-#     ^ meta.compound.conditional.shell meta.group.shell meta.string.glob.shell - meta.set
+#^^^^^ meta.compound.conditional.shell meta.group.shell meta.string.glob.shell meta.character-class.regexp.shell
+#     ^ meta.compound.conditional.shell meta.group.shell meta.string.glob.shell - meta.character-class
 #      ^^ meta.compound.conditional.shell meta.group.shell - meta.string
 #        ^^^ meta.compound.conditional.shell - meta.group
 #         ^^ punctuation.section.compound.end.shell
@@ -9700,14 +9690,14 @@ $[var + 1]
 #             ^^ - punctuation
    [!0-9]+ ) ]]
 # <- meta.compound.conditional.shell meta.string.glob.shell meta.group.regexp.shell
-#^^ meta.compound.conditional.shell meta.string.glob.shell meta.group.regexp.shell - meta.set
-#  ^^^^^^ meta.compound.conditional.shell meta.string.glob.shell meta.group.regexp.shell meta.set.regexp.shell
-#        ^^^ meta.compound.conditional.shell meta.string.glob.shell meta.group.regexp.shell - meta.set
+#^^ meta.compound.conditional.shell meta.string.glob.shell meta.group.regexp.shell - meta.character-class
+#  ^^^^^^ meta.compound.conditional.shell meta.string.glob.shell meta.group.regexp.shell meta.character-class.regexp.shell
+#        ^^^ meta.compound.conditional.shell meta.string.glob.shell meta.group.regexp.shell - meta.character-class
 #           ^^^ - meta.string.regexp
-#  ^ punctuation.definition.set.begin.regexp.shell
+#  ^ punctuation.definition.character-class.begin.regexp.shell
 #   ^ keyword.operator.logical.regexp.shell
 #    ^^^ constant.other.range.regexp.shell
-#       ^ punctuation.definition.set.end.regexp.shell
+#       ^ punctuation.definition.character-class.end.regexp.shell
 #        ^ - constant - keyword
 #          ^ punctuation.section.group.end.regexp.shell
 #            ^^ punctuation.section.compound.end.shell
@@ -9732,259 +9722,241 @@ $[var + 1]
 [[ a =~ [ ]]
 #^^^^^^^^^^^ meta.compound.conditional.shell
 #^^^^^^^ - meta.string.regexp.shell
-#       ^ meta.string.regexp.shell - meta.set
+#       ^ meta.string.regexp.shell - meta.character-class
 #        ^^^ - meta.string.regexp.shell
 #         ^^ punctuation.section.compound.end.shell
 
 [[ a =~ ] ]]
 #^^^^^^^^^^^ meta.compound.conditional.shell
 #^^^^^^^ - meta.string.regexp.shell
-#       ^ meta.string.regexp.shell - meta.set
+#       ^ meta.string.regexp.shell - meta.character-class
 #        ^^^ - meta.string.regexp.shell
 #         ^^ punctuation.section.compound.end.shell
 
 [[ a =~ [[] ]]
 #^^^^^^^^^^^^^ meta.compound.conditional.shell
 #^^^^^^^ - meta.string.regexp.shell
-#       ^^^ meta.string.regexp.shell meta.set.regexp.shell
+#       ^^^ meta.string.regexp.shell meta.character-class.regexp.shell
 #          ^^^ - meta.string.regexp.shell
 #           ^^ punctuation.section.compound.end.shell
 
 [[ a =~ [^[] ]]
 #^^^^^^^^^^^^^^ meta.compound.conditional.shell
 #^^^^^^^ - meta.string.regexp.shell
-#       ^^^^ meta.string.regexp.shell meta.set.regexp.shell
+#       ^^^^ meta.string.regexp.shell meta.character-class.regexp.shell
 #           ^^^ - meta.string.regexp.shell
-#       ^ punctuation.definition.set.begin.regexp.shell
+#       ^ punctuation.definition.character-class.begin.regexp.shell
 #        ^ keyword.operator.logical.regexp.shell
 #         ^ - punctuation
-#          ^ punctuation.definition.set.end.regexp.shell
+#          ^ punctuation.definition.character-class.end.regexp.shell
 #            ^^ punctuation.section.compound.end.shell
 
 [[ a =~ [![] ]]  # ! is not an operator in ERE
 #^^^^^^^^^^^^^^ meta.compound.conditional.shell
 #^^^^^^^ - meta.string.regexp.shell
-#       ^^^^ meta.string.regexp.shell meta.set.regexp.shell
+#       ^^^^ meta.string.regexp.shell meta.character-class.regexp.shell
 #           ^^^ - meta.string.regexp.shell
-#       ^ punctuation.definition.set.begin.regexp.shell
+#       ^ punctuation.definition.character-class.begin.regexp.shell
 #        ^^ - keyword - punctuation
-#          ^ punctuation.definition.set.end.regexp.shell
+#          ^ punctuation.definition.character-class.end.regexp.shell
 #            ^^ punctuation.section.compound.end.shell
 
 [[ a =~ [\[] ]]
 #^^^^^^^^^^^^^^ meta.compound.conditional.shell
 #^^^^^^^ - meta.string.regexp.shell
-#       ^^^^ meta.string.regexp.shell meta.set.regexp.shell
+#       ^^^^ meta.string.regexp.shell meta.character-class.regexp.shell
 #           ^^^ - meta.string.regexp.shell
 #            ^^ punctuation.section.compound.end.shell
 
 [[ a =~ [^\[] ]]
 #^^^^^^^^^^^^^^ meta.compound.conditional.shell
 #^^^^^^^ - meta.string.regexp.shell
-#       ^^^^^ meta.string.regexp.shell meta.set.regexp.shell
+#       ^^^^^ meta.string.regexp.shell meta.character-class.regexp.shell
 #            ^^^ - meta.string.regexp.shell
 #             ^^ punctuation.section.compound.end.shell
 
 [[ a =~ []] ]]
 #^^^^^^^^^^^^^ meta.compound.conditional.shell
 #^^^^^^^ - meta.string.regexp.shell
-#       ^^^ meta.string.regexp.shell meta.set.regexp.shell
+#       ^^^ meta.string.regexp.shell meta.character-class.regexp.shell
 #          ^^^ - meta.string.regexp.shell
 #           ^^ punctuation.section.compound.end.shell
 
 [[ a =~ []-[] ]]
 #^^^^^^^^^^^^^^^ meta.compound.conditional.shell
 #^^^^^^^ - meta.string.regexp.shell
-#       ^^^^^ meta.string.regexp.shell meta.set.regexp.shell
+#       ^^^^^ meta.string.regexp.shell meta.character-class.regexp.shell
 #            ^^^ - meta.string.regexp.shell
-#       ^ punctuation.definition.set.begin.regexp.shell
+#       ^ punctuation.definition.character-class.begin.regexp.shell
 #        ^^^ constant.other.range.regexp.shell
-#           ^ punctuation.definition.set.end.regexp.shell
+#           ^ punctuation.definition.character-class.end.regexp.shell
 #             ^^ punctuation.section.compound.end.shell
 
 [[ a =~ [^]] ]]
 #^^^^^^^^^^^^^^ meta.compound.conditional.shell
 #^^^^^^^ - meta.string.regexp.shell
-#       ^^^^ meta.string.regexp.shell meta.set.regexp.shell
+#       ^^^^ meta.string.regexp.shell meta.character-class.regexp.shell
 #           ^^^ - meta.string.regexp.shell
 #            ^^ punctuation.section.compound.end.shell
 
 [[ a =~ [!]] ]]  # ! is not an operator in ERE
 #^^^^^^^^^^^^^^ meta.compound.conditional.shell
 #^^^^^^^ - meta.string.regexp.shell
-#       ^^^ meta.string.regexp.shell meta.set.regexp.shell
-#          ^ meta.string.regexp.shell - meta.set
+#       ^^^ meta.string.regexp.shell meta.character-class.regexp.shell
+#          ^ meta.string.regexp.shell - meta.character-class
 #           ^^^ - meta.string.regexp.shell
-#       ^ punctuation.definition.set.begin.regexp.shell
+#       ^ punctuation.definition.character-class.begin.regexp.shell
 #        ^ - keyword - punctuation
-#         ^ punctuation.definition.set.end.regexp.shell
+#         ^ punctuation.definition.character-class.end.regexp.shell
 #          ^ - punctuation
 #            ^^ punctuation.section.compound.end.shell
 
 [[ a =~ [\]] ]]
 #^^^^^^^^^^^^^^ meta.compound.conditional.shell
 #^^^^^^^ - meta.string.regexp.shell
-#       ^^^^ meta.string.regexp.shell meta.set.regexp.shell
+#       ^^^^ meta.string.regexp.shell meta.character-class.regexp.shell
 #           ^^^ - meta.string.regexp.shell
 #            ^^ punctuation.section.compound.end.shell
 
 [[ a =~ [^\]] ]]
 #^^^^^^^^^^^^^^^ meta.compound.conditional.shell
 #^^^^^^^ - meta.string.regexp.shell
-#       ^^^^^ meta.string.regexp.shell meta.set.regexp.shell
+#       ^^^^^ meta.string.regexp.shell meta.character-class.regexp.shell
 #            ^^^ - meta.string.regexp.shell
 #             ^^ punctuation.section.compound.end.shell
 
 [[ a =~ [\\\]] ]]
 #^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
 #^^^^^^^ - meta.string.regexp.shell
-#       ^^^^^^ meta.string.regexp.shell meta.set.regexp.shell
+#       ^^^^^^ meta.string.regexp.shell meta.character-class.regexp.shell
 #             ^^^ - meta.string.regexp.shell
 #              ^^ punctuation.section.compound.end.shell
 
 [[ a =~ [\\\] ]]
 #^^^^^^^^^^^^^^^ meta.compound.conditional.shell
 #^^^^^^^ - meta.string.regexp.shell
-#       ^^^^^ meta.string.regexp.shell - meta.set
+#       ^^^^^ meta.string.regexp.shell - meta.character-class
 #            ^^^ - meta.string.regexp.shell
 #             ^^ punctuation.section.compound.end.shell
 
 [[ a =~ [[:alpha: ]]
 #^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
 #^^^^^^^ - meta.string.regexp.shell
-#       ^^^^^^^^^ meta.string.regexp.shell - meta.set
+#       ^^^^^^^^^ meta.string.regexp.shell - meta.character-class
 #                ^^^ - meta.string.regexp.shell
 #                 ^^ punctuation.section.compound.end.shell
 
 [[ a =~ [[:alpha:] ]]
 #^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
 #^^^^^^^ - meta.string.regexp.shell
-#       ^ meta.string.regexp.shell - meta.set
-#        ^^^^^^^^^ meta.string.regexp.shell meta.set.regexp.shell
+#       ^ meta.string.regexp.shell - meta.character-class
+#        ^^^^^^^^^ meta.string.regexp.shell meta.character-class.regexp.shell
 #                 ^^^ - meta.string.regexp.shell
 #                  ^^ punctuation.section.compound.end.shell
 
 [[ a =~ [[:alpha:]][^[:alpha:]][[^:alpha:]] ]]
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
 #^^^^^^^ - meta.string.regexp.shell
-#       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.regexp.shell meta.set.regexp.shell
-#                                         ^ meta.string.regexp.shell - meta.set
+#       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.regexp.shell meta.character-class.regexp.shell
+#                                         ^ meta.string.regexp.shell - meta.character-class
 #                                          ^^^ - meta.string.regexp.shell
-#       ^^ punctuation.definition.set.begin.regexp.shell
-#         ^ punctuation.definition.class.begin.regexp.shell
-#         ^^^^^^^ constant.other.posix-class.regexp.shell
-#               ^ punctuation.definition.class.end.regexp.shell
-#                ^^ punctuation.definition.set.end.regexp.shell
-#                  ^ punctuation.definition.set.begin.regexp.shell
+#       ^^^ punctuation.definition.character-class.begin.regexp.shell
+#          ^^^^^ constant.other.character-class.posix.regexp.shell
+#               ^^^ punctuation.definition.character-class.end.regexp.shell
+#                  ^ punctuation.definition.character-class.begin.regexp.shell
 #                   ^ keyword.operator.logical.regexp.shell
-#                    ^ punctuation.definition.set.begin.regexp.shell
-#                     ^^^^^^^ constant.other.posix-class.regexp.shell
-#                            ^^ punctuation.definition.set.end.regexp.shell
-#                              ^ punctuation.definition.set.begin.regexp.shell
+#                    ^^ punctuation.definition.character-class.begin.regexp.shell
+#                      ^^^^^ constant.other.character-class.posix.regexp.shell
+#                           ^^^ punctuation.definition.character-class.end.regexp.shell
+#                              ^ punctuation.definition.character-class.begin.regexp.shell
 #                               ^^^^^^^^^ - constant.other.posix-class
-#                                        ^ punctuation.definition.set.end.regexp.shell
+#                                        ^ punctuation.definition.character-class.end.regexp.shell
 #                                         ^ - punctuation
 #                                           ^^ punctuation.section.compound.end.shell
 
 [[ a =~ [[:${posix}:]][[:$foo:]] ]]
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
 #^^^^^^^ - meta.string.regexp.shell
-#       ^^^ meta.string.regexp.shell meta.set.regexp.shell - meta.interpolation
-#          ^^^^^^^^ meta.string.regexp.shell meta.set.regexp.shell meta.set.regexp.shell meta.interpolation.parameter.shell
-#                  ^^^^^^ meta.string.regexp.shell meta.set.regexp.shell  - meta.interpolation
-#                        ^^^^ meta.string.regexp.shell meta.set.regexp.shell meta.set.regexp.shell meta.interpolation.parameter.shell
-#                            ^^^ meta.string.regexp.shell meta.set.regexp.shell  - meta.interpolation
+#       ^^^ meta.string.regexp.shell meta.character-class.regexp.shell - meta.interpolation
+#          ^^^^^^^^ meta.string.regexp.shell meta.character-class.regexp.shell meta.character-class.regexp.shell meta.interpolation.parameter.shell
+#                  ^^^^^^ meta.string.regexp.shell meta.character-class.regexp.shell  - meta.interpolation
+#                        ^^^^ meta.string.regexp.shell meta.character-class.regexp.shell meta.character-class.regexp.shell meta.interpolation.parameter.shell
+#                            ^^^ meta.string.regexp.shell meta.character-class.regexp.shell  - meta.interpolation
 #                               ^^^ - meta.string.regexp.shell
 #                                ^^ punctuation.section.compound.end.shell
-#       ^^ punctuation.definition.set.begin.regexp.shell
-#         ^ constant.other.posix-class.regexp.shell punctuation.definition.class.begin.regexp.shell
+#       ^^^ punctuation.definition.character-class.begin.regexp.shell
 #          ^ punctuation.definition.variable.shell
 #           ^ punctuation.section.interpolation.begin.shell
 #            ^^^^^ variable.other.readwrite.shell
 #                 ^ punctuation.section.interpolation.end.shell
-#                  ^ constant.other.posix-class.regexp.shell punctuation.definition.class.end.regexp.shell
-#                   ^^ punctuation.definition.set.end.regexp.shell
-#                     ^^ punctuation.definition.set.begin.regexp.shell
-#                       ^ punctuation.definition.class.begin.regexp.shell
+#                  ^^^ punctuation.definition.character-class.end.regexp.shell
+#                     ^^^ punctuation.definition.character-class.begin.regexp.shell
 #                        ^^^^ variable.other.readwrite.shell
-#                            ^ punctuation.definition.class.end.regexp.shell
-#                             ^^ punctuation.definition.set.end.regexp.shell
+#                            ^^^ punctuation.definition.character-class.end.regexp.shell
 #                                ^^ punctuation.section.compound.end.shell
 
 [[ a =~ [[=a=]] ]]
 #^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
 #^^^^^^^ - meta.string.regexp.shell
-#       ^^^^^^^ meta.string.regexp.shell meta.set.regexp.shell
+#       ^^^^^^^ meta.string.regexp.shell meta.character-class.regexp.shell
 #              ^^^ - meta.string.regexp.shell
-#       ^^ punctuation.definition.set.begin.regexp.shell
-#         ^ punctuation.definition.class.begin.regexp.shell
-#         ^^^ constant.character.equivalence-class.regexp.shell
-#           ^ punctuation.definition.class.end.regexp.shell
-#            ^^ punctuation.definition.set.end.regexp.shell
+#       ^^^ punctuation.definition.character-class.begin.regexp.shell
+#          ^ constant.other.character-class.equivalence.regexp.shell
+#           ^^^ punctuation.definition.character-class.end.regexp.shell
 #               ^^ punctuation.section.compound.end.shell
 
 [[ a =~ [[=$a=]] ]]
 #^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
 #^^^^^^^ - meta.string.regexp.shell
-#       ^^^^^^^^ meta.string.regexp.shell meta.set.regexp.shell
+#       ^^^^^^^^ meta.string.regexp.shell meta.character-class.regexp.shell
 #               ^^^ - meta.string.regexp.shell
-#       ^^ punctuation.definition.set.begin.regexp.shell
-#         ^ punctuation.definition.class.begin.regexp.shell
-#         ^^^^ constant.character.equivalence-class.regexp.shell
-#          ^^ meta.interpolation.parameter.shell variable.other.readwrite.shell
-#            ^ punctuation.definition.class.end.regexp.shell
-#             ^^ punctuation.definition.set.end.regexp.shell
+#       ^^^ punctuation.definition.character-class.begin.regexp.shell
+#          ^^ constant.other.character-class.equivalence.regexp.shell meta.interpolation.parameter.shell variable.other.readwrite.shell
+#            ^^^ punctuation.definition.character-class.end.regexp.shell
 #                ^^ punctuation.section.compound.end.shell
 
 [[ a =~ [[.ch.]] ]]
 #^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
 #^^^^^^^ - meta.string.regexp.shell
-#       ^^^^^^^^ meta.string.regexp.shell meta.set.regexp.shell
+#       ^^^^^^^^ meta.string.regexp.shell meta.character-class.regexp.shell
 #               ^^^ - meta.string.regexp.shell
-#       ^^ punctuation.definition.set.begin.regexp.shell
-#         ^ punctuation.definition.collate.begin.regexp.shell
-#         ^^^^ constant.character.collate.regexp.shell
-#            ^ punctuation.definition.collate.end.regexp.shell
-#             ^^ punctuation.definition.set.end.regexp.shell
+#       ^^^ punctuation.definition.character-class.begin.regexp.shell
+#          ^^ constant.other.character-class.collate.regexp.shell
+#            ^^^ punctuation.definition.character-class.end.regexp.shell
 #                ^^ punctuation.section.compound.end.shell
 
 [[ a =~ [[.dollar-sign.]] ]]
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
 #^^^^^^^ - meta.string.regexp.shell
-#       ^^^^^^^^^^^^^^^^^ meta.string.regexp.shell meta.set.regexp.shell
+#       ^^^^^^^^^^^^^^^^^ meta.string.regexp.shell meta.character-class.regexp.shell
 #                        ^^^ - meta.string.regexp.shell
-#       ^^ punctuation.definition.set.begin.regexp.shell
-#         ^ punctuation.definition.collate.begin.regexp.shell
-#         ^^^^^^^^^^^^^ constant.character.collate.regexp.shell
-#                     ^ punctuation.definition.collate.end.regexp.shell
-#                      ^^ punctuation.definition.set.end.regexp.shell
+#       ^^^ punctuation.definition.character-class.begin.regexp.shell
+#          ^^^^^^^^^^^ constant.other.character-class.collate.regexp.shell
+#                     ^^^ punctuation.definition.character-class.end.regexp.shell
 #                         ^^ punctuation.section.compound.end.shell
 
 [[ a =~ [[.${equiv}.]] ]]
 #^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
 #^^^^^^^ - meta.string.regexp.shell
-#       ^^^^^^^^^^^^^^ meta.string.regexp.shell meta.set.regexp.shell
+#       ^^^^^^^^^^^^^^ meta.string.regexp.shell meta.character-class.regexp.shell
 #                     ^^^ - meta.string.regexp.shell
-#       ^^ punctuation.definition.set.begin.regexp.shell
-#         ^ punctuation.definition.collate.begin.regexp.shell
-#         ^^^^^^^^^^ constant.character.collate.regexp.shell
-#          ^^^^^^^^ meta.interpolation.parameter.shell
-#                  ^ punctuation.definition.collate.end.regexp.shell
-#                   ^^ punctuation.definition.set.end.regexp.shell
+#       ^^^ punctuation.definition.character-class.begin.regexp.shell
+#          ^^^^^^^^ constant.other.character-class.collate.regexp.shell meta.interpolation.parameter.shell
+#                  ^^^ punctuation.definition.character-class.end.regexp.shell
 #                      ^^ punctuation.section.compound.end.shell
 
 [[ a =~ [[.alpha=]] ]]
 #^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
 #^^^^^^^ - meta.string.regexp.shell
-#       ^^^^^^^^^^ meta.string.regexp.shell meta.set.regexp.shell - constant
-#                 ^ meta.string.regexp.shell - meta.set
+#       ^^^^^^^^^^ meta.string.regexp.shell meta.character-class.regexp.shell - constant
+#                 ^ meta.string.regexp.shell - meta.character-class
 #                  ^^^ - meta.string.regexp.shell
 #                   ^^ punctuation.section.compound.end.shell
 
 [[ a =~ [-9][0-][$0-9][0-$9] ]]
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
 #^^^^^^^ - meta.string.regexp.shell
-#       ^^^^^^^^^^^^^^^^^^^^ meta.string.regexp.shell meta.set.regexp.shell
+#       ^^^^^^^^^^^^^^^^^^^^ meta.string.regexp.shell meta.character-class.regexp.shell
 #        ^^ - constant - operator
 #                ^^ meta.interpolation.parameter.shell variable.language.positional.shell
 #                  ^^ constant.other.range.regexp.shell
@@ -9996,7 +9968,7 @@ $[var + 1]
 [[ a =~ [${ bar }] ]]
 #^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
 #^^^^^^^ - meta.string.regexp.shell
-#       ^^^^^^^^^^ meta.string.regexp.shell meta.set.regexp.shell
+#       ^^^^^^^^^^ meta.string.regexp.shell meta.character-class.regexp.shell
 #        ^^^^^^^^ meta.interpolation.parameter.shell
 #                 ^^^ - meta.string.regexp.shell
 #                  ^^ punctuation.section.compound.end.shell
@@ -10047,9 +10019,9 @@ $[var + 1]
 #^^^^^^^ - meta.string.regexp.shell
 #       ^^^^^^^ meta.string.regexp.shell - meta.interpolation
 #              ^^^ - meta.string.regexp.shell
-#       ^ punctuation.definition.set.begin.regexp.shell
+#       ^ punctuation.definition.character-class.begin.regexp.shell
 #           ^ - keyword.control
-#            ^ punctuation.definition.set.end.regexp.shell
+#            ^ punctuation.definition.character-class.end.regexp.shell
 #             ^ keyword.operator.quantifier.regexp.shell
 
 [[ "${foo}" =~ bar*baz ]]
@@ -10102,14 +10074,14 @@ $[var + 1]
 #                              ^ - meta.conditional
 #^^^^^^^^^^ - meta.string.regexp.shell
 #          ^^^^^^^^^^^^^^^^^ meta.string.regexp.shell
-#          ^^^^^^^^^^^ meta.set.regexp.shell
+#          ^^^^^^^^^^^ meta.character-class.regexp.shell
 #                       ^^^ meta.group.regexp.shell
 #                           ^^^ - meta.string.regexp.shell
 #  ^^^^ meta.interpolation.parameter.shell variable.other.readwrite.shell
 #       ^^ keyword.operator.comparison.shell
-#          ^^ punctuation.definition.set.begin.regexp.shell
-#            ^^^^^^^ constant.other.posix-class.regexp.shell
-#                   ^^ punctuation.definition.set.end.regexp.shell
+#          ^^^ punctuation.definition.character-class.begin.regexp.shell
+#             ^^^^^ constant.other.character-class.posix.regexp.shell
+#                  ^^^ punctuation.definition.character-class.end.regexp.shell
 #                     ^^ keyword.operator.quantifier.regexp.shell
 #                       ^ punctuation.section.group.begin.regexp.shell
 #                         ^ punctuation.section.group.end.regexp.shell
@@ -10174,9 +10146,9 @@ $[var + 1]
 #              ^^^^^^^^ meta.group.regexp.shell
 #              ^ punctuation.section.group.begin.regexp.shell
 #               ^^ constant.character.escape
-#                 ^^^^^ meta.set.regexp.shell
-#                 ^ punctuation.definition.set.begin.regexp.
-#                     ^ punctuation.definition.set.end.regexp.shell
+#                 ^^^^^ meta.character-class.regexp.shell
+#                 ^ punctuation.definition.character-class.begin.regexp.
+#                     ^ punctuation.definition.character-class.end.regexp.shell
 #                      ^ keyword.operator.quantifier.regexp.shell
 #                       ^ punctuation.section.group.end.regexp.shell
 #                         ^ punctuation.section.group.end.shell
@@ -10304,29 +10276,29 @@ $[var + 1]
 [[ ' foo ' =~ ([ ]foo[ ]) ]]  # evaluates to true
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
 #  ^^^^^^^ meta.string.glob.shell string.quoted.single.shell
-#             ^ meta.string.regexp.shell meta.group.regexp.shell - meta.set
-#              ^^^ meta.string.regexp.shell meta.group.regexp.shell meta.set.regexp.shell
-#                 ^^^ meta.string.regexp.shell meta.group.regexp.shell - meta.set
-#                    ^^^ meta.string.regexp.shell meta.group.regexp.shell meta.set.regexp.shell
-#                       ^ meta.string.regexp.shell meta.group.regexp.shell - meta.set
+#             ^ meta.string.regexp.shell meta.group.regexp.shell - meta.character-class
+#              ^^^ meta.string.regexp.shell meta.group.regexp.shell meta.character-class.regexp.shell
+#                 ^^^ meta.string.regexp.shell meta.group.regexp.shell - meta.character-class
+#                    ^^^ meta.string.regexp.shell meta.group.regexp.shell meta.character-class.regexp.shell
+#                       ^ meta.string.regexp.shell meta.group.regexp.shell - meta.character-class
 #          ^^ keyword.operator.comparison.shell
 #             ^ punctuation.section.group.begin.regexp.shell
-#              ^ punctuation.definition.set.begin.regexp.shell
-#                ^ punctuation.definition.set.end.regexp.shell
-#                    ^ punctuation.definition.set.begin.regexp.shell
-#                      ^ punctuation.definition.set.end.regexp.shell
+#              ^ punctuation.definition.character-class.begin.regexp.shell
+#                ^ punctuation.definition.character-class.end.regexp.shell
+#                    ^ punctuation.definition.character-class.begin.regexp.shell
+#                      ^ punctuation.definition.character-class.end.regexp.shell
 #                       ^ punctuation.section.group.end.regexp.shell
 #                         ^^ punctuation.section.compound.end.shell
 
 [[ foo =~ ^foo//:/[}] ]]
 #^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
 #^^^^^^^^^ - meta.string.regexp.shell
-#         ^^^^^^^^ meta.string.regexp.shell - meta.set
-#                 ^^^ meta.string.regexp.shell meta.set.regexp.shell
+#         ^^^^^^^^ meta.string.regexp.shell - meta.character-class
+#                 ^^^ meta.string.regexp.shell meta.character-class.regexp.shell
 #                    ^^^ - meta.string.regexp.shell
 #      ^^ keyword.operator.comparison.shell
-#                 ^ punctuation.definition.set.begin.regexp.shell
-#                   ^ punctuation.definition.set.end.regexp.shell
+#                 ^ punctuation.definition.character-class.begin.regexp.shell
+#                   ^ punctuation.definition.character-class.end.regexp.shell
 #                     ^^ punctuation.section.compound.end.shell
 
 [[ foo =~ ^[0-9]+\.[0-9]+(([ab]|rc)[0-9]+)?$ ]]
@@ -10341,12 +10313,12 @@ $[var + 1]
 #^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.compound.conditional.shell
 #                          ^ - meta.conditional
 #^^^^^^^^^^^^^^^ - meta.string.regexp.shell
-#               ^^^^ meta.set.regexp.shell
+#               ^^^^ meta.character-class.regexp.shell
 #               ^^^^^^^^ meta.string.regexp.shell
 #                       ^^^ - meta.string.regexp.shell
-#               ^ punctuation.definition.set.begin.regexp.shell
+#               ^ punctuation.definition.character-class.begin.regexp.shell
 #                ^^ constant.character.escape
-#                  ^ punctuation.definition.set.end.regexp.shell
+#                  ^ punctuation.definition.character-class.end.regexp.shell
 #                      ^ keyword.operator.quantifier.regexp.shell
 
 [[ a\$bc =~ ^a'$b'c$ ]]
@@ -11322,7 +11294,7 @@ EOF
 #                ^^^^^^^^^^^^^^^^ meta.string.glob.shell
 #                ^ variable.language.tilde.shell
 #                  ^^ constant.other.wildcard.asterisk.shell
-#                     ^^^^ meta.set.regexp.shell
+#                     ^^^^ meta.character-class.regexp.shell
 #                           ^ constant.other.wildcard.questionmark.shell
 
 : <<< "word --opt ~/**/[Ff]oo?.bar"
@@ -13844,7 +13816,7 @@ test var[0] != var[^0-9]*$
 #^^^ meta.function-call.identifier.shell support.function.shell
 #   ^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell
 #    ^^^^^^ meta.string.glob.shell string.unquoted.shell
-#       ^^^ meta.set.regexp.shell
+#       ^^^ meta.character-class.regexp.shell
 #           ^^ keyword.operator.comparison.shell
 #              ^^^^^^^^^^^ meta.string.glob.shell string.unquoted.shell - meta.string.regexp
 
@@ -13853,7 +13825,7 @@ test $var[0] != var[^0-9]*$
 #^^^ meta.function-call.identifier.shell support.function.shell
 #   ^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell
 #    ^^^^ meta.interpolation.parameter.shell variable.other.readwrite.shell
-#        ^^^ meta.set.regexp.shell
+#        ^^^ meta.character-class.regexp.shell
 #            ^^ keyword.operator.comparison.shell
 #               ^^^^^^^^^^^ meta.string.glob.shell string.unquoted.shell - meta.string.regexp
 

--- a/ShellScript/Zsh.sublime-syntax
+++ b/ShellScript/Zsh.sublime-syntax
@@ -616,7 +616,7 @@ contexts:
     # zsh glob range with string scope cleared
     # only groups are valid in groups, no glob qualifiers
     - match: \(
-      scope: punctuation.section.group.begin.regexp.shell
+      scope: punctuation.section.group.begin.glob.shell
       push: pattern-group-body
 
   pattern-group-content:
@@ -634,10 +634,10 @@ contexts:
   pattern-common:
     - meta_prepend: true
     - match: '[~^]'
-      scope: keyword.operator.logical.regexp.shell.zsh
+      scope: keyword.operator.logical.glob.shell.zsh
       push: maybe-tilde-interpolation
     - match: \#{1,2}
-      scope: keyword.operator.quantifier.regexp.shell.zsh
+      scope: keyword.operator.quantifier.glob.shell.zsh
 
 ###[ POSIX EXTENDED REGULAR EXPRESSIONS ]######################################
 
@@ -830,7 +830,7 @@ contexts:
     - include: zsh-parameter-glob-ranges
     # prefer EXTENDED_GLOB over optional KSH_GLOB
     - match: \(
-      scope: punctuation.section.group.begin.regexp.shell
+      scope: punctuation.section.group.begin.glob.shell
       push: parameter-expansion-pattern-group-body
 
   parameter-expansion-pattern-group-content:
@@ -948,7 +948,7 @@ contexts:
 
   zsh-parameter-modifier-subst-replacement:
     - meta_include_prototype: false
-    - meta_content_scope: meta.string.regexp.shell string.unquoted.shell
+    - meta_content_scope: meta.string.glob.shell string.unquoted.shell
     - include: brace-pop
     - include: zsh-modifier-subst-replacement
 
@@ -1203,7 +1203,7 @@ contexts:
 
   zsh-glob-qualifier-modifier-subst-replacement:
     - meta_include_prototype: false
-    - meta_content_scope: meta.string.regexp.shell string.unquoted.shell
+    - meta_content_scope: meta.string.glob.shell string.unquoted.shell
     - include: paren-pop
     - include: zsh-modifier-subst-replacement
 
@@ -1362,7 +1362,7 @@ contexts:
 
   zsh-modifier-subst-replacement:
     - meta_include_prototype: false
-    - meta_content_scope: meta.string.regexp.shell string.unquoted.shell
+    - meta_content_scope: meta.string.glob.shell string.unquoted.shell
     - match: \&
       scope: variable.language.reference.shell.zsh
     - include: zsh-modifier-subst-pattern
@@ -1374,7 +1374,7 @@ contexts:
       scope: meta.substitution.shell.zsh
       captures:
         1: punctuation.separator.modifier.shell.zsh
-        2: constant.other.flag.regexp.shell.zsh
+        2: constant.other.flag.glob.shell.zsh
       pop: 1
     - include: line-continuations
     - include: immediately-pop

--- a/ShellScript/Zsh/tests/syntax_test_scope.zsh
+++ b/ShellScript/Zsh/tests/syntax_test_scope.zsh
@@ -501,9 +501,9 @@ case $word {
 
     ws-+([0-9]).host.com)
 #   ^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.case.body.shell meta.block.shell.zsh meta.clause.patterns.shell meta.string.glob.shell string.unquoted.shell
-#       ^ meta.group.regexp.shell - meta.character-class
-#        ^^^^^ meta.group.regexp.shell meta.character-class.regexp.shell
-#             ^ meta.group.regexp.shell - meta.character-class
+#       ^ meta.group.glob.shell - meta.character-class
+#        ^^^^^ meta.group.glob.shell meta.character-class.glob.shell
+#             ^ meta.group.glob.shell - meta.character-class
 #                       ^ meta.clause.patterns.shell - meta.group - string
 #                        ^ meta.statement.conditional.case.body.shell meta.block.shell.zsh meta.clause.shell - meta.clause.patterns
         ;;
@@ -511,44 +511,44 @@ case $word {
 
     ((foo|bar)baz) cmd arg ;|
 #   ^ meta.clause.patterns.shell - meta.string - string
-#    ^^^^^^^^^ meta.clause.patterns.shell meta.string.glob.shell meta.group.regexp.shell string.unquoted.shell
+#    ^^^^^^^^^ meta.clause.patterns.shell meta.string.glob.shell meta.group.glob.shell string.unquoted.shell
 #             ^^^ meta.clause.patterns.shell meta.string.glob.shell string.unquoted.shell
 #                ^ meta.clause.patterns.shell - meta.string - string
 #                 ^ meta.clause.shell
 #                  ^^^^^^^^ meta.clause.body.shell
 #   ^ punctuation.section.patterns.begin.shell
-#    ^ punctuation.section.group.begin.regexp.shell
-#        ^ keyword.operator.alternation.regexp.shell
-#            ^ punctuation.section.group.end.regexp.shell
+#    ^ punctuation.section.group.begin.glob.shell
+#        ^ keyword.operator.alternation.glob.shell
+#            ^ punctuation.section.group.end.glob.shell
 #                ^ punctuation.section.patterns.end.shell
 #                  ^^^ variable.function.shell
 #                      ^^^ meta.string.glob.shell string.unquoted.shell
 #                          ^^ punctuation.terminator.clause.shell
 
     (foo|bar)baz) cmd arg ;&
-#   ^^^^^^^^^ meta.clause.patterns.shell meta.string.glob.shell meta.group.regexp.shell string.unquoted.shell
+#   ^^^^^^^^^ meta.clause.patterns.shell meta.string.glob.shell meta.group.glob.shell string.unquoted.shell
 #            ^^^ meta.clause.patterns.shell meta.string.glob.shell string.unquoted.shell
 #               ^ meta.clause.patterns.shell - meta.string - string
 #                ^ meta.clause.shell
 #                 ^^^^^^^^ meta.clause.body.shell
-#   ^ punctuation.section.group.begin.regexp.shell
-#       ^ keyword.operator.alternation.regexp.shell
-#           ^ punctuation.section.group.end.regexp.shell
+#   ^ punctuation.section.group.begin.glob.shell
+#       ^ keyword.operator.alternation.glob.shell
+#           ^ punctuation.section.group.end.glob.shell
 #               ^ punctuation.section.patterns.end.shell
 #                 ^^^ variable.function.shell
 #                     ^^^ meta.string.glob.shell string.unquoted.shell
 #                         ^^ punctuation.terminator.clause.shell
 
     ( foo | bar ) | baz ) cmd arg ;;
-#   ^^^^^^^^^^^^^ meta.clause.patterns.shell meta.string.glob.shell meta.group.regexp.shell string.unquoted.shell
+#   ^^^^^^^^^^^^^ meta.clause.patterns.shell meta.string.glob.shell meta.group.glob.shell string.unquoted.shell
 #                ^^^ meta.clause.patterns.shell - meta.string - string
 #                   ^^^ meta.clause.patterns.shell meta.string.glob.shell string.unquoted.shell
 #                      ^^ meta.clause.patterns.shell - meta.string - string
 #                        ^ meta.clause.shell
 #                         ^^^^^^^^ meta.clause.body.shell
-#   ^ punctuation.section.group.begin.regexp.shell
-#         ^ keyword.operator.alternation.regexp.shell
-#               ^ punctuation.section.group.end.regexp.shell
+#   ^ punctuation.section.group.begin.glob.shell
+#         ^ keyword.operator.alternation.glob.shell
+#               ^ punctuation.section.group.end.glob.shell
 #                 ^ keyword.operator.logical.shell
 #                   ^^^ meta.string.glob.shell string.unquoted.shell
 #                       ^ punctuation.section.patterns.end.shell
@@ -558,14 +558,14 @@ case $word {
 
     ((foo|bar)baz)
 #   ^ meta.clause.patterns.shell - meta.string - string
-#    ^^^^^^^^^ meta.clause.patterns.shell meta.string.glob.shell meta.group.regexp.shell string.unquoted.shell
+#    ^^^^^^^^^ meta.clause.patterns.shell meta.string.glob.shell meta.group.glob.shell string.unquoted.shell
 #             ^^^ meta.clause.patterns.shell meta.string.glob.shell string.unquoted.shell
 #                ^ meta.clause.patterns.shell - meta.string - string
 #                 ^ meta.clause.shell
 #   ^ punctuation.section.patterns.begin.shell
-#    ^ punctuation.section.group.begin.regexp.shell
-#        ^ keyword.operator.alternation.regexp.shell
-#            ^ punctuation.section.group.end.regexp.shell
+#    ^ punctuation.section.group.begin.glob.shell
+#        ^ keyword.operator.alternation.glob.shell
+#            ^ punctuation.section.group.end.glob.shell
 #                ^ punctuation.section.patterns.end.shell
         cmd arg ;;
 #       ^^^^^^^^ meta.clause.body.shell
@@ -574,13 +574,13 @@ case $word {
 #               ^^ punctuation.terminator.clause.shell
 
     (foo|bar)baz)
-#   ^^^^^^^^^ meta.clause.patterns.shell meta.string.glob.shell meta.group.regexp.shell string.unquoted.shell
+#   ^^^^^^^^^ meta.clause.patterns.shell meta.string.glob.shell meta.group.glob.shell string.unquoted.shell
 #            ^^^ meta.clause.patterns.shell meta.string.glob.shell string.unquoted.shell
 #               ^ meta.clause.patterns.shell - meta.string - string
 #                ^ meta.clause.shell
-#   ^ punctuation.section.group.begin.regexp.shell
-#       ^ keyword.operator.alternation.regexp.shell
-#           ^ punctuation.section.group.end.regexp.shell
+#   ^ punctuation.section.group.begin.glob.shell
+#       ^ keyword.operator.alternation.glob.shell
+#           ^ punctuation.section.group.end.glob.shell
 #               ^ punctuation.section.patterns.end.shell
         cmd arg ;;
 #       ^^^^^^^^ meta.clause.body.shell
@@ -933,7 +933,7 @@ EOF
 #                ^^^^^^^^^^^^^^^^ meta.string.glob.shell
 #                ^ variable.language.tilde.shell
 #                  ^^ constant.other.wildcard.asterisk.shell
-#                     ^^^^ meta.character-class.regexp.shell
+#                     ^^^^ meta.character-class.glob.shell
 #                           ^ constant.other.wildcard.questionmark.shell
 
 : <<< "word --opt ~/**/[Ff]oo?.bar"
@@ -1467,7 +1467,7 @@ ${foo/b([a-z]r|buuz)/baz)}() { : }
 #^ punctuation.section.interpolation.begin.shell
 # ^^^ variable.other.readwrite.shell
 #    ^ keyword.operator.substitution.shell
-#     ^^^^^^^^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#     ^^^^^^^^^^^^^^ meta.string.glob.shell string.unquoted.shell
 #                   ^ keyword.operator.substitution.shell
 #                    ^^^^ meta.string.shell string.unquoted.shell
 #                        ^ punctuation.section.interpolation.end.shell
@@ -1599,7 +1599,7 @@ autoload $dir/*/*~*.zwc(#q.N:t)
 #            ^^^^^^^^^^ string.unquoted.shell
 #             ^ constant.other.wildcard.asterisk.shell
 #               ^ constant.other.wildcard.asterisk.shell
-#                ^ keyword.operator.logical.regexp.shell.zsh
+#                ^ keyword.operator.logical.glob.shell.zsh
 #                 ^ constant.other.wildcard.asterisk.shell
 #                      ^^^^^^^^ meta.modifier.glob.shell.zsh
 #                      ^^ punctuation.definition.modifier.begin.shell.zsh
@@ -2409,11 +2409,11 @@ ip=10.10.20.14
 #  ^ punctuation.definition.variable.shell
 #       ^^ keyword.operator.comparison.shell
 #          ^^^^^^^^^^^^^^^^^^ meta.string.glob.shell string.unquoted.shell
-#                 ^^^^^ meta.character-class.regexp.shell
-#                 ^ punctuation.definition.character-class.begin.regexp.shell
-#                  ^^^ constant.other.range.regexp.shell
-#                   ^ punctuation.separator.sequence.regexp.shell
-#                     ^ punctuation.definition.character-class.end.regexp.shell
+#                 ^^^^^ meta.character-class.glob.shell
+#                 ^ punctuation.definition.character-class.begin.glob.shell
+#                  ^^^ constant.other.range.glob.shell
+#                   ^ punctuation.separator.sequence.glob.shell
+#                     ^ punctuation.definition.character-class.end.glob.shell
 #                      ^ constant.other.wildcard.questionmark.shell
 #                             ^^ punctuation.section.compound.end.shell
 
@@ -2558,9 +2558,9 @@ ip=10.10.20.14
 ###############################################################################
 
 : /(:v) # not a valid modifier, fallback to normal regexp group
-#  ^^^^ meta.string.glob.shell meta.group.regexp.shell string.unquoted.shell
-#  ^ punctuation.section.group.begin.regexp.shell
-#     ^ punctuation.section.group.end.regexp.shell
+#  ^^^^ meta.string.glob.shell meta.group.glob.shell string.unquoted.shell
+#  ^ punctuation.section.group.begin.glob.shell
+#     ^ punctuation.section.group.end.glob.shell
 
 : /(:a) # Turn a file name into an absolute path
 #  ^^^^ meta.string.glob.shell meta.modifier.glob.shell.zsh
@@ -2648,9 +2648,9 @@ ip=10.10.20.14
 #                    ^ - meta.string - meta.modifier
 #    ^^ support.function.substitution.shell.zsh
 #      ^ keyword.operator.substitution.shell.zsh - string
-#       ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#       ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 #              ^ keyword.operator.substitution.shell.zsh
-#               ^^^^ meta.string.regexp.shell string.unquoted.shell
+#               ^^^^ meta.string.glob.shell string.unquoted.shell
 #                   ^ punctuation.definition.modifier.end.shell.zsh
 #                     ^ meta.string.glob.shell - meta.modifier
 #                      ^^ meta.string.glob.shell meta.modifier.glob.shell.zsh - meta.substitution
@@ -2659,9 +2659,9 @@ ip=10.10.20.14
 #                                         ^ - meta.string - meta.modifier
 #                        ^^ support.function.substitution.shell.zsh
 #                          ^^ keyword.operator.substitution.shell.zsh - string
-#                            ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#                            ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 #                                   ^ keyword.operator.substitution.shell.zsh
-#                                    ^^^^ meta.string.regexp.shell string.unquoted.shell
+#                                    ^^^^ meta.string.glob.shell string.unquoted.shell
 #                                       ^ variable.language.reference.shell.zsh
 #                                        ^ punctuation.definition.modifier.end.shell.zsh
 #                                          ^ meta.string.glob.shell - meta.modifier
@@ -2671,9 +2671,9 @@ ip=10.10.20.14
 #                                                                ^ - meta.string - meta.modifier
 #                                             ^^ support.function.substitution.shell.zsh
 #                                               ^^^ keyword.operator.substitution.shell.zsh - string
-#                                                  ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#                                                  ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 #                                                         ^^ keyword.operator.substitution.shell.zsh
-#                                                           ^^^^ meta.string.regexp.shell string.unquoted.shell
+#                                                           ^^^^ meta.string.glob.shell string.unquoted.shell
 #                                                               ^ punctuation.definition.modifier.end.shell.zsh
 
 : /(:s/pa*t?rn/repl) /(:s:pattern:repl) /(:s;pattern;repl;:G)
@@ -2684,9 +2684,9 @@ ip=10.10.20.14
 #                   ^ - meta.string - meta.modifier
 #    ^ support.function.substitution.shell.zsh
 #     ^ keyword.operator.substitution.shell.zsh - string
-#      ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#      ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 #             ^ keyword.operator.substitution.shell.zsh
-#              ^^^^ meta.string.regexp.shell string.unquoted.shell
+#              ^^^^ meta.string.glob.shell string.unquoted.shell
 #                  ^ punctuation.definition.modifier.end.shell.zsh
 #                    ^ meta.string.glob.shell - meta.modifier
 #                     ^^ meta.string.glob.shell meta.modifier.glob.shell.zsh - meta.substitution
@@ -2695,9 +2695,9 @@ ip=10.10.20.14
 #                                      ^ - meta.string - meta.modifier
 #                       ^ support.function.substitution.shell.zsh
 #                        ^ keyword.operator.substitution.shell.zsh - string
-#                         ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#                         ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 #                                ^ keyword.operator.substitution.shell.zsh
-#                                 ^^^^ meta.string.regexp.shell string.unquoted.shell
+#                                 ^^^^ meta.string.glob.shell string.unquoted.shell
 #                                     ^ punctuation.definition.modifier.end.shell.zsh
 #                                       ^ meta.string.glob.shell - meta.modifier
 #                                        ^^ meta.string.glob.shell meta.modifier.glob.shell.zsh - meta.substitution
@@ -2706,12 +2706,12 @@ ip=10.10.20.14
 #                                                            ^ - meta.string - meta.modifier
 #                                          ^ support.function.substitution.shell.zsh
 #                                           ^ keyword.operator.substitution.shell.zsh - string
-#                                            ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#                                            ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 #                                                   ^ keyword.operator.substitution.shell.zsh
-#                                                    ^^^^ meta.string.regexp.shell string.unquoted.shell
+#                                                    ^^^^ meta.string.glob.shell string.unquoted.shell
 #                                                        ^ keyword.operator.substitution.shell.zsh
 #                                                         ^ punctuation.separator.modifier.shell.zsh
-#                                                          ^ constant.other.flag.regexp.shell.zsh
+#                                                          ^ constant.other.flag.glob.shell.zsh
 #                                                           ^ punctuation.definition.modifier.end.shell.zsh
 
 : /(:s(pattern)repl)
@@ -3029,7 +3029,7 @@ ip=10.10.20.14
 #       ^^^^ meta.substitution.shell.zsh
 #       ^ support.function.substitution.shell.zsh
 #        ^ keyword.operator.substitution.shell.zsh
-#         ^^^^ meta.string.regexp.shell string.unquoted.shell constant.character.escape.shell
+#         ^^^^ meta.string.glob.shell string.unquoted.shell constant.character.escape.shell
 #             ^ punctuation.section.interpolation.end.shell
 
 : ${var:s/\\/\\\\}  # substitution without optional trailing `/`
@@ -3041,7 +3041,7 @@ ip=10.10.20.14
 #       ^^^^^^^^^ meta.substitution.shell.zsh
 #       ^ support.function.substitution.shell.zsh
 #        ^ keyword.operator.substitution.shell.zsh
-#         ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#         ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 #         ^^ constant.character.escape.shell
 #           ^ keyword.operator.substitution.shell.zsh
 #            ^^^^ constant.character.escape.shell
@@ -3056,7 +3056,7 @@ ip=10.10.20.14
 #       ^^^^^^^^^^ meta.substitution.shell.zsh
 #       ^ support.function.substitution.shell.zsh
 #        ^ keyword.operator.substitution.shell.zsh
-#         ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#         ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 #         ^^ constant.character.escape.shell
 #           ^ keyword.operator.substitution.shell.zsh
 #            ^^^^ constant.character.escape.shell
@@ -3072,36 +3072,36 @@ ip=10.10.20.14
 #       ^^^^^^^^^^^^ meta.substitution.shell.zsh
 #       ^ support.function.substitution.shell.zsh
 #        ^ keyword.operator.substitution.shell.zsh
-#         ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#         ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 #         ^^ constant.character.escape.shell
 #           ^ keyword.operator.substitution.shell.zsh
 #            ^^^^ constant.character.escape.shell
 #                ^ keyword.operator.substitution.shell.zsh
 #                 ^ punctuation.separator.modifier.shell.zsh
-#                  ^ constant.other.flag.regexp.shell.zsh
+#                  ^ constant.other.flag.glob.shell.zsh
 #                   ^ punctuation.section.interpolation.end.shell
 
 : ${var:s/\\/\\
 \}/:G} # substitution with flag
-# <- meta.interpolation.parameter.shell meta.substitution.shell.zsh meta.string.regexp.shell string.unquoted.shell constant.character.escape.shell
+# <- meta.interpolation.parameter.shell meta.substitution.shell.zsh meta.string.glob.shell string.unquoted.shell constant.character.escape.shell
 #^^^^^ meta.interpolation.parameter.shell
 #^^^^ meta.substitution.shell.zsh
-#^ meta.string.regexp.shell string.unquoted.shell constant.character.escape.shell
+#^ meta.string.glob.shell string.unquoted.shell constant.character.escape.shell
 # ^ keyword.operator.substitution.shell.zsh
 #  ^ punctuation.separator.modifier.shell.zsh
-#   ^ constant.other.flag.regexp.shell.zsh
+#   ^ constant.other.flag.glob.shell.zsh
 #    ^ punctuation.section.interpolation.end.shell
 
 : ${var:s/\\/\\\
 #              ^ punctuation.separator.continuation.line.shell
 \}/:G} # substitution with flag
-# <- meta.interpolation.parameter.shell meta.substitution.shell.zsh meta.string.regexp.shell string.unquoted.shell constant.character.escape.shell
+# <- meta.interpolation.parameter.shell meta.substitution.shell.zsh meta.string.glob.shell string.unquoted.shell constant.character.escape.shell
 #^^^^^ meta.interpolation.parameter.shell
 #^^^^ meta.substitution.shell.zsh
-#^ meta.string.regexp.shell string.unquoted.shell constant.character.escape.shell
+#^ meta.string.glob.shell string.unquoted.shell constant.character.escape.shell
 # ^ keyword.operator.substitution.shell.zsh
 #  ^ punctuation.separator.modifier.shell.zsh
-#   ^ constant.other.flag.regexp.shell.zsh
+#   ^ constant.other.flag.glob.shell.zsh
 #    ^ punctuation.section.interpolation.end.shell
 
 : ${var:gs/\//\/\/}  # alternative representation of global flag
@@ -3113,7 +3113,7 @@ ip=10.10.20.14
 #       ^^^^^^^^^^ meta.substitution.shell.zsh
 #       ^^ support.function.substitution.shell.zsh
 #         ^ keyword.operator.substitution.shell.zsh
-#          ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#          ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 #          ^^ constant.character.escape.shell
 #            ^ keyword.operator.substitution.shell.zsh
 #             ^^^^ constant.character.escape.shell
@@ -3128,7 +3128,7 @@ ip=10.10.20.14
 #       ^^^^^^^^^^ meta.substitution.shell.zsh
 #       ^^ support.function.substitution.shell.zsh
 #         ^ keyword.operator.substitution.shell.zsh
-#          ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#          ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 #          ^^ constant.character.escape.shell
 #            ^ keyword.operator.substitution.shell.zsh
 #             ^^^^ constant.character.escape.shell
@@ -3143,7 +3143,7 @@ ip=10.10.20.14
 #       ^^^^^^^^^^ meta.substitution.shell.zsh
 #       ^^ support.function.substitution.shell.zsh
 #         ^ keyword.operator.substitution.shell.zsh
-#          ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#          ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 #          ^^ constant.character.escape.shell
 #            ^ keyword.operator.substitution.shell.zsh
 #             ^^^^ constant.character.escape.shell
@@ -3158,7 +3158,7 @@ ip=10.10.20.14
 #       ^^^^^^^^^^ meta.substitution.shell.zsh
 #       ^^ support.function.substitution.shell.zsh
 #         ^ keyword.operator.substitution.shell.zsh
-#          ^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#          ^^^^^^^ meta.string.glob.shell string.unquoted.shell
 #          ^^ constant.character.escape.shell
 #            ^ keyword.operator.substitution.shell.zsh
 #             ^^^^ constant.character.escape.shell
@@ -3173,7 +3173,7 @@ ip=10.10.20.14
 #       ^^^^^^ meta.substitution.shell.zsh
 #       ^ support.function.substitution.shell.zsh
 #        ^^ keyword.operator.substitution.shell.zsh
-#          ^^^ meta.string.regexp.shell string.unquoted.shell
+#          ^^^ meta.string.glob.shell string.unquoted.shell
 #           ^ keyword.operator.substitution.shell.zsh
 #             ^ punctuation.section.interpolation.end.shell
 
@@ -4647,7 +4647,7 @@ ip=10.10.20.14
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^^^ variable.other.readwrite.shell
 #      ^ keyword.operator.expansion.shell
-#       ^^^ meta.string.regexp.shell
+#       ^^^ meta.string.glob.shell
 #          ^ punctuation.section.interpolation.end.shell
 
 : ${var##pat}    # max match of pat removed from head
@@ -4656,7 +4656,7 @@ ip=10.10.20.14
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^^^ variable.other.readwrite.shell
 #      ^^ keyword.operator.expansion.shell
-#        ^^^ meta.string.regexp.shell
+#        ^^^ meta.string.glob.shell
 #           ^ punctuation.section.interpolation.end.shell
 
 : ${var%pat}     # min match of pat removed from tail
@@ -4665,7 +4665,7 @@ ip=10.10.20.14
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^^^ variable.other.readwrite.shell
 #      ^ keyword.operator.expansion.shell
-#       ^^^ meta.string.regexp.shell
+#       ^^^ meta.string.glob.shell
 #          ^ punctuation.section.interpolation.end.shell
 
 : ${var%%pat}    # max match of pat removed from tail
@@ -4674,7 +4674,7 @@ ip=10.10.20.14
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^^^ variable.other.readwrite.shell
 #      ^^ keyword.operator.expansion.shell
-#        ^^^ meta.string.regexp.shell
+#        ^^^ meta.string.glob.shell
 #           ^ punctuation.section.interpolation.end.shell
 
 : ${var^pat}    # upper case all chars matching `pat`
@@ -4683,7 +4683,7 @@ ip=10.10.20.14
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^^^ variable.other.readwrite.shell
 #      ^ keyword.operator.expansion.shell
-#       ^^^ meta.string.regexp.shell string.unquoted.shell
+#       ^^^ meta.string.glob.shell string.unquoted.shell
 #          ^ punctuation.section.interpolation.end.shell
 
 : ${var^^pat}   # upper case all chars matching `pat`
@@ -4692,7 +4692,7 @@ ip=10.10.20.14
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^^^ variable.other.readwrite.shell
 #      ^^ keyword.operator.expansion.shell
-#        ^^^ meta.string.regexp.shell string.unquoted.shell
+#        ^^^ meta.string.glob.shell string.unquoted.shell
 #           ^ punctuation.section.interpolation.end.shell
 
 : ${var,pat}    # lower case all chars matching `pat`
@@ -4701,7 +4701,7 @@ ip=10.10.20.14
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^^^ variable.other.readwrite.shell
 #      ^ keyword.operator.expansion.shell
-#       ^^^ meta.string.regexp.shell string.unquoted.shell
+#       ^^^ meta.string.glob.shell string.unquoted.shell
 #          ^ punctuation.section.interpolation.end.shell
 
 : ${var,,pat}   # lower case all chars matching `pat`
@@ -4710,7 +4710,7 @@ ip=10.10.20.14
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^^^ variable.other.readwrite.shell
 #      ^^ keyword.operator.expansion.shell
-#        ^^^ meta.string.regexp.shell string.unquoted.shell
+#        ^^^ meta.string.glob.shell string.unquoted.shell
 #           ^ punctuation.section.interpolation.end.shell
 
 : ${var~pat}    # toggle case all chars matching `pat` (Bash only)
@@ -4719,7 +4719,7 @@ ip=10.10.20.14
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^^^ variable.other.readwrite.shell
 #      ^ invalid.illegal.unexpacted-token.shell
-#       ^^^ meta.string.regexp.shell string.unquoted.shell
+#       ^^^ meta.string.glob.shell string.unquoted.shell
 #          ^ punctuation.section.interpolation.end.shell
 
 : ${var~~pat}   # toggle case all chars matching `pat` (Bash only)
@@ -4728,7 +4728,7 @@ ip=10.10.20.14
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^^^ variable.other.readwrite.shell
 #      ^^ invalid.illegal.unexpacted-token.shell
-#        ^^^ meta.string.regexp.shell string.unquoted.shell
+#        ^^^ meta.string.glob.shell string.unquoted.shell
 #           ^ punctuation.section.interpolation.end.shell
 
 : ${var:#pat}    # $var unless pat matches, then empty
@@ -4782,7 +4782,7 @@ ip=10.10.20.14
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^^^ variable.other.readwrite.shell
 #      ^ keyword.operator.substitution.shell
-#       ^ meta.string.regexp.shell string.unquoted.shell
+#       ^ meta.string.glob.shell string.unquoted.shell
 #        ^ keyword.operator.substitution.shell
 #         ^ meta.string.glob.shell string.unquoted.shell
 #          ^ punctuation.section.interpolation.end.shell
@@ -4793,7 +4793,7 @@ ip=10.10.20.14
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^^^ variable.other.readwrite.shell
 #      ^^ keyword.operator.substitution.shell
-#        ^ meta.string.regexp.shell string.unquoted.shell
+#        ^ meta.string.glob.shell string.unquoted.shell
 #         ^ keyword.operator.substitution.shell
 #          ^ meta.string.glob.shell string.unquoted.shell
 #           ^ punctuation.section.interpolation.end.shell
@@ -4804,7 +4804,7 @@ ip=10.10.20.14
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^^^ variable.other.readwrite.shell
 #      ^^ keyword.operator.substitution.shell
-#        ^ meta.string.regexp.shell string.unquoted.shell
+#        ^ meta.string.glob.shell string.unquoted.shell
 #         ^ keyword.operator.substitution.shell
 #          ^ meta.string.glob.shell string.unquoted.shell
 #           ^ punctuation.section.interpolation.end.shell
@@ -4819,10 +4819,10 @@ ip=10.10.20.14
 #    ^ punctuation.section.interpolation.begin.shell
 #     ^^^ variable.other.readwrite.shell
 #        ^ keyword.operator.expansion.shell
-#         ^ meta.string.regexp.shell string.unquoted.shell
+#         ^ meta.string.glob.shell string.unquoted.shell
 #          ^ punctuation.section.interpolation.end.shell
 #           ^ keyword.operator.expansion.shell
-#            ^ meta.string.regexp.shell string.unquoted.shell
+#            ^ meta.string.glob.shell string.unquoted.shell
 #             ^ punctuation.section.interpolation.end.shell
 
 : ${${var%{p}}#{q}}  # Ensure balanced braces (ZSH only)
@@ -4836,10 +4836,10 @@ ip=10.10.20.14
 #    ^ punctuation.section.interpolation.begin.shell
 #     ^^^ variable.other.readwrite.shell
 #        ^ keyword.operator.expansion.shell
-#         ^^^ meta.string.regexp.shell string.unquoted.shell
+#         ^^^ meta.string.glob.shell string.unquoted.shell
 #            ^ punctuation.section.interpolation.end.shell
 #             ^ keyword.operator.expansion.shell
-#              ^^^ meta.string.regexp.shell string.unquoted.shell
+#              ^^^ meta.string.glob.shell string.unquoted.shell
 #                 ^ punctuation.section.interpolation.end.shell
 
 
@@ -4852,7 +4852,7 @@ ip=10.10.20.14
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^ variable.language.special.shell
 #    ^ keyword.operator.substitution.shell
-#     ^^^ meta.string.regexp.shell
+#     ^^^ meta.string.glob.shell
 #        ^ keyword.operator.substitution.shell
 #         ^^^ meta.string.glob.shell string.unquoted.shell
 #            ^ punctuation.section.interpolation.end.shell
@@ -4864,7 +4864,7 @@ ip=10.10.20.14
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^ variable.language.special.shell
 #    ^ keyword.operator.substitution.shell
-#     ^^^ meta.string.regexp.shell
+#     ^^^ meta.string.glob.shell
 #        ^ keyword.operator.substitution.shell
 #         ^^^ meta.string.glob.shell string.unquoted.shell
 #            ^ punctuation.section.interpolation.end.shell
@@ -4876,7 +4876,7 @@ ip=10.10.20.14
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^ variable.language.special.shell
 #    ^ keyword.operator.substitution.shell
-#     ^^^ meta.string.regexp.shell
+#     ^^^ meta.string.glob.shell
 #        ^ keyword.operator.substitution.shell
 #         ^^^ meta.string.glob.shell string.unquoted.shell
 #            ^ punctuation.section.interpolation.end.shell
@@ -4888,7 +4888,7 @@ ip=10.10.20.14
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^ variable.language.special.shell
 #    ^ keyword.operator.substitution.shell
-#     ^^^ meta.string.regexp.shell
+#     ^^^ meta.string.glob.shell
 #        ^ keyword.operator.substitution.shell
 #         ^^^ meta.string.glob.shell string.unquoted.shell
 #            ^ punctuation.section.interpolation.end.shell
@@ -4900,7 +4900,7 @@ ip=10.10.20.14
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^ variable.language.special.shell
 #    ^ keyword.operator.substitution.shell
-#     ^^^ meta.string.regexp.shell
+#     ^^^ meta.string.glob.shell
 #        ^ keyword.operator.substitution.shell
 #         ^^^ meta.string.glob.shell string.unquoted.shell
 #            ^ punctuation.section.interpolation.end.shell
@@ -4912,7 +4912,7 @@ ip=10.10.20.14
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^ variable.language.special.shell
 #    ^ keyword.operator.substitution.shell
-#     ^^^ meta.string.regexp.shell
+#     ^^^ meta.string.glob.shell
 #        ^ keyword.operator.substitution.shell
 #         ^^^ meta.string.glob.shell string.unquoted.shell
 #            ^ punctuation.section.interpolation.end.shell
@@ -4924,7 +4924,7 @@ ip=10.10.20.14
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^ variable.language.special.shell
 #    ^ keyword.operator.substitution.shell
-#     ^^^ meta.string.regexp.shell
+#     ^^^ meta.string.glob.shell
 #        ^ keyword.operator.substitution.shell
 #         ^^^ meta.string.glob.shell string.unquoted.shell
 #            ^ punctuation.section.interpolation.end.shell
@@ -4936,7 +4936,7 @@ ip=10.10.20.14
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^ variable.language.builtin.shell
 #    ^ keyword.operator.substitution.shell
-#     ^^^ meta.string.regexp.shell
+#     ^^^ meta.string.glob.shell
 #        ^ keyword.operator.substitution.shell
 #         ^^^ meta.string.glob.shell string.unquoted.shell
 #            ^ punctuation.section.interpolation.end.shell
@@ -4948,7 +4948,7 @@ ip=10.10.20.14
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^^^ variable.other.readwrite.shell
 #      ^ keyword.operator.substitution.shell
-#       ^^^ meta.string.regexp.shell
+#       ^^^ meta.string.glob.shell
 #          ^ keyword.operator.substitution.shell
 #           ^^^ meta.string.glob.shell string.unquoted.shell
 #              ^ punctuation.section.interpolation.end.shell
@@ -4961,7 +4961,7 @@ ip=10.10.20.14
 #   ^^^ variable.other.readwrite.shell
 #      ^ variable.language.special.shell
 #       ^ keyword.operator.substitution.shell
-#        ^^^ meta.string.regexp.shell
+#        ^^^ meta.string.glob.shell
 #           ^ keyword.operator.substitution.shell
 #            ^^^ meta.string.glob.shell string.unquoted.shell
 #               ^ punctuation.section.interpolation.end.shell
@@ -4974,7 +4974,7 @@ ip=10.10.20.14
 #   ^^^ variable.other.readwrite.shell
 #      ^ variable.language.special.shell
 #       ^ keyword.operator.substitution.shell
-#        ^^^ meta.string.regexp.shell
+#        ^^^ meta.string.glob.shell
 #           ^ keyword.operator.substitution.shell
 #            ^^^ meta.string.glob.shell string.unquoted.shell
 #               ^ punctuation.section.interpolation.end.shell
@@ -4989,7 +4989,7 @@ ip=10.10.20.14
 #       ^ variable.language.array.shell
 #        ^ punctuation.section.item-access.end.shell
 #         ^ keyword.operator.substitution.shell
-#          ^^^ meta.string.regexp.shell
+#          ^^^ meta.string.glob.shell
 #             ^ keyword.operator.substitution.shell
 #              ^^^ meta.string.glob.shell string.unquoted.shell
 #                 ^ punctuation.section.interpolation.end.shell
@@ -5004,7 +5004,7 @@ ip=10.10.20.14
 #       ^ variable.language.array.shell
 #        ^ punctuation.section.item-access.end.shell
 #         ^ keyword.operator.substitution.shell
-#          ^^^ meta.string.regexp.shell
+#          ^^^ meta.string.glob.shell
 #             ^ keyword.operator.substitution.shell
 #              ^^^ meta.string.glob.shell string.unquoted.shell
 #                 ^ punctuation.section.interpolation.end.shell
@@ -5065,7 +5065,7 @@ ip=10.10.20.14
 #  ^ punctuation.section.interpolation.begin.shell
 #           ^ - meta.interpolation
 #      ^^ keyword.operator.substitution.shell
-#        ^ keyword.operator.quantifier.regexp.shell.zsh
+#        ^ keyword.operator.quantifier.glob.shell.zsh
 #         ^ keyword.operator.substitution.shell
 #          ^ punctuation.section.interpolation.end.shell
 
@@ -5142,8 +5142,8 @@ ip=10.10.20.14
 
 : ${foo//\
 a\/b/c/d}
-# <- meta.interpolation.parameter.shell meta.string.regexp.shell
-#^^^ meta.interpolation.parameter.shell meta.string.regexp.shell
+# <- meta.interpolation.parameter.shell meta.string.glob.shell
+#^^^ meta.interpolation.parameter.shell meta.string.glob.shell
 #   ^ meta.interpolation.parameter.shell - meta.interpolation.parameter.shell meta.string
 #    ^^^ meta.interpolation.parameter.shell meta.string.shell
 #       ^ meta.interpolation.parameter.shell - meta.interpolation.parameter.shell meta.string
@@ -5229,7 +5229,7 @@ a\/b/c/d}
 
 : ${foo//+([a-:/\}} # incomplete charset in incomplete group
 # ^^^^^^^^ meta.interpolation.parameter.shell - meta.group
-#         ^^^^^^^^ meta.interpolation.parameter.shell meta.group.regexp.shell
+#         ^^^^^^^^ meta.interpolation.parameter.shell meta.group.glob.shell
 #                 ^ meta.interpolation.parameter.shell - meta.group
 #                  ^ - meta.interpolation
 # ^ punctuation.definition.variable.shell
@@ -5237,14 +5237,14 @@ a\/b/c/d}
 #   ^^^ variable.other.readwrite.shell
 #      ^^ keyword.operator.substitution.shell
 #        ^ - keyword.operator
-#         ^ punctuation.section.group.begin.regexp.shell
+#         ^ punctuation.section.group.begin.glob.shell
 #          ^^^^^ - constant - punctuation
 #               ^^ constant.character.escape.shell
 #                 ^ punctuation.section.interpolation.end.shell
 
 : ${foo//+([a|&)/\}} # incomplete charset in group
 # ^^^^^^^^ meta.interpolation.parameter.shell - meta.group
-#         ^^^^^^ meta.interpolation.parameter.shell meta.group.regexp.shell
+#         ^^^^^^ meta.interpolation.parameter.shell meta.group.glob.shell
 #               ^^^^ meta.interpolation.parameter.shell - meta.group
 #                   ^ - meta.interpolation
 # ^ punctuation.definition.variable.shell
@@ -5252,29 +5252,29 @@ a\/b/c/d}
 #   ^^^ variable.other.readwrite.shell
 #      ^^ keyword.operator.substitution.shell
 #        ^ - keyword.operator
-#         ^ punctuation.section.group.begin.regexp.shell
+#         ^ punctuation.section.group.begin.glob.shell
 #          ^^^^ - constant - punctuation
-#            ^ keyword.operator.alternation.regexp.shell
-#              ^ punctuation.section.group.end.regexp.shell
+#            ^ keyword.operator.alternation.glob.shell
+#              ^ punctuation.section.group.end.glob.shell
 #               ^ keyword.operator.substitution.shell
 #                ^^ constant.character.escape.shell
 #                  ^ punctuation.section.interpolation.end.shell
 
 : ${foo//[abc[]/x}  # `[` has no meaning within charsets
 # ^^^^^^^ meta.interpolation.parameter.shell - meta.string meta.character-class
-#        ^^^^^^ meta.interpolation.parameter.shell meta.string.regexp.shell meta.character-class.regexp.shell
+#        ^^^^^^ meta.interpolation.parameter.shell meta.string.glob.shell meta.character-class.glob.shell
 #              ^^^ meta.interpolation.parameter.shell - meta.string meta.character-class
 #      ^^ keyword.operator.substitution.shell
-#        ^ punctuation.definition.character-class.begin.regexp.shell
+#        ^ punctuation.definition.character-class.begin.glob.shell
 #            ^ - keyword - punctuation
-#             ^ punctuation.definition.character-class.end.regexp.shell
+#             ^ punctuation.definition.character-class.end.glob.shell
 #              ^ keyword.operator.substitution.shell
 #                ^ punctuation.section.interpolation.end.shell
 
 : ${var//f|o/b|ar}  # `|` has no meaning in patterns or replacement strings
 # ^^^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #      ^^ keyword.operator.substitution.shell
-#        ^^^ meta.string.regexp.shell string.unquoted.shell - keyword - punctuation
+#        ^^^ meta.string.glob.shell string.unquoted.shell - keyword - punctuation
 #           ^ keyword.operator.substitution.shell
 #            ^^^^ meta.string.glob.shell string.unquoted.shell - keyword - punctuation
 #                ^ punctuation.section.interpolation.end.shell
@@ -5282,7 +5282,7 @@ a\/b/c/d}
 : ${var//f&o/b&ar}  # `&` has no meaning in patterns or replacement strings
 # ^^^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #      ^^ keyword.operator.substitution.shell
-#        ^^^ meta.string.regexp.shell string.unquoted.shell - keyword - punctuation
+#        ^^^ meta.string.glob.shell string.unquoted.shell - keyword - punctuation
 #           ^ keyword.operator.substitution.shell
 #            ^^^^ meta.string.glob.shell string.unquoted.shell - keyword - punctuation
 #                ^ punctuation.section.interpolation.end.shell
@@ -5290,7 +5290,7 @@ a\/b/c/d}
 : ${var//f>o/b>ar}  # `>` has no meaning in patterns or replacement strings
 # ^^^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #      ^^ keyword.operator.substitution.shell
-#        ^^^ meta.string.regexp.shell string.unquoted.shell - keyword - punctuation
+#        ^^^ meta.string.glob.shell string.unquoted.shell - keyword - punctuation
 #           ^ keyword.operator.substitution.shell
 #            ^^^^ meta.string.glob.shell string.unquoted.shell - keyword - punctuation
 #                ^ punctuation.section.interpolation.end.shell
@@ -5298,7 +5298,7 @@ a\/b/c/d}
 : ${var//f<o/b<ar}  # `<` has no meaning in patterns or replacement strings
 # ^^^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #      ^^ keyword.operator.substitution.shell
-#        ^^^ meta.string.regexp.shell string.unquoted.shell - keyword - punctuation
+#        ^^^ meta.string.glob.shell string.unquoted.shell - keyword - punctuation
 #           ^ keyword.operator.substitution.shell
 #            ^^^^ meta.string.glob.shell string.unquoted.shell - keyword - punctuation
 #                ^ punctuation.section.interpolation.end.shell
@@ -5306,24 +5306,24 @@ a\/b/c/d}
 : ${var//f;o/b;ar}  # `;` has no meaning in patterns or replacement strings
 # ^^^^^^^^^^^^^^^^ meta.interpolation.parameter.shell
 #      ^^ keyword.operator.substitution.shell
-#        ^^^ meta.string.regexp.shell string.unquoted.shell - keyword - punctuation
+#        ^^^ meta.string.glob.shell string.unquoted.shell - keyword - punctuation
 #           ^ keyword.operator.substitution.shell
 #            ^^^^ meta.string.glob.shell string.unquoted.shell - keyword - punctuation
 #                ^ punctuation.section.interpolation.end.shell
 
 : ${foo/{{\}[a-z]}({b[a-z]} | ({{([0-9])}}))}/[]]{{\}}}}  # advanced brace balancing in patterns (ZSH only)
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell
-#       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.regexp.shell string.unquoted.shell
+#       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.glob.shell string.unquoted.shell
 #         ^^ constant.character.escape.shell
-#           ^^^^^ meta.character-class.regexp.shell
-#                 ^^^^^^^^^^^^ meta.group.regexp.shell - meta.group meta.group
-#                    ^^^^^ meta.character-class.regexp.shell
-#                           ^ keyword.operator.alternation.regexp.shell
-#                             ^^^ meta.group.regexp.shell meta.group.regexp.shell - meta.group meta.group meta.group
-#                                ^^^^^^^ meta.group.regexp.shell meta.group.regexp.shell meta.group.regexp.shell
-#                                 ^^^^^ meta.character-class.regexp.shell
-#                                       ^^^ meta.group.regexp.shell meta.group.regexp.shell - meta.group meta.group meta.group
-#                                          ^ meta.group.regexp.shell - meta.group meta.group
+#           ^^^^^ meta.character-class.glob.shell
+#                 ^^^^^^^^^^^^ meta.group.glob.shell - meta.group meta.group
+#                    ^^^^^ meta.character-class.glob.shell
+#                           ^ keyword.operator.alternation.glob.shell
+#                             ^^^ meta.group.glob.shell meta.group.glob.shell - meta.group meta.group meta.group
+#                                ^^^^^^^ meta.group.glob.shell meta.group.glob.shell meta.group.glob.shell
+#                                 ^^^^^ meta.character-class.glob.shell
+#                                       ^^^ meta.group.glob.shell meta.group.glob.shell - meta.group meta.group meta.group
+#                                          ^ meta.group.glob.shell - meta.group meta.group
 #                                            ^ keyword.operator.substitution.shell
 #                                             ^^^^^^^^^ meta.string.shell string.unquoted.shell
 #                                                      ^ punctuation.section.interpolation.end.shell
@@ -5336,7 +5336,7 @@ a\/b/c/d}
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^^^ variable.other.readwrite.shell
 #      ^ keyword.operator.substitution.shell
-#       ^ meta.string.regexp.shell variable.language.tilde.shell
+#       ^ meta.string.glob.shell variable.language.tilde.shell
 #        ^ keyword.operator.substitution.shell
 #         ^ punctuation.section.interpolation.end.shell
 
@@ -5356,7 +5356,7 @@ a\/b/c/d}
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^^^ variable.other.readwrite.shell
 #      ^ keyword.operator.substitution.shell
-#       ^^^^^^^ meta.string.regexp.shell
+#       ^^^^^^^ meta.string.glob.shell
 #       ^ meta.interpolation.tilde.shell variable.language.tilde.shell
 #        ^^ constant.character.escape.shell - meta.interpolation.tilde
 #          ^^ constant.other.wildcard.asterisk.shell
@@ -5371,7 +5371,7 @@ a\/b/c/d}
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^^^ variable.other.readwrite.shell
 #      ^ keyword.operator.substitution.shell
-#       ^^ meta.string.regexp.shell variable.language.tilde.shell
+#       ^^ meta.string.glob.shell variable.language.tilde.shell
 #         ^ keyword.operator.substitution.shell
 #          ^ punctuation.section.interpolation.end.shell
 
@@ -5381,7 +5381,7 @@ a\/b/c/d}
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^^^ variable.other.readwrite.shell
 #      ^ keyword.operator.substitution.shell
-#       ^^^^^ meta.string.regexp.shell meta.interpolation.tilde.shell
+#       ^^^^^ meta.string.glob.shell meta.interpolation.tilde.shell
 #       ^ variable.language.tilde.shell
 #        ^^^^ meta.string.glob.shell constant.other.username.shell
 #            ^ keyword.operator.substitution.shell
@@ -5637,7 +5637,7 @@ stash) || true)
 #   ^ punctuation.separator.sequence.shell
 #    ^ meta.string.glob.shell string.unquoted.shell
 #     ^ punctuation.separator.sequence.shell
-#      ^ keyword.operator.logical.regexp.shell
+#      ^ keyword.operator.logical.glob.shell
 #       ^ punctuation.separator.sequence.shell
 #        ^ meta.string.glob.shell string.unquoted.shell - keyword - punctuation - variable
 #         ^ punctuation.separator.sequence.shell
@@ -6167,124 +6167,124 @@ cat =( <<< foo )
 # ^ constant.other.wildcard.questionmark.shell
 
 : [[:alnum:]] # The character is alphanumeric
-# ^^^^^^^^^^^ meta.character-class.regexp.shell
-# ^^^ punctuation.definition.character-class.begin.regexp.shell
-#    ^^^^^ constant.other.character-class.posix.regexp.shell
-#         ^^^ punctuation.definition.character-class.end.regexp.shell
+# ^^^^^^^^^^^ meta.character-class.glob.shell
+# ^^^ punctuation.definition.character-class.begin.glob.shell
+#    ^^^^^ constant.other.character-class.posix.glob.shell
+#         ^^^ punctuation.definition.character-class.end.glob.shell
 
 : [[:alpha:]] # The character is alphabetic
-# ^^^^^^^^^^^ meta.character-class.regexp.shell
-# ^^^ punctuation.definition.character-class.begin.regexp.shell
-#    ^^^^^ constant.other.character-class.posix.regexp.shell
-#         ^^^ punctuation.definition.character-class.end.regexp.shell
+# ^^^^^^^^^^^ meta.character-class.glob.shell
+# ^^^ punctuation.definition.character-class.begin.glob.shell
+#    ^^^^^ constant.other.character-class.posix.glob.shell
+#         ^^^ punctuation.definition.character-class.end.glob.shell
 
 : [[:ascii:]] # The character is 7-bit, i.e. is a single-byte character without the top bit set.
-# ^^^^^^^^^^^ meta.character-class.regexp.shell
-# ^^^ punctuation.definition.character-class.begin.regexp.shell
-#    ^^^^^ constant.other.character-class.posix.regexp.shell
-#         ^^^ punctuation.definition.character-class.end.regexp.shell
+# ^^^^^^^^^^^ meta.character-class.glob.shell
+# ^^^ punctuation.definition.character-class.begin.glob.shell
+#    ^^^^^ constant.other.character-class.posix.glob.shell
+#         ^^^ punctuation.definition.character-class.end.glob.shell
 
 : [[:blank:]] # The character is a blank character
-# ^^^^^^^^^^^ meta.character-class.regexp.shell
-# ^^^ punctuation.definition.character-class.begin.regexp.shell
-#    ^^^^^ constant.other.character-class.posix.regexp.shell
-#         ^^^ punctuation.definition.character-class.end.regexp.shell
+# ^^^^^^^^^^^ meta.character-class.glob.shell
+# ^^^ punctuation.definition.character-class.begin.glob.shell
+#    ^^^^^ constant.other.character-class.posix.glob.shell
+#         ^^^ punctuation.definition.character-class.end.glob.shell
 
 : [[:cntrl:]] # The character is a control character
-# ^^^^^^^^^^^ meta.character-class.regexp.shell
-# ^^^ punctuation.definition.character-class.begin.regexp.shell
-#    ^^^^^ constant.other.character-class.posix.regexp.shell
-#         ^^^ punctuation.definition.character-class.end.regexp.shell
+# ^^^^^^^^^^^ meta.character-class.glob.shell
+# ^^^ punctuation.definition.character-class.begin.glob.shell
+#    ^^^^^ constant.other.character-class.posix.glob.shell
+#         ^^^ punctuation.definition.character-class.end.glob.shell
 
 : [[:digit:]] # The character is a decimal digit
-# ^^^^^^^^^^^ meta.character-class.regexp.shell
-# ^^^ punctuation.definition.character-class.begin.regexp.shell
-#    ^^^^^ constant.other.character-class.posix.regexp.shell
-#         ^^^ punctuation.definition.character-class.end.regexp.shell
+# ^^^^^^^^^^^ meta.character-class.glob.shell
+# ^^^ punctuation.definition.character-class.begin.glob.shell
+#    ^^^^^ constant.other.character-class.posix.glob.shell
+#         ^^^ punctuation.definition.character-class.end.glob.shell
 
 : [[:graph:]] # The character is a printable character other than whitespace
-# ^^^^^^^^^^^ meta.character-class.regexp.shell
-# ^^^ punctuation.definition.character-class.begin.regexp.shell
-#    ^^^^^ constant.other.character-class.posix.regexp.shell
-#         ^^^ punctuation.definition.character-class.end.regexp.shell
+# ^^^^^^^^^^^ meta.character-class.glob.shell
+# ^^^ punctuation.definition.character-class.begin.glob.shell
+#    ^^^^^ constant.other.character-class.posix.glob.shell
+#         ^^^ punctuation.definition.character-class.end.glob.shell
 
 : [[:lower:]] # The character is a lowercase letter
-# ^^^^^^^^^^^ meta.character-class.regexp.shell
-# ^^^ punctuation.definition.character-class.begin.regexp.shell
-#    ^^^^^ constant.other.character-class.posix.regexp.shell
-#         ^^^ punctuation.definition.character-class.end.regexp.shell
+# ^^^^^^^^^^^ meta.character-class.glob.shell
+# ^^^ punctuation.definition.character-class.begin.glob.shell
+#    ^^^^^ constant.other.character-class.posix.glob.shell
+#         ^^^ punctuation.definition.character-class.end.glob.shell
 
 : [[:print:]] # The character is printable
-# ^^^^^^^^^^^ meta.character-class.regexp.shell
-# ^^^ punctuation.definition.character-class.begin.regexp.shell
-#    ^^^^^ constant.other.character-class.posix.regexp.shell
-#         ^^^ punctuation.definition.character-class.end.regexp.shell
+# ^^^^^^^^^^^ meta.character-class.glob.shell
+# ^^^ punctuation.definition.character-class.begin.glob.shell
+#    ^^^^^ constant.other.character-class.posix.glob.shell
+#         ^^^ punctuation.definition.character-class.end.glob.shell
 
 : [[:punct:]] # The character is printable but neither alphanumeric nor whitespace
-# ^^^^^^^^^^^ meta.character-class.regexp.shell
-# ^^^ punctuation.definition.character-class.begin.regexp.shell
-#    ^^^^^ constant.other.character-class.posix.regexp.shell
-#         ^^^ punctuation.definition.character-class.end.regexp.shell
+# ^^^^^^^^^^^ meta.character-class.glob.shell
+# ^^^ punctuation.definition.character-class.begin.glob.shell
+#    ^^^^^ constant.other.character-class.posix.glob.shell
+#         ^^^ punctuation.definition.character-class.end.glob.shell
 
 : [[:space:]] # The character is whitespace
-# ^^^^^^^^^^^ meta.character-class.regexp.shell
-# ^^^ punctuation.definition.character-class.begin.regexp.shell
-#    ^^^^^ constant.other.character-class.posix.regexp.shell
-#         ^^^ punctuation.definition.character-class.end.regexp.shell
+# ^^^^^^^^^^^ meta.character-class.glob.shell
+# ^^^ punctuation.definition.character-class.begin.glob.shell
+#    ^^^^^ constant.other.character-class.posix.glob.shell
+#         ^^^ punctuation.definition.character-class.end.glob.shell
 
 : [[:upper:]] # The character is an uppercase letter
-# ^^^^^^^^^^^ meta.character-class.regexp.shell
-# ^^^ punctuation.definition.character-class.begin.regexp.shell
-#    ^^^^^ constant.other.character-class.posix.regexp.shell
-#         ^^^ punctuation.definition.character-class.end.regexp.shell
+# ^^^^^^^^^^^ meta.character-class.glob.shell
+# ^^^ punctuation.definition.character-class.begin.glob.shell
+#    ^^^^^ constant.other.character-class.posix.glob.shell
+#         ^^^ punctuation.definition.character-class.end.glob.shell
 
 : [[:xdigit:]] # The character is a hexadecimal digit
-# ^^^^^^^^^^^^ meta.character-class.regexp.shell
-# ^^^ punctuation.definition.character-class.begin.regexp.shell
-#    ^^^^^^ constant.other.character-class.posix.regexp.shell
-#          ^^^ punctuation.definition.character-class.end.regexp.shell
+# ^^^^^^^^^^^^ meta.character-class.glob.shell
+# ^^^ punctuation.definition.character-class.begin.glob.shell
+#    ^^^^^^ constant.other.character-class.posix.glob.shell
+#          ^^^ punctuation.definition.character-class.end.glob.shell
 
 # Another set of named classes is handled internally by the shell and is not sensitive to the locale:
 
 : [[:IDENT:]] # The character is allowed to form part of a shell identifier, such as a parameter name.
-# ^^^^^^^^^^^ meta.character-class.regexp.shell
-# ^^^ punctuation.definition.character-class.begin.regexp.shell
-#    ^^^^^ constant.other.character-class.posix.regexp.shell
-#         ^^^ punctuation.definition.character-class.end.regexp.shell
+# ^^^^^^^^^^^ meta.character-class.glob.shell
+# ^^^ punctuation.definition.character-class.begin.glob.shell
+#    ^^^^^ constant.other.character-class.posix.glob.shell
+#         ^^^ punctuation.definition.character-class.end.glob.shell
 
 : [[:IFS:]] # The character is used as an input field separator, i.e. is contained in the IFS parameter
-# ^^^^^^^^^ meta.character-class.regexp.shell
-# ^^^ punctuation.definition.character-class.begin.regexp.shell
-#    ^^^ constant.other.character-class.posix.regexp.shell
-#       ^^^ punctuation.definition.character-class.end.regexp.shell
+# ^^^^^^^^^ meta.character-class.glob.shell
+# ^^^ punctuation.definition.character-class.begin.glob.shell
+#    ^^^ constant.other.character-class.posix.glob.shell
+#       ^^^ punctuation.definition.character-class.end.glob.shell
 
 : [[:IFSSPACE:]] # The character is an IFS white space character.
-# ^^^^^^^^^^^^^^ meta.character-class.regexp.shell
-# ^^^ punctuation.definition.character-class.begin.regexp.shell
-#    ^^^^^^^^ constant.other.character-class.posix.regexp.shell
-#            ^^^ punctuation.definition.character-class.end.regexp.shell
+# ^^^^^^^^^^^^^^ meta.character-class.glob.shell
+# ^^^ punctuation.definition.character-class.begin.glob.shell
+#    ^^^^^^^^ constant.other.character-class.posix.glob.shell
+#            ^^^ punctuation.definition.character-class.end.glob.shell
 
 : [[:INCOMPLETE:]] # Matches a byte that starts an incomplete multibyte character.
-# ^^^^^^^^^^^^^^^^ meta.character-class.regexp.shell
-# ^^^ punctuation.definition.character-class.begin.regexp.shell
-#    ^^^^^^^^^^ constant.other.character-class.posix.regexp.shell
-#              ^^^ punctuation.definition.character-class.end.regexp.shell
+# ^^^^^^^^^^^^^^^^ meta.character-class.glob.shell
+# ^^^ punctuation.definition.character-class.begin.glob.shell
+#    ^^^^^^^^^^ constant.other.character-class.posix.glob.shell
+#              ^^^ punctuation.definition.character-class.end.glob.shell
 
 : [[:WORD:]] # The character is treated as part of a word.
-# ^^^^^^^^^^ meta.character-class.regexp.shell
-# ^^^ punctuation.definition.character-class.begin.regexp.shell
-#    ^^^^ constant.other.character-class.posix.regexp.shell
-#        ^^^ punctuation.definition.character-class.end.regexp.shell
+# ^^^^^^^^^^ meta.character-class.glob.shell
+# ^^^ punctuation.definition.character-class.begin.glob.shell
+#    ^^^^ constant.other.character-class.posix.glob.shell
+#        ^^^ punctuation.definition.character-class.end.glob.shell
 
 : [^.][!\ ] # Like [...], except that it matches any character which is not in the given set.
-# ^^^^^^^^^ meta.string.glob.shell string.unquoted.shell meta.character-class.regexp.shell
-# ^ punctuation.definition.character-class.begin.regexp.shell
-#  ^ keyword.operator.logical.regexp.shell
-#    ^ punctuation.definition.character-class.end.regexp.shell
-#     ^ punctuation.definition.character-class.begin.regexp.shell
-#      ^ keyword.operator.logical.regexp.shell
+# ^^^^^^^^^ meta.string.glob.shell string.unquoted.shell meta.character-class.glob.shell
+# ^ punctuation.definition.character-class.begin.glob.shell
+#  ^ keyword.operator.logical.glob.shell
+#    ^ punctuation.definition.character-class.end.glob.shell
+#     ^ punctuation.definition.character-class.begin.glob.shell
+#      ^ keyword.operator.logical.glob.shell
 #       ^^ constant.character.escape.shell
-#         ^ punctuation.definition.character-class.end.regexp.shell
+#         ^ punctuation.definition.character-class.end.glob.shell
 
 ## Zsh Glob Ranges
 
@@ -6339,7 +6339,7 @@ cat =( <<< foo )
 : <${start##<1-5>0<1-}->  # optional glob range in default values, with `<` treated literal
 # ^ meta.range.shell.zsh - meta.interpolation - meta.range meta.range
 #  ^^^^^^^^^ meta.range.shell.zsh meta.interpolation.parameter.shell - meta.range meta.range
-#           ^^^^^ meta.range.shell.zsh meta.interpolation.parameter.shell meta.string.regexp.shell meta.range.shell.zsh - string
+#           ^^^^^ meta.range.shell.zsh meta.interpolation.parameter.shell meta.string.glob.shell meta.range.shell.zsh - string
 #                ^^^^^ meta.range.shell.zsh meta.interpolation.parameter.shell - meta.range meta.range
 #                 ^ - keyword - punctuation
 #                     ^^ meta.range.shell.zsh
@@ -6348,9 +6348,9 @@ cat =( <<< foo )
 : <-${start/f<o<1-$end>o>bar/b<a>z}>  # optional glob range in replacements, with `<` treated literal
 # ^^ meta.range.shell.zsh - meta.interpolation - meta.range meta.range
 #   ^^^^^^^^^^^ meta.range.shell.zsh meta.interpolation.parameter.shell - meta.range meta.range
-#              ^^^ meta.range.shell.zsh meta.interpolation.parameter.shell meta.string.regexp.shell meta.range.shell.zsh - string
+#              ^^^ meta.range.shell.zsh meta.interpolation.parameter.shell meta.string.glob.shell meta.range.shell.zsh - string
 #                 ^^^^ meta.range.shell.zsh meta.number.integer.decimal.shell meta.interpolation.parameter.shell meta.range.shell.zsh meta.number.integer.decimal.shell meta.interpolation.parameter.shell variable.other.readwrite.shell - string
-#                     ^ meta.range.shell.zsh meta.number.integer.decimal.shell meta.interpolation.parameter.shell meta.string.regexp.shell meta.range.shell.zsh - string
+#                     ^ meta.range.shell.zsh meta.number.integer.decimal.shell meta.interpolation.parameter.shell meta.string.glob.shell meta.range.shell.zsh - string
 #                      ^^^^^^^^^^^^ meta.range.shell.zsh meta.interpolation.parameter.shell - meta.range meta.range
 #                                  ^ meta.range.shell.zsh - meta.interpolation - meta.range meta.range
 #                                    ^ - meta.range
@@ -6394,9 +6394,9 @@ cat =( <<< foo )
 #                        ^ meta.redirection.shell meta.file-descriptor.shell meta.number.integer.decimal.shell constant.numeric.value.shell
 
 : (<1-5>foo|bar<1-)<1-5>  # glob ranges in pattern groups
-# ^ meta.string.glob.shell meta.group.regexp.shell string.unquoted.shell punctuation.section.group.begin.regexp.shell
-#  ^^^^^ meta.string.glob.shell meta.group.regexp.shell meta.range.shell.zsh - string
-#       ^^^^^^^ meta.string.glob.shell meta.group.regexp.shell string.unquoted.shell - meta.range
+# ^ meta.string.glob.shell meta.group.glob.shell string.unquoted.shell punctuation.section.group.begin.glob.shell
+#  ^^^^^ meta.string.glob.shell meta.group.glob.shell meta.range.shell.zsh - string
+#       ^^^^^^^ meta.string.glob.shell meta.group.glob.shell string.unquoted.shell - meta.range
 #              ^^^ meta.redirection.shell
 #                 ^ invalid.illegal.stray.shell
 #                  ^^^^^ meta.string.glob.shell meta.range.shell.zsh - string
@@ -6437,14 +6437,14 @@ a=(<1-2>foo [foo]=<3-4>bar [buz]=s(<5-6>uf) <10-foo ^~<err>or)  # glob ranges wi
 #                         ^ meta.assignment.r-value.shell meta.sequence.list.shell - meta.string
 #                          ^^^^^^ meta.assignment.r-value.shell meta.sequence.list.shell
 #                                ^ meta.assignment.r-value.shell meta.sequence.list.shell meta.string.glob.shell - meta.group
-#                                 ^ meta.assignment.r-value.shell meta.sequence.list.shell meta.string.glob.shell meta.group.regexp.shell - meta.range
-#                                  ^^^^^ meta.assignment.r-value.shell meta.sequence.list.shell meta.string.glob.shell meta.group.regexp.shell meta.range.shell.zsh - string
-#                                       ^^^ meta.assignment.r-value.shell meta.sequence.list.shell meta.string.glob.shell meta.group.regexp.shell - meta.range
+#                                 ^ meta.assignment.r-value.shell meta.sequence.list.shell meta.string.glob.shell meta.group.glob.shell - meta.range
+#                                  ^^^^^ meta.assignment.r-value.shell meta.sequence.list.shell meta.string.glob.shell meta.group.glob.shell meta.range.shell.zsh - string
+#                                       ^^^ meta.assignment.r-value.shell meta.sequence.list.shell meta.string.glob.shell meta.group.glob.shell - meta.range
 #                                          ^ meta.assignment.r-value.shell meta.sequence.list.shell - meta.string
 #                                           ^ meta.assignment.r-value.shell meta.sequence.list.shell invalid.illegal.unexpected-token.shell.zsh
 #                                            ^^^^^^ meta.assignment.r-value.shell meta.sequence.list.shell meta.string.glob.shell string.unquoted.shell
 #                                                   ^^^^^^ meta.assignment.r-value.shell meta.sequence.list.shell meta.string.glob.shell
-#                                                   ^ keyword.operator.logical.regexp.shell.zsh
+#                                                   ^ keyword.operator.logical.glob.shell.zsh
 #                                                    ^ variable.language.tilde.shell
 #                                                     ^ invalid.illegal.unexpected-token.shell.zsh
 #                                                      ^^^ string.unquoted.shell
@@ -6462,7 +6462,7 @@ declare -A a=(key <1-2>value key <1-2ill key ^~<err>or)  # glob ranges within as
 #                                 ^^^^^^ meta.string.glob.shell string.unquoted.shell
 #                                        ^^^ entity.name.key.shell
 #                                            ^^^^^^ meta.string.glob.shell
-#                                            ^ keyword.operator.logical.regexp.shell.zsh
+#                                            ^ keyword.operator.logical.glob.shell.zsh
 #                                             ^ variable.language.tilde.shell
 #                                              ^ invalid.illegal.unexpected-token.shell.zsh
 #                                               ^^^ string.unquoted.shell
@@ -6487,9 +6487,9 @@ case $foo in
 #                           ^^ meta.string.glob.shell string.unquoted.shell
 
   (<1-2>|<-) | foo<1-2> | <- ) ;;
-# ^ meta.clause.patterns.shell meta.string.glob.shell meta.group.regexp.shell - meta.range
-#  ^^^^^ meta.clause.patterns.shell meta.string.glob.shell meta.group.regexp.shell meta.range.shell.zsh
-#       ^ meta.clause.patterns.shell meta.string.glob.shell meta.group.regexp.shell - meta.range
+# ^ meta.clause.patterns.shell meta.string.glob.shell meta.group.glob.shell - meta.range
+#  ^^^^^ meta.clause.patterns.shell meta.string.glob.shell meta.group.glob.shell meta.range.shell.zsh
+#       ^ meta.clause.patterns.shell meta.string.glob.shell meta.group.glob.shell - meta.range
 #        ^^ meta.clause.patterns.shell meta.string.glob.shell - meta.group
 #          ^ meta.clause.patterns.shell - meta.string
 #           ^ meta.clause.shell - meta.clause.patterns
@@ -6644,25 +6644,25 @@ esac
 
 : foo/(a*/)#bar               # bar matches foo/bar, foo/any/bar, foo/any/anyother/bar, ...
 # ^^^^ meta.string.glob.shell string.unquoted.shell
-#     ^^^^^ meta.string.glob.shell meta.group.regexp.shell string.unquoted.shell
+#     ^^^^^ meta.string.glob.shell meta.group.glob.shell string.unquoted.shell
 #          ^^^^ meta.string.glob.shell string.unquoted.shell
-#     ^ punctuation.section.group.begin.regexp.shell
+#     ^ punctuation.section.group.begin.glob.shell
 #       ^ constant.other.wildcard.asterisk.shell
-#         ^ punctuation.section.group.end.regexp.shell
-#          ^  keyword.operator.quantifier.regexp.shell.zsh
+#         ^ punctuation.section.group.end.glob.shell
+#          ^  keyword.operator.quantifier.glob.shell.zsh
 
 : (foo|bar)|baz
-# ^^^^^^^^^ meta.group.regexp.shell string.unquoted.shell
-# ^ punctuation.section.group.begin.regexp.shell
-#     ^ keyword.operator.alternation.regexp.shell
-#         ^ punctuation.section.group.end.regexp.shell
+# ^^^^^^^^^ meta.group.glob.shell string.unquoted.shell
+# ^ punctuation.section.group.begin.glob.shell
+#     ^ keyword.operator.alternation.glob.shell
+#         ^ punctuation.section.group.end.glob.shell
 #          ^ keyword.operator.assignment.pipe.shell
 #           ^^^ variable.function.shell
 
 : (foo&bar)|baz  # `&` terminates group and command arguments
-# ^^^^ meta.group.regexp.shell string.unquoted.shell
+# ^^^^ meta.group.glob.shell string.unquoted.shell
 #     ^^^^^^^^^^ - meta.group
-# ^ punctuation.section.group.begin.regexp.shell
+# ^ punctuation.section.group.begin.glob.shell
 #     ^ keyword.operator.assignment.pipe.shell
 #      ^^^ variable.function.shell
 #         ^ invalid.illegal.stray.shell
@@ -6670,9 +6670,9 @@ esac
 #           ^^^ variable.function.shell
 
 : (foo;bar)|baz  # `;` terminates group and command arguments
-# ^^^^ meta.group.regexp.shell string.unquoted.shell
+# ^^^^ meta.group.glob.shell string.unquoted.shell
 #     ^^^^^^^^^^ - meta.group
-# ^ punctuation.section.group.begin.regexp.shell
+# ^ punctuation.section.group.begin.glob.shell
 #     ^ punctuation.terminator.statement.shell
 #      ^^^ variable.function.shell
 #         ^ invalid.illegal.stray.shell
@@ -6680,10 +6680,10 @@ esac
 #           ^^^ variable.function.shell
 
 : (foo>bar)|baz  # `>` terminates group and command arguments
-# ^^^^ meta.group.regexp.shell string.unquoted.shell
+# ^^^^ meta.group.glob.shell string.unquoted.shell
 #     ^^^^ meta.redirection.shell - meta.group
 #         ^^^^^^ - meta.group - meta.redirection
-# ^ punctuation.section.group.begin.regexp.shell
+# ^ punctuation.section.group.begin.glob.shell
 #     ^ keyword.operator.assignment.redirection.shell
 #      ^^^ string.unquoted.shell
 #         ^ invalid.illegal.stray.shell
@@ -6691,10 +6691,10 @@ esac
 #           ^^^ variable.function.shell
 
 : (foo<bar)|baz  # `<` terminates group and command arguments
-# ^^^^ meta.group.regexp.shell string.unquoted.shell
+# ^^^^ meta.group.glob.shell string.unquoted.shell
 #     ^^^^ meta.redirection.shell - meta.group
 #         ^^^^^^ - meta.group - meta.redirection
-# ^ punctuation.section.group.begin.regexp.shell
+# ^ punctuation.section.group.begin.glob.shell
 #     ^ keyword.operator.assignment.redirection.shell
 #      ^^^ string.unquoted.shell
 #         ^ invalid.illegal.stray.shell
@@ -6707,22 +6707,22 @@ esac
 #          ^^^^^^^^ meta.function-call.arguments.shell meta.string.glob.shell
 #                  ^ - meta
 # ^^^^^^^^ variable.function.shell
-# ^ keyword.operator.logical.regexp.shell.zsh
+# ^ keyword.operator.logical.glob.shell.zsh
 #     ^ punctuation.separator.path.shell
 #          ^^^^^^^^ string.unquoted.shell
-#          ^ keyword.operator.logical.regexp.shell.zsh
+#          ^ keyword.operator.logical.glob.shell.zsh
 
   ^~/foo/bar ^~/foo/bar      # Matches anything except the pattern x
 # ^^^^^^^^^^ meta.function-call.identifier.shell meta.command.shell
 #           ^ meta.function-call.arguments.shell - variable - string
 #            ^^^^^^^^^^ meta.function-call.arguments.shell meta.string.glob.shell
 #                      ^ - meta
-# ^ keyword.operator.logical.regexp.shell.zsh
+# ^ keyword.operator.logical.glob.shell.zsh
 #  ^ variable.language.tilde.shell
 #   ^^^^^^^^ variable.function.shell
 #   ^ punctuation.separator.path.shell
 #       ^ punctuation.separator.path.shell
-#            ^ string.unquoted.shell keyword.operator.logical.regexp.shell.zsh
+#            ^ string.unquoted.shell keyword.operator.logical.glob.shell.zsh
 #             ^ variable.language.tilde.shell
 #              ^^^^^^^^ string.unquoted.shell
 
@@ -6733,10 +6733,10 @@ esac
 #                    ^ - meta
 # ^^^^^^^^^ variable.function.shell
 # ^ punctuation.separator.path.shell
-#     ^ keyword.operator.logical.regexp.shell.zsh
+#     ^ keyword.operator.logical.glob.shell.zsh
 #      ^ punctuation.separator.path.shell
 #           ^^^^^^^^^ string.unquoted.shell
-#               ^ keyword.operator.logical.regexp.shell.zsh
+#               ^ keyword.operator.logical.glob.shell.zsh
 
   ^/foo~^/bar ^/foo~^/bar
 # ^^^^^^^^^^^ meta.function-call.identifier.shell meta.command.shell
@@ -6744,13 +6744,13 @@ esac
 #             ^^^^^^^^^^^ meta.function-call.arguments.shell meta.string.glob.shell
 #                        ^ - meta
 # ^^^^^^^^^^^ variable.function.shell
-# ^ keyword.operator.logical.regexp.shell.zsh
+# ^ keyword.operator.logical.glob.shell.zsh
 #  ^ punctuation.separator.path.shell
-#      ^^ keyword.operator.logical.regexp.shell.zsh
+#      ^^ keyword.operator.logical.glob.shell.zsh
 #        ^ punctuation.separator.path.shell
 #             ^^^^^^^^^^^ string.unquoted.shell
-#             ^ keyword.operator.logical.regexp.shell.zsh
-#                  ^^ keyword.operator.logical.regexp.shell.zsh
+#             ^ keyword.operator.logical.glob.shell.zsh
+#                  ^^ keyword.operator.logical.glob.shell.zsh
 
   ~/foo~~/bar ~/foo~~/bar
 # ^^^^^^^^^^^ meta.function-call.identifier.shell meta.command.shell
@@ -6760,13 +6760,13 @@ esac
 # ^ variable.language.tilde.shell
 #  ^^^^^ variable.function.shell
 #  ^ punctuation.separator.path.shell
-#      ^ keyword.operator.logical.regexp.shell.zsh
+#      ^ keyword.operator.logical.glob.shell.zsh
 #       ^ variable.language.tilde.shell
 #        ^^^^ variable.function.shell
 #        ^ punctuation.separator.path.shell
 #             ^ variable.language.tilde.shell
 #              ^^^^ string.unquoted.shell
-#                  ^ keyword.operator.logical.regexp.shell.zsh
+#                  ^ keyword.operator.logical.glob.shell.zsh
 #                   ^ variable.language.tilde.shell
 #                    ^^^^ string.unquoted.shell
 
@@ -6778,13 +6778,13 @@ esac
 #  ^ variable.language.tilde.shell
 #   ^^^^ variable.function.shell
 #   ^ punctuation.separator.path.shell
-#       ^^ keyword.operator.logical.regexp.shell.zsh
+#       ^^ keyword.operator.logical.glob.shell.zsh
 #         ^ variable.language.tilde.shell
 #          ^^^^ variable.function.shell
 #          ^ punctuation.separator.path.shell
 #                ^ variable.language.tilde.shell
 #                 ^^^^ string.unquoted.shell
-#                     ^^ keyword.operator.logical.regexp.shell.zsh
+#                     ^^ keyword.operator.logical.glob.shell.zsh
 #                       ^ variable.language.tilde.shell
 #                        ^^^^ string.unquoted.shell
 
@@ -6796,51 +6796,51 @@ esac
 ###############################################################################
 
 : @(___) is (___)    # Match the pattern in the parentheses. (Like ‘(___)’.)
-#  ^^^^^ meta.group.regexp.shell
-#  ^ punctuation.section.group.begin.regexp.shell
-#      ^ punctuation.section.group.end.regexp.shell
-#           ^^^^^ meta.group.regexp.shell
-#           ^ punctuation.section.group.begin.regexp.shell
-#               ^ punctuation.section.group.end.regexp.shell
+#  ^^^^^ meta.group.glob.shell
+#  ^ punctuation.section.group.begin.glob.shell
+#      ^ punctuation.section.group.end.glob.shell
+#           ^^^^^ meta.group.glob.shell
+#           ^ punctuation.section.group.begin.glob.shell
+#               ^ punctuation.section.group.end.glob.shell
 
 : *(___) is (___)#   # Match any number of occurrences. (Like ‘(___)#’, except that recursive directory searching is not supported.)
-#  ^^^^^ meta.group.regexp.shell
-#  ^ punctuation.section.group.begin.regexp.shell
-#      ^ punctuation.section.group.end.regexp.shell
-#           ^^^^^ meta.group.regexp.shell
-#           ^ punctuation.section.group.begin.regexp.shell
-#               ^ punctuation.section.group.end.regexp.shell
-#                ^ keyword.operator.quantifier.regexp.shell
+#  ^^^^^ meta.group.glob.shell
+#  ^ punctuation.section.group.begin.glob.shell
+#      ^ punctuation.section.group.end.glob.shell
+#           ^^^^^ meta.group.glob.shell
+#           ^ punctuation.section.group.begin.glob.shell
+#               ^ punctuation.section.group.end.glob.shell
+#                ^ keyword.operator.quantifier.glob.shell
 
 : +(___) is (___)##  # Match at least one occurrence. (Like ‘(___)##’, except that recursive directory searching is not supported.)
-#  ^^^^^ meta.group.regexp.shell
-#  ^ punctuation.section.group.begin.regexp.shell
-#      ^ punctuation.section.group.end.regexp.shell
-#           ^^^^^ meta.group.regexp.shell
-#           ^ punctuation.section.group.begin.regexp.shell
-#               ^ punctuation.section.group.end.regexp.shell
-#                ^^ keyword.operator.quantifier.regexp.shell
+#  ^^^^^ meta.group.glob.shell
+#  ^ punctuation.section.group.begin.glob.shell
+#      ^ punctuation.section.group.end.glob.shell
+#           ^^^^^ meta.group.glob.shell
+#           ^ punctuation.section.group.begin.glob.shell
+#               ^ punctuation.section.group.end.glob.shell
+#                ^^ keyword.operator.quantifier.glob.shell
 
 : ?(___) is (|___)   # Match zero or one occurrence. (Like ‘(|___)’.)
-#  ^^^^^ meta.group.regexp.shell
-#  ^ punctuation.section.group.begin.regexp.shell
-#      ^ punctuation.section.group.end.regexp.shell
-#           ^^^^^^ meta.group.regexp.shell
-#           ^ punctuation.section.group.begin.regexp.shell
-#            ^ keyword.operator.alternation.regexp.shell
-#                ^ punctuation.section.group.end.regexp.shell
+#  ^^^^^ meta.group.glob.shell
+#  ^ punctuation.section.group.begin.glob.shell
+#      ^ punctuation.section.group.end.glob.shell
+#           ^^^^^^ meta.group.glob.shell
+#           ^ punctuation.section.group.begin.glob.shell
+#            ^ keyword.operator.alternation.glob.shell
+#                ^ punctuation.section.group.end.glob.shell
 
 : !(___) is (^(___)) # Match anything but the expression in parentheses. (Like ‘(^(___))’.)
-#  ^^^^^ meta.group.regexp.shell
-#  ^ punctuation.section.group.begin.regexp.shell
-#      ^ punctuation.section.group.end.regexp.shell
-#           ^^ meta.group.regexp.shell - meta.group.regexp meta.group.regexp
-#           ^ punctuation.section.group.begin.regexp.shell
-#            ^ keyword.operator.logical.regexp.shell
-#             ^^^^^ meta.group.regexp.shell meta.group.regexp.shell
-#             ^ punctuation.section.group.begin.regexp.shell
-#                 ^^ punctuation.section.group.end.regexp.shell
-#                  ^ meta.group.regexp.shell - meta.group.regexp meta.group.regexp
+#  ^^^^^ meta.group.glob.shell
+#  ^ punctuation.section.group.begin.glob.shell
+#      ^ punctuation.section.group.end.glob.shell
+#           ^^ meta.group.glob.shell - meta.group.regexp meta.group.regexp
+#           ^ punctuation.section.group.begin.glob.shell
+#            ^ keyword.operator.logical.glob.shell
+#             ^^^^^ meta.group.glob.shell meta.group.glob.shell
+#             ^ punctuation.section.group.begin.glob.shell
+#                 ^^ punctuation.section.group.end.glob.shell
+#                  ^ meta.group.glob.shell - meta.group.regexp meta.group.regexp
 
 
 ###############################################################################
@@ -6984,21 +6984,21 @@ esac
 
 : ${var##(#c$start,$end)pat}    # requires between N and M matches
 # ^^^^^^^ meta.interpolation.parameter.shell - meta.string meta.string
-#        ^^^ meta.interpolation.parameter.shell meta.string.regexp.shell meta.modifier.glob.shell.zsh - meta.interpolation.parameter meta.interpolation.parameter
-#           ^^^^^^ meta.interpolation.parameter.shell meta.string.regexp.shell meta.modifier.glob.shell.zsh meta.interpolation.parameter.shell
-#                 ^ meta.interpolation.parameter.shell meta.string.regexp.shell meta.modifier.glob.shell.zsh - meta.interpolation.parameter meta.interpolation.parameter
-#                  ^^^^ meta.interpolation.parameter.shell meta.string.regexp.shell meta.modifier.glob.shell.zsh meta.interpolation.parameter.shell
-#                      ^ meta.interpolation.parameter.shell meta.string.regexp.shell meta.modifier.glob.shell.zsh - meta.interpolation.parameter meta.interpolation.parameter
-#                       ^^^ meta.interpolation.parameter.shell meta.string.regexp.shell string.unquoted.shell - meta.modifier
+#        ^^^ meta.interpolation.parameter.shell meta.string.glob.shell meta.modifier.glob.shell.zsh - meta.interpolation.parameter meta.interpolation.parameter
+#           ^^^^^^ meta.interpolation.parameter.shell meta.string.glob.shell meta.modifier.glob.shell.zsh meta.interpolation.parameter.shell
+#                 ^ meta.interpolation.parameter.shell meta.string.glob.shell meta.modifier.glob.shell.zsh - meta.interpolation.parameter meta.interpolation.parameter
+#                  ^^^^ meta.interpolation.parameter.shell meta.string.glob.shell meta.modifier.glob.shell.zsh meta.interpolation.parameter.shell
+#                      ^ meta.interpolation.parameter.shell meta.string.glob.shell meta.modifier.glob.shell.zsh - meta.interpolation.parameter meta.interpolation.parameter
+#                       ^^^ meta.interpolation.parameter.shell meta.string.glob.shell string.unquoted.shell - meta.modifier
 #                          ^ meta.interpolation.parameter.shell punctuation.section.interpolation.end.shell - meta.modifier
 #                           ^ - meta.interpolation.parameter
 
 : ${var##(#b)}      # terminate on invalid flag to ensure proper bailouts
 # ^^^^^^^ meta.interpolation.parameter.shell - meta.string meta.string
-#        ^^^^ meta.interpolation.parameter.shell meta.string.regexp.shell meta.modifier.glob.shell.zsh - meta.interpolation.parameter meta.interpolation.parameter
+#        ^^^^ meta.interpolation.parameter.shell meta.string.glob.shell meta.modifier.glob.shell.zsh - meta.interpolation.parameter meta.interpolation.parameter
 #            ^ meta.interpolation.parameter.shell punctuation.section.interpolation.end.shell - meta.modifier
 #             ^ - meta.interpolation.parameter
-#        ^^^^ meta.string.regexp.shell meta.modifier.glob.shell.zsh
+#        ^^^^ meta.string.glob.shell meta.modifier.glob.shell.zsh
 #        ^^ punctuation.definition.modifier.begin.shell.zsh
 #          ^ storage.modifier.mode.glob.shell.zsh
 #           ^ punctuation.definition.modifier.end.shell.zsh
@@ -7006,31 +7006,31 @@ esac
 
 : ${var##(#b)(d|b)}	# globbing flags and groups
 # ^^^^^^^ meta.interpolation.parameter.shell - meta.string meta.string
-#        ^^^^^^^^^ meta.interpolation.parameter.shell meta.string.regexp.shell
+#        ^^^^^^^^^ meta.interpolation.parameter.shell meta.string.glob.shell
 #                 ^ meta.interpolation.parameter.shell - meta.modifier
 #        ^^^^ meta.modifier.glob.shell.zsh
 #        ^^ punctuation.definition.modifier.begin.shell.zsh
 #          ^ storage.modifier.mode.glob.shell.zsh
 #           ^ punctuation.definition.modifier.end.shell.zsh
-#            ^^^^^ meta.group.regexp.shell string.unquoted.shell
-#            ^ punctuation.section.group.begin.regexp.shell
-#              ^ keyword.operator.alternation.regexp.shell
-#                ^ punctuation.section.group.end.regexp.shell
+#            ^^^^^ meta.group.glob.shell string.unquoted.shell
+#            ^ punctuation.section.group.begin.glob.shell
+#              ^ keyword.operator.alternation.glob.shell
+#                ^ punctuation.section.group.end.glob.shell
 #                 ^ punctuation.section.interpolation.end.shell
 
 : ${var##(#bd)}     # terminate on invalid flag to ensure proper bailouts
-#        ^^^ meta.interpolation.parameter.shell meta.string.regexp.shell meta.modifier.glob.shell.zsh
-#           ^^ meta.interpolation.parameter.shell meta.string.regexp.shell string.unquoted.shell - meta.modifier
+#        ^^^ meta.interpolation.parameter.shell meta.string.glob.shell meta.modifier.glob.shell.zsh
+#           ^^ meta.interpolation.parameter.shell meta.string.glob.shell string.unquoted.shell - meta.modifier
 #             ^ meta.interpolation.parameter.shell punctuation.section.interpolation.end.shell - meta.modifier
 
 : ${var##(#b})      # glob flags are terminated together with expansion by closing brace
-#        ^^^ meta.interpolation.parameter.shell meta.string.regexp.shell meta.modifier.glob.shell.zsh
+#        ^^^ meta.interpolation.parameter.shell meta.string.glob.shell meta.modifier.glob.shell.zsh
 #           ^ meta.interpolation.parameter.shell punctuation.section.interpolation.end.shell - meta.modifier
 #            ^ invalid.illegal.stray.shell
 
 : ${var##(#b\})}    # glob flags are terminated by escaped braces, but expansion isn't
-#        ^^^ meta.interpolation.parameter.shell meta.string.regexp.shell meta.modifier.glob.shell.zsh
-#           ^^^ meta.interpolation.parameter.shell meta.string.regexp.shell string.unquoted.shell - meta.modifier
+#        ^^^ meta.interpolation.parameter.shell meta.string.glob.shell meta.modifier.glob.shell.zsh
+#           ^^^ meta.interpolation.parameter.shell meta.string.glob.shell string.unquoted.shell - meta.modifier
 #              ^ meta.interpolation.parameter.shell punctuation.section.interpolation.end.shell - meta.modifier
 
 
@@ -7043,9 +7043,9 @@ esac
 
 : ((#i)foo)bar
 # ^^^^^^^^^^^^ meta.function-call.arguments.shell meta.string.glob.shell
-# ^ meta.group.regexp.shell punctuation.section.group.begin.regexp.shell
-#  ^^^^ meta.group.regexp.shell meta.modifier.glob.shell.zsh - string
-#      ^^^^ meta.group.regexp.shell string.unquoted.shell
+# ^ meta.group.glob.shell punctuation.section.group.begin.glob.shell
+#  ^^^^ meta.group.glob.shell meta.modifier.glob.shell.zsh - string
+#      ^^^^ meta.group.glob.shell string.unquoted.shell
 #          ^^^ string.unquoted.shell
 
 arr=(veldt jynx grimps waqf zho buck)
@@ -7057,8 +7057,8 @@ print ${arr//(#m)[aeiou]/${(U)MATCH}}
 #      ^ meta.interpolation.parameter.shell punctuation.section.interpolation.begin.shell
 #       ^^^ variable.other.readwrite.shell
 #          ^^ keyword.operator.substitution.shell
-#            ^^^^ meta.interpolation.parameter.shell meta.string.regexp.shell meta.modifier.glob.shell.zsh
-#                ^^^^^^^ meta.interpolation.parameter.shell meta.string.regexp.shell meta.character-class.regexp.shell
+#            ^^^^ meta.interpolation.parameter.shell meta.string.glob.shell meta.modifier.glob.shell.zsh
+#                ^^^^^^^ meta.interpolation.parameter.shell meta.string.glob.shell meta.character-class.glob.shell
 #                       ^ keyword.operator.substitution.shell
 #                        ^ punctuation.definition.variable.shell
 #                         ^ punctuation.section.interpolation.begin.shell
@@ -7069,13 +7069,13 @@ print ${arr//(#m)[aeiou]/${(U)MATCH}}
 : *((#s)|/)test((#e)|/)*
 # ^^^^^^^^^^^^^^^^^^^^^^ meta.string.glob.shell
 # ^ constant.other.wildcard.asterisk.shell
-#  ^ meta.group.regexp.shell - meta.modifier
-#   ^^^^ meta.group.regexp.shell meta.modifier.glob.shell.zsh - string
-#       ^^^ meta.group.regexp.shell - meta.modifier
+#  ^ meta.group.glob.shell - meta.modifier
+#   ^^^^ meta.group.glob.shell meta.modifier.glob.shell.zsh - string
+#       ^^^ meta.group.glob.shell - meta.modifier
 #       ^^^^^^^^ string.unquoted.shell
-#              ^ meta.group.regexp.shell - meta.modifier
-#               ^^^^ meta.group.regexp.shell meta.modifier.glob.shell.zsh - string
-#                   ^^^ meta.group.regexp.shell string.unquoted.shell - meta.modifier
+#              ^ meta.group.glob.shell - meta.modifier
+#               ^^^^ meta.group.glob.shell meta.modifier.glob.shell.zsh - string
+#                   ^^^ meta.group.glob.shell string.unquoted.shell - meta.modifier
 #                      ^ constant.other.wildcard.asterisk.shell
 
 ###############################################################################
@@ -7087,15 +7087,15 @@ print ${arr//(#m)[aeiou]/${(U)MATCH}}
 ## ----------------------------------------------------------------------------
 
 : (D)       # bare qualifiers never start a word
-# ^^^ meta.string.glob.shell meta.group.regexp.shell string.unquoted.shell - meta.modifier
+# ^^^ meta.string.glob.shell meta.group.glob.shell string.unquoted.shell - meta.modifier
 
 : (#b)(D)   # bare qualifiers never start a word, even if preceded by glob flags
 # ^^^^ meta.string.glob.shell meta.modifier.glob.shell.zsh
-#     ^^^ meta.string.glob.shell meta.group.regexp.shell string.unquoted.shell - meta.modifier
+#     ^^^ meta.string.glob.shell meta.group.glob.shell string.unquoted.shell - meta.modifier
 
 : /(D)/     # bare qualifiers don't appear in the middle of words
 # ^^^^^ meta.string.glob.shell string.unquoted.shell
-#  ^^^ meta.group.regexp.shell - meta.modifier
+#  ^^^ meta.group.glob.shell - meta.modifier
 
 : /(D)      # bare qualifiers always appear at the end of words
 # ^ meta.string.glob.shell string.unquoted.shell
@@ -7105,7 +7105,7 @@ print ${arr//(#m)[aeiou]/${(U)MATCH}}
 # as it is still within a word, but may appear at the end
 : /(D)~/*(D)
 # ^ meta.string.glob.shell - meta.group - meta.modifier
-#  ^^^ meta.string.glob.shell meta.group.regexp.shell - meta.modifier
+#  ^^^ meta.string.glob.shell meta.group.glob.shell - meta.modifier
 #     ^^^ meta.string.glob.shell - meta.group - meta.modifier
 #        ^^^ meta.string.glob.shell meta.modifier.glob.shell.zsh
 #           ^ - meta.string - meta.group - meta.modifier
@@ -7118,16 +7118,16 @@ print ${arr//(#m)[aeiou]/${(U)MATCH}}
 
 : /((D))    # bare qualifiers are not valid in groups
 # ^^^^^^ meta.string.glob.shell string.unquoted.shell
-#  ^^^^^ meta.group.regexp.shell - meta.modifier
+#  ^^^^^ meta.group.glob.shell - meta.modifier
 
 : (/*(D))   # bare qualifiers are not valid in groups
-# ^^^ meta.string.glob.shell meta.group.regexp.shell string.unquoted.shell - meta.modifier
-#    ^^^ meta.string.glob.shell meta.group.regexp.shell meta.group.regexp.shell string.unquoted.shell - meta.modifier
-#       ^ meta.string.glob.shell meta.group.regexp.shell string.unquoted.shell - meta.modifier
-# ^ meta.group.regexp.shell string.unquoted.shell punctuation.section.group.begin.regexp.shell
+# ^^^ meta.string.glob.shell meta.group.glob.shell string.unquoted.shell - meta.modifier
+#    ^^^ meta.string.glob.shell meta.group.glob.shell meta.group.glob.shell string.unquoted.shell - meta.modifier
+#       ^ meta.string.glob.shell meta.group.glob.shell string.unquoted.shell - meta.modifier
+# ^ meta.group.glob.shell string.unquoted.shell punctuation.section.group.begin.glob.shell
 #   ^ constant.other.wildcard.asterisk.shell
-#    ^ punctuation.section.group.begin.regexp.shell
-#      ^^ punctuation.section.group.end.regexp.shell
+#    ^ punctuation.section.group.begin.glob.shell
+#      ^^ punctuation.section.group.end.glob.shell
 
 a=(/*(D))   # bare qualifiers are valid in arrays
 # ^ meta.sequence.list.shell - meta.string
@@ -7151,15 +7151,15 @@ a=(/*(D))   # bare qualifiers are valid in arrays
 
 : /(e())    # bare qualifiers can't contain parentheses
 # ^^^^^^ meta.string.glob.shell string.unquoted.shell
-#  ^^^^^ meta.group.regexp.shell - meta.modifier
+#  ^^^^^ meta.group.glob.shell - meta.modifier
 
 : /(e~~)    # bare qualifiers can't contain tildes
 # ^ meta.string.glob.shell - meta.group - meta.modifier
-#  ^^^^^ meta.string.glob.shell meta.group.regexp.shell - meta.modifier
+#  ^^^^^ meta.string.glob.shell meta.group.glob.shell - meta.modifier
 
 : /(e||)    # bare qualifiers can't contain pipes
 # ^^^^^^ meta.string.glob.shell string.unquoted.shell
-#  ^^^^^ meta.group.regexp.shell - meta.modifier
+#  ^^^^^ meta.group.glob.shell - meta.modifier
 
 : /(e.'( ) << >> | ; &'.) # bare qualifiers' quoted arguments' can contain any character
 # ^ meta.string.glob.shell string.unquoted.shell
@@ -7168,13 +7168,13 @@ a=(/*(D))   # bare qualifiers are valid in arrays
 #                       ^ meta.string.glob.shell meta.modifier.glob.shell.zsh - meta.quoted
 
 : ${var##/(D)}          # bare qualifiers don't appear within parmaeter expansions
-#        ^^^^ meta.interpolation.parameter.shell meta.string.regexp.shell string.unquoted.shell - meta.modifier
+#        ^^^^ meta.interpolation.parameter.shell meta.string.glob.shell string.unquoted.shell - meta.modifier
 
 : ${var:-/(D)}          # bare qualifiers don't appear within parmaeter expansions
-#        ^^^^ meta.interpolation.parameter.shell meta.string.regexp.shell string.unquoted.shell - meta.modifier
+#        ^^^^ meta.interpolation.parameter.shell meta.string.glob.shell string.unquoted.shell - meta.modifier
 
 : ${var/\/(D)/\/(D)}    # bare qualifiers don't appear within parmaeter expansions
-#       ^^^^^ meta.interpolation.parameter.shell meta.string.regexp.shell string.unquoted.shell - meta.modifier
+#       ^^^^^ meta.interpolation.parameter.shell meta.string.glob.shell string.unquoted.shell - meta.modifier
 #             ^^^^^ meta.interpolation.parameter.shell meta.string.shell string.unquoted.shell
 
 test $var == ~/*(D)     # bare qualifiers can be appear in test arguments, but cause "too many arguments error"
@@ -7255,14 +7255,14 @@ test $var == ~/*(D)     # bare qualifiers can be appear in test arguments, but c
 
 : /((#qD))    # extended glob qualifiers are valid in groups
 # ^ meta.string.glob.shell - meta.group - meta.modifier
-#  ^ meta.string.glob.shell meta.group.regexp.shell - meta.modifier
-#   ^^^^^ meta.string.glob.shell meta.group.regexp.shell meta.modifier.glob.shell.zsh
-#        ^ meta.string.glob.shell meta.group.regexp.shell - meta.modifier
+#  ^ meta.string.glob.shell meta.group.glob.shell - meta.modifier
+#   ^^^^^ meta.string.glob.shell meta.group.glob.shell meta.modifier.glob.shell.zsh
+#        ^ meta.string.glob.shell meta.group.glob.shell - meta.modifier
 
 : (/*(#qD))   # extended glob qualifiers are valid in groups
-# ^^^ meta.string.glob.shell meta.group.regexp.shell - meta.modifier
-#    ^^^^^ meta.string.glob.shell meta.group.regexp.shell meta.modifier.glob.shell.zsh
-#         ^ meta.string.glob.shell meta.group.regexp.shell - meta.modifier
+# ^^^ meta.string.glob.shell meta.group.glob.shell - meta.modifier
+#    ^^^^^ meta.string.glob.shell meta.group.glob.shell meta.modifier.glob.shell.zsh
+#         ^ meta.string.glob.shell meta.group.glob.shell - meta.modifier
 
 a=(/*(#qD))   # extended glob qualifiers are valid in arrays
 # ^ meta.sequence.list.shell - meta.string
@@ -7319,13 +7319,13 @@ a=(/*(#qD))   # extended glob qualifiers are valid in arrays
 #                         ^ meta.string.glob.shell meta.modifier.glob.shell.zsh - meta.quoted
 
 : ${var##/(#qD)}            # extended glob qualifiers are syntectically valid in parameter expansions
-#         ^^^^^ meta.string.regexp.shell meta.modifier.glob.shell.zsh
+#         ^^^^^ meta.string.glob.shell meta.modifier.glob.shell.zsh
 
 : ${var:-/(#qD)}            # extended glob qualifiers are syntectically valid in parameter expansions
-#         ^^^^^ meta.string.regexp.shell meta.modifier.glob.shell.zsh
+#         ^^^^^ meta.string.glob.shell meta.modifier.glob.shell.zsh
 
 : ${var/\/(#qD)/\/(#qD)}    # extended glob qualifiers are syntectically valid in parameter expansions
-#         ^^^^^ meta.string.regexp.shell meta.modifier.glob.shell.zsh
+#         ^^^^^ meta.string.glob.shell meta.modifier.glob.shell.zsh
 #               ^^^^^^^ meta.interpolation.parameter.shell meta.string.shell string.unquoted.shell
 
 
@@ -8108,9 +8108,9 @@ print -rC1 /tmp/foo*(u0^@:t)
 # except for lex.c, lex.h, parse.c and parse.h.
 ls -ld -- *.*~(lex|parse).[ch](^D^l1)
 #         ^^^^ meta.string.glob.shell string.unquoted.shell
-#             ^^^^^^^^^^^ meta.string.glob.shell meta.group.regexp.shell string.unquoted.shell
+#             ^^^^^^^^^^^ meta.string.glob.shell meta.group.glob.shell string.unquoted.shell
 #                        ^ meta.string.glob.shell string.unquoted.shell
-#                         ^^^^ meta.string.glob.shell string.unquoted.shell meta.character-class.regexp.shell
+#                         ^^^^ meta.string.glob.shell string.unquoted.shell meta.character-class.glob.shell
 #                             ^^^^^^^ meta.string.glob.shell meta.modifier.glob.shell.zsh
 
 # demonstrates how colon modifiers and other qualifiers may be chained together.
@@ -8195,7 +8195,7 @@ ls *~*.*(.)                          # List all files that does not have a dot i
 #  ^^^^^^^^ meta.string.glob.shell
 #  ^^^^^ string.unquoted.shell
 #  ^ constant.other.wildcard.asterisk.shell
-#   ^ keyword.operator.logical.regexp.shell.zsh
+#   ^ keyword.operator.logical.glob.shell.zsh
 #    ^ constant.other.wildcard.asterisk.shell
 #      ^ constant.other.wildcard.asterisk.shell
 #       ^^^ meta.modifier.glob.shell.zsh
@@ -8225,11 +8225,11 @@ ls DATA_[0-9](#c4,7).csv             # List DATA_nnnn.csv to DATA_nnnnnnn.csv
 # ^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell
 #  ^^^^^^^^^^^^^^^^^^^^^ meta.string.glob.shell
 #  ^^^^^^^^^^ string.unquoted.shell
-#       ^^^^^ meta.character-class.regexp.shell
-#       ^ punctuation.definition.character-class.begin.regexp.shell
-#        ^^^ constant.other.range.regexp.shell
-#         ^ punctuation.separator.sequence.regexp.shell
-#           ^ punctuation.definition.character-class.end.regexp.shell
+#       ^^^^^ meta.character-class.glob.shell
+#       ^ punctuation.definition.character-class.begin.glob.shell
+#        ^^^ constant.other.range.glob.shell
+#         ^ punctuation.separator.sequence.glob.shell
+#           ^ punctuation.definition.character-class.end.glob.shell
 #            ^^^^^^^ meta.modifier.glob.shell.zsh
 #            ^^ punctuation.definition.modifier.begin.shell.zsh
 #              ^ storage.modifier.mode.glob.shell.zsh
@@ -8284,11 +8284,11 @@ ls -l *.(png|jpg|gif)                # List pictures only
 #     ^^^^^^^^^^^^^^^ meta.string.glob.shell
 #     ^^ string.unquoted.shell
 #     ^ constant.other.wildcard.asterisk.shell
-#       ^^^^^^^^^^^^^ meta.group.regexp.shell string.unquoted.shell
-#       ^ punctuation.section.group.begin.regexp.shell
-#           ^ keyword.operator.alternation.regexp.shell
-#               ^ keyword.operator.alternation.regexp.shell
-#                   ^ punctuation.section.group.end.regexp.shell
+#       ^^^^^^^^^^^^^ meta.group.glob.shell string.unquoted.shell
+#       ^ punctuation.section.group.begin.glob.shell
+#           ^ keyword.operator.alternation.glob.shell
+#               ^ keyword.operator.alternation.glob.shell
+#                   ^ punctuation.section.group.end.glob.shell
 #                                    ^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.shell
 #                                    ^ punctuation.definition.comment.shell
 
@@ -8326,7 +8326,7 @@ ls foo*~*bar*                        # Match everything that starts with foo but
 # ^^^^^^^^^^^ meta.function-call.arguments.shell
 #  ^^^^^^^^^^ meta.string.glob.shell string.unquoted.shell
 #     ^ constant.other.wildcard.asterisk.shell
-#      ^ keyword.operator.logical.regexp.shell.zsh
+#      ^ keyword.operator.logical.glob.shell.zsh
 #       ^ constant.other.wildcard.asterisk.shell
 #           ^ constant.other.wildcard.asterisk.shell
 
@@ -8485,10 +8485,10 @@ ls -l *.(c|h)                        # Show only all *.c and *.h files
 #     ^^^^^^^ meta.string.glob.shell
 #     ^^ string.unquoted.shell
 #     ^ constant.other.wildcard.asterisk.shell
-#       ^^^^^ meta.group.regexp.shell string.unquoted.shell
-#       ^ punctuation.section.group.begin.regexp.shell
-#         ^ keyword.operator.alternation.regexp.shell
-#           ^ punctuation.section.group.end.regexp.shell
+#       ^^^^^ meta.group.glob.shell string.unquoted.shell
+#       ^ punctuation.section.group.begin.glob.shell
+#         ^ keyword.operator.alternation.glob.shell
+#           ^ punctuation.section.group.end.glob.shell
 
 ls -l *(R)                           # Show only world-readable files
 #^ meta.function-call.identifier.shell meta.command.shell variable.function.shell
@@ -8570,7 +8570,7 @@ ls *.c~foo.c                         # Show only all *.c files and ignore foo.c
 # ^^^^^^^^^^ meta.function-call.arguments.shell
 #  ^^^^^^^^^ meta.string.glob.shell string.unquoted.shell
 #  ^ constant.other.wildcard.asterisk.shell
-#     ^ keyword.operator.logical.regexp.shell.zsh
+#     ^ keyword.operator.logical.glob.shell.zsh
 
 print -rl /home/me/**/*(D/e{'reply=($REPLY/*(N[-1]:t))'})  # Find all directories, list their contents, and output the first item in the above list
 #^^^^ meta.function-call.identifier.shell meta.command.shell support.function.shell
@@ -8623,13 +8623,13 @@ print -rl /**/*~^*/path(|/*)         # Find command to search for directory name
 #         ^^^^^^^^^^^^^ string.unquoted.shell
 #          ^^ constant.other.wildcard.asterisk.shell
 #             ^ constant.other.wildcard.asterisk.shell
-#              ^^ keyword.operator.logical.regexp.shell.zsh
+#              ^^ keyword.operator.logical.glob.shell.zsh
 #                ^ constant.other.wildcard.asterisk.shell
-#                      ^^^^^ meta.group.regexp.shell string.unquoted.shell
-#                      ^ punctuation.section.group.begin.regexp.shell
-#                       ^ keyword.operator.alternation.regexp.shell
+#                      ^^^^^ meta.group.glob.shell string.unquoted.shell
+#                      ^ punctuation.section.group.begin.glob.shell
+#                       ^ keyword.operator.alternation.glob.shell
 #                         ^ constant.other.wildcard.asterisk.shell
-#                          ^ punctuation.section.group.end.regexp.shell
+#                          ^ punctuation.section.group.end.glob.shell
 
 print -l ~/*(ND.^w)                  # List files in the current directory that are not writable by the owner
 #^^^^ meta.function-call.identifier.shell meta.command.shell support.function.shell
@@ -8798,7 +8798,7 @@ for a in ./**/*\ *(Dod); do mv $a ${a:h}/${a:t:gs/ /_}; done   # Remove spaces f
 #                                              ^^ support.function.substitution.shell.zsh
 #                                                ^ keyword.operator.substitution.shell.zsh
 #                                                  ^ keyword.operator.substitution.shell.zsh
-#                                                   ^ meta.string.regexp.shell string.unquoted.shell
+#                                                   ^ meta.string.glob.shell string.unquoted.shell
 #                                                    ^ punctuation.section.interpolation.end.shell
 #                                                     ^ punctuation.terminator.statement.shell
 #                                                       ^^^^ keyword.control.loop.end.shell
@@ -8873,9 +8873,9 @@ echo $var[1] World
 #       ^ punctuation.separator.sequence.shell
 #        ^ meta.arithmetic.shell meta.number.integer.decimal.shell constant.numeric.value.shell
 #         ^ punctuation.section.item-access.end.shell
-#          ^^^ string.unquoted.shell meta.character-class.regexp.shell
-#          ^ punctuation.definition.character-class.begin.regexp.shell
-#            ^ punctuation.definition.character-class.end.regexp.shell
+#          ^^^ string.unquoted.shell meta.character-class.glob.shell
+#          ^ punctuation.definition.character-class.begin.glob.shell
+#            ^ punctuation.definition.character-class.end.glob.shell
 
 : "$var[1][2]"
 # ^ meta.string.glob.shell - meta.interpolation
@@ -9353,7 +9353,7 @@ foo[${bar[$baz]}]=buz
 #      ^ punctuation.definition.modifier.begin.shell.zsh
 #       ^ storage.modifier.subscript.shell.zsh
 #        ^ punctuation.definition.modifier.end.shell.zsh
-#         ^^^^^^^^^^ meta.string.glob.shell.zsh meta.group.regexp.shell string.unquoted.shell
+#         ^^^^^^^^^^ meta.string.glob.shell.zsh meta.group.glob.shell string.unquoted.shell
 #                   ^^^ meta.string.glob.shell.zsh string.unquoted.shell - meta.group - meta.modifier.subscript
 #                      ^ punctuation.section.item-access.end.shell
 
@@ -9364,7 +9364,7 @@ foo[${bar[$baz]}]=buz
 #      ^ punctuation.definition.modifier.begin.shell.zsh
 #       ^ storage.modifier.subscript.shell.zsh
 #        ^ punctuation.definition.modifier.end.shell.zsh
-#         ^^^^^^^^^^ meta.string.glob.shell.zsh meta.group.regexp.shell string.unquoted.shell
+#         ^^^^^^^^^^ meta.string.glob.shell.zsh meta.group.glob.shell string.unquoted.shell
 #                   ^^^ meta.string.glob.shell.zsh string.unquoted.shell - meta.group - meta.modifier.subscript
 #                      ^ punctuation.section.item-access.end.shell
 
@@ -9375,7 +9375,7 @@ foo[${bar[$baz]}]=buz
 #      ^ punctuation.definition.modifier.begin.shell.zsh
 #       ^ storage.modifier.subscript.shell.zsh
 #        ^ punctuation.definition.modifier.end.shell.zsh
-#         ^^^^^^^^^^ meta.string.glob.shell.zsh meta.group.regexp.shell string.unquoted.shell
+#         ^^^^^^^^^^ meta.string.glob.shell.zsh meta.group.glob.shell string.unquoted.shell
 #                   ^^^ meta.string.glob.shell.zsh string.unquoted.shell - meta.group - meta.modifier.subscript
 #                      ^ punctuation.section.item-access.end.shell
 
@@ -9386,7 +9386,7 @@ foo[${bar[$baz]}]=buz
 #      ^ punctuation.definition.modifier.begin.shell.zsh
 #       ^ storage.modifier.subscript.shell.zsh
 #        ^ punctuation.definition.modifier.end.shell.zsh
-#         ^^^^^^^^^^ meta.string.glob.shell.zsh meta.group.regexp.shell string.unquoted.shell
+#         ^^^^^^^^^^ meta.string.glob.shell.zsh meta.group.glob.shell string.unquoted.shell
 #                   ^^^ meta.string.glob.shell.zsh string.unquoted.shell - meta.group - meta.modifier.subscript
 #                      ^ punctuation.section.item-access.end.shell
 
@@ -9397,7 +9397,7 @@ foo[${bar[$baz]}]=buz
 #      ^ punctuation.definition.modifier.begin.shell.zsh
 #       ^ storage.modifier.subscript.shell.zsh
 #        ^ punctuation.definition.modifier.end.shell.zsh
-#         ^^^^^^^^^^ meta.string.glob.shell.zsh meta.group.regexp.shell string.unquoted.shell
+#         ^^^^^^^^^^ meta.string.glob.shell.zsh meta.group.glob.shell string.unquoted.shell
 #                   ^^^ meta.string.glob.shell.zsh string.unquoted.shell - meta.group - meta.modifier.subscript
 #                      ^ punctuation.section.item-access.end.shell
 
@@ -9408,7 +9408,7 @@ foo[${bar[$baz]}]=buz
 #      ^ punctuation.definition.modifier.begin.shell.zsh
 #       ^ storage.modifier.subscript.shell.zsh
 #        ^ punctuation.definition.modifier.end.shell.zsh
-#         ^^^^^^^^^^ meta.string.glob.shell.zsh meta.group.regexp.shell string.unquoted.shell
+#         ^^^^^^^^^^ meta.string.glob.shell.zsh meta.group.glob.shell string.unquoted.shell
 #                   ^^^ meta.string.glob.shell.zsh string.unquoted.shell - meta.group - meta.modifier.subscript
 #                      ^ punctuation.section.item-access.end.shell
 
@@ -9477,7 +9477,7 @@ foo[${bar[$baz]}]=buz
 #       ^ storage.modifier.subscript.shell.zsh
 #        ^ punctuation.definition.modifier.end.shell.zsh
 #         ^^^^^ meta.string.glob.shell.zsh string.unquoted.shell
-#         ^ keyword.operator.logical.regexp.shell.zsh
+#         ^ keyword.operator.logical.glob.shell.zsh
 #             ^ constant.other.wildcard.asterisk.shell
 #              ^ punctuation.separator.sequence.shell - string
 #               ^^^ meta.modifier.subscript.shell.zsh
@@ -10079,9 +10079,9 @@ echo not a function () {}
 #    ^^^ meta.string.glob.shell string.unquoted.shell
 #        ^ meta.string.glob.shell string.unquoted.shell
 #          ^^^^^^^^ meta.string.glob.shell string.unquoted.shell
-#                   ^^ meta.string.glob.shell meta.group.regexp.shell string.unquoted.shell
-#                   ^ punctuation.section.group.begin.regexp.shell
-#                    ^ punctuation.section.group.end.regexp.shell
+#                   ^^ meta.string.glob.shell meta.group.glob.shell string.unquoted.shell
+#                   ^ punctuation.section.group.begin.glob.shell
+#                    ^ punctuation.section.group.end.glob.shell
 #                      ^^ meta.string.glob.shell string.unquoted.shell
 
 echo 'ssl-cert-'${sh}'() {

--- a/ShellScript/Zsh/tests/syntax_test_scope.zsh
+++ b/ShellScript/Zsh/tests/syntax_test_scope.zsh
@@ -501,9 +501,9 @@ case $word {
 
     ws-+([0-9]).host.com)
 #   ^^^^^^^^^^^^^^^^^^^^ meta.statement.conditional.case.body.shell meta.block.shell.zsh meta.clause.patterns.shell meta.string.glob.shell string.unquoted.shell
-#       ^ meta.group.regexp.shell - meta.set
-#        ^^^^^ meta.group.regexp.shell meta.set.regexp.shell
-#             ^ meta.group.regexp.shell - meta.set
+#       ^ meta.group.regexp.shell - meta.character-class
+#        ^^^^^ meta.group.regexp.shell meta.character-class.regexp.shell
+#             ^ meta.group.regexp.shell - meta.character-class
 #                       ^ meta.clause.patterns.shell - meta.group - string
 #                        ^ meta.statement.conditional.case.body.shell meta.block.shell.zsh meta.clause.shell - meta.clause.patterns
         ;;
@@ -933,7 +933,7 @@ EOF
 #                ^^^^^^^^^^^^^^^^ meta.string.glob.shell
 #                ^ variable.language.tilde.shell
 #                  ^^ constant.other.wildcard.asterisk.shell
-#                     ^^^^ meta.set.regexp.shell
+#                     ^^^^ meta.character-class.regexp.shell
 #                           ^ constant.other.wildcard.questionmark.shell
 
 : <<< "word --opt ~/**/[Ff]oo?.bar"
@@ -2409,11 +2409,11 @@ ip=10.10.20.14
 #  ^ punctuation.definition.variable.shell
 #       ^^ keyword.operator.comparison.shell
 #          ^^^^^^^^^^^^^^^^^^ meta.string.glob.shell string.unquoted.shell
-#                 ^^^^^ meta.set.regexp.shell
-#                 ^ punctuation.definition.set.begin.regexp.shell
+#                 ^^^^^ meta.character-class.regexp.shell
+#                 ^ punctuation.definition.character-class.begin.regexp.shell
 #                  ^^^ constant.other.range.regexp.shell
 #                   ^ punctuation.separator.sequence.regexp.shell
-#                     ^ punctuation.definition.set.end.regexp.shell
+#                     ^ punctuation.definition.character-class.end.regexp.shell
 #                      ^ constant.other.wildcard.questionmark.shell
 #                             ^^ punctuation.section.compound.end.shell
 
@@ -2468,11 +2468,11 @@ ip=10.10.20.14
 #  ^ punctuation.definition.variable.shell
 #       ^^ keyword.operator.comparison.shell
 #          ^^^^^^^^^^^^^^^^ meta.string.regexp.shell string.unquoted.shell
-#                 ^^^^^ meta.set.regexp.shell
-#                 ^ punctuation.definition.set.begin.regexp.shell
+#                 ^^^^^ meta.character-class.regexp.shell
+#                 ^ punctuation.definition.character-class.begin.regexp.shell
 #                  ^^^ constant.other.range.regexp.shell
 #                   ^ punctuation.separator.sequence.regexp.shell
-#                     ^ punctuation.definition.set.end.regexp.shell
+#                     ^ punctuation.definition.character-class.end.regexp.shell
 #                      ^ keyword.operator.quantifier.regexp.shell
 #                          ^ invalid.illegal.stray.shell - meta.string - string
 #                            ^^ punctuation.section.compound.end.shell
@@ -5182,7 +5182,7 @@ a\/b/c/d}
 
 : ${foo//:/[}]
 # ^^^^^^^^^^^ meta.interpolation.parameter.shell
-#          ^^^ - meta.string.regexp - meta.set
+#          ^^^ - meta.string.regexp - meta.character-class
 #            ^ - meta.interpolation
 # ^ punctuation.definition.variable.shell
 #  ^ punctuation.section.interpolation.begin.shell
@@ -5199,7 +5199,7 @@ a\/b/c/d}
 #   ^^^ variable.other.readwrite.shell
 #      ^^ keyword.operator.substitution.shell
 #         ^ keyword.operator.substitution.shell
-#          ^^^^ - meta.string.regexp - meta.set - punctuation
+#          ^^^^ - meta.string.regexp - meta.character-class - punctuation
 #           ^^ constant.character.escape.shell
 #              ^ punctuation.section.interpolation.end.shell
 
@@ -5211,7 +5211,7 @@ a\/b/c/d}
 #   ^^^ variable.other.readwrite.shell
 #      ^^ keyword.operator.substitution.shell
 #         ^ keyword.operator.substitution.shell
-#          ^^^^^^ - meta.string.regexp - meta.set - punctuation
+#          ^^^^^^ - meta.string.regexp - meta.character-class - punctuation
 #            ^^ constant.character.escape.shell
 #                ^ punctuation.section.interpolation.end.shell
 
@@ -5222,7 +5222,7 @@ a\/b/c/d}
 #  ^ punctuation.section.interpolation.begin.shell
 #   ^^^ variable.other.readwrite.shell
 #      ^^ keyword.operator.substitution.shell
-#        ^^^ - meta.set - punctuation
+#        ^^^ - meta.character-class - punctuation
 #           ^ keyword.operator.substitution.shell
 #            ^^ constant.character.escape.shell
 #              ^ punctuation.section.interpolation.end.shell
@@ -5261,13 +5261,13 @@ a\/b/c/d}
 #                  ^ punctuation.section.interpolation.end.shell
 
 : ${foo//[abc[]/x}  # `[` has no meaning within charsets
-# ^^^^^^^ meta.interpolation.parameter.shell - meta.string meta.set
-#        ^^^^^^ meta.interpolation.parameter.shell meta.string.regexp.shell meta.set.regexp.shell
-#              ^^^ meta.interpolation.parameter.shell - meta.string meta.set
+# ^^^^^^^ meta.interpolation.parameter.shell - meta.string meta.character-class
+#        ^^^^^^ meta.interpolation.parameter.shell meta.string.regexp.shell meta.character-class.regexp.shell
+#              ^^^ meta.interpolation.parameter.shell - meta.string meta.character-class
 #      ^^ keyword.operator.substitution.shell
-#        ^ punctuation.definition.set.begin.regexp.shell
+#        ^ punctuation.definition.character-class.begin.regexp.shell
 #            ^ - keyword - punctuation
-#             ^ punctuation.definition.set.end.regexp.shell
+#             ^ punctuation.definition.character-class.end.regexp.shell
 #              ^ keyword.operator.substitution.shell
 #                ^ punctuation.section.interpolation.end.shell
 
@@ -5315,13 +5315,13 @@ a\/b/c/d}
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.glob.shell meta.interpolation.parameter.shell
 #       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.regexp.shell string.unquoted.shell
 #         ^^ constant.character.escape.shell
-#           ^^^^^ meta.set.regexp.shell
+#           ^^^^^ meta.character-class.regexp.shell
 #                 ^^^^^^^^^^^^ meta.group.regexp.shell - meta.group meta.group
-#                    ^^^^^ meta.set.regexp.shell
+#                    ^^^^^ meta.character-class.regexp.shell
 #                           ^ keyword.operator.alternation.regexp.shell
 #                             ^^^ meta.group.regexp.shell meta.group.regexp.shell - meta.group meta.group meta.group
 #                                ^^^^^^^ meta.group.regexp.shell meta.group.regexp.shell meta.group.regexp.shell
-#                                 ^^^^^ meta.set.regexp.shell
+#                                 ^^^^^ meta.character-class.regexp.shell
 #                                       ^^^ meta.group.regexp.shell meta.group.regexp.shell - meta.group meta.group meta.group
 #                                          ^ meta.group.regexp.shell - meta.group meta.group
 #                                            ^ keyword.operator.substitution.shell
@@ -6167,124 +6167,124 @@ cat =( <<< foo )
 # ^ constant.other.wildcard.questionmark.shell
 
 : [[:alnum:]] # The character is alphanumeric
-# ^^^^^^^^^^^ meta.set.regexp.shell
-# ^^ punctuation.definition.set.begin.regexp.shell
-#   ^^^^^^^ constant.other.posix-class.regexp.shell
-#          ^^ punctuation.definition.set.end.regexp.shell
+# ^^^^^^^^^^^ meta.character-class.regexp.shell
+# ^^^ punctuation.definition.character-class.begin.regexp.shell
+#    ^^^^^ constant.other.character-class.posix.regexp.shell
+#         ^^^ punctuation.definition.character-class.end.regexp.shell
 
 : [[:alpha:]] # The character is alphabetic
-# ^^^^^^^^^^^ meta.set.regexp.shell
-# ^^ punctuation.definition.set.begin.regexp.shell
-#   ^^^^^^^ constant.other.posix-class.regexp.shell
-#          ^^ punctuation.definition.set.end.regexp.shell
+# ^^^^^^^^^^^ meta.character-class.regexp.shell
+# ^^^ punctuation.definition.character-class.begin.regexp.shell
+#    ^^^^^ constant.other.character-class.posix.regexp.shell
+#         ^^^ punctuation.definition.character-class.end.regexp.shell
 
 : [[:ascii:]] # The character is 7-bit, i.e. is a single-byte character without the top bit set.
-# ^^^^^^^^^^^ meta.set.regexp.shell
-# ^^ punctuation.definition.set.begin.regexp.shell
-#   ^^^^^^^ constant.other.posix-class.regexp.shell
-#          ^^ punctuation.definition.set.end.regexp.shell
+# ^^^^^^^^^^^ meta.character-class.regexp.shell
+# ^^^ punctuation.definition.character-class.begin.regexp.shell
+#    ^^^^^ constant.other.character-class.posix.regexp.shell
+#         ^^^ punctuation.definition.character-class.end.regexp.shell
 
 : [[:blank:]] # The character is a blank character
-# ^^^^^^^^^^^ meta.set.regexp.shell
-# ^^ punctuation.definition.set.begin.regexp.shell
-#   ^^^^^^^ constant.other.posix-class.regexp.shell
-#          ^^ punctuation.definition.set.end.regexp.shell
+# ^^^^^^^^^^^ meta.character-class.regexp.shell
+# ^^^ punctuation.definition.character-class.begin.regexp.shell
+#    ^^^^^ constant.other.character-class.posix.regexp.shell
+#         ^^^ punctuation.definition.character-class.end.regexp.shell
 
 : [[:cntrl:]] # The character is a control character
-# ^^^^^^^^^^^ meta.set.regexp.shell
-# ^^ punctuation.definition.set.begin.regexp.shell
-#   ^^^^^^^ constant.other.posix-class.regexp.shell
-#          ^^ punctuation.definition.set.end.regexp.shell
+# ^^^^^^^^^^^ meta.character-class.regexp.shell
+# ^^^ punctuation.definition.character-class.begin.regexp.shell
+#    ^^^^^ constant.other.character-class.posix.regexp.shell
+#         ^^^ punctuation.definition.character-class.end.regexp.shell
 
 : [[:digit:]] # The character is a decimal digit
-# ^^^^^^^^^^^ meta.set.regexp.shell
-# ^^ punctuation.definition.set.begin.regexp.shell
-#   ^^^^^^^ constant.other.posix-class.regexp.shell
-#          ^^ punctuation.definition.set.end.regexp.shell
+# ^^^^^^^^^^^ meta.character-class.regexp.shell
+# ^^^ punctuation.definition.character-class.begin.regexp.shell
+#    ^^^^^ constant.other.character-class.posix.regexp.shell
+#         ^^^ punctuation.definition.character-class.end.regexp.shell
 
 : [[:graph:]] # The character is a printable character other than whitespace
-# ^^^^^^^^^^^ meta.set.regexp.shell
-# ^^ punctuation.definition.set.begin.regexp.shell
-#   ^^^^^^^ constant.other.posix-class.regexp.shell
-#          ^^ punctuation.definition.set.end.regexp.shell
+# ^^^^^^^^^^^ meta.character-class.regexp.shell
+# ^^^ punctuation.definition.character-class.begin.regexp.shell
+#    ^^^^^ constant.other.character-class.posix.regexp.shell
+#         ^^^ punctuation.definition.character-class.end.regexp.shell
 
 : [[:lower:]] # The character is a lowercase letter
-# ^^^^^^^^^^^ meta.set.regexp.shell
-# ^^ punctuation.definition.set.begin.regexp.shell
-#   ^^^^^^^ constant.other.posix-class.regexp.shell
-#          ^^ punctuation.definition.set.end.regexp.shell
+# ^^^^^^^^^^^ meta.character-class.regexp.shell
+# ^^^ punctuation.definition.character-class.begin.regexp.shell
+#    ^^^^^ constant.other.character-class.posix.regexp.shell
+#         ^^^ punctuation.definition.character-class.end.regexp.shell
 
 : [[:print:]] # The character is printable
-# ^^^^^^^^^^^ meta.set.regexp.shell
-# ^^ punctuation.definition.set.begin.regexp.shell
-#   ^^^^^^^ constant.other.posix-class.regexp.shell
-#          ^^ punctuation.definition.set.end.regexp.shell
+# ^^^^^^^^^^^ meta.character-class.regexp.shell
+# ^^^ punctuation.definition.character-class.begin.regexp.shell
+#    ^^^^^ constant.other.character-class.posix.regexp.shell
+#         ^^^ punctuation.definition.character-class.end.regexp.shell
 
 : [[:punct:]] # The character is printable but neither alphanumeric nor whitespace
-# ^^^^^^^^^^^ meta.set.regexp.shell
-# ^^ punctuation.definition.set.begin.regexp.shell
-#   ^^^^^^^ constant.other.posix-class.regexp.shell
-#          ^^ punctuation.definition.set.end.regexp.shell
+# ^^^^^^^^^^^ meta.character-class.regexp.shell
+# ^^^ punctuation.definition.character-class.begin.regexp.shell
+#    ^^^^^ constant.other.character-class.posix.regexp.shell
+#         ^^^ punctuation.definition.character-class.end.regexp.shell
 
 : [[:space:]] # The character is whitespace
-# ^^^^^^^^^^^ meta.set.regexp.shell
-# ^^ punctuation.definition.set.begin.regexp.shell
-#   ^^^^^^^ constant.other.posix-class.regexp.shell
-#          ^^ punctuation.definition.set.end.regexp.shell
+# ^^^^^^^^^^^ meta.character-class.regexp.shell
+# ^^^ punctuation.definition.character-class.begin.regexp.shell
+#    ^^^^^ constant.other.character-class.posix.regexp.shell
+#         ^^^ punctuation.definition.character-class.end.regexp.shell
 
 : [[:upper:]] # The character is an uppercase letter
-# ^^^^^^^^^^^ meta.set.regexp.shell
-# ^^ punctuation.definition.set.begin.regexp.shell
-#   ^^^^^^^ constant.other.posix-class.regexp.shell
-#          ^^ punctuation.definition.set.end.regexp.shell
+# ^^^^^^^^^^^ meta.character-class.regexp.shell
+# ^^^ punctuation.definition.character-class.begin.regexp.shell
+#    ^^^^^ constant.other.character-class.posix.regexp.shell
+#         ^^^ punctuation.definition.character-class.end.regexp.shell
 
 : [[:xdigit:]] # The character is a hexadecimal digit
-# ^^^^^^^^^^^^ meta.set.regexp.shell
-# ^^ punctuation.definition.set.begin.regexp.shell
-#   ^^^^^^^^ constant.other.posix-class.regexp.shell
-#           ^^ punctuation.definition.set.end.regexp.shell
+# ^^^^^^^^^^^^ meta.character-class.regexp.shell
+# ^^^ punctuation.definition.character-class.begin.regexp.shell
+#    ^^^^^^ constant.other.character-class.posix.regexp.shell
+#          ^^^ punctuation.definition.character-class.end.regexp.shell
 
 # Another set of named classes is handled internally by the shell and is not sensitive to the locale:
 
 : [[:IDENT:]] # The character is allowed to form part of a shell identifier, such as a parameter name.
-# ^^^^^^^^^^^ meta.set.regexp.shell
-# ^^ punctuation.definition.set.begin.regexp.shell
-#   ^^^^^^^ constant.other.posix-class.regexp.shell
-#          ^^ punctuation.definition.set.end.regexp.shell
+# ^^^^^^^^^^^ meta.character-class.regexp.shell
+# ^^^ punctuation.definition.character-class.begin.regexp.shell
+#    ^^^^^ constant.other.character-class.posix.regexp.shell
+#         ^^^ punctuation.definition.character-class.end.regexp.shell
 
 : [[:IFS:]] # The character is used as an input field separator, i.e. is contained in the IFS parameter
-# ^^^^^^^^^ meta.set.regexp.shell
-# ^^ punctuation.definition.set.begin.regexp.shell
-#   ^^^^^ constant.other.posix-class.regexp.shell
-#        ^^ punctuation.definition.set.end.regexp.shell
+# ^^^^^^^^^ meta.character-class.regexp.shell
+# ^^^ punctuation.definition.character-class.begin.regexp.shell
+#    ^^^ constant.other.character-class.posix.regexp.shell
+#       ^^^ punctuation.definition.character-class.end.regexp.shell
 
 : [[:IFSSPACE:]] # The character is an IFS white space character.
-# ^^^^^^^^^^^^^^ meta.set.regexp.shell
-# ^^ punctuation.definition.set.begin.regexp.shell
-#   ^^^^^^^^^^ constant.other.posix-class.regexp.shell
-#             ^^ punctuation.definition.set.end.regexp.shell
+# ^^^^^^^^^^^^^^ meta.character-class.regexp.shell
+# ^^^ punctuation.definition.character-class.begin.regexp.shell
+#    ^^^^^^^^ constant.other.character-class.posix.regexp.shell
+#            ^^^ punctuation.definition.character-class.end.regexp.shell
 
 : [[:INCOMPLETE:]] # Matches a byte that starts an incomplete multibyte character.
-# ^^^^^^^^^^^^^^^^ meta.set.regexp.shell
-# ^^ punctuation.definition.set.begin.regexp.shell
-#   ^^^^^^^^^^^^ constant.other.posix-class.regexp.shell
-#               ^^ punctuation.definition.set.end.regexp.shell
+# ^^^^^^^^^^^^^^^^ meta.character-class.regexp.shell
+# ^^^ punctuation.definition.character-class.begin.regexp.shell
+#    ^^^^^^^^^^ constant.other.character-class.posix.regexp.shell
+#              ^^^ punctuation.definition.character-class.end.regexp.shell
 
 : [[:WORD:]] # The character is treated as part of a word.
-# ^^^^^^^^^^ meta.set.regexp.shell
-# ^^ punctuation.definition.set.begin.regexp.shell
-#   ^^^^^^ constant.other.posix-class.regexp.shell
-#         ^^ punctuation.definition.set.end.regexp.shell
+# ^^^^^^^^^^ meta.character-class.regexp.shell
+# ^^^ punctuation.definition.character-class.begin.regexp.shell
+#    ^^^^ constant.other.character-class.posix.regexp.shell
+#        ^^^ punctuation.definition.character-class.end.regexp.shell
 
 : [^.][!\ ] # Like [...], except that it matches any character which is not in the given set.
-# ^^^^^^^^^ meta.string.glob.shell string.unquoted.shell meta.set.regexp.shell
-# ^ punctuation.definition.set.begin.regexp.shell
+# ^^^^^^^^^ meta.string.glob.shell string.unquoted.shell meta.character-class.regexp.shell
+# ^ punctuation.definition.character-class.begin.regexp.shell
 #  ^ keyword.operator.logical.regexp.shell
-#    ^ punctuation.definition.set.end.regexp.shell
-#     ^ punctuation.definition.set.begin.regexp.shell
+#    ^ punctuation.definition.character-class.end.regexp.shell
+#     ^ punctuation.definition.character-class.begin.regexp.shell
 #      ^ keyword.operator.logical.regexp.shell
 #       ^^ constant.character.escape.shell
-#         ^ punctuation.definition.set.end.regexp.shell
+#         ^ punctuation.definition.character-class.end.regexp.shell
 
 ## Zsh Glob Ranges
 
@@ -7058,7 +7058,7 @@ print ${arr//(#m)[aeiou]/${(U)MATCH}}
 #       ^^^ variable.other.readwrite.shell
 #          ^^ keyword.operator.substitution.shell
 #            ^^^^ meta.interpolation.parameter.shell meta.string.regexp.shell meta.modifier.glob.shell.zsh
-#                ^^^^^^^ meta.interpolation.parameter.shell meta.string.regexp.shell meta.set.regexp.shell
+#                ^^^^^^^ meta.interpolation.parameter.shell meta.string.regexp.shell meta.character-class.regexp.shell
 #                       ^ keyword.operator.substitution.shell
 #                        ^ punctuation.definition.variable.shell
 #                         ^ punctuation.section.interpolation.begin.shell
@@ -8110,7 +8110,7 @@ ls -ld -- *.*~(lex|parse).[ch](^D^l1)
 #         ^^^^ meta.string.glob.shell string.unquoted.shell
 #             ^^^^^^^^^^^ meta.string.glob.shell meta.group.regexp.shell string.unquoted.shell
 #                        ^ meta.string.glob.shell string.unquoted.shell
-#                         ^^^^ meta.string.glob.shell string.unquoted.shell meta.set.regexp.shell
+#                         ^^^^ meta.string.glob.shell string.unquoted.shell meta.character-class.regexp.shell
 #                             ^^^^^^^ meta.string.glob.shell meta.modifier.glob.shell.zsh
 
 # demonstrates how colon modifiers and other qualifiers may be chained together.
@@ -8225,11 +8225,11 @@ ls DATA_[0-9](#c4,7).csv             # List DATA_nnnn.csv to DATA_nnnnnnn.csv
 # ^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell
 #  ^^^^^^^^^^^^^^^^^^^^^ meta.string.glob.shell
 #  ^^^^^^^^^^ string.unquoted.shell
-#       ^^^^^ meta.set.regexp.shell
-#       ^ punctuation.definition.set.begin.regexp.shell
+#       ^^^^^ meta.character-class.regexp.shell
+#       ^ punctuation.definition.character-class.begin.regexp.shell
 #        ^^^ constant.other.range.regexp.shell
 #         ^ punctuation.separator.sequence.regexp.shell
-#           ^ punctuation.definition.set.end.regexp.shell
+#           ^ punctuation.definition.character-class.end.regexp.shell
 #            ^^^^^^^ meta.modifier.glob.shell.zsh
 #            ^^ punctuation.definition.modifier.begin.shell.zsh
 #              ^ storage.modifier.mode.glob.shell.zsh
@@ -8873,9 +8873,9 @@ echo $var[1] World
 #       ^ punctuation.separator.sequence.shell
 #        ^ meta.arithmetic.shell meta.number.integer.decimal.shell constant.numeric.value.shell
 #         ^ punctuation.section.item-access.end.shell
-#          ^^^ string.unquoted.shell meta.set.regexp.shell
-#          ^ punctuation.definition.set.begin.regexp.shell
-#            ^ punctuation.definition.set.end.regexp.shell
+#          ^^^ string.unquoted.shell meta.character-class.regexp.shell
+#          ^ punctuation.definition.character-class.begin.regexp.shell
+#            ^ punctuation.definition.character-class.end.regexp.shell
 
 : "$var[1][2]"
 # ^ meta.string.glob.shell - meta.interpolation


### PR DESCRIPTION
This PR...

1. aligns glob pattern matching related scopes with PR #4569

   - simplify punctuation of character classes (collate and equivalence).
   - scope character classes `meta.character-class` instead of `meta.set` 
     (to be applied to other RegExp syntaxes in future PRs)

2. fully separates glob and (e)regexp patterns, with regards to contexts and scope names.

   Glob patterns are finalized with `.glob.shell`

   Regular Expressions are finalized with `.regexp.shell`