### PR TITLE
[C#] Remove stray braces from raw strings

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -3133,7 +3133,6 @@ contexts:
     - include: string-placeholder-escapes
     - include: string-guids
     - include: extended-raw-string-placeholders
-    - include: invalid-string-placeholders
 
   inside-raw-string:
     - meta_include_prototype: false
@@ -3145,7 +3144,6 @@ contexts:
     - include: string-placeholder-escapes
     - include: string-guids
     - include: extended-raw-string-placeholders
-    - include: invalid-string-placeholders
 
   extended-raw-string-placeholders:
     - match: (?=\{\d)

--- a/C#/tests/syntax_test_scope_C#11.cs
+++ b/C#/tests/syntax_test_scope_C#11.cs
@@ -25,7 +25,7 @@ string longMessage = """
 ///                           ^ punctuation.separator.colon.cs
 ///                            ^^ constant.other.format-spec.cs
 ///                              ^ punctuation.definition.placeholder.end.cs
-///                               ^ invalid.illegal.unescaped-placeholder.cs
+///                               ^ - invalid - punctuation
 
     GMT is {{DateTime.Now,width:yyyyMMdd\THHmmss\Z}}!
 ///        ^^ constant.character.escape.cs
@@ -52,7 +52,7 @@ with five double quotes.
 ///                           ^ punctuation.separator.colon.cs
 ///                            ^^ constant.other.format-spec.cs
 ///                              ^ punctuation.definition.placeholder.end.cs
-///                               ^ invalid.illegal.unescaped-placeholder.cs
+///                               ^ - invalid - punctuation
 
     GMT is {{DateTime.Now,width:yyyyMMdd\THHmmss\Z}}!
 ///        ^^ constant.character.escape.cs


### PR DESCRIPTION
This commit scopes stray closing braces ordinary raw string content as C# compiler accepts them. Stray braces are illegal in interpolated strings, only.