### PR TITLE
[Markdown] Fix footnote termination

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -2433,7 +2433,7 @@ contexts:
   footnote-def-continuation:
     # if line starts with footnote or reference definition,
     # rollback to previous line and pop footnote contexts.
-    - match: ^(?=[ \t]*{{reference_definition}})
+    - match: ^(?=[ \t]*(?:{{atx_heading}}|{{reference_definition}}))
       fail: footnote-def-end
     - match: ^
       pop: 1

--- a/Markdown/tests/syntax_test_markdown.md
+++ b/Markdown/tests/syntax_test_markdown.md
@@ -3351,6 +3351,10 @@ with a *second* line.
 |  ^ punctuation.definition.reference.end.markdown
 |   ^ punctuation.separator.key-value.markdown
 
+# not-a-foot-note
+| <- markup.heading.1.markdown punctuation.definition.heading.begin.markdown - meta.link
+|^^^^^^^^^^^^^^^^^ markup.heading.1.markdown - meta.link
+
 ## https://custom-tests/footnote-reference-definitions/in-block-quotes
 
 > [^1]: And that's the footnote.


### PR DESCRIPTION
This commit terminates footnote definitions at EOL before ATX heading starts in order to ensure a gap, required to separate symbols.

Workaround for https://github.com/sublimehq/sublime_text/issues/4504

Limitations: Not implemented (and not planned) for SEText headings.