### PR TITLE
[Python] Tweak keyword scopes

### DIFF
--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -681,7 +681,7 @@ contexts:
     - match: (?:(async)\s+)?(def)\b
       scope: meta.function.python
       captures:
-        1: keyword.declaration.async.python
+        1: keyword.declaration.function.async.python
         2: keyword.declaration.function.python
       push:
         - function-parameter-list
@@ -1378,7 +1378,7 @@ contexts:
   for-statements:
     - match: (?:(async)\s+)?(for)\b
       captures:
-        1: storage.modifier.async.python
+        1: keyword.control.loop.for.async.python
         2: keyword.control.loop.for.python
       push: for-statement-target-list
 
@@ -1507,7 +1507,7 @@ contexts:
   with-statements:
     - match: (?:(async)\s+)?(with)\b
       captures:
-        1: storage.modifier.async.python
+        1: keyword.control.context.with.async.python
         2: keyword.control.context.with.python
       branch_point: with-statement-tuple
       branch:
@@ -1520,7 +1520,7 @@ contexts:
       scope: punctuation.section.block.begin.python
       pop: 1
     - match: as\b
-      scope: keyword.control.flow.with.as.python
+      scope: keyword.control.context.with.as.python
       push: with-statement-plain-as
     - include: line-continuation-or-pop
     - include: expression-in-a-statement
@@ -1614,7 +1614,7 @@ contexts:
   for-expressions:
     - match: (?:(async)\s+)?(for)\b
       captures:
-        1: keyword.control.loop.async.python
+        1: keyword.control.loop.for.generator.async.python
         2: keyword.control.loop.for.generator.python
       push: for-expression-target-list
 

--- a/Python/Python.sublime-syntax
+++ b/Python/Python.sublime-syntax
@@ -1508,7 +1508,7 @@ contexts:
     - match: (?:(async)\s+)?(with)\b
       captures:
         1: storage.modifier.async.python
-        2: keyword.control.flow.with.python
+        2: keyword.control.context.with.python
       branch_point: with-statement-tuple
       branch:
         - with-statement-tuple
@@ -1547,7 +1547,7 @@ contexts:
     - match: (?={{colon}})
       pop: 1
     - match: as\b
-      scope: keyword.control.flow.with.as.python
+      scope: keyword.control.context.with.as.python
       push: with-statement-tuple-as
     - include: expression-in-a-sequence
 
@@ -1614,7 +1614,7 @@ contexts:
   for-expressions:
     - match: (?:(async)\s+)?(for)\b
       captures:
-        1: storage.modifier.async.python
+        1: keyword.control.loop.async.python
         2: keyword.control.loop.for.generator.python
       push: for-expression-target-list
 

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -1340,7 +1340,7 @@ def _():
 
     async for i in myfunc():
 #   ^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.loop.for
-#   ^^^^^ storage.modifier.async
+#   ^^^^^ keyword.control.loop.for.async
 #         ^^^ keyword.control.loop.for
 #               ^^ keyword.control.loop.in
 #                          ^ punctuation.section.block.begin
@@ -1571,7 +1571,7 @@ def _():
 
     async with context_manager() as c:
 #   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.with.python
-#   ^^^^^ storage.modifier.async
+#   ^^^^^ keyword.control.context.with.async
 #         ^^^^ keyword.control.context.with
 #                                ^^ keyword.control.context.with.as
 #                                    ^ punctuation.section.block.begin
@@ -2438,7 +2438,7 @@ def last_type_annotation(
 async def coroutine(param1):
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
 #                  ^^^^^^^^ meta.function.parameters - meta.function meta.function
-# <- keyword.declaration.async
+# <- keyword.declaration.function.async
 #     ^^^ keyword.declaration.function.python
 #         ^ entity.name.function
    pass
@@ -3380,7 +3380,7 @@ mydict = { a : b async for b in range(1, 2) }
 #           ^^^ meta.mapping.python
 #              ^ meta.mapping.value.python
 #               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.python
-#                ^^^^^ storage.modifier.async.python
+#                ^^^^^ keyword.control.loop.for.generator.async.python
 #                      ^^^ keyword.control.loop.for.generator.python
 
 myset = {"key", True, key2, [-1], {}:1}
@@ -3722,8 +3722,10 @@ _ = [m
 #          ^^ keyword.control.loop.in
 #             ^^^ variable.language.this.python
 
+result = [i async]
+
 result = [i async for i in aiter() if i % 2]
-#           ^^^^^ storage.modifier.async
+#           ^^^^^ keyword.control.loop.for.generator.async.python
 result = [await fun() for fun in funcs]
 #         ^^^^^ keyword.control.flow.await.python
 

--- a/Python/tests/syntax_test_python.py
+++ b/Python/tests/syntax_test_python.py
@@ -1366,7 +1366,7 @@ def _():
 #        ^^^^^^^^^^^^^^^^^^^^^ meta.group.python
 #                              ^^^^ meta.function-call.identifier.python meta.path.python
 #                                  ^^ meta.function-call.arguments.python
-#   ^^^^ keyword.control.flow.with.python
+#   ^^^^ keyword.control.context.with.python
 #        ^ punctuation.section.group.begin.python
 #         ^^^^^^ variable.other.python
 #                ^ keyword.operator.arithmetic.python
@@ -1376,7 +1376,7 @@ def _():
 #                              ^^^^ variable.function.python - support
 #                                  ^ punctuation.section.arguments.begin.python
 #                                   ^ punctuation.section.arguments.end.python
-#                                     ^^ keyword.control.flow.with.as.python
+#                                     ^^ keyword.control.context.with.as.python
 #                                        ^ variable.other.python
 #                                         ^ punctuation.section.block.begin.python
 
@@ -1388,7 +1388,7 @@ def _():
 #                               ^^^^ meta.function-call.identifier.python
 #                                   ^^ meta.function-call.arguments.python
 #                                           ^ - meta.sequence
-#   ^^^^ keyword.control.flow.with.python
+#   ^^^^ keyword.control.context.with.python
 #        ^ punctuation.section.sequence.begin.python
 #         ^ punctuation.section.group.begin.python
 #          ^^^^^^ variable.other.python
@@ -1399,7 +1399,7 @@ def _():
 #                               ^^^^ variable.function.python - support
 #                                   ^ punctuation.section.arguments.begin.python
 #                                    ^ punctuation.section.arguments.end.python
-#                                      ^^ keyword.control.flow.with.as.python
+#                                      ^^ keyword.control.context.with.as.python
 #                                         ^ variable.other.python
 #                                          ^ punctuation.section.sequence.end.python
 #                                           ^ punctuation.section.block.begin.python
@@ -1414,7 +1414,7 @@ def _():
 #                               ^^^^^^^^^^ meta.group.python meta.group.python - meta.group meta.group meta.group
 #                                         ^^^ meta.group.python - meta.group meta.group
 #                                            ^ - meta.group
-#   ^^^^ keyword.control.flow.with.python
+#   ^^^^ keyword.control.context.with.python
 #        ^ punctuation.section.group.begin.python
 #         ^^ punctuation.section.group.begin.python
 #           ^^^^^^ variable.other.python
@@ -1433,20 +1433,20 @@ def _():
 
     with open(), open() as x, open() as as:
 #   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.with.python - meta.statement.with meta.statement.with
-#   ^^^^ keyword.control.flow.with
+#   ^^^^ keyword.control.context.with
 #        ^^^^ support.function
 #              ^ punctuation.separator.sequence
-#                       ^^ keyword.control.flow.with.as
+#                       ^^ keyword.control.context.with.as
 #                           ^ punctuation.separator.sequence
 #                             ^^^^ support.function
-#                                    ^^ keyword.control.flow.with.as
+#                                    ^^ keyword.control.context.with.as
 #                                       ^^ invalid.illegal.name.python
 
     with (
 #   ^^^^^^^ - meta.statement.with meta.statement.with
 #   ^^^^^ meta.statement.with.python - meta.sequence
 #        ^^ meta.statement.with.python meta.sequence.tuple.python
-#   ^^^^ keyword.control.flow.with
+#   ^^^^ keyword.control.context.with
 #        ^ punctuation.section.sequence.begin.python
         open(),
 #      ^^^^^^^^^ meta.statement.with.python meta.sequence.tuple.python
@@ -1456,12 +1456,12 @@ def _():
         open() as x,
 #      ^^^^^^^^^^^^^^ meta.statement.with.python meta.sequence.tuple.python
 #       ^^^^ support.function
-#              ^^ keyword.control.flow.with.as
+#              ^^ keyword.control.context.with.as
 #                  ^ punctuation.separator.sequence
         open() as as
 #      ^^^^^^^^^^^^^ meta.statement.with.python meta.sequence.tuple.python
 #       ^^^^ support.function
-#              ^^ keyword.control.flow.with.as
+#              ^^ keyword.control.context.with.as
 #                 ^^ invalid.illegal.name.python
     ):
 # ^^^^ - meta.statement.with meta.statement.with
@@ -1470,32 +1470,32 @@ def _():
 
     with ( open() as x, captured() as :  # unclosed tuple
 #   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.with.python
-#   ^^^^ keyword.control.flow.with.python
+#   ^^^^ keyword.control.context.with.python
 #        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence.tuple.python
 #        ^ punctuation.section.sequence.begin.python
 #          ^^^^ meta.function-call.identifier.python support.function.builtin.python
 #              ^^ meta.function-call.arguments.python
 #              ^ punctuation.section.arguments.begin.python
 #               ^ punctuation.section.arguments.end.python
-#                 ^^ keyword.control.flow.with.as.python
+#                 ^^ keyword.control.context.with.as.python
 #                    ^ variable.other.python
 #                     ^ punctuation.separator.sequence.python
 #                       ^^^^^^^^ meta.function-call.identifier.python variable.function.python
 #                               ^^ meta.function-call.arguments.python
 #                               ^ punctuation.section.arguments.begin.python
 #                                ^ punctuation.section.arguments.end.python
-#                                  ^^ keyword.control.flow.with.as.python
+#                                  ^^ keyword.control.context.with.as.python
 #                                     ^ punctuation.section.block.begin.python
 #                                        ^^^^^^^^^^^^^^^^^ comment.line.number-sign.python
 #                                        ^ punctuation.definition.comment.python
 
     with captured() as out, err:   # `err` is not part of `captured()` context
 #   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.with.python - meta.sequence
-#   ^^^^ keyword.control.flow.with
+#   ^^^^ keyword.control.context.with
 #        ^^^^^^^^ variable.function
 #                ^ punctuation.section.arguments.begin
 #                 ^ punctuation.section.arguments.end
-#                   ^^ keyword.control.flow.with.as
+#                   ^^ keyword.control.context.with.as
 #                      ^^^ variable.other
 #                         ^ punctuation.separator.sequence
 #                           ^^^ variable.other
@@ -1503,11 +1503,11 @@ def _():
 
     with captured() as (out, err):
 #   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.with.python - meta.statement.with meta.statement.with
-#   ^^^^ keyword.control.flow.with
+#   ^^^^ keyword.control.context.with
 #        ^^^^^^^^ variable.function
 #                ^ punctuation.section.arguments.begin
 #                 ^ punctuation.section.arguments.end
-#                   ^^ keyword.control.flow.with.as
+#                   ^^ keyword.control.context.with.as
 #                      ^ punctuation.section.sequence.begin
 #                       ^^^ variable.other
 #                          ^ punctuation.separator.sequence
@@ -1538,11 +1538,11 @@ def _():
 #   ^^^^^^^^^^^^^^^^^^^ meta.statement.with.python - meta.sequence
 #                      ^^^^^^^^^^ meta.statement.with.python meta.sequence.list.python
 #                                ^ meta.statement.with.python - meta.sequence
-#   ^^^^ keyword.control.flow.with
+#   ^^^^ keyword.control.context.with
 #        ^^^^^^^^ variable.function
 #                ^ punctuation.section.arguments.begin
 #                 ^ punctuation.section.arguments.end
-#                   ^^ keyword.control.flow.with.as
+#                   ^^ keyword.control.context.with.as
 #                      ^ punctuation.section.sequence.begin
 #                       ^^^ variable.other
 #                          ^ punctuation.separator.sequence
@@ -1572,8 +1572,8 @@ def _():
     async with context_manager() as c:
 #   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.with.python
 #   ^^^^^ storage.modifier.async
-#         ^^^^ keyword.control.flow.with
-#                                ^^ keyword.control.flow.with.as
+#         ^^^^ keyword.control.context.with
+#                                ^^ keyword.control.context.with.as
 #                                    ^ punctuation.section.block.begin
         await something()
 #       ^^^^^ keyword.control.flow.await
@@ -1651,7 +1651,7 @@ def _():
     for
 #   ^^^ keyword.control.loop.for.python
     with
-#   ^^^^ keyword.control.flow.with.python
+#   ^^^^ keyword.control.context.with.python
     if
 #   ^^ keyword.control.conditional.if.python
     finally


### PR DESCRIPTION
This PR...

1. scopes `with` `keyword.control.context.with` as `flow` may be dedicated to `return`, `continue`, ... .
2. scopes `async` as part of corresponding control keyword to ensure consistent highlighting in default and basic color schemes. (For details, please refer to commit message).


Before:

<img width="740" height="160" alt="grafik" src="https://github.com/user-attachments/assets/46f6b9d5-01c3-448e-bdb1-96397750877e" />


After:

<img width="668" height="130" alt="grafik" src="https://github.com/user-attachments/assets/adffb065-aecf-4b37-a4e3-c97f6fdedf86" />
