### PR TITLE
[Markdown] Fix Github Alerts in nested list items

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -1008,7 +1008,7 @@ contexts:
         4: markup.list.numbered.markdown
 
   list-block-quotes:
-    - match: '[ \t]{,3}(>)[ ]?[ \t]{,3}((\[)!CAUTION(\]))'
+    - match: '[ \t]*(>)[ ]?[ \t]{,3}((\[)!CAUTION(\]))'
       captures:
         1: punctuation.definition.blockquote.markdown
         2: markup.heading.alert.caution.markdown
@@ -1017,7 +1017,7 @@ contexts:
       push:
         - block-quote-caution-meta
         - list-block-quote-body
-    - match: '[ \t]{,3}(>)[ ]?[ \t]{,3}((\[)!WARNING(\]))'
+    - match: '[ \t]*(>)[ ]?[ \t]{,3}((\[)!WARNING(\]))'
       captures:
         1: punctuation.definition.blockquote.markdown
         2: markup.heading.alert.warning.markdown
@@ -1026,7 +1026,7 @@ contexts:
       push:
         - block-quote-warning-meta
         - list-block-quote-body
-    - match: '[ \t]{,3}(>)[ ]?[ \t]{,3}((\[)!IMPORTANT(\]))'
+    - match: '[ \t]*(>)[ ]?[ \t]{,3}((\[)!IMPORTANT(\]))'
       captures:
         1: punctuation.definition.blockquote.markdown
         2: markup.heading.alert.important.markdown
@@ -1035,7 +1035,7 @@ contexts:
       push:
         - block-quote-important-meta
         - list-block-quote-body
-    - match: '[ \t]{,3}(>)[ ]?[ \t]{,3}((\[)!NOTE(\]))'
+    - match: '[ \t]*(>)[ ]?[ \t]{,3}((\[)!NOTE(\]))'
       captures:
         1: punctuation.definition.blockquote.markdown
         2: markup.heading.alert.note.markdown
@@ -1044,7 +1044,7 @@ contexts:
       push:
         - block-quote-note-meta
         - list-block-quote-body
-    - match: '[ \t]{,3}(>)[ ]?[ \t]{,3}((\[)!TIP(\]))'
+    - match: '[ \t]*(>)[ ]?[ \t]{,3}((\[)!TIP(\]))'
       captures:
         1: punctuation.definition.blockquote.markdown
         2: markup.heading.alert.tip.markdown

--- a/Markdown/tests/syntax_test_markdown.md
+++ b/Markdown/tests/syntax_test_markdown.md
@@ -9308,6 +9308,21 @@ This is a [[wiki link]].
    |^ markup.quote.alert.tip.markdown - markup.paragraph
    | ^^^^^ markup.quote.alert.tip.markdown markup.paragraph.markdown
 
+   - item
+
+     > [!TIP]
+     | <- markup.quote.alert.tip.markdown punctuation.definition.blockquote.markdown
+     |^^^^^^^^ markup.quote.alert.tip.markdown
+     | ^^^^^^ markup.heading.alert.tip.markdown
+     | ^ punctuation.definition.heading.begin.markdown
+     |      ^ punctuation.definition.heading.end.markdown
+
+     > [!TIP]
+     > 
+     > Text
+     | <- markup.quote.alert.tip.markdown punctuation.definition.blockquote.markdown
+     |^ markup.quote.alert.tip.markdown - markup.paragraph
+     | ^^^^^ markup.quote.alert.tip.markdown markup.paragraph.markdown
 
 # TEST: MATHJAX BLOCKS MARKUP #################################################
 


### PR DESCRIPTION
This commit applies loosen leading whitespace patterns to ensure Github Alerts are consumed as expected in nested list items, which require indentation by more than 3 characters.