### PR TITLE
[Python] Fix escaped braces in fr-strings

### DIFF
--- a/Python/Embeddings/RegExp (for Python raw-f-string).sublime-syntax
+++ b/Python/Embeddings/RegExp (for Python raw-f-string).sublime-syntax
@@ -21,3 +21,9 @@ contexts:
         1: constant.character.escape.python
     - match: (?:{{brace_start}}|{{brace_end}})
       scope: constant.character.escape.python
+
+  ranged-quantifier-fallback:
+    - meta_include_prototype: false
+    - match: '{{brace_start}}'
+      scope: constant.character.escape.python
+      pop: 1

--- a/Python/Embeddings/RegExp (for Python).sublime-syntax
+++ b/Python/Embeddings/RegExp (for Python).sublime-syntax
@@ -133,5 +133,6 @@ contexts:
 
   ranged-quantifier-fallback:
     - meta_include_prototype: false
-    - match: ''
+    - match: '{{brace_start}}'
+      scope: constant.character.escape.python
       pop: 1

--- a/Python/Embeddings/RegExp (for Python).sublime-syntax
+++ b/Python/Embeddings/RegExp (for Python).sublime-syntax
@@ -134,5 +134,4 @@ contexts:
   ranged-quantifier-fallback:
     - meta_include_prototype: false
     - match: '{{brace_start}}'
-      scope: constant.character.escape.python
       pop: 1

--- a/Python/tests/syntax_test_python_strings.py
+++ b/Python/tests/syntax_test_python_strings.py
@@ -1520,6 +1520,12 @@ fmt = u'string \r \n \u2040 %s \{{ {x} \}}'
 #                                      ^ invalid.deprecated.character.escape.python
 #                                      ^^^ constant.character.escape.python
 
+r'\b{{{{{ss_var}_active}}}}'
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.python string.quoted.single.python - constant.character
+#^ punctuation.definition.string.begin.python
+#                          ^ punctuation.definition.string.end.python
+
+
 ################################
 # regular expression backrefs
 ################################

--- a/Python/tests/syntax_test_python_strings.py
+++ b/Python/tests/syntax_test_python_strings.py
@@ -1960,6 +1960,23 @@ re.sub(rf" ?\{{\\i.?\}}({x})\{{\\i.?\}}", r"\1", line)
 #                                   ^ constant.character.escape.regexp - constant.character.escape.python
 #                                    ^^ constant.character.escape.regexp constant.character.escape.python
 
+fr'\b{{{{{ss_var}_active}}}}'
+#^ storage.type.string.python
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.python
+# ^^^^^^^ string.quoted.single.python
+# ^ punctuation.definition.string.begin.python
+#  ^^^^^^ source.regexp.python meta.mode.basic.regexp
+#  ^^ keyword.control.anchor.regexp
+#    ^^^^ constant.character.escape.python
+#        ^^^^^^^^ meta.interpolation.python - string
+#        ^ punctuation.section.interpolation.begin.python
+#         ^^^^^^ variable.other.python
+#               ^ punctuation.section.interpolation.end.python
+#                ^^^^^^^^^^^^ string.quoted.single.python
+#                ^^^^^^^^^^^ source.regexp.python meta.mode.basic.regexp
+#                       ^^^^ constant.character.escape.python
+#                           ^ punctuation.definition.string.end.python
+
 fr'\x{c:02x} becomes \xAB'
 #^ storage.type.string.python
 # ^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.python


### PR DESCRIPTION
Fixes #4580

This PR consumes `{{` in fallback branch of quantifiers to ensure all of them being scoped as expected.