### PR TITLE
[C#] Fix array item subscripts

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -1699,18 +1699,21 @@ contexts:
         8: punctuation.accessor.dot.cs
         9: meta.function-call.identifier.cs variable.function.cs
       push: regex-function-call-argument-list
-    - match: '{{name}}(?={{generic_declaration}}?\s*\()'
+    - match: '{{name}}(?={{generic_declaration}}?{{item_access}}*\s*\()'
       scope: meta.function-call.identifier.cs variable.function.cs
       push:
+        - maybe-item-access
         - function-call-argument-list
+        - maybe-item-access
         - type-argument-list
-    - match: '{{name}}(?={{generic_declaration}}\s*\.)'
+    - match: '{{name}}(?={{generic_declaration}})'
       scope: support.type.cs
       push:
         - type-suffix
         - type-argument-list
     - match: '{{name}}'
       scope: variable.other.cs
+      push: maybe-item-access
     - match: '@'
       scope: invalid.illegal.reserved-char.cs
 
@@ -2205,19 +2208,21 @@ contexts:
     - include: expression-list
 
   maybe-member-access:
-    - match: (\?)?(\.)
+    - match: \s*(\?)?(\.)
       captures:
         1: keyword.operator.null-coalescing.cs
         2: punctuation.accessor.dot.cs
       set: member-access
-    - include: else-pop
+    - include: noeol-pop
 
   member-access:
-    - match: '{{unreserved_name}}(?={{generic_declaration}}?\s*\()'
+    - match: '{{unreserved_name}}(?={{generic_declaration}}?{{item_access}}*\s*\()'
       scope: meta.function-call.identifier.cs variable.function.cs
       set:
         - maybe-member-access
+        - maybe-item-access
         - function-call-argument-list
+        - maybe-item-access
         - type-argument-list
     - match: '{{unreserved_name}}(?={{generic_declaration}})'
       scope: support.type.cs
@@ -2229,7 +2234,7 @@ contexts:
       scope: variable.other.member.cs
       set:
         - maybe-member-access
-        - type-argument-list
+        - maybe-item-access
     - include: else-pop
 
 ###[ LAMBDA EXPRESSIONS ]######################################################
@@ -3413,6 +3418,8 @@ variables:
   base_type: (?x:bool|byte|sbyte|char|decimal|double|float|int|uint|nint|nuint|long|ulong|short|ushort|dynamic|object|string|void)\b
   type_suffix: (?:\s*(?:\[,*\]|\*|\?)*)
   generic_declaration: (?:\s*<[^={};]*>)
+
+  item_access: (?:\s*\[[^]]*\])
 
   statement_keywords: (?:break|case|catch|class|continue|do|else|enum|event|finally|fixed|for|foreach|goto|if|interface|namespace|operator|return|switch|try|union|using|while)\b
   expression_keywords: (?:as|checked|default|delegate|in|is|lock|nameof|new|not|params|sizeof|stackalloc|throw|typeof|unchecked)\b

--- a/C#/tests/syntax_test_scope_GeneralStructure.cs
+++ b/C#/tests/syntax_test_scope_GeneralStructure.cs
@@ -1449,6 +1449,23 @@ namespace TestNamespace . Test
 ///                        ^^^^^^ variable.other.member.cs
 ///                               ^ punctuation.section.braces.end.cs
 
+                new { this.member[0][0] }
+///             ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.instantiation.cs
+///             ^^^ keyword.operator.new.cs
+///                 ^^^^^^^^^^^^^^^^^^^^^ meta.braces.cs
+///                 ^ punctuation.section.braces.begin.cs
+///                   ^^^^ variable.language.this.cs
+///                       ^ punctuation.accessor.dot.cs
+///                        ^^^^^^ variable.other.member.cs
+///                              ^^^^^^ meta.brackets.cs
+///                              ^ punctuation.section.brackets.begin.cs
+///                               ^ meta.number.integer.decimal.cs constant.numeric.value.cs
+///                                ^ punctuation.section.brackets.end.cs
+///                                 ^ punctuation.section.brackets.begin.cs
+///                                  ^ meta.number.integer.decimal.cs constant.numeric.value.cs
+///                                   ^ punctuation.section.brackets.end.cs
+///                                     ^ punctuation.section.braces.end.cs
+
                 new { this.member<int> }
 ///             ^^^^^^^^^^^^^^^^^^^^^^^^ meta.instantiation.cs
 ///             ^^^ keyword.operator.new.cs
@@ -1462,6 +1479,26 @@ namespace TestNamespace . Test
 ///                               ^^^ storage.type.primitive.cs
 ///                                  ^ punctuation.definition.generic.end.cs
 ///                                    ^ punctuation.section.braces.end.cs
+
+                new { this.member<int>[0][] }
+///             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.instantiation.cs
+///             ^^^ keyword.operator.new.cs
+///                 ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.braces.cs
+///                 ^ punctuation.section.braces.begin.cs
+///                   ^^^^ variable.language.this.cs
+///                       ^ punctuation.accessor.dot.cs
+///                        ^^^^^^ support.type.cs
+///                              ^^^^^ meta.generic.cs
+///                              ^ punctuation.definition.generic.begin.cs
+///                               ^^^ storage.type.primitive.cs
+///                                  ^ punctuation.definition.generic.end.cs
+///                                   ^^^^^ meta.brackets.cs
+///                                   ^ punctuation.section.brackets.begin.cs
+///                                    ^ meta.number.integer.decimal.cs constant.numeric.value.cs
+///                                     ^ punctuation.section.brackets.end.cs
+///                                      ^ punctuation.section.brackets.begin.cs
+///                                       ^ punctuation.section.brackets.end.cs
+///                                         ^ punctuation.section.braces.end.cs
 
                 // Anonymous class instantiation with member access
 
@@ -3176,6 +3213,109 @@ public class TestExpressions
 ///                         ^^ meta.number.integer.decimal.cs constant.numeric.value.cs
 ///                           ^ punctuation.section.brackets.end.cs
 ///                            ^ punctuation.terminator.statement.cs
+
+        this.List[0];
+///     ^^^^ variable.language.this.cs
+///         ^ punctuation.accessor.dot.cs
+///          ^^^^ variable.other.member.cs
+///              ^^^ meta.brackets.cs
+///              ^ punctuation.section.brackets.begin.cs
+///               ^ meta.number.integer.decimal.cs constant.numeric.value.cs
+///                ^ punctuation.section.brackets.end.cs
+///                 ^ punctuation.terminator.statement.cs
+
+        Method(arg)[5][idx];
+///     ^^^^^^ meta.function-call.identifier.cs variable.function.cs
+///           ^^^^^ meta.function-call.arguments.cs meta.group.cs
+///           ^ punctuation.section.group.begin.cs
+///            ^^^ variable.other.cs
+///               ^ punctuation.section.group.end.cs
+///                ^^^^^^^^ meta.brackets.cs
+///                ^ punctuation.section.brackets.begin.cs
+///                 ^ meta.number.integer.decimal.cs constant.numeric.value.cs
+///                  ^ punctuation.section.brackets.end.cs
+///                   ^ punctuation.section.brackets.begin.cs
+///                    ^^^ variable.other.cs
+///                       ^ punctuation.section.brackets.end.cs
+///                        ^ punctuation.terminator.statement.cs
+
+        this.Method(arg)[5][idx];
+///     ^^^^ variable.language.this.cs
+///         ^ punctuation.accessor.dot.cs
+///          ^^^^^^ meta.function-call.identifier.cs variable.function.cs
+///                ^^^^^ meta.function-call.arguments.cs meta.group.cs
+///                ^ punctuation.section.group.begin.cs
+///                 ^^^ variable.other.cs
+///                    ^ punctuation.section.group.end.cs
+///                     ^^^^^^^^ meta.brackets.cs
+///                     ^ punctuation.section.brackets.begin.cs
+///                      ^ meta.number.integer.decimal.cs constant.numeric.value.cs
+///                       ^ punctuation.section.brackets.end.cs
+///                        ^ punctuation.section.brackets.begin.cs
+///                         ^^^ variable.other.cs
+///                            ^ punctuation.section.brackets.end.cs
+///                             ^ punctuation.terminator.statement.cs
+
+        Methods[5](arg)[5];
+///     ^^^^^^^^^^ meta.function-call.identifier.cs
+///     ^^^^^^^ variable.function.cs
+///            ^^^ meta.brackets.cs
+///            ^ punctuation.section.brackets.begin.cs
+///             ^ meta.number.integer.decimal.cs constant.numeric.value.cs
+///              ^ punctuation.section.brackets.end.cs
+///               ^^^^^ meta.function-call.arguments.cs meta.group.cs
+///               ^ punctuation.section.group.begin.cs
+///                ^^^ variable.other.cs
+///                   ^ punctuation.section.group.end.cs
+///                    ^^^ meta.brackets.cs
+///                    ^ punctuation.section.brackets.begin.cs
+///                     ^ meta.number.integer.decimal.cs constant.numeric.value.cs
+///                      ^ punctuation.section.brackets.end.cs
+///                       ^ punctuation.terminator.statement.cs
+
+        this.Methods[5](arg)[5];
+///     ^^^^ variable.language.this.cs
+///         ^ punctuation.accessor.dot.cs
+///          ^^^^^^^ meta.function-call.identifier.cs variable.function.cs
+///                 ^^^ meta.brackets.cs
+///                 ^ punctuation.section.brackets.begin.cs
+///                  ^ meta.number.integer.decimal.cs constant.numeric.value.cs
+///                   ^ punctuation.section.brackets.end.cs
+///                    ^^^^^ meta.group.cs
+///                    ^ punctuation.section.group.begin.cs
+///                     ^^^ variable.other.cs
+///                        ^ punctuation.section.group.end.cs
+///                         ^^^ meta.brackets.cs
+///                         ^ punctuation.section.brackets.begin.cs
+///                          ^ meta.number.integer.decimal.cs constant.numeric.value.cs
+///                           ^ punctuation.section.brackets.end.cs
+///                            ^ punctuation.terminator.statement.cs
+
+        Type<int>[5];
+///     ^^^^ support.type.cs
+///         ^^^^^ meta.generic.cs
+///         ^ punctuation.definition.generic.begin.cs
+///          ^^^ storage.type.primitive.cs
+///             ^ punctuation.definition.generic.end.cs
+///              ^^^ meta.brackets.cs
+///              ^ punctuation.section.brackets.begin.cs
+///               ^ meta.number.integer.decimal.cs constant.numeric.value.cs
+///                ^ punctuation.section.brackets.end.cs
+///                 ^ punctuation.terminator.statement.cs
+
+        this.Type<int>[5];
+///     ^^^^ variable.language.this.cs
+///         ^ punctuation.accessor.dot.cs
+///          ^^^^ support.type.cs
+///              ^^^^^ meta.generic.cs
+///              ^ punctuation.definition.generic.begin.cs
+///               ^^^ storage.type.primitive.cs
+///                  ^ punctuation.definition.generic.end.cs
+///                   ^^^ meta.brackets.cs
+///                   ^ punctuation.section.brackets.begin.cs
+///                    ^ meta.number.integer.decimal.cs constant.numeric.value.cs
+///                     ^ punctuation.section.brackets.end.cs
+///                      ^ punctuation.terminator.statement.cs
     }
 
     void testDefault()

--- a/C#/tests/syntax_test_scope_Operators.cs
+++ b/C#/tests/syntax_test_scope_Operators.cs
@@ -355,13 +355,49 @@ class TestOperatorDefinitions {
 
     // Comparison
 
-    a == b != c <= d < e > f >= g
+    a == b;
 ///   ^^ keyword.operator.comparison.cs
-///        ^^ keyword.operator.comparison.cs
-///             ^^ keyword.operator.comparison.cs
-///                  ^ keyword.operator.comparison.cs
-///                      ^ keyword.operator.comparison.cs
-///                          ^^ keyword.operator.comparison.cs
+
+    a != b;
+///   ^^ keyword.operator.comparison.cs
+
+    a <= b;
+///   ^^ keyword.operator.comparison.cs
+
+    a >= b
+///   ^^ keyword.operator.comparison.cs
+
+    a < b;
+///   ^ keyword.operator.comparison.cs
+
+    a > b;
+///   ^ keyword.operator.comparison.cs
+
+    a<t> > b<t>
+/// ^ support.type.cs
+///  ^^^ meta.generic.cs
+///  ^ punctuation.definition.generic.begin.cs
+///   ^ support.type.cs
+///    ^ punctuation.definition.generic.end.cs
+///      ^ keyword.operator.comparison.cs
+///        ^ support.type.cs
+///         ^^^ meta.generic.cs
+///         ^ punctuation.definition.generic.begin.cs
+///          ^ support.type.cs
+///           ^ punctuation.definition.generic.end.cs
+
+    a<t> < b<t>
+/// ^ support.type.cs
+///  ^^^ meta.generic.cs
+///  ^ punctuation.definition.generic.begin.cs
+///   ^ support.type.cs
+///    ^ punctuation.definition.generic.end.cs
+///      ^ keyword.operator.comparison.cs
+///        ^ support.type.cs
+///         ^^^ meta.generic.cs
+///         ^ punctuation.definition.generic.begin.cs
+///          ^ support.type.cs
+///           ^ punctuation.definition.generic.end.cs
 
     // Logical
 


### PR DESCRIPTION
fixes #4587

This PR...

1. fixes subscript related syntax highlighting issues.
2. fixes comparison operator vs. generic type argument precedence.