### PR TITLE
[C#] Restrict generic type variable lookahead

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -3417,7 +3417,7 @@ variables:
 
   base_type: (?x:bool|byte|sbyte|char|decimal|double|float|int|uint|nint|nuint|long|ulong|short|ushort|dynamic|object|string|void)\b
   type_suffix: (?:\s*(?:\[,*\]|\*|\?)*)
-  generic_declaration: (?:\s*<[^={};]*>)
+  generic_declaration: (?:\s*<(?:{{escape_uni16}}|{{escape_uni32}}|[\s\w_.()<>,?@])*>)
 
   item_access: (?:\s*\[[^]]*\])
 
@@ -3431,8 +3431,8 @@ variables:
   name_normal: '{{start_char}}{{other_char}}*\b'
   cap_name: '[[:upper:]]{{other_char}}*\b'
   lower_name: '[[:lower:]]{{other_char}}*\b'
-  start_char: (?:{{escape_uni16}}|{{escape_uni32}}|[_[[:alpha:]]])
-  other_char: (?:{{escape_uni16}}|{{escape_uni32}}|[_[[:alnum:]]])
+  start_char: (?:{{escape_uni16}}|{{escape_uni32}}|[_[:alpha:]])
+  other_char: (?:{{escape_uni16}}|{{escape_uni32}}|[_[:alnum:]])
 
   wspace_eol: \s*(?:\n|$)
 

--- a/C#/tests/syntax_test_scope_Operators.cs
+++ b/C#/tests/syntax_test_scope_Operators.cs
@@ -373,6 +373,16 @@ class TestOperatorDefinitions {
     a > b;
 ///   ^ keyword.operator.comparison.cs
 
+    (U < 0f || U > 1f)
+///    ^ keyword.operator.comparison.cs
+///         ^^ keyword.operator.logical.cs
+///              ^ keyword.operator.comparison.cs
+
+    (U < 0f && U > 1f)
+///    ^ keyword.operator.comparison.cs
+///         ^^ keyword.operator.logical.cs
+///              ^ keyword.operator.comparison.cs
+
     a<t> > b<t>
 /// ^ support.type.cs
 ///  ^^^ meta.generic.cs


### PR DESCRIPTION
Resolves #4590

This commit restricts allowed characters within `Generic< ... >` brackets, to reduce risk of false positives.

Only common tokens of type arguments such as identifiers, whitespace, parens, angled brackets, commas and question marks are allowed.