### PR TITLE
[JavaScript] Fix pre-mature termination of for loops in TypeScript

### DIFF
--- a/JavaScript/TypeScript.sublime-syntax
+++ b/JavaScript/TypeScript.sublime-syntax
@@ -785,7 +785,7 @@ contexts:
     - meta_include_prototype: false
     - match: '<'
       scope: keyword.operator.comparison.js
-      pop: 1
+      set: expression-begin
 
   ts-non-null-assertion:
     - match: '!(?!=)'

--- a/JavaScript/tests/syntax_test_jsx_control.ts
+++ b/JavaScript/tests/syntax_test_jsx_control.ts
@@ -1,0 +1,570 @@
+// SYNTAX TEST "Packages/JavaScript/JSX.sublime-syntax"
+
+    if ( true ) { } ;
+//  ^^^^^^^^^^^^^^^ meta.conditional
+//  ^^ keyword.control.conditional.if
+//     ^^^^^^^^ meta.group
+//     ^ punctuation.section.group.begin
+//       ^^^^ constant.language.boolean.true
+//            ^ punctuation.section.group.end
+//              ^^^ meta.block
+//              ^ punctuation.section.block.begin
+//                ^ punctuation.section.block.end
+//                 ^ - meta.conditional
+//                  ^ punctuation.terminator.statement.empty
+
+    if ( true ) null ;
+//  ^^^^^^^^^^^^^^^^^^ meta.conditional
+//  ^^ keyword.control.conditional.if
+//     ^^^^^^^^ meta.group
+//     ^ punctuation.section.group.begin
+//       ^^^^ constant.language.boolean.true
+//            ^ punctuation.section.group.end
+//              ^^^^ constant.language.null
+//                   ^ punctuation.terminator.statement - punctuation.terminator.statement.empty
+//                    ^ - meta.conditional
+
+    if (true) {}/**/
+//              ^^^^ - meta.conditional
+
+    if (true) ;
+//  ^^^^^^^^^^ meta.conditional
+//            ^ punctuation.terminator.statement.empty
+
+    if (true) ;
+    else { } ;
+//  ^^^^^^^^ meta.conditional
+//  ^^^^ keyword.control.conditional.else
+//       ^^^ meta.block
+//       ^ punctuation.section.block.begin
+//         ^ punctuation.section.block.end
+//          ^ - meta.conditional
+//           ^ punctuation.terminator.statement.empty
+
+    else if (true) { } ;
+//  ^^^^^^^^^^^^^^^^^^ meta.conditional
+//  ^^^^^^^ keyword.control.conditional.elseif
+//          ^^^^^^ meta.group
+//          ^ punctuation.section.group.begin
+//           ^^^^ constant.language.boolean.true
+//               ^ punctuation.section.group.end
+//                 ^^^ meta.block
+//                 ^ punctuation.section.block.begin
+//                   ^ punctuation.section.block.end
+//                    ^^^ - meta.conditional
+//                     ^ punctuation.terminator.statement.empty
+
+    do { } while ( true ) ;
+//  ^^^^^^^^^^^^^^^^^^^^^ meta.do-while
+//  ^^ keyword.control.loop.do-while
+//     ^^^ meta.block
+//     ^ punctuation.section.block.begin
+//       ^ punctuation.section.block.end
+//         ^^^^^ keyword.control.loop.while
+//               ^^^^^^^^ meta.group
+//               ^ punctuation.section.group.begin
+//                 ^^^^ constant.language.boolean.true
+//                      ^ punctuation.section.group.end
+//                       ^ - meta.do-while
+//                        ^ punctuation.terminator.statement.empty
+
+    do 42 ; while ( true ) ;
+//  ^^^^^^^^^^^^^^^^^^^^^^ meta.do-while
+//  ^^ keyword.control.loop.do-while
+//     ^^ meta.number.integer.decimal constant.numeric.value
+//        ^ punctuation.terminator.statement
+//          ^^^^^ keyword.control.loop.while
+//                ^^^^^^^^ meta.group
+//                ^ punctuation.section.group.begin
+//                  ^^^^ constant.language.boolean.true
+//                       ^ punctuation.section.group.end
+//                         ^ punctuation.terminator.statement.empty
+
+    do {} while (false)/**/
+//                     ^ - meta.do-while
+
+    for (var i = 0; i < 10; i++) { } ;
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^^^^^^^^^^^^^^ meta.group
+//      ^ punctuation.section.group
+//       ^^^ keyword.declaration
+//           ^ meta.binding.name variable.other.readwrite
+//             ^ keyword.operator.assignment
+//               ^ meta.number.integer.decimal constant.numeric.value
+//                ^ punctuation.separator.expression
+//                  ^ variable.other.readwrite
+//                    ^ keyword.operator.comparison
+//                      ^^ meta.number.integer.decimal constant.numeric.value
+//                        ^ punctuation.separator.expression
+//                          ^ variable.other.readwrite
+//                           ^^ keyword.operator.arithmetic
+//                             ^ punctuation.section.group
+//                               ^^^ meta.block
+//                               ^ punctuation.section.block.begin
+//                                 ^ punctuation.section.block.end
+//                                  ^ - meta.for
+//                                   ^ punctuation.terminator.statement.empty
+
+    for ( var i = 0 ; i < 10 ; i++ ) { } ;
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group
+//      ^ punctuation.section.group
+//        ^^^ keyword.declaration
+//            ^ meta.binding.name variable.other.readwrite
+//              ^ keyword.operator.assignment
+//                ^ meta.number.integer.decimal constant.numeric.value
+//                  ^ punctuation.separator.expression
+//                    ^ variable.other.readwrite
+//                      ^ keyword.operator.comparison
+//                        ^^ meta.number.integer.decimal constant.numeric.value
+//                           ^ punctuation.separator.expression
+//                             ^ variable.other.readwrite
+//                              ^^ keyword.operator.arithmetic
+//                                 ^ punctuation.section.group
+//                                   ^^^ meta.block
+//                                   ^ punctuation.section.block.begin
+//                                     ^ punctuation.section.block.end
+//                                      ^ - meta.for
+//                                       ^ punctuation.terminator.statement.empty
+
+    for ( 
+//  ^^^^ meta.for - meta.group
+//      ^^^ meta.for meta.group
+//  ^^^ keyword.control.loop.for
+//      ^ punctuation.section.group.begin
+        var i = 0 ; 
+//     ^^^^^^^^^^^^^ meta.for meta.group
+//      ^^^ keyword.declaration
+//          ^ meta.binding.name variable.other.readwrite
+//            ^ keyword.operator.assignment
+//              ^ meta.number.integer.decimal constant.numeric.value
+//                ^ punctuation.separator.expression
+
+        i < 10 ; 
+//     ^^^^^^^^^^ meta.for meta.group
+//      ^ variable.other.readwrite
+//        ^ keyword.operator.comparison
+//          ^^ meta.number.integer.decimal constant.numeric.value
+//             ^ punctuation.separator.expression
+        i++ 
+//     ^^^^^ meta.for meta.group
+//      ^ variable.other.readwrite
+//       ^^ keyword.operator.arithmetic
+    ) { } ;
+//^^^ meta.for meta.group
+//   ^ meta.for - meta.block - meta.group
+//    ^^^ meta.for meta.block
+//  ^ punctuation.section.group
+//    ^^^ meta.block
+//    ^ punctuation.section.block.begin
+//      ^ punctuation.section.block.end
+//       ^ - meta.for
+//        ^ punctuation.terminator.statement.empty
+
+    for (;;) 42;
+//  ^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^ meta.group
+//      ^ punctuation.section.group
+//       ^^ punctuation.separator.expression
+//         ^ punctuation.section.group
+//           ^^ meta.number.integer.decimal constant.numeric.value
+//             ^ punctuation.terminator.statement - punctuation.terminator.statement.empty
+//              ^ - meta.for
+
+    for (; x in list;) {}
+//  ^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^^^^ meta.group
+//       ^ punctuation.separator.expression
+//           ^^ keyword.operator
+//                  ^ punctuation.separator.expression
+
+    for (a[x in list];;;) {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^^^^^^ meta.group
+//        ^^^^^^^^^^^ meta.brackets
+//           ^^ keyword.operator
+//                   ^ punctuation.separator.expression
+//                    ^ punctuation.separator.expression
+//                     ^ invalid.illegal.unexpected-token
+
+    for (;function () {}/a/g;) {}
+//                      ^ keyword.operator
+
+    for (const x in list) {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^^^^^^^ meta.group
+//       ^^^^^ keyword.declaration
+//               ^^ keyword.control.loop.in
+
+    for (const x of list) {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^^^^^^^ meta.group
+//       ^^^^^ keyword.declaration
+//               ^^ keyword.control.loop.of
+
+    for (x in list) {}
+//  ^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^ meta.group
+//         ^^ keyword.control.loop.in
+
+    for (a in b, c ? d: e, f(g());) {};
+//  ^^^^ meta.for - meta.group
+//      ^^^^^^^^^^^^^^^^^^^ meta.for meta.group - meta.function-call
+//                         ^^^^^^ meta.for meta.group meta.function-call
+//                               ^^ meta.for meta.group - meta.function-call
+//                                 ^ meta.for - meta.block - meta.group
+//                                  ^^ meta.for meta.block
+//  ^^^ keyword.control.loop.for
+//      ^ punctuation.section.group.begin
+//       ^ variable.other.readwrite
+//         ^^ keyword.control.loop.in
+//            ^ variable.other.readwrite
+//             ^ keyword.operator.comma
+//               ^ variable.other.readwrite
+//                 ^ keyword.operator.ternary
+//                   ^ variable.other.readwrite
+//                    ^ keyword.operator.ternary
+//                      ^ variable.other.readwrite
+//                       ^ keyword.operator.comma
+//                         ^ variable.function
+//                          ^ punctuation.section.group.begin
+//                           ^ variable.function
+//                            ^ punctuation.section.group.begin
+//                             ^^ punctuation.section.group.end
+//                               ^ invalid.illegal.unexpected-token
+//                                ^ punctuation.section.group.end
+//                                  ^ punctuation.section.block.begin
+//                                   ^ punctuation.section.block.end
+
+    for (x of list) {}
+//  ^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^ meta.group
+//         ^^ keyword.control.loop.of
+
+    for (x.y.z of list) {}
+//  ^^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^^^^^ meta.group
+//      ^ punctuation.section.group.begin
+//       ^ variable.other.readwrite
+//        ^ punctuation.accessor
+//         ^ meta.property.object
+//          ^ punctuation.accessor
+//           ^ meta.property.object
+//             ^^ keyword.control.loop.of
+//                ^^^^ variable.other.readwrite
+//                    ^ punctuation.section.group.end
+//                      ^^ meta.block
+
+    for await (const x of list) {}
+//  ^^^ keyword.control.loop.for
+//      ^^^^^ keyword.control.flow.await
+
+    for ( using x of list ) {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^^^^^^^^^ meta.group
+//      ^ punctuation.section.group.begin
+//        ^^^^^ keyword.declaration
+//              ^ meta.binding.name variable.other.readwrite
+//                ^^ keyword.control.loop.of
+//                   ^^^^ variable.other.readwrite
+//                        ^ punctuation.section.group.end
+//                          ^^ meta.block
+
+    for ( await using x of list ) {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group
+//      ^ punctuation.section.group.begin
+//        ^^^^^ keyword.declaration
+//              ^^^^^ keyword.declaration
+//        ^^^^^ keyword.declaration
+//              ^^^^^ keyword.declaration
+//                    ^ meta.binding.name variable.other.readwrite
+//                      ^^ keyword.control.loop.of
+//                         ^^^^ variable.other.readwrite
+//                              ^ punctuation.section.group.end
+//                                ^^ meta.block
+
+    for ( await using of of list ) {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group
+//      ^ punctuation.section.group.begin
+//        ^^^^^ keyword.declaration
+//              ^^^^^ keyword.declaration
+//                    ^^ meta.binding.name variable.other.readwrite
+//                       ^^ keyword.control.loop.of
+//                          ^^^^ variable.other.readwrite
+//                               ^ punctuation.section.group.end
+//                                 ^^ meta.block
+//                                 ^ punctuation.section.block.begin
+//                                  ^ punctuation.section.block.end
+
+    for ( using of list ) {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^^^^^^^ meta.group
+//      ^ punctuation.section.group.begin
+//        ^^^^^ variable.other.readwrite
+//              ^^ keyword.control.loop.of
+//                 ^^^^ variable.other.readwrite
+//                      ^ punctuation.section.group.end
+//                        ^^ meta.block
+
+    for ( using [x] of list ) {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^^^^^^^^^^^ meta.group
+//      ^ punctuation.section.group.begin
+//        ^^^^^ variable.other.readwrite
+//              ^^^ meta.brackets
+//              ^ punctuation.section.brackets.begin
+//               ^ variable.other.readwrite
+//                ^ punctuation.section.brackets.end
+//                  ^^ keyword.control.loop.of
+//                     ^^^^ variable.other.readwrite
+//                          ^ punctuation.section.group.end
+//                            ^^ meta.block
+
+    for ( await using ;;) {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^^^^^^^ meta.group
+//      ^ punctuation.section.group.begin
+//        ^^^^^ keyword.control.flow.await
+//              ^^^^^ variable.other.readwrite
+//                    ^^ punctuation.separator.expression
+//                      ^ punctuation.section.group.end
+//                        ^^ meta.block
+//                        ^ punctuation.section.block.begin
+//                         ^ punctuation.section.block.end
+
+    for ( await using instanceof x ;;) {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group
+//      ^ punctuation.section.group.begin
+//        ^^^^^ keyword.control.flow.await
+//              ^^^^^ variable.other.readwrite
+//                    ^^^^^^^^^^ keyword.operator
+//                               ^ variable.other.readwrite
+//                                 ^^ punctuation.separator.expression
+//                                   ^ punctuation.section.group.end
+//                                     ^^ meta.block
+
+    for (var in list) (i = 0 ; i < 10; i++)
+//  ^^^^^^^^^^^^^^^^^^ meta.for.js
+//                    ^^^^^^^^^^^^^^^^^^^^^ meta.group.js - meta.for
+
+for
+    42;
+//  ^^ constant.numeric - meta.for
+
+for(;;){}/**/
+//       ^ - meta.for
+
+{}/**/
+//^ - meta.block
+
+while (true)
+// ^^^^^^^^^ meta.while
+//     ^^^^ meta.group
+{
+// <- meta.block
+    x = yield;
+//      ^^^^^ keyword.control.flow.yield
+
+    x = yield* 42;
+//      ^^^^^ keyword.control.flow.yield
+//           ^ storage.modifier.generator.js
+
+    x = yield * 42;
+//      ^^^^^ keyword.control.flow.yield
+//            ^ storage.modifier.generator.js
+
+    x = yield
+    function f() {}
+    [];
+//  ^^ meta.sequence - meta.brackets
+
+
+    x = yield*
+    function f() {}
+    [];
+//  ^^ meta.brackets - meta.sequence
+
+    y = await 42;
+//      ^^^^^ keyword.control.flow.await
+
+    y = yield await 42;
+//      ^^^^^ keyword.control.flow.yield
+//            ^^^^^ keyword.control.flow.await
+
+    yield (parenthesized_expression);
+//  ^^^^^ keyword.control.flow.yield
+
+    yield `template`;
+//  ^^^^^ keyword.control.flow.yield
+
+    break;
+//  ^^^^^ keyword.control.flow.break
+
+    break foo;
+//  ^^^^^ keyword.control.flow.break
+//        ^^^ variable.label
+
+    break
+    foo;
+//  ^^^ variable.other.readwrite - variable.label
+
+    break/**/foo;
+//           ^^^ variable.label - variable.other.readwrite
+
+    break/*
+    */foo;
+//    ^^^ variable.other.readwrite - variable.label
+
+    break function;
+//        ^^^^^^^^ invalid.illegal.identifier variable.label
+
+    continue;
+//  ^^^^^^^^ keyword.control.flow.continue
+
+    continue foo;
+//  ^^^^^^^^ keyword.control.flow.continue
+//           ^^^ variable.label
+
+    continue
+    foo;
+//  ^^^ variable.other.readwrite - variable.label
+
+    continue/**/foo;
+//              ^^^ variable.label - variable.other.readwrite
+
+    continue/*
+    */ foo;
+//     ^^^ variable.other.readwrite - variable.label
+
+    goto;
+//  ^^^^ variable.other.readwrite - keyword
+}
+// <- meta.block
+
+    while (true) 42 ;
+//  ^^^^^^^^^^^^^ meta.while
+//  ^^^^^ keyword.control.loop.while
+//        ^^^^^^ meta.group
+//        ^ punctuation.section.group.begin
+//         ^^^^ constant.language.boolean.true
+//             ^ punctuation.section.group.end
+//               ^^ meta.number.integer.decimal constant.numeric.value
+//                  ^ punctuation.terminator.statement - punctuation.terminator.statement.empty
+
+while // Incomplete statement
+    42;
+//  ^^ constant.numeric - meta.while
+
+while(false){}/**/
+//            ^ - meta.while
+
+with (undefined) {
+// <- keyword.control.import.with
+//^^^^^^^^^^ meta.with
+//    ^^^^^^^^^ constant.language.undefined
+    return;
+//  ^^^^^^ meta.with meta.block keyword.control.flow.return
+}
+
+with // Incomplete statement
+    42;
+//  ^^ constant.numeric - meta.while
+
+with(false){}/**/
+//           ^ - meta.with
+
+switch ($foo) {
+// <- meta.switch keyword.control.conditional.switch
+// ^^^^^^^^^^^^ meta.switch
+//^^^^ keyword.control.conditional.switch
+//      ^^^^ meta.group
+//            ^ meta.block punctuation.section.block.begin
+    case foo:
+    // ^ meta.switch meta.block keyword.control.conditional.case
+    //      ^ - punctuation.separator.key-value
+        qux = 1;
+        break;
+        // ^ keyword.control.flow.break
+    case "baz":
+    // ^ keyword.control.conditional.case
+    //        ^ - punctuation.separator.key-value string
+        qux = 2;
+        break;
+        // ^ keyword.control.flow.break
+    default:
+    // ^ meta.switch meta.block keyword.control.conditional.default
+    //     ^ - punctuation.separator.key-value
+        qux = 3;
+
+    case$
+//  ^^^^^ - keyword
+    ;
+
+    default$
+//  ^^^^^^^^ - keyword
+    ;
+
+    case 0: {}
+    case 1:
+//  ^^^^ keyword.control.conditional.case
+}
+// <- meta.block punctuation.section.block.end
+
+try {
+// <- meta.try keyword.control.exception.try
+// ^^ meta.try
+//  ^ meta.block
+    foobar = qux.bar();
+//  ^^^^^^^^^^^^^^^^^^^ meta.try meta.block
+} catch (e) {
+// <- meta.block
+//^^^^^^^^^^^^ meta.catch
+//^^^^^ keyword.control.exception.catch
+//      ^^^ meta.group
+//       ^ meta.binding.name variable.other.readwrite
+//          ^ meta.block
+    foobar = 0
+//  ^^^^^^^^^^ meta.catch meta.block
+} finally {
+// <- meta.block
+//^^^^^^^^^^ meta.finally
+//^^^^^^^ keyword.control.exception.finally
+//        ^ meta.block
+    foobar += 1
+//  ^^^^^^^^^^^ meta.finally meta.block
+}
+// <- meta.block
+
+switch // Incomplete statement
+    42;
+//  ^^ constant.numeric - meta.switch
+
+switch(x){}/**/
+//         ^^ - meta.switch
+
+try{}/**/
+//   ^ - meta.try
+catch{}/**/
+//     ^ - meta.catch
+finally{}/**/
+//       ^ - meta.finally

--- a/JavaScript/tests/syntax_test_tsx_control.ts
+++ b/JavaScript/tests/syntax_test_tsx_control.ts
@@ -1,0 +1,570 @@
+// SYNTAX TEST "Packages/JavaScript/TSX.sublime-syntax"
+
+    if ( true ) { } ;
+//  ^^^^^^^^^^^^^^^ meta.conditional
+//  ^^ keyword.control.conditional.if
+//     ^^^^^^^^ meta.group
+//     ^ punctuation.section.group.begin
+//       ^^^^ constant.language.boolean.true
+//            ^ punctuation.section.group.end
+//              ^^^ meta.block
+//              ^ punctuation.section.block.begin
+//                ^ punctuation.section.block.end
+//                 ^ - meta.conditional
+//                  ^ punctuation.terminator.statement.empty
+
+    if ( true ) null ;
+//  ^^^^^^^^^^^^^^^^^^ meta.conditional
+//  ^^ keyword.control.conditional.if
+//     ^^^^^^^^ meta.group
+//     ^ punctuation.section.group.begin
+//       ^^^^ constant.language.boolean.true
+//            ^ punctuation.section.group.end
+//              ^^^^ constant.language.null
+//                   ^ punctuation.terminator.statement - punctuation.terminator.statement.empty
+//                    ^ - meta.conditional
+
+    if (true) {}/**/
+//              ^^^^ - meta.conditional
+
+    if (true) ;
+//  ^^^^^^^^^^ meta.conditional
+//            ^ punctuation.terminator.statement.empty
+
+    if (true) ;
+    else { } ;
+//  ^^^^^^^^ meta.conditional
+//  ^^^^ keyword.control.conditional.else
+//       ^^^ meta.block
+//       ^ punctuation.section.block.begin
+//         ^ punctuation.section.block.end
+//          ^ - meta.conditional
+//           ^ punctuation.terminator.statement.empty
+
+    else if (true) { } ;
+//  ^^^^^^^^^^^^^^^^^^ meta.conditional
+//  ^^^^^^^ keyword.control.conditional.elseif
+//          ^^^^^^ meta.group
+//          ^ punctuation.section.group.begin
+//           ^^^^ constant.language.boolean.true
+//               ^ punctuation.section.group.end
+//                 ^^^ meta.block
+//                 ^ punctuation.section.block.begin
+//                   ^ punctuation.section.block.end
+//                    ^^^ - meta.conditional
+//                     ^ punctuation.terminator.statement.empty
+
+    do { } while ( true ) ;
+//  ^^^^^^^^^^^^^^^^^^^^^ meta.do-while
+//  ^^ keyword.control.loop.do-while
+//     ^^^ meta.block
+//     ^ punctuation.section.block.begin
+//       ^ punctuation.section.block.end
+//         ^^^^^ keyword.control.loop.while
+//               ^^^^^^^^ meta.group
+//               ^ punctuation.section.group.begin
+//                 ^^^^ constant.language.boolean.true
+//                      ^ punctuation.section.group.end
+//                       ^ - meta.do-while
+//                        ^ punctuation.terminator.statement.empty
+
+    do 42 ; while ( true ) ;
+//  ^^^^^^^^^^^^^^^^^^^^^^ meta.do-while
+//  ^^ keyword.control.loop.do-while
+//     ^^ meta.number.integer.decimal constant.numeric.value
+//        ^ punctuation.terminator.statement
+//          ^^^^^ keyword.control.loop.while
+//                ^^^^^^^^ meta.group
+//                ^ punctuation.section.group.begin
+//                  ^^^^ constant.language.boolean.true
+//                       ^ punctuation.section.group.end
+//                         ^ punctuation.terminator.statement.empty
+
+    do {} while (false)/**/
+//                     ^ - meta.do-while
+
+    for (var i = 0; i < 10; i++) { } ;
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^^^^^^^^^^^^^^ meta.group
+//      ^ punctuation.section.group
+//       ^^^ keyword.declaration
+//           ^ meta.binding.name variable.other.readwrite
+//             ^ keyword.operator.assignment
+//               ^ meta.number.integer.decimal constant.numeric.value
+//                ^ punctuation.separator.expression
+//                  ^ variable.other.readwrite
+//                    ^ keyword.operator.comparison
+//                      ^^ meta.number.integer.decimal constant.numeric.value
+//                        ^ punctuation.separator.expression
+//                          ^ variable.other.readwrite
+//                           ^^ keyword.operator.arithmetic
+//                             ^ punctuation.section.group
+//                               ^^^ meta.block
+//                               ^ punctuation.section.block.begin
+//                                 ^ punctuation.section.block.end
+//                                  ^ - meta.for
+//                                   ^ punctuation.terminator.statement.empty
+
+    for ( var i = 0 ; i < 10 ; i++ ) { } ;
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group
+//      ^ punctuation.section.group
+//        ^^^ keyword.declaration
+//            ^ meta.binding.name variable.other.readwrite
+//              ^ keyword.operator.assignment
+//                ^ meta.number.integer.decimal constant.numeric.value
+//                  ^ punctuation.separator.expression
+//                    ^ variable.other.readwrite
+//                      ^ keyword.operator.comparison
+//                        ^^ meta.number.integer.decimal constant.numeric.value
+//                           ^ punctuation.separator.expression
+//                             ^ variable.other.readwrite
+//                              ^^ keyword.operator.arithmetic
+//                                 ^ punctuation.section.group
+//                                   ^^^ meta.block
+//                                   ^ punctuation.section.block.begin
+//                                     ^ punctuation.section.block.end
+//                                      ^ - meta.for
+//                                       ^ punctuation.terminator.statement.empty
+
+    for ( 
+//  ^^^^ meta.for - meta.group
+//      ^^^ meta.for meta.group
+//  ^^^ keyword.control.loop.for
+//      ^ punctuation.section.group.begin
+        var i = 0 ; 
+//     ^^^^^^^^^^^^^ meta.for meta.group
+//      ^^^ keyword.declaration
+//          ^ meta.binding.name variable.other.readwrite
+//            ^ keyword.operator.assignment
+//              ^ meta.number.integer.decimal constant.numeric.value
+//                ^ punctuation.separator.expression
+
+        i < 10 ; 
+//     ^^^^^^^^^^ meta.for meta.group
+//      ^ variable.other.readwrite
+//        ^ keyword.operator.comparison
+//          ^^ meta.number.integer.decimal constant.numeric.value
+//             ^ punctuation.separator.expression
+        i++ 
+//     ^^^^^ meta.for meta.group
+//      ^ variable.other.readwrite
+//       ^^ keyword.operator.arithmetic
+    ) { } ;
+//^^^ meta.for meta.group
+//   ^ meta.for - meta.block - meta.group
+//    ^^^ meta.for meta.block
+//  ^ punctuation.section.group
+//    ^^^ meta.block
+//    ^ punctuation.section.block.begin
+//      ^ punctuation.section.block.end
+//       ^ - meta.for
+//        ^ punctuation.terminator.statement.empty
+
+    for (;;) 42;
+//  ^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^ meta.group
+//      ^ punctuation.section.group
+//       ^^ punctuation.separator.expression
+//         ^ punctuation.section.group
+//           ^^ meta.number.integer.decimal constant.numeric.value
+//             ^ punctuation.terminator.statement - punctuation.terminator.statement.empty
+//              ^ - meta.for
+
+    for (; x in list;) {}
+//  ^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^^^^ meta.group
+//       ^ punctuation.separator.expression
+//           ^^ keyword.operator
+//                  ^ punctuation.separator.expression
+
+    for (a[x in list];;;) {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^^^^^^ meta.group
+//        ^^^^^^^^^^^ meta.brackets
+//           ^^ keyword.operator
+//                   ^ punctuation.separator.expression
+//                    ^ punctuation.separator.expression
+//                     ^ invalid.illegal.unexpected-token
+
+    for (;function () {}/a/g;) {}
+//                      ^ keyword.operator
+
+    for (const x in list) {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^^^^^^^ meta.group
+//       ^^^^^ keyword.declaration
+//               ^^ keyword.control.loop.in
+
+    for (const x of list) {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^^^^^^^ meta.group
+//       ^^^^^ keyword.declaration
+//               ^^ keyword.control.loop.of
+
+    for (x in list) {}
+//  ^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^ meta.group
+//         ^^ keyword.control.loop.in
+
+    for (a in b, c ? d: e, f(g());) {};
+//  ^^^^ meta.for - meta.group
+//      ^^^^^^^^^^^^^^^^^^^ meta.for meta.group - meta.function-call
+//                         ^^^^^^ meta.for meta.group meta.function-call
+//                               ^^ meta.for meta.group - meta.function-call
+//                                 ^ meta.for - meta.block - meta.group
+//                                  ^^ meta.for meta.block
+//  ^^^ keyword.control.loop.for
+//      ^ punctuation.section.group.begin
+//       ^ variable.other.readwrite
+//         ^^ keyword.control.loop.in
+//            ^ variable.other.readwrite
+//             ^ keyword.operator.comma
+//               ^ variable.other.readwrite
+//                 ^ keyword.operator.ternary
+//                   ^ variable.other.readwrite
+//                    ^ keyword.operator.ternary
+//                      ^ variable.other.readwrite
+//                       ^ keyword.operator.comma
+//                         ^ variable.function
+//                          ^ punctuation.section.group.begin
+//                           ^ variable.function
+//                            ^ punctuation.section.group.begin
+//                             ^^ punctuation.section.group.end
+//                               ^ invalid.illegal.unexpected-token
+//                                ^ punctuation.section.group.end
+//                                  ^ punctuation.section.block.begin
+//                                   ^ punctuation.section.block.end
+
+    for (x of list) {}
+//  ^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^ meta.group
+//         ^^ keyword.control.loop.of
+
+    for (x.y.z of list) {}
+//  ^^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^^^^^ meta.group
+//      ^ punctuation.section.group.begin
+//       ^ variable.other.readwrite
+//        ^ punctuation.accessor
+//         ^ meta.property.object
+//          ^ punctuation.accessor
+//           ^ meta.property.object
+//             ^^ keyword.control.loop.of
+//                ^^^^ variable.other.readwrite
+//                    ^ punctuation.section.group.end
+//                      ^^ meta.block
+
+    for await (const x of list) {}
+//  ^^^ keyword.control.loop.for
+//      ^^^^^ keyword.control.flow.await
+
+    for ( using x of list ) {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^^^^^^^^^ meta.group
+//      ^ punctuation.section.group.begin
+//        ^^^^^ keyword.declaration
+//              ^ meta.binding.name variable.other.readwrite
+//                ^^ keyword.control.loop.of
+//                   ^^^^ variable.other.readwrite
+//                        ^ punctuation.section.group.end
+//                          ^^ meta.block
+
+    for ( await using x of list ) {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group
+//      ^ punctuation.section.group.begin
+//        ^^^^^ keyword.declaration
+//              ^^^^^ keyword.declaration
+//        ^^^^^ keyword.declaration
+//              ^^^^^ keyword.declaration
+//                    ^ meta.binding.name variable.other.readwrite
+//                      ^^ keyword.control.loop.of
+//                         ^^^^ variable.other.readwrite
+//                              ^ punctuation.section.group.end
+//                                ^^ meta.block
+
+    for ( await using of of list ) {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group
+//      ^ punctuation.section.group.begin
+//        ^^^^^ keyword.declaration
+//              ^^^^^ keyword.declaration
+//                    ^^ meta.binding.name variable.other.readwrite
+//                       ^^ keyword.control.loop.of
+//                          ^^^^ variable.other.readwrite
+//                               ^ punctuation.section.group.end
+//                                 ^^ meta.block
+//                                 ^ punctuation.section.block.begin
+//                                  ^ punctuation.section.block.end
+
+    for ( using of list ) {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^^^^^^^ meta.group
+//      ^ punctuation.section.group.begin
+//        ^^^^^ variable.other.readwrite
+//              ^^ keyword.control.loop.of
+//                 ^^^^ variable.other.readwrite
+//                      ^ punctuation.section.group.end
+//                        ^^ meta.block
+
+    for ( using [x] of list ) {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^^^^^^^^^^^ meta.group
+//      ^ punctuation.section.group.begin
+//        ^^^^^ variable.other.readwrite
+//              ^^^ meta.brackets
+//              ^ punctuation.section.brackets.begin
+//               ^ variable.other.readwrite
+//                ^ punctuation.section.brackets.end
+//                  ^^ keyword.control.loop.of
+//                     ^^^^ variable.other.readwrite
+//                          ^ punctuation.section.group.end
+//                            ^^ meta.block
+
+    for ( await using ;;) {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^^^^^^^ meta.group
+//      ^ punctuation.section.group.begin
+//        ^^^^^ keyword.control.flow.await
+//              ^^^^^ variable.other.readwrite
+//                    ^^ punctuation.separator.expression
+//                      ^ punctuation.section.group.end
+//                        ^^ meta.block
+//                        ^ punctuation.section.block.begin
+//                         ^ punctuation.section.block.end
+
+    for ( await using instanceof x ;;) {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group
+//      ^ punctuation.section.group.begin
+//        ^^^^^ keyword.control.flow.await
+//              ^^^^^ variable.other.readwrite
+//                    ^^^^^^^^^^ keyword.operator
+//                               ^ variable.other.readwrite
+//                                 ^^ punctuation.separator.expression
+//                                   ^ punctuation.section.group.end
+//                                     ^^ meta.block
+
+    for (var in list) (i = 0 ; i < 10; i++)
+//  ^^^^^^^^^^^^^^^^^^ meta.for.js
+//                    ^^^^^^^^^^^^^^^^^^^^^ meta.group.js - meta.for
+
+for
+    42;
+//  ^^ constant.numeric - meta.for
+
+for(;;){}/**/
+//       ^ - meta.for
+
+{}/**/
+//^ - meta.block
+
+while (true)
+// ^^^^^^^^^ meta.while
+//     ^^^^ meta.group
+{
+// <- meta.block
+    x = yield;
+//      ^^^^^ keyword.control.flow.yield
+
+    x = yield* 42;
+//      ^^^^^ keyword.control.flow.yield
+//           ^ storage.modifier.generator.js
+
+    x = yield * 42;
+//      ^^^^^ keyword.control.flow.yield
+//            ^ storage.modifier.generator.js
+
+    x = yield
+    function f() {}
+    [];
+//  ^^ meta.sequence - meta.brackets
+
+
+    x = yield*
+    function f() {}
+    [];
+//  ^^ meta.brackets - meta.sequence
+
+    y = await 42;
+//      ^^^^^ keyword.control.flow.await
+
+    y = yield await 42;
+//      ^^^^^ keyword.control.flow.yield
+//            ^^^^^ keyword.control.flow.await
+
+    yield (parenthesized_expression);
+//  ^^^^^ keyword.control.flow.yield
+
+    yield `template`;
+//  ^^^^^ keyword.control.flow.yield
+
+    break;
+//  ^^^^^ keyword.control.flow.break
+
+    break foo;
+//  ^^^^^ keyword.control.flow.break
+//        ^^^ variable.label
+
+    break
+    foo;
+//  ^^^ variable.other.readwrite - variable.label
+
+    break/**/foo;
+//           ^^^ variable.label - variable.other.readwrite
+
+    break/*
+    */foo;
+//    ^^^ variable.other.readwrite - variable.label
+
+    break function;
+//        ^^^^^^^^ invalid.illegal.identifier variable.label
+
+    continue;
+//  ^^^^^^^^ keyword.control.flow.continue
+
+    continue foo;
+//  ^^^^^^^^ keyword.control.flow.continue
+//           ^^^ variable.label
+
+    continue
+    foo;
+//  ^^^ variable.other.readwrite - variable.label
+
+    continue/**/foo;
+//              ^^^ variable.label - variable.other.readwrite
+
+    continue/*
+    */ foo;
+//     ^^^ variable.other.readwrite - variable.label
+
+    goto;
+//  ^^^^ variable.other.readwrite - keyword
+}
+// <- meta.block
+
+    while (true) 42 ;
+//  ^^^^^^^^^^^^^ meta.while
+//  ^^^^^ keyword.control.loop.while
+//        ^^^^^^ meta.group
+//        ^ punctuation.section.group.begin
+//         ^^^^ constant.language.boolean.true
+//             ^ punctuation.section.group.end
+//               ^^ meta.number.integer.decimal constant.numeric.value
+//                  ^ punctuation.terminator.statement - punctuation.terminator.statement.empty
+
+while // Incomplete statement
+    42;
+//  ^^ constant.numeric - meta.while
+
+while(false){}/**/
+//            ^ - meta.while
+
+with (undefined) {
+// <- keyword.control.import.with
+//^^^^^^^^^^ meta.with
+//    ^^^^^^^^^ constant.language.undefined
+    return;
+//  ^^^^^^ meta.with meta.block keyword.control.flow.return
+}
+
+with // Incomplete statement
+    42;
+//  ^^ constant.numeric - meta.while
+
+with(false){}/**/
+//           ^ - meta.with
+
+switch ($foo) {
+// <- meta.switch keyword.control.conditional.switch
+// ^^^^^^^^^^^^ meta.switch
+//^^^^ keyword.control.conditional.switch
+//      ^^^^ meta.group
+//            ^ meta.block punctuation.section.block.begin
+    case foo:
+    // ^ meta.switch meta.block keyword.control.conditional.case
+    //      ^ - punctuation.separator.key-value
+        qux = 1;
+        break;
+        // ^ keyword.control.flow.break
+    case "baz":
+    // ^ keyword.control.conditional.case
+    //        ^ - punctuation.separator.key-value string
+        qux = 2;
+        break;
+        // ^ keyword.control.flow.break
+    default:
+    // ^ meta.switch meta.block keyword.control.conditional.default
+    //     ^ - punctuation.separator.key-value
+        qux = 3;
+
+    case$
+//  ^^^^^ - keyword
+    ;
+
+    default$
+//  ^^^^^^^^ - keyword
+    ;
+
+    case 0: {}
+    case 1:
+//  ^^^^ keyword.control.conditional.case
+}
+// <- meta.block punctuation.section.block.end
+
+try {
+// <- meta.try keyword.control.exception.try
+// ^^ meta.try
+//  ^ meta.block
+    foobar = qux.bar();
+//  ^^^^^^^^^^^^^^^^^^^ meta.try meta.block
+} catch (e) {
+// <- meta.block
+//^^^^^^^^^^^^ meta.catch
+//^^^^^ keyword.control.exception.catch
+//      ^^^ meta.group
+//       ^ meta.binding.name variable.other.readwrite
+//          ^ meta.block
+    foobar = 0
+//  ^^^^^^^^^^ meta.catch meta.block
+} finally {
+// <- meta.block
+//^^^^^^^^^^ meta.finally
+//^^^^^^^ keyword.control.exception.finally
+//        ^ meta.block
+    foobar += 1
+//  ^^^^^^^^^^^ meta.finally meta.block
+}
+// <- meta.block
+
+switch // Incomplete statement
+    42;
+//  ^^ constant.numeric - meta.switch
+
+switch(x){}/**/
+//         ^^ - meta.switch
+
+try{}/**/
+//   ^ - meta.try
+catch{}/**/
+//     ^ - meta.catch
+finally{}/**/
+//       ^ - meta.finally

--- a/JavaScript/tests/syntax_test_typescript_control.ts
+++ b/JavaScript/tests/syntax_test_typescript_control.ts
@@ -1,0 +1,570 @@
+// SYNTAX TEST "Packages/JavaScript/TypeScript.sublime-syntax"
+
+    if ( true ) { } ;
+//  ^^^^^^^^^^^^^^^ meta.conditional
+//  ^^ keyword.control.conditional.if
+//     ^^^^^^^^ meta.group
+//     ^ punctuation.section.group.begin
+//       ^^^^ constant.language.boolean.true
+//            ^ punctuation.section.group.end
+//              ^^^ meta.block
+//              ^ punctuation.section.block.begin
+//                ^ punctuation.section.block.end
+//                 ^ - meta.conditional
+//                  ^ punctuation.terminator.statement.empty
+
+    if ( true ) null ;
+//  ^^^^^^^^^^^^^^^^^^ meta.conditional
+//  ^^ keyword.control.conditional.if
+//     ^^^^^^^^ meta.group
+//     ^ punctuation.section.group.begin
+//       ^^^^ constant.language.boolean.true
+//            ^ punctuation.section.group.end
+//              ^^^^ constant.language.null
+//                   ^ punctuation.terminator.statement - punctuation.terminator.statement.empty
+//                    ^ - meta.conditional
+
+    if (true) {}/**/
+//              ^^^^ - meta.conditional
+
+    if (true) ;
+//  ^^^^^^^^^^ meta.conditional
+//            ^ punctuation.terminator.statement.empty
+
+    if (true) ;
+    else { } ;
+//  ^^^^^^^^ meta.conditional
+//  ^^^^ keyword.control.conditional.else
+//       ^^^ meta.block
+//       ^ punctuation.section.block.begin
+//         ^ punctuation.section.block.end
+//          ^ - meta.conditional
+//           ^ punctuation.terminator.statement.empty
+
+    else if (true) { } ;
+//  ^^^^^^^^^^^^^^^^^^ meta.conditional
+//  ^^^^^^^ keyword.control.conditional.elseif
+//          ^^^^^^ meta.group
+//          ^ punctuation.section.group.begin
+//           ^^^^ constant.language.boolean.true
+//               ^ punctuation.section.group.end
+//                 ^^^ meta.block
+//                 ^ punctuation.section.block.begin
+//                   ^ punctuation.section.block.end
+//                    ^^^ - meta.conditional
+//                     ^ punctuation.terminator.statement.empty
+
+    do { } while ( true ) ;
+//  ^^^^^^^^^^^^^^^^^^^^^ meta.do-while
+//  ^^ keyword.control.loop.do-while
+//     ^^^ meta.block
+//     ^ punctuation.section.block.begin
+//       ^ punctuation.section.block.end
+//         ^^^^^ keyword.control.loop.while
+//               ^^^^^^^^ meta.group
+//               ^ punctuation.section.group.begin
+//                 ^^^^ constant.language.boolean.true
+//                      ^ punctuation.section.group.end
+//                       ^ - meta.do-while
+//                        ^ punctuation.terminator.statement.empty
+
+    do 42 ; while ( true ) ;
+//  ^^^^^^^^^^^^^^^^^^^^^^ meta.do-while
+//  ^^ keyword.control.loop.do-while
+//     ^^ meta.number.integer.decimal constant.numeric.value
+//        ^ punctuation.terminator.statement
+//          ^^^^^ keyword.control.loop.while
+//                ^^^^^^^^ meta.group
+//                ^ punctuation.section.group.begin
+//                  ^^^^ constant.language.boolean.true
+//                       ^ punctuation.section.group.end
+//                         ^ punctuation.terminator.statement.empty
+
+    do {} while (false)/**/
+//                     ^ - meta.do-while
+
+    for (var i = 0; i < 10; i++) { } ;
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^^^^^^^^^^^^^^ meta.group
+//      ^ punctuation.section.group
+//       ^^^ keyword.declaration
+//           ^ meta.binding.name variable.other.readwrite
+//             ^ keyword.operator.assignment
+//               ^ meta.number.integer.decimal constant.numeric.value
+//                ^ punctuation.separator.expression
+//                  ^ variable.other.readwrite
+//                    ^ keyword.operator.comparison
+//                      ^^ meta.number.integer.decimal constant.numeric.value
+//                        ^ punctuation.separator.expression
+//                          ^ variable.other.readwrite
+//                           ^^ keyword.operator.arithmetic
+//                             ^ punctuation.section.group
+//                               ^^^ meta.block
+//                               ^ punctuation.section.block.begin
+//                                 ^ punctuation.section.block.end
+//                                  ^ - meta.for
+//                                   ^ punctuation.terminator.statement.empty
+
+    for ( var i = 0 ; i < 10 ; i++ ) { } ;
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group
+//      ^ punctuation.section.group
+//        ^^^ keyword.declaration
+//            ^ meta.binding.name variable.other.readwrite
+//              ^ keyword.operator.assignment
+//                ^ meta.number.integer.decimal constant.numeric.value
+//                  ^ punctuation.separator.expression
+//                    ^ variable.other.readwrite
+//                      ^ keyword.operator.comparison
+//                        ^^ meta.number.integer.decimal constant.numeric.value
+//                           ^ punctuation.separator.expression
+//                             ^ variable.other.readwrite
+//                              ^^ keyword.operator.arithmetic
+//                                 ^ punctuation.section.group
+//                                   ^^^ meta.block
+//                                   ^ punctuation.section.block.begin
+//                                     ^ punctuation.section.block.end
+//                                      ^ - meta.for
+//                                       ^ punctuation.terminator.statement.empty
+
+    for ( 
+//  ^^^^ meta.for - meta.group
+//      ^^^ meta.for meta.group
+//  ^^^ keyword.control.loop.for
+//      ^ punctuation.section.group.begin
+        var i = 0 ; 
+//     ^^^^^^^^^^^^^ meta.for meta.group
+//      ^^^ keyword.declaration
+//          ^ meta.binding.name variable.other.readwrite
+//            ^ keyword.operator.assignment
+//              ^ meta.number.integer.decimal constant.numeric.value
+//                ^ punctuation.separator.expression
+
+        i < 10 ; 
+//     ^^^^^^^^^^ meta.for meta.group
+//      ^ variable.other.readwrite
+//        ^ keyword.operator.comparison
+//          ^^ meta.number.integer.decimal constant.numeric.value
+//             ^ punctuation.separator.expression
+        i++ 
+//     ^^^^^ meta.for meta.group
+//      ^ variable.other.readwrite
+//       ^^ keyword.operator.arithmetic
+    ) { } ;
+//^^^ meta.for meta.group
+//   ^ meta.for - meta.block - meta.group
+//    ^^^ meta.for meta.block
+//  ^ punctuation.section.group
+//    ^^^ meta.block
+//    ^ punctuation.section.block.begin
+//      ^ punctuation.section.block.end
+//       ^ - meta.for
+//        ^ punctuation.terminator.statement.empty
+
+    for (;;) 42;
+//  ^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^ meta.group
+//      ^ punctuation.section.group
+//       ^^ punctuation.separator.expression
+//         ^ punctuation.section.group
+//           ^^ meta.number.integer.decimal constant.numeric.value
+//             ^ punctuation.terminator.statement - punctuation.terminator.statement.empty
+//              ^ - meta.for
+
+    for (; x in list;) {}
+//  ^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^^^^ meta.group
+//       ^ punctuation.separator.expression
+//           ^^ keyword.operator
+//                  ^ punctuation.separator.expression
+
+    for (a[x in list];;;) {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^^^^^^ meta.group
+//        ^^^^^^^^^^^ meta.brackets
+//           ^^ keyword.operator
+//                   ^ punctuation.separator.expression
+//                    ^ punctuation.separator.expression
+//                     ^ invalid.illegal.unexpected-token
+
+    for (;function () {}/a/g;) {}
+//                      ^ keyword.operator
+
+    for (const x in list) {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^^^^^^^ meta.group
+//       ^^^^^ keyword.declaration
+//               ^^ keyword.control.loop.in
+
+    for (const x of list) {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^^^^^^^ meta.group
+//       ^^^^^ keyword.declaration
+//               ^^ keyword.control.loop.of
+
+    for (x in list) {}
+//  ^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^ meta.group
+//         ^^ keyword.control.loop.in
+
+    for (a in b, c ? d: e, f(g());) {};
+//  ^^^^ meta.for - meta.group
+//      ^^^^^^^^^^^^^^^^^^^ meta.for meta.group - meta.function-call
+//                         ^^^^^^ meta.for meta.group meta.function-call
+//                               ^^ meta.for meta.group - meta.function-call
+//                                 ^ meta.for - meta.block - meta.group
+//                                  ^^ meta.for meta.block
+//  ^^^ keyword.control.loop.for
+//      ^ punctuation.section.group.begin
+//       ^ variable.other.readwrite
+//         ^^ keyword.control.loop.in
+//            ^ variable.other.readwrite
+//             ^ keyword.operator.comma
+//               ^ variable.other.readwrite
+//                 ^ keyword.operator.ternary
+//                   ^ variable.other.readwrite
+//                    ^ keyword.operator.ternary
+//                      ^ variable.other.readwrite
+//                       ^ keyword.operator.comma
+//                         ^ variable.function
+//                          ^ punctuation.section.group.begin
+//                           ^ variable.function
+//                            ^ punctuation.section.group.begin
+//                             ^^ punctuation.section.group.end
+//                               ^ invalid.illegal.unexpected-token
+//                                ^ punctuation.section.group.end
+//                                  ^ punctuation.section.block.begin
+//                                   ^ punctuation.section.block.end
+
+    for (x of list) {}
+//  ^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^ meta.group
+//         ^^ keyword.control.loop.of
+
+    for (x.y.z of list) {}
+//  ^^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^^^^^ meta.group
+//      ^ punctuation.section.group.begin
+//       ^ variable.other.readwrite
+//        ^ punctuation.accessor
+//         ^ meta.property.object
+//          ^ punctuation.accessor
+//           ^ meta.property.object
+//             ^^ keyword.control.loop.of
+//                ^^^^ variable.other.readwrite
+//                    ^ punctuation.section.group.end
+//                      ^^ meta.block
+
+    for await (const x of list) {}
+//  ^^^ keyword.control.loop.for
+//      ^^^^^ keyword.control.flow.await
+
+    for ( using x of list ) {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^^^^^^^^^ meta.group
+//      ^ punctuation.section.group.begin
+//        ^^^^^ keyword.declaration
+//              ^ meta.binding.name variable.other.readwrite
+//                ^^ keyword.control.loop.of
+//                   ^^^^ variable.other.readwrite
+//                        ^ punctuation.section.group.end
+//                          ^^ meta.block
+
+    for ( await using x of list ) {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group
+//      ^ punctuation.section.group.begin
+//        ^^^^^ keyword.declaration
+//              ^^^^^ keyword.declaration
+//        ^^^^^ keyword.declaration
+//              ^^^^^ keyword.declaration
+//                    ^ meta.binding.name variable.other.readwrite
+//                      ^^ keyword.control.loop.of
+//                         ^^^^ variable.other.readwrite
+//                              ^ punctuation.section.group.end
+//                                ^^ meta.block
+
+    for ( await using of of list ) {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group
+//      ^ punctuation.section.group.begin
+//        ^^^^^ keyword.declaration
+//              ^^^^^ keyword.declaration
+//                    ^^ meta.binding.name variable.other.readwrite
+//                       ^^ keyword.control.loop.of
+//                          ^^^^ variable.other.readwrite
+//                               ^ punctuation.section.group.end
+//                                 ^^ meta.block
+//                                 ^ punctuation.section.block.begin
+//                                  ^ punctuation.section.block.end
+
+    for ( using of list ) {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^^^^^^^ meta.group
+//      ^ punctuation.section.group.begin
+//        ^^^^^ variable.other.readwrite
+//              ^^ keyword.control.loop.of
+//                 ^^^^ variable.other.readwrite
+//                      ^ punctuation.section.group.end
+//                        ^^ meta.block
+
+    for ( using [x] of list ) {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^^^^^^^^^^^ meta.group
+//      ^ punctuation.section.group.begin
+//        ^^^^^ variable.other.readwrite
+//              ^^^ meta.brackets
+//              ^ punctuation.section.brackets.begin
+//               ^ variable.other.readwrite
+//                ^ punctuation.section.brackets.end
+//                  ^^ keyword.control.loop.of
+//                     ^^^^ variable.other.readwrite
+//                          ^ punctuation.section.group.end
+//                            ^^ meta.block
+
+    for ( await using ;;) {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^^^^^^^ meta.group
+//      ^ punctuation.section.group.begin
+//        ^^^^^ keyword.control.flow.await
+//              ^^^^^ variable.other.readwrite
+//                    ^^ punctuation.separator.expression
+//                      ^ punctuation.section.group.end
+//                        ^^ meta.block
+//                        ^ punctuation.section.block.begin
+//                         ^ punctuation.section.block.end
+
+    for ( await using instanceof x ;;) {}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.for
+//  ^^^ keyword.control.loop.for
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group
+//      ^ punctuation.section.group.begin
+//        ^^^^^ keyword.control.flow.await
+//              ^^^^^ variable.other.readwrite
+//                    ^^^^^^^^^^ keyword.operator
+//                               ^ variable.other.readwrite
+//                                 ^^ punctuation.separator.expression
+//                                   ^ punctuation.section.group.end
+//                                     ^^ meta.block
+
+    for (var in list) (i = 0 ; i < 10; i++)
+//  ^^^^^^^^^^^^^^^^^^ meta.for.js
+//                    ^^^^^^^^^^^^^^^^^^^^^ meta.group.js - meta.for
+
+for
+    42;
+//  ^^ constant.numeric - meta.for
+
+for(;;){}/**/
+//       ^ - meta.for
+
+{}/**/
+//^ - meta.block
+
+while (true)
+// ^^^^^^^^^ meta.while
+//     ^^^^ meta.group
+{
+// <- meta.block
+    x = yield;
+//      ^^^^^ keyword.control.flow.yield
+
+    x = yield* 42;
+//      ^^^^^ keyword.control.flow.yield
+//           ^ storage.modifier.generator.js
+
+    x = yield * 42;
+//      ^^^^^ keyword.control.flow.yield
+//            ^ storage.modifier.generator.js
+
+    x = yield
+    function f() {}
+    [];
+//  ^^ meta.sequence - meta.brackets
+
+
+    x = yield*
+    function f() {}
+    [];
+//  ^^ meta.brackets - meta.sequence
+
+    y = await 42;
+//      ^^^^^ keyword.control.flow.await
+
+    y = yield await 42;
+//      ^^^^^ keyword.control.flow.yield
+//            ^^^^^ keyword.control.flow.await
+
+    yield (parenthesized_expression);
+//  ^^^^^ keyword.control.flow.yield
+
+    yield `template`;
+//  ^^^^^ keyword.control.flow.yield
+
+    break;
+//  ^^^^^ keyword.control.flow.break
+
+    break foo;
+//  ^^^^^ keyword.control.flow.break
+//        ^^^ variable.label
+
+    break
+    foo;
+//  ^^^ variable.other.readwrite - variable.label
+
+    break/**/foo;
+//           ^^^ variable.label - variable.other.readwrite
+
+    break/*
+    */foo;
+//    ^^^ variable.other.readwrite - variable.label
+
+    break function;
+//        ^^^^^^^^ invalid.illegal.identifier variable.label
+
+    continue;
+//  ^^^^^^^^ keyword.control.flow.continue
+
+    continue foo;
+//  ^^^^^^^^ keyword.control.flow.continue
+//           ^^^ variable.label
+
+    continue
+    foo;
+//  ^^^ variable.other.readwrite - variable.label
+
+    continue/**/foo;
+//              ^^^ variable.label - variable.other.readwrite
+
+    continue/*
+    */ foo;
+//     ^^^ variable.other.readwrite - variable.label
+
+    goto;
+//  ^^^^ variable.other.readwrite - keyword
+}
+// <- meta.block
+
+    while (true) 42 ;
+//  ^^^^^^^^^^^^^ meta.while
+//  ^^^^^ keyword.control.loop.while
+//        ^^^^^^ meta.group
+//        ^ punctuation.section.group.begin
+//         ^^^^ constant.language.boolean.true
+//             ^ punctuation.section.group.end
+//               ^^ meta.number.integer.decimal constant.numeric.value
+//                  ^ punctuation.terminator.statement - punctuation.terminator.statement.empty
+
+while // Incomplete statement
+    42;
+//  ^^ constant.numeric - meta.while
+
+while(false){}/**/
+//            ^ - meta.while
+
+with (undefined) {
+// <- keyword.control.import.with
+//^^^^^^^^^^ meta.with
+//    ^^^^^^^^^ constant.language.undefined
+    return;
+//  ^^^^^^ meta.with meta.block keyword.control.flow.return
+}
+
+with // Incomplete statement
+    42;
+//  ^^ constant.numeric - meta.while
+
+with(false){}/**/
+//           ^ - meta.with
+
+switch ($foo) {
+// <- meta.switch keyword.control.conditional.switch
+// ^^^^^^^^^^^^ meta.switch
+//^^^^ keyword.control.conditional.switch
+//      ^^^^ meta.group
+//            ^ meta.block punctuation.section.block.begin
+    case foo:
+    // ^ meta.switch meta.block keyword.control.conditional.case
+    //      ^ - punctuation.separator.key-value
+        qux = 1;
+        break;
+        // ^ keyword.control.flow.break
+    case "baz":
+    // ^ keyword.control.conditional.case
+    //        ^ - punctuation.separator.key-value string
+        qux = 2;
+        break;
+        // ^ keyword.control.flow.break
+    default:
+    // ^ meta.switch meta.block keyword.control.conditional.default
+    //     ^ - punctuation.separator.key-value
+        qux = 3;
+
+    case$
+//  ^^^^^ - keyword
+    ;
+
+    default$
+//  ^^^^^^^^ - keyword
+    ;
+
+    case 0: {}
+    case 1:
+//  ^^^^ keyword.control.conditional.case
+}
+// <- meta.block punctuation.section.block.end
+
+try {
+// <- meta.try keyword.control.exception.try
+// ^^ meta.try
+//  ^ meta.block
+    foobar = qux.bar();
+//  ^^^^^^^^^^^^^^^^^^^ meta.try meta.block
+} catch (e) {
+// <- meta.block
+//^^^^^^^^^^^^ meta.catch
+//^^^^^ keyword.control.exception.catch
+//      ^^^ meta.group
+//       ^ meta.binding.name variable.other.readwrite
+//          ^ meta.block
+    foobar = 0
+//  ^^^^^^^^^^ meta.catch meta.block
+} finally {
+// <- meta.block
+//^^^^^^^^^^ meta.finally
+//^^^^^^^ keyword.control.exception.finally
+//        ^ meta.block
+    foobar += 1
+//  ^^^^^^^^^^^ meta.finally meta.block
+}
+// <- meta.block
+
+switch // Incomplete statement
+    42;
+//  ^^ constant.numeric - meta.switch
+
+switch(x){}/**/
+//         ^^ - meta.switch
+
+try{}/**/
+//   ^ - meta.try
+catch{}/**/
+//     ^ - meta.catch
+finally{}/**/
+//       ^ - meta.finally


### PR DESCRIPTION
Fixes #4592

This PR makes sure `expression-begin` is pushed onto stack after `<` in both `postfix-operators` and `ts-less-than` contexts. The latter was popping before, which terminated a comparison expression too early.

Re-use JavaScript related control structure syntax tests to verify TypeScript behaving equally.