### PR TITLE
[Rust] Restrict formatspec placeholder types

### DIFF
--- a/Rust/Rust.sublime-syntax
+++ b/Rust/Rust.sublime-syntax
@@ -1674,14 +1674,14 @@ contexts:
         \{
           (\d+|{{identifier}})?
           (
-            :                     # format_spec delimiter
-            (.?[<>^])?            # [[fill]align]
-            [+-]?                 # [sign]
-            \#?                   # ['#']
-            0?                    # [0]
-            ((\d+\$?)|{{identifier}}\$)?           # [width]
-            (\.(\d+\$?|\*|{{identifier}}\$)?)?     # ['.' precision]
-            (([xX]?\?)|{{identifier}})?  # [type]
+            :                                   # format_spec delimiter
+            (.?[<>^])?                          # [[fill]align]
+            [+-]?                               # [sign]
+            \#?                                 # ['#']
+            0?                                  # [0]
+               (\d+\$?|{{identifier}}\$)?       # [width]
+            (\.(\d+\$?|{{identifier}}\$|\*)?)?  # ['.' precision]
+            (([xX]?\?)|[oxXpbeE])?              # [type]
           )?
         \}
       scope: constant.other.placeholder.rust

--- a/Rust/tests/syntax_test_macros.rs
+++ b/Rust/tests/syntax_test_macros.rs
@@ -84,6 +84,36 @@ my_var = format!("Hello {name}, how are you?",
 //                                                   ^^^^ variable.other.rust
 //                                                        ^ keyword.operator.assignment.rust
 //                                                                      ^^^^ constant.numeric.float.rust
+        println!("{}",6);
+//                ^^       constant.other.placeholder.rust
+        println!("{:>6}",6);
+//                ^^^^^    constant.other.placeholder.rust
+        println!("{:>pad$}",5,pad=2);
+//                ^^^^^^^^ constant.other.placeholder.rust
+        println!("{:?}"); //? ⇒ Debug
+//                ^^^^     constant.other.placeholder.rust
+        println!("{:x?}"); //x? ⇒ Debug with lower-case hexadecimal integers
+//                ^^^^^    constant.other.placeholder.rust
+        println!("{:X?}"); //X? ⇒ Debug with upper-case hexadecimal integers
+//                ^^^^^    constant.other.placeholder.rust
+        println!("{:o}"); //o ⇒ Octal
+//                ^^^^     constant.other.placeholder.rust
+        println!("{:x}"); //x ⇒ LowerHex
+//                ^^^^     constant.other.placeholder.rust
+        println!("{:X}"); //X ⇒ UpperHex
+//                ^^^^     constant.other.placeholder.rust
+        println!("{:p}"); //p ⇒ Pointer
+//                ^^^^     constant.other.placeholder.rust
+        println!("{:b}"); //b ⇒ Binary
+//                ^^^^     constant.other.placeholder.rust
+        println!("{:e}"); //e ⇒ LowerExp
+//                ^^^^     constant.other.placeholder.rust
+        println!("{:E}"); //E ⇒ UpperExp
+//                ^^^^     constant.other.placeholder.rust
+        println!("{:>pad}",5,pad=2);
+//                ^^^^^^^  string.quoted.double.rust
+//                should be an error as it's missing the mandatory $ for the identifier 'pad', but currently the syntax file is too permissive as it doesn't split/check for subitems within the format escapes
+
 // Alignement from https://doc.rust-lang.org/std/fmt/
         assert_eq!(format!("Hello {:<5}!", "x"),  "Hello x    !");
 //      ^^^^^^^^^^ support.macro


### PR DESCRIPTION
This PR syncs with Rust Enhanced and cherry picks changes from commit [708f76a6b71ca8b39f1332057d7efe03b9797eab](https://github.com/rust-lang/rust-enhanced/commit/708f76a6b71ca8b39f1332057d7efe03b9797eab).