### PR TITLE
[Markdown] Disable indentation rules

### DIFF
--- a/Markdown/Indentation Rules - Code Blocks.tmPreferences
+++ b/Markdown/Indentation Rules - Code Blocks.tmPreferences
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>scope</key>
+	<string>text.html.markdown markup.raw</string>
+	<key>settings</key>
+	<dict>
+		<key>decreaseIndentPattern</key>
+		<string>^(.*\*/)?\s*\}[;\s]*$</string>
+		<key>increaseIndentPattern</key>
+		<string>^.*(\{[^}"']*|\([^)"']*)$</string>
+	</dict>
+</dict>
+</plist>

--- a/Markdown/Indentation Rules.tmPreferences
+++ b/Markdown/Indentation Rules.tmPreferences
@@ -1,14 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
 	<key>scope</key>
-	<string>text.html.markdown markup.raw</string>
+	<string>text.html.markdown</string>
 	<key>settings</key>
 	<dict>
 		<key>decreaseIndentPattern</key>
-		<string>^(.*\*/)?\s*\}[;\s]*$</string>
+		<string></string>
 		<key>increaseIndentPattern</key>
-		<string>^.*(\{[^}"']*|\([^)"']*)$</string>
+		<string></string>
+		<key>bracketIndentNextLinePattern</key>
+		<string></string>
 	</dict>
 </dict>
 </plist>

--- a/Markdown/Indentation Rules.tmPreferences
+++ b/Markdown/Indentation Rules.tmPreferences
@@ -4,6 +4,11 @@
 	<string>text.html.markdown</string>
 	<key>settings</key>
 	<dict>
+		<!--
+		Override indentation patterns of `text.html` scope
+		to clear and therefore disable them in inherited
+		`text.html.markdown` scope.
+		-->
 		<key>decreaseIndentPattern</key>
 		<string></string>
 		<key>increaseIndentPattern</key>

--- a/Markdown/tests/syntax_test_indentation.md
+++ b/Markdown/tests/syntax_test_indentation.md
@@ -1,0 +1,9 @@
+| SYNTAX TEST reindent "Packages/Markdown/Markdown.sublime-syntax"
+
+<table>
+<tr>
+<td>
+content
+</td>
+</tr>
+</table>


### PR DESCRIPTION
Fixes #4597 

This PR...

1. renames existing indentation rules file as it targets raw code blocks, only.
2. disables indentation rules in normal content to prevent rules from html being applied.