### PR TITLE
[Go] Replace .tmpl extension by .gotmpl and .go.tmpl

### DIFF
--- a/Go/HTML (Go).sublime-syntax
+++ b/Go/HTML (Go).sublime-syntax
@@ -9,8 +9,9 @@ extends: Packages/HTML/HTML.sublime-syntax
 
 file_extensions:
   - gohtml
+  - gotmpl
   - go.html
-  - tmpl
+  - go.tmpl
 
 variables:
 


### PR DESCRIPTION
Resolves #4595

This PR intents to reduce risk of false positives as .tmpl file extension might be used for anything, not only Go Templates.