### PR TITLE
[Markdown] Improve table performance with fast reject

### DIFF
--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -2571,7 +2571,7 @@ contexts:
 ###[ LEAF BLOCKS: TABLES ]####################################################
 
   tables:
-    - match: ^(?=[^|\n]*\|)(?={{table_first_row}})
+    - match: ^(?=[^|]*\|)(?={{table_first_row}})
       push: table-header
 
   table-header:

--- a/Markdown/Markdown.sublime-syntax
+++ b/Markdown/Markdown.sublime-syntax
@@ -2571,7 +2571,7 @@ contexts:
 ###[ LEAF BLOCKS: TABLES ]####################################################
 
   tables:
-    - match: ^(?={{table_first_row}})
+    - match: ^(?=[^|\n]*\|)(?={{table_first_row}})
       push: table-header
 
   table-header:


### PR DESCRIPTION
 - [X] My commit messages start with the package name in square brackets, e.g. `[XML] `.
 - [ ] I have included new or enhanced [syntax tests](https://www.sublimetext.com/docs/syntax.html#testing) to cover the changes.
 
 No tests added because it's just performance: no regressions introduced.
 
 Found this through syntect, which I use in one of my projects. Sublime's optimized engine does not have the issue, or it's not as bad, and neither does Oniguruma, but `fancy-regex` does.
 
 `{{table_first_row}}` expands to ~25 KB of regex whose first alternative is `(?:{{table_cell}}?\|){2}`, and `{{table_cell}}` is itself a `(?:…)+` over alternations. That nesting is exponential on failure, and it always fails on ordinary paragraph text.
 
 Both alternatives of `{{table_first_row}}` require a literal pipe on the line, and without it the nested quantifiers in `{{table_cell}}` backtrack over every paragraph line. The lookahead acts as a faster reject for the same condition.
 
 I suppose the main risk is the possibility of drift, but hopefully the existing test coverage is enough to prevent that.
 
 The fast reject, on top of fixing the pathological case in `fancy-regex`, also speeds up Sublime's syntax in prose-heavy Markdown docs, when there are no tables (around 10% on my measurements, YMMV).

(Side note: #4600 is also great for performance, amazing stuff!)