### PR TITLE
[C#] Fix null coalescing item access vs. ternary expression

### DIFF
--- a/C#/C#.sublime-syntax
+++ b/C#/C#.sublime-syntax
@@ -1644,6 +1644,11 @@ contexts:
     - include: else-pop
 
   expression-common:
+    - match: \[
+      scope: meta.brackets.cs punctuation.section.brackets.begin.cs
+      push:
+        - inside-item-access
+        - maybe-pointer
     # accessors and operators (Note: order matters!)
     - match: ->
       scope: punctuation.accessor.arrow.cs
@@ -1674,21 +1679,13 @@ contexts:
         1: keyword.operator.null-coalescing.cs
         2: punctuation.accessor.dot.cs
       push: maybe-pointer
-    - match: (\?)?\s*(\[)
-      captures:
-        1: keyword.operator.null-coalescing.cs
-        2: meta.brackets.cs punctuation.section.brackets.begin.cs
-      push:
-        - inside-item-access
-        - maybe-pointer
     - match: \?\?
       scope: keyword.operator.null-coalescing.cs
-      push: maybe-pointer
-    - match: \?
-      scope: keyword.operator.ternary.cs
-      push:
-        - inside-ternary-expression
-        - maybe-pointer
+    - match: (?=\?)
+      branch_point: null-coalescing
+      branch:
+        - null-coalescing
+        - ternary-expression
     # keywords
     - match: '{{sql_keywords}}'
       scope: keyword.other.sql.cs
@@ -1741,10 +1738,39 @@ contexts:
     - match: '@'
       scope: invalid.illegal.reserved-char.cs
 
+  null-coalescing:
+    - meta_include_prototype: false
+    - match: \?
+      scope: keyword.operator.null-coalescing.cs
+      set: null-coalescing-item-access
+    - include: immediately-pop
+
+  null-coalescing-item-access:
+    - match: \[
+      scope: meta.brackets.cs punctuation.section.brackets.begin.cs
+      set:
+        - null-coalescing-item-access-check
+        - inside-item-access
+        - maybe-pointer
+    - match: (?=\S)
+      fail: null-coalescing
+
+  null-coalescing-item-access-check:
+    - match: (?=:)
+      fail: null-coalescing
+    - include: else-pop
+
+  ternary-expression:
+    - meta_include_prototype: false
+    - match: \?
+      scope: keyword.operator.ternary.cs
+      set: inside-ternary-expression
+    - include: immediately-pop
+
   inside-ternary-expression:
     - match: ':'
       scope: keyword.operator.ternary.cs
-      pop: 1
+      set: expression
     - include: expression
 
   keywords:

--- a/C#/tests/syntax_test_scope_Operators.cs
+++ b/C#/tests/syntax_test_scope_Operators.cs
@@ -422,6 +422,49 @@ class TestOperatorDefinitions {
 ///           ^ keyword.operator.ternary
 ///                              ^ keyword.operator.ternary
 
+    (Radius != 1f) ? [a,b,c] : [e,f,g];
+/// ^^^^^^^^^^^^^^ meta.group.cs
+/// ^ punctuation.section.group.begin.cs
+///  ^^^^^^ variable.other.cs
+///         ^^ keyword.operator.comparison.cs
+///            ^^ meta.number.float.decimal.cs
+///            ^ constant.numeric.value.cs
+///             ^ constant.numeric.suffix.cs
+///              ^ punctuation.section.group.end.cs
+///                ^ keyword.operator.ternary.cs
+///                  ^^^^^^^ meta.brackets.cs
+///                  ^ punctuation.section.brackets.begin.cs
+///                   ^ variable.other.cs
+///                    ^ punctuation.separator.comma.cs
+///                     ^ variable.other.cs
+///                      ^ punctuation.separator.comma.cs
+///                       ^ variable.other.cs
+///                        ^ punctuation.section.brackets.end.cs
+///                          ^ keyword.operator.ternary.cs
+///                            ^^^^^^^ meta.brackets.cs
+///                            ^ punctuation.section.brackets.begin.cs
+///                             ^ variable.other.cs
+///                              ^ punctuation.separator.comma.cs
+///                               ^ variable.other.cs
+///                                ^ punctuation.separator.comma.cs
+///                                 ^ variable.other.cs
+///                                  ^ punctuation.section.brackets.end.cs
+///                                   ^ punctuation.terminator.statement.cs
+
+    C?[0]:[1];
+/// ^ variable.other.cs
+///  ^ keyword.operator.ternary.cs
+///   ^^^ meta.brackets.cs
+///   ^ punctuation.section.brackets.begin.cs
+///    ^ meta.number.integer.decimal.cs constant.numeric.value.cs
+///     ^ punctuation.section.brackets.end.cs
+///      ^ keyword.operator.ternary.cs
+///       ^^^ meta.brackets.cs
+///       ^ punctuation.section.brackets.begin.cs
+///        ^ meta.number.integer.decimal.cs constant.numeric.value.cs
+///         ^ punctuation.section.brackets.end.cs
+///          ^ punctuation.terminator.statement.cs
+
     // Pointer Arithmetic
 
     a = &obj;
@@ -501,6 +544,19 @@ A?.B?.C?[0] ?? E;
 ///     ^ punctuation.section.brackets.begin
 ///         ^^ keyword.operator.null-coalescing
 ///             ^ punctuation.terminator
+
+A?.B?.C?[0] ?? [""];
+ /// <- keyword.operator.null-coalescing.cs
+  /// <- punctuation.accessor.dot.cs
+/// ^ keyword.operator.null-coalescing.cs
+///  ^ punctuation.accessor.dot.cs
+///     ^ punctuation.section.brackets.begin
+///         ^^ keyword.operator.null-coalescing
+///            ^^^^ meta.brackets.cs
+///            ^ punctuation.section.brackets.begin.cs
+///             ^^ string.quoted.double.cs
+///               ^ punctuation.section.brackets.end.cs
+///                ^ punctuation.terminator.statement.cs
 
 A?.B?.C?[0] == E;
  /// <- keyword.operator.null-coalescing.cs


### PR DESCRIPTION
Fixes #4607

This PR adds branch points to distinguish null-coalescing item access and ternary expressions containing list literals.